### PR TITLE
Make Rust Development Easier

### DIFF
--- a/.vscode/doenet.code-workspace
+++ b/.vscode/doenet.code-workspace
@@ -1,0 +1,15 @@
+{
+    "folders": [
+        {
+            "path": "..",
+            "name": "All DoenetML Packages"
+        },
+        {
+            "path": "../packages/doenetml-worker-rust",
+            "name": "Rust Worker"
+        }
+    ],
+    "settings": {
+        "rust-analyzer.diagnostics.disabled": ["non_snake_case"]
+    }
+}

--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ When using Visual Studio Code to work on DoenetML, you should open the pre-confi
 located at `.vscode/doenet.code-workspace`. This will, among other things, make sure that `rust-analyzer` is pointed
 at the correct directory.
 
+You can do this directly by running
+```bash
+code .vscode/doenet.code-workspace
+```
+
 ### Automatic Rebuilding (watch mode)
 
 Because of the complicated build process for some packages, `npx vite build --watch` will often fail as dependencies

--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ using `vite`. Automatic building
 of dependencies is handled via the [wireit](https://github.com/google/wireit) project, which is configured in
 each workspace's `package.json`.
 
+### VSCode
+
+When using Visual Studio Code to work on DoenetML, you should open the pre-configured VSCode workspaces
+located at `.vscode/doenet.code-workspace`. This will, among other things, make sure that `rust-analyzer` is pointed
+at the correct directory.
+
 ### Automatic Rebuilding (watch mode)
 
 Because of the complicated build process for some packages, `npx vite build --watch` will often fail as dependencies


### PR DESCRIPTION
This PR adds a `.vscode/doenet.code-workspace` file. Clicking that file and then `Open Workspace`, or invoking

```
code .vscode/doenet.code-workspace
```

directly will open a multi-root vscode workspace where rust-analyzer is configured correctly.