### PR TITLE
Use wireit to auto-build dependencies

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -27,7 +27,7 @@ jobs:
             - name: Build
               run: |
                   export NODE_OPTIONS="--max_old_space_size=4096"
-                  npm run build -ws
+                  npm run build && npm run build:all
 
             - name: Test
               run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ client/server
 build
 test.doenet
 stats.html
+
+.wireit

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cd packages/test-viewer
 npm run dev
 ```
 
-Paste demo code into `src/test/testCode.doenet` and navigate to the URL specified in the console (probably http://localhost:5173 )
+Paste demo code into `src/test/testCode.doenet` and navigate to the URL specified in the console (probably http://localhost:8012 )
 
 ## Demos
 

--- a/README.md
+++ b/README.md
@@ -22,15 +22,21 @@ Semantic markup for building interactive web activities.
 
 ## Quickstart
 
-In the project folder:
+In root directory, run
 
-`$ npm install`
+```bash
+npm install
+npm run build
+```
 
-`$ npm run dev`
+To test code, you can use the `projects/test-viewer` package.
 
-Paste demo code into `src/test/testCode.doenet`
+```bash
+cd packages/test-viewer
+npm run dev
+```
 
-Navigate to `localhost:5173`
+Paste demo code into `src/test/testCode.doenet` and navigate to the URL specified in the console (probably http://localhost:5173 )
 
 ## Demos
 
@@ -156,3 +162,43 @@ Now try changing the number
 JavaScript parses the DoenetML and calls Rust functions, passing in strings. On core creation, Rust returns a pointer to its main struct, existing in WASM linear memory. Javascript uses this to access the other core functions. Rust returns rendering data as strings.
 
 The Doenet Rust code is in the doenet-core crate, doenet-core/src/lib.rs being the main file. The crate can be built as a library independent of javascript, but without a parser, one would need pre-parsed DoenetML objects as its input. -->
+
+## Development
+
+DoenetML features are split into npm _workspace_ located in the `packages/*` directory. Each package is built
+using `vite`. Automatic building
+of dependencies is handled via the [wireit](https://github.com/google/wireit) project, which is configured in
+each workspace's `package.json`.
+
+### Automatic Rebuilding (watch mode)
+
+Because of the complicated build process for some packages, `npx vite build --watch` will often fail as dependencies
+get rebuilt. Instead you should use
+
+```bash
+npm run build --watch
+```
+
+from a package's directory to have `wireit` manage rebuilding of dependencies. For example, to automatically rebuild
+`doenetml` on any change and have that reflected in `test-viewer`, you could run
+
+```bash
+cd packages/doenetml
+npm run build --watch &
+cd ../test-viewer
+npm run dev
+```
+
+Since `doenetml` should include most packages as dependencies, a change to almost any package will cause it to be rebuilt
+automatically.
+
+### Consistency checks
+
+Keeping every `package.json` file consistent as well as keeping the `wireit` dependencies correct can be hard.
+Programs in `scripts/` can help.
+
+```bash
+npx vite-node scripts/ensure-consistency.ts
+```
+
+will show the dependencies imported by each package and cross-reference this with those dependencies specified in its `package.json`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "./packages/static-assets",
                 "./packages/parser",
                 "./packages/lsp-tools",
+                "./packages/lsp",
                 "./packages/doenetml-worker",
                 "./packages/virtual-keyboard",
                 "./packages/codemirror",
@@ -22,7 +23,8 @@
             ],
             "dependencies": {
                 "@uiw/react-codemirror": "^4.21.21",
-                "micromark": "^4.0.0"
+                "micromark": "^4.0.0",
+                "wireit": "^0.14.1"
             },
             "devDependencies": {
                 "@qualified/lsp-connection": "^0.3.0",
@@ -30,10 +32,12 @@
                 "@rollup/pluginutils": "^5.0.5",
                 "@vitest/web-worker": "^0.34.6",
                 "@vscode/test-web": "^0.0.47",
+                "chalk": "^5.3.0",
                 "compress-json": "^2.1.2",
                 "jsdom": "^22.1.0",
                 "prettier": "^3.0.3",
                 "rollup-plugin-visualizer": "^5.9.2",
+                "ts-morph": "^21.0.1",
                 "typescript": "^5.2.2",
                 "vite-node": "^0.34.6",
                 "vitest": "^0.34.6"
@@ -133,6 +137,19 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/code-frame/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/@babel/compat-data": {
@@ -360,6 +377,19 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/highlight/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/@babel/parser": {
@@ -2640,7 +2670,6 @@
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
@@ -2652,7 +2681,6 @@
         },
         "node_modules/@nodelib/fs.stat": {
             "version": "2.0.5",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
@@ -2660,7 +2688,6 @@
         },
         "node_modules/@nodelib/fs.walk": {
             "version": "1.2.8",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
@@ -2849,6 +2876,57 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/@ts-morph/common": {
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.22.0.tgz",
+            "integrity": "sha512-HqNBuV/oIlMKdkLshXd1zKBqNQCsuPEsgQOkfFQ/eUKjRlwndXW1AjN9LVkBEIukm00gGXSRmfkl0Wv5VXLnlw==",
+            "dev": true,
+            "dependencies": {
+                "fast-glob": "^3.3.2",
+                "minimatch": "^9.0.3",
+                "mkdirp": "^3.0.1",
+                "path-browserify": "^1.0.1"
+            }
+        },
+        "node_modules/@ts-morph/common/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@ts-morph/common/node_modules/minimatch": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@ts-morph/common/node_modules/mkdirp": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+            "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+            "dev": true,
+            "bin": {
+                "mkdirp": "dist/cjs/src/bin.js"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@types/argparse": {
@@ -3623,7 +3701,8 @@
         },
         "node_modules/ansi-styles": {
             "version": "3.2.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dependencies": {
                 "color-convert": "^1.9.0"
             },
@@ -3633,7 +3712,6 @@
         },
         "node_modules/anymatch": {
             "version": "3.1.2",
-            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "normalize-path": "^3.0.0",
@@ -4378,7 +4456,6 @@
         },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -4409,7 +4486,6 @@
         },
         "node_modules/braces": {
             "version": "3.0.2",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "fill-range": "^7.0.1"
@@ -4718,15 +4794,15 @@
             }
         },
         "node_modules/chalk": {
-            "version": "2.4.2",
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+            "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+            "dev": true,
             "engines": {
-                "node": ">=4"
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
         "node_modules/character-entities": {
@@ -4783,7 +4859,6 @@
         },
         "node_modules/chokidar": {
             "version": "3.5.3",
-            "devOptional": true,
             "funding": [
                 {
                     "type": "individual",
@@ -4970,6 +5045,12 @@
                 "node": ">= 0.12.0"
             }
         },
+        "node_modules/code-block-writer": {
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-12.0.0.tgz",
+            "integrity": "sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w==",
+            "dev": true
+        },
         "node_modules/codemirror": {
             "version": "6.0.1",
             "license": "MIT",
@@ -4996,14 +5077,16 @@
         },
         "node_modules/color-convert": {
             "version": "1.9.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
             "dependencies": {
                 "color-name": "1.1.3"
             }
         },
         "node_modules/color-name": {
             "version": "1.1.3",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "node_modules/color2k": {
             "version": "2.0.2",
@@ -7128,9 +7211,9 @@
             "license": "MIT"
         },
         "node_modules/fast-glob": {
-            "version": "3.3.1",
-            "dev": true,
-            "license": "MIT",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+            "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
@@ -7154,7 +7237,6 @@
         },
         "node_modules/fastq": {
             "version": "1.13.0",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
@@ -7195,7 +7277,6 @@
         },
         "node_modules/fill-range": {
             "version": "7.0.1",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -7569,7 +7650,6 @@
         },
         "node_modules/glob-parent": {
             "version": "5.1.2",
-            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.1"
@@ -8232,7 +8312,6 @@
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "binary-extensions": "^2.0.0"
@@ -8479,7 +8558,6 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
@@ -8866,7 +8944,6 @@
         },
         "node_modules/jsonc-parser": {
             "version": "3.2.0",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/jsonfile": {
@@ -9972,7 +10049,6 @@
         },
         "node_modules/micromatch": {
             "version": "4.0.5",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "braces": "^3.0.2",
@@ -10430,7 +10506,6 @@
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
-            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -11274,6 +11349,16 @@
             "version": "16.13.1",
             "license": "MIT"
         },
+        "node_modules/proper-lockfile": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+            "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "retry": "^0.12.0",
+                "signal-exit": "^3.0.2"
+            }
+        },
         "node_modules/proxy-from-env": {
             "version": "1.0.0",
             "dev": true,
@@ -11366,7 +11451,6 @@
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -11723,7 +11807,6 @@
         },
         "node_modules/readdirp": {
             "version": "3.6.0",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "picomatch": "^2.2.1"
@@ -11947,9 +12030,16 @@
                 "node": ">=0.12"
             }
         },
+        "node_modules/retry": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
         "node_modules/reusify": {
             "version": "1.0.4",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "iojs": ">=1.0.0",
@@ -12156,7 +12246,6 @@
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -13349,7 +13438,6 @@
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "is-number": "^7.0.0"
@@ -13409,6 +13497,16 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/ts-morph": {
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-21.0.1.tgz",
+            "integrity": "sha512-dbDtVdEAncKctzrVZ+Nr7kHpHkv+0JDJb2MjjpBaj8bFeCkePU9rHfMklmhuLFnpeq/EJZk2IhStY6NzqgjOkg==",
+            "dev": true,
+            "dependencies": {
+                "@ts-morph/common": "~0.22.0",
+                "code-block-writer": "^12.0.0"
             }
         },
         "node_modules/tslib": {
@@ -14460,6 +14558,24 @@
         "node_modules/wicked-good-xpath": {
             "version": "1.3.0",
             "license": "MIT"
+        },
+        "node_modules/wireit": {
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.14.1.tgz",
+            "integrity": "sha512-q5sixPM/vKQEpyaub6J9QoHAFAF9g4zBdnjoYelH9/RLAekcUf3x1dmFLACGZ6nYjqehCsTlXC1irmzU7znPhA==",
+            "dependencies": {
+                "braces": "^3.0.2",
+                "chokidar": "^3.5.3",
+                "fast-glob": "^3.2.11",
+                "jsonc-parser": "^3.0.0",
+                "proper-lockfile": "^4.1.2"
+            },
+            "bin": {
+                "wireit": "bin/wireit.js"
+            },
+            "engines": {
+                "node": ">=14.14.0"
+            }
         },
         "node_modules/workerpool": {
             "version": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
         "./packages/*"
     ],
     "scripts": {
-        "build": "npm run build -ws",
+        "build": "npm run build --workspace packages/test-viewer",
+        "build:all": "npm run build -ws",
         "test": "npm run test -ws -- run"
     },
     "repository": {
@@ -36,10 +37,12 @@
         "@rollup/pluginutils": "^5.0.5",
         "@vitest/web-worker": "^0.34.6",
         "@vscode/test-web": "^0.0.47",
+        "chalk": "^5.3.0",
         "compress-json": "^2.1.2",
         "jsdom": "^22.1.0",
         "prettier": "^3.0.3",
         "rollup-plugin-visualizer": "^5.9.2",
+        "ts-morph": "^21.0.1",
         "typescript": "^5.2.2",
         "vite-node": "^0.34.6",
         "vitest": "^0.34.6"
@@ -49,6 +52,7 @@
     },
     "dependencies": {
         "@uiw/react-codemirror": "^4.21.21",
-        "micromark": "^4.0.0"
+        "micromark": "^4.0.0",
+        "wireit": "^0.14.1"
     }
 }

--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -22,7 +22,25 @@
         "dev": "vite",
         "watch": "vite build --watch",
         "test": "echo \"No tests \"",
-        "build": "vite build"
+        "build": "wireit"
+    },
+    "wireit": {
+        "build": {
+            "command": "vite build",
+            "files": [
+                "src/**/*.ts",
+                "tsconfig.json"
+            ],
+            "output": [
+                "dist/**/*.js",
+                "dist/**/*.d.ts",
+                "dist/**/*.json"
+            ],
+            "dependencies": [
+                "../parser:build",
+                "../lsp:build"
+            ]
+        }
     },
     "dependencies": {
         "codemirror": "6.0.1",

--- a/packages/doenetml-worker/package.json
+++ b/packages/doenetml-worker/package.json
@@ -30,6 +30,7 @@
             "command": "vite build",
             "files": [
                 "src/**/*.ts",
+                "src/**/*.js",
                 "tsconfig.json"
             ],
             "output": [

--- a/packages/doenetml-worker/package.json
+++ b/packages/doenetml-worker/package.json
@@ -23,7 +23,25 @@
     "scripts": {
         "watch": "vite build --watch",
         "test": "echo \"No tests \"",
-        "build": "vite build"
+        "build": "wireit"
+    },
+    "wireit": {
+        "build": {
+            "command": "vite build",
+            "files": [
+                "src/**/*.ts",
+                "tsconfig.json"
+            ],
+            "output": [
+                "dist/**/*.js",
+                "dist/**/*.d.ts",
+                "dist/**/*.json"
+            ],
+            "dependencies": [
+                "../utils:build",
+                "../parser:build"
+            ]
+        }
     },
     "peerDependencies": {
         "react": "^18.2.0",

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -21,10 +21,32 @@
     },
     "scripts": {
         "dev": "vite",
-        "build": "vite build",
+        "build": "wireit",
         "preview": "vite preview",
         "test": "echo \"No tests \"",
         "lint": "eslint src --ext js,jsx --report-unused-disable-directives --max-warnings 0"
+    },
+    "wireit": {
+        "build": {
+            "command": "vite build",
+            "files": [
+                "src/**/*.ts",
+                "tsconfig.json"
+            ],
+            "output": [
+                "dist/**/*.js",
+                "dist/**/*.d.ts",
+                "dist/**/*.json"
+            ],
+            "dependencies": [
+                "../doenetml-worker:build",
+                "../codemirror:build",
+                "../ui-components:build",
+                "../utils:build",
+                "../virtual-keyboard:build",
+                "../parser:build"
+            ]
+        }
     },
     "peerDependencies": {
         "react": "^18.2.0",

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -31,6 +31,10 @@
             "command": "vite build",
             "files": [
                 "src/**/*.ts",
+                "src/**/*.tsx",
+                "src/**/*.js",
+                "src/**/*.jsx",
+                "src/**/*.css",
                 "tsconfig.json"
             ],
             "output": [

--- a/packages/lsp-tools/package.json
+++ b/packages/lsp-tools/package.json
@@ -18,9 +18,27 @@
     "scripts": {
         "dev": "vite",
         "watch": "vite build --watch",
-        "build": "vite build",
+        "build": "wireit",
         "test": "vitest",
         "compile_grammar": "npx lezer-generator --output src/generated-assets/lezer-doenet.ts src/doenet.grammar"
+    },
+    "wireit": {
+        "build": {
+            "command": "vite build",
+            "files": [
+                "src/**/*.ts",
+                "tsconfig.json"
+            ],
+            "output": [
+                "dist/**/*.js",
+                "dist/**/*.d.ts",
+                "dist/**/*.json"
+            ],
+            "dependencies": [
+                "../static-assets:build",
+                "../parser:build"
+            ]
+        }
     },
     "devDependencies": {
         "vite": "^4.5.0",

--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -20,8 +20,26 @@
     },
     "scripts": {
         "watch": "vite build --watch",
-        "build": "vite build",
+        "build": "wireit",
         "test": "vitest",
         "compile_grammar": "npx lezer-generator --output src/generated-assets/lezer-doenet.ts src/doenet.grammar"
+    },
+    "wireit": {
+        "build": {
+            "command": "vite build",
+            "files": [
+                "src/**/*.ts",
+                "tsconfig.json"
+            ],
+            "output": [
+                "dist/**/*.js",
+                "dist/**/*.d.ts",
+                "dist/**/*.json"
+            ],
+            "dependencies": [
+                "../lsp-tools:build",
+                "../parser:build"
+            ]
+        }
     }
 }

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -18,9 +18,26 @@
     "scripts": {
         "dev": "vite",
         "watch": "vite build --watch",
-        "build": "vite build",
+        "build": "wireit",
         "test": "vitest",
         "compile_grammar": "npx lezer-generator --output src/generated-assets/lezer-doenet.ts src/doenet.grammar"
+    },
+    "wireit": {
+        "build": {
+            "command": "vite build",
+            "files": [
+                "src/**/*.ts",
+                "tsconfig.json"
+            ],
+            "output": [
+                "dist/**/*.js",
+                "dist/**/*.d.ts",
+                "dist/**/*.json"
+            ],
+            "dependencies": [
+                "../static-assets:build"
+            ]
+        }
     },
     "dependencies": {
         "@lezer/common": "^1.1.0",

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -13,9 +13,26 @@
     "main": "dist/doenet-standalone.js",
     "scripts": {
         "dev": "vite",
-        "build": "vite build",
+        "build": "wireit",
         "test": "echo \"No tests \"",
         "preview": "vite preview"
+    },
+    "wireit": {
+        "build": {
+            "command": "vite build",
+            "files": [
+                "src/**/*.ts",
+                "tsconfig.json"
+            ],
+            "output": [
+                "dist/**/*.js",
+                "dist/**/*.d.ts",
+                "dist/**/*.json"
+            ],
+            "dependencies": [
+                "../doenetml:build"
+            ]
+        }
     },
     "peerDependencies": {
         "react": "^18.2.0",

--- a/packages/static-assets/package.json
+++ b/packages/static-assets/package.json
@@ -20,7 +20,21 @@
     },
     "scripts": {
         "test": "echo \"No tests \"",
-        "build": "vite build",
+        "build": "wireit",
         "build:schema": "vite-node ./scripts/generate-schema.ts && vite-node ./scripts/generate-entity-map.ts"
+    },
+    "wireit": {
+        "build": {
+            "command": "vite build",
+            "files": [
+                "src/**/*.ts",
+                "tsconfig.json"
+            ],
+            "output": [
+                "dist/**/*.js",
+                "dist/**/*.d.ts",
+                "dist/**/*.json"
+            ]
+        }
     }
 }

--- a/packages/test-viewer/package.json
+++ b/packages/test-viewer/package.json
@@ -12,9 +12,27 @@
     ],
     "scripts": {
         "dev": "vite",
-        "build": "vite build",
+        "build": "wireit",
         "test": "echo \"No tests \"",
         "preview": "vite preview"
+    },
+    "wireit": {
+        "build": {
+            "command": "vite build",
+            "files": [
+                "src/**/*.ts",
+                "tsconfig.json"
+            ],
+            "output": [
+                "dist/**/*.js",
+                "dist/**/*.d.ts",
+                "dist/**/*.json"
+            ],
+            "dependencies": [
+                "../doenetml:build",
+                "../ui-components:build"
+            ]
+        }
     },
     "peerDependencies": {
         "react": "^18.2.0",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -19,7 +19,21 @@
         "dev": "vite",
         "watch": "vite build --watch",
         "test": "echo \"No tests \"",
-        "build": "vite build"
+        "build": "wireit"
+    },
+    "wireit": {
+        "build": {
+            "command": "vite build",
+            "files": [
+                "src/**/*.ts",
+                "tsconfig.json"
+            ],
+            "output": [
+                "dist/**/*.js",
+                "dist/**/*.d.ts",
+                "dist/**/*.json"
+            ]
+        }
     },
     "dependencies": {},
     "devDependencies": {}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,7 +19,21 @@
         "dev": "vite",
         "watch": "vite build --watch",
         "test": "echo \"No tests \"",
-        "build": "vite build"
+        "build": "wireit"
+    },
+    "wireit": {
+        "build": {
+            "command": "vite build",
+            "files": [
+                "src/**/*.ts",
+                "tsconfig.json"
+            ],
+            "output": [
+                "dist/**/*.js",
+                "dist/**/*.d.ts",
+                "dist/**/*.json"
+            ]
+        }
     },
     "dependencies": {},
     "devDependencies": {}

--- a/packages/virtual-keyboard/package.json
+++ b/packages/virtual-keyboard/package.json
@@ -22,7 +22,21 @@
         "dev": "vite",
         "watch": "vite build --watch",
         "test": "echo \"No tests \"",
-        "build": "vite build"
+        "build": "wireit"
+    },
+    "wireit": {
+        "build": {
+            "command": "vite build",
+            "files": [
+                "src/**/*.ts",
+                "tsconfig.json"
+            ],
+            "output": [
+                "dist/**/*.js",
+                "dist/**/*.d.ts",
+                "dist/**/*.json"
+            ]
+        }
     },
     "dependencies": {
         "recoil": "^0.7.7",

--- a/scripts/ensure-consistency.ts
+++ b/scripts/ensure-consistency.ts
@@ -1,0 +1,188 @@
+/**
+ * Provide information about the consistency of package.json files and all the workspaces in packages/*
+ */
+
+import { Project } from "ts-morph";
+import * as glob from "glob";
+import * as path from "node:path";
+import chalk from "chalk";
+import os from "os";
+import * as fs from "node:fs/promises";
+
+if (os.platform() === "win32") {
+    console.warn(
+        chalk.bold(
+            chalk.red(
+                "Warning: This script may not work correctly on Windows.",
+            ),
+        ),
+    );
+}
+
+const PWD = new URL("./", import.meta.url).pathname;
+const TSCONFIG_FILES = glob
+    .sync(path.join(PWD, "..", "packages", "*", "tsconfig.json"))
+    .filter((x) => !x.includes("cypress"));
+const DOENETML_DIR = path.resolve(path.join(PWD, ".."));
+
+for (const tsconfig of TSCONFIG_FILES) {
+    const currentPackage = tsconfig.match(/packages\/(.*?)\//)?.[1];
+    if (!currentPackage) {
+        console.warn(
+            chalk.redBright("Could not find package name for"),
+            tsconfig,
+        );
+        continue;
+    }
+    console.log("Analyzing", chalk.bold(chalk.blueBright(currentPackage)));
+
+    const project = new Project({
+        tsConfigFilePath: tsconfig,
+    });
+
+    // We only care about source files, not declaration files.
+    const sourceFiles = project.getSourceFiles().filter((file) => {
+        const filePath = file.getFilePath();
+        return (
+            // Type declarations are skipped
+            !filePath.endsWith(".d.ts") &&
+            !filePath.endsWith(".test.ts") &&
+            // `dev-site.tsx` is never built. It's only for vite preview.
+            !filePath.endsWith("dev-site.tsx")
+        );
+    });
+
+    let absoluteImports: Set<string> = new Set();
+
+    for (const sourceFile of sourceFiles) {
+        const importDeclarations = sourceFile.getImportDeclarations();
+        for (const importDeclaration of importDeclarations) {
+            const importString = importDeclaration.getModuleSpecifierValue();
+            const fileThatUsedImport = sourceFile.getFilePath();
+
+            if (!importString.startsWith(".")) {
+                absoluteImports.add(importString);
+            } else {
+                // Find out if the relative import accesses something outside of the package.
+                const resolvedImport = path.resolve(
+                    path.dirname(fileThatUsedImport),
+                    importString,
+                );
+                if (!resolvedImport.includes(`packages/${currentPackage}`)) {
+                    console.warn(
+                        "    ",
+                        chalk.redBright("import"),
+                        chalk.gray("... from"),
+                        chalk.redBright(`"${importString}"`),
+                        "in file",
+                        chalk.gray(
+                            path.relative(DOENETML_DIR, fileThatUsedImport),
+                        ),
+                        "imports from outside of the",
+                        currentPackage,
+                        "package. It imports",
+                        chalk.gray(path.relative(DOENETML_DIR, resolvedImport)),
+                    );
+                }
+            }
+        }
+    }
+
+    absoluteImports = new Set(
+        Array.from(absoluteImports).map(normalizeImportName),
+    );
+
+    // Find all the `@doenet` absolute imports
+    const doenetImports = Array.from(
+        new Set(
+            Array.from(absoluteImports)
+                .filter((x) => x.startsWith("@doenet/"))
+                .map(normalizeImportName),
+        ),
+    ).sort();
+    const externalImports = Array.from(
+        new Set(
+            Array.from(absoluteImports)
+                .filter((x) => !doenetImports.includes(x))
+                .map(normalizeImportName),
+        ),
+    ).sort();
+
+    // Check that the package.json includes all external imports
+    const packageJsonPath = path.resolve(
+        path.join(PWD, "..", "packages", currentPackage, "package.json"),
+    );
+    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, "utf-8"));
+    const packageJsonDeps = new Set([
+        ...Object.keys(packageJson.dependencies ?? {}),
+        ...Object.keys(packageJson.devDependencies ?? {}),
+        ...Object.keys(packageJson.peerDependencies ?? {}),
+    ]);
+
+    const missingDepsWarnings = externalImports.filter(
+        (dep) =>
+            !packageJsonDeps.has(dep) && !packageJsonDeps.has(`@types/${dep}`),
+    );
+    if (missingDepsWarnings.length > 0) {
+        console.log(
+            "    ",
+            chalk.redBright(path.relative(DOENETML_DIR, packageJsonPath)),
+            "is",
+            chalk.redBright("missing external dependencies:"),
+        );
+        missingDepsWarnings.forEach((dep) => {
+            console.warn("        ", dep);
+        });
+    }
+
+    // Find the internal `@doenet` dependencies
+    if (doenetImports.length > 0) {
+        console.log("    ", chalk.blue("@doenet dependencies"));
+        doenetImports.forEach((dep) => {
+            console.log("        ", dep);
+        });
+        // Check that any `wireit` build statements have the dependencies listed.
+        const wireitBuild = packageJson?.wireit?.build;
+        if (wireitBuild) {
+            const expected = doenetImports.map(
+                (dep) => `../${dep.split("/")[1]}:build`,
+            );
+            const existing = wireitBuild.dependencies ?? [];
+            const missing = expected.filter((x) => !existing.includes(x));
+            const excessive = existing.filter((x) => !expected.includes(x));
+
+            if (missing.length > 0 || excessive.length > 0) {
+                console.log(
+                    "\n    ",
+                    chalk.redBright("wireit"),
+                    "has incorrect dependencies in",
+                    chalk.gray(path.relative(DOENETML_DIR, packageJsonPath)),
+                );
+                missing.forEach((dep) => {
+                    console.log("        ", chalk.red(dep), "\tis missing");
+                });
+                if (missing.length > 0 && excessive.length > 0) {
+                    console.log("        ");
+                }
+                excessive.forEach((dep) => {
+                    console.log(
+                        "        ",
+                        chalk.green(dep),
+                        "\tshould not be included",
+                    );
+                });
+            }
+        }
+    }
+}
+
+/**
+ * Find the "basename" of the import. For example, if the import is "@doenet/blah/bar", return "@doenet/blah".
+ */
+function normalizeImportName(importName: string) {
+    if (!importName.startsWith("@")) {
+        return importName.split("/")[0];
+    }
+
+    return importName.split("/").slice(0, 2).join("/");
+}


### PR DESCRIPTION
[wireit](https://github.com/google/wireit) is a script that handles dependency building and caching, configured in `package.json`. This PR changes the build processes for most packages to use `wireit`.

Results:
  * building should be much faster since building of deps can happen in parallel
  * You can now run `npm run build --watch` in a workspace and it will automatically rebuild all deps when a file changes (no need for multiple watched directories)

The top-level `npm run build` was changed to only build `test-viewer`, which skips the building of `test-cypress` and `standalone`. This should speed things up for most devs. The CI should still build all of the packages.