### PR TITLE
Add a `preserve_refs` annotation for attributes

### DIFF
--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/components/component.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/components/component.rs
@@ -157,6 +157,9 @@ impl ComponentAttributes for Component {
     fn get_attribute_names(&self) -> Vec<&'static str> {
         self.variant.get_attribute_names()
     }
+    fn get_preserve_ref_attribute_indices(&self) -> &[usize] {
+        self.variant.get_preserve_ref_attribute_indices()
+    }
 }
 
 impl ComponentCommon for Component {

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/components/component_enum.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/components/component_enum.rs
@@ -3,6 +3,7 @@ use strum_macros::EnumString;
 
 pub use super::_error::_Error;
 pub use super::_external::_External;
+pub use super::_ref::_Ref;
 pub use super::doenet::_fragment::_Fragment;
 pub use super::doenet::boolean::Boolean;
 pub use super::doenet::document::Document;
@@ -12,6 +13,7 @@ pub use super::doenet::section::Section;
 pub use super::doenet::text::Text;
 pub use super::doenet::text_input::TextInput;
 pub use super::doenet::title::Title;
+pub use super::doenet::xref::Xref;
 
 /// A enum that can contain a component of any possible component type.
 ///
@@ -37,7 +39,9 @@ pub enum ComponentEnum {
     Title(Title),
     P(P),
     Document(Document),
+    Xref(Xref),
     _Error(_Error),
     _External(_External),
     _Fragment(_Fragment),
+    _Ref(_Ref),
 }

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/components/doenet/mod.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/components/doenet/mod.rs
@@ -9,3 +9,4 @@ pub mod section;
 pub mod text;
 pub mod text_input;
 pub mod title;
+pub mod xref;

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/components/doenet/xref.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/components/doenet/xref.rs
@@ -1,0 +1,64 @@
+use crate::components::prelude::*;
+use crate::general_prop::RenderedChildrenPassthroughProp;
+use crate::props::UpdaterObject;
+
+/// The `<xref>` component renders its children
+#[component(name = Xref)]
+mod component {
+
+    use super::*;
+    use crate::general_prop::{BooleanProp, ComponentRefProp};
+
+    enum Props {
+        /// Whether the `<xref>` should be hidden.
+        #[prop(
+            value_type = PropValueType::Boolean,
+            profile = PropProfile::Hidden
+        )]
+        Hidden,
+
+        /// The component that this `<xref>` refers to.
+        #[prop(
+            value_type = PropValueType::ComponentRef,
+        )]
+        Referent,
+
+        #[prop(
+            value_type = PropValueType::ContentRefs,
+            profile = PropProfile::RenderedChildren
+        )]
+        RenderedChildren,
+    }
+
+    enum Attributes {
+        /// Whether the `<xref>` should be hidden.
+        #[attribute(prop = BooleanProp, default = false)]
+        Hide,
+
+        /// The item this `<xref>` refers to.
+        #[attribute(prop = ComponentRefProp, default = None, preserve_refs)]
+        Ref,
+    }
+}
+
+pub use component::Xref;
+pub use component::XrefActions;
+pub use component::XrefAttributes;
+pub use component::XrefProps;
+
+impl PropGetUpdater for XrefProps {
+    fn get_updater(&self) -> UpdaterObject {
+        match self {
+            XrefProps::Hidden => as_updater_object::<_, component::props::types::Hidden>(
+                component::attrs::Hide::get_prop_updater(),
+            ),
+            XrefProps::RenderedChildren => as_updater_object::<
+                _,
+                component::props::types::RenderedChildren,
+            >(RenderedChildrenPassthroughProp::new()),
+            XrefProps::Referent => as_updater_object::<_, component::props::types::Referent>(
+                component::attrs::Ref::get_prop_updater(),
+            ),
+        }
+    }
+}

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/components/special/_ref.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/components/special/_ref.rs
@@ -1,0 +1,97 @@
+//! A `_Ref` component is a placeholder component that does nothing but hold a reference to another component. It is used
+//! to keep track of referents when they shouldn't be expanded in the tree. For example `<section name="foo"/><xref ref="$foo" />` would normally
+//! be expanded to `<section name="foo"><xref ref="<section />"/>` where `<section />` was linked to `<section name="foo"/>`.
+//! However, `<xref />` actually needs to know what component is being referenced. It doesn't want a clone of the component.
+//! In these situations `$foo` is replaced with `<_ref />` where `<_ref />` holds a pointer to `<section name="foo"/>`, but is not
+//! actually extending `<section name="foo"/>`.
+
+use std::rc::Rc;
+
+use crate::{
+    components::prelude::*, general_prop::IndependentProp, props::UpdaterObject,
+    state::types::component_refs::ComponentRef,
+};
+
+/// A `_Ref` component is a placeholder component that does nothing but hold a reference to another component.
+/// It can only be created by special processing and not from regular DoenetML source code.
+#[derive(Debug, Default, Clone)]
+pub struct _Ref {
+    /// The index of the component that this _ref refers to
+    pub referent_idx: ComponentIdx,
+}
+
+impl _Ref {
+    /// Return the value of `self.referent_idx` in a form that
+    /// can be used in a prop.
+    pub fn get_referent_idx_as_prop_value(&self) -> prop_type::ComponentRef {
+        Some(ComponentRef(self.referent_idx))
+    }
+}
+
+impl ComponentActions for _Ref {}
+impl ComponentOnAction for _Ref {}
+impl ComponentAttributes for _Ref {}
+impl ComponentProps for _Ref {
+    fn generate_props(&self) -> Vec<PropDefinition> {
+        vec![]
+    }
+    fn get_prop_profile_local_prop_indices(&self) -> impl Iterator<Item = LocalPropIdx> {
+        vec![].into_iter()
+    }
+    fn get_default_prop_local_index(&self) -> Option<LocalPropIdx> {
+        None
+    }
+    fn get_for_render_local_prop_indices(&self) -> impl Iterator<Item = LocalPropIdx> {
+        vec![].into_iter()
+    }
+    fn get_local_prop_index_from_name(&self, _name: &str) -> Option<LocalPropIdx> {
+        None
+    }
+    fn get_public_local_prop_index_from_name_case_insensitive(
+        &self,
+        _name: &str,
+    ) -> Option<LocalPropIdx> {
+        None
+    }
+}
+
+impl ComponentNode for _Ref {
+    fn get_component_type(&self) -> &str {
+        "_ref"
+    }
+}
+
+impl ComponentVariantProps for _Ref {
+    fn get_default_prop_local_index(&self) -> Option<LocalPropIdx> {
+        None
+    }
+    fn get_num_props(&self) -> usize {
+        1
+    }
+    fn get_prop_is_for_render(&self, _local_prop_idx: LocalPropIdx) -> bool {
+        false
+    }
+    fn get_prop_name(&self, local_prop_idx: LocalPropIdx) -> &'static str {
+        self.get_prop_names()[local_prop_idx.as_usize()]
+    }
+    fn get_prop_profile(&self, _local_prop_idx: LocalPropIdx) -> Option<PropProfile> {
+        Some(PropProfile::_Ref)
+    }
+    fn get_prop_value_type(&self, _local_prop_idx: LocalPropIdx) -> PropValueType {
+        PropValueType::ComponentRef
+    }
+    fn get_prop_is_public(&self, _local_prop_idx: LocalPropIdx) -> bool {
+        false
+    }
+    fn get_prop_names(&self) -> &'static [&'static str] {
+        &["referent"]
+    }
+    fn get_prop_updater_object(&self, local_prop_idx: LocalPropIdx) -> UpdaterObject {
+        match local_prop_idx.as_usize() {
+            0 => Rc::new(IndependentProp::new_frozen(
+                self.get_referent_idx_as_prop_value(),
+            )),
+            _ => panic!("Invalid prop index {:?}", local_prop_idx),
+        }
+    }
+}

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/components/special/mod.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/components/special/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod _error;
 pub mod _external;
+pub mod _ref;

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/components/traits/component_attributes.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/components/traits/component_attributes.rs
@@ -16,6 +16,13 @@ pub trait ComponentAttributes {
         // If so, should provide a mechanism for including default props depending on them.
         vec![]
     }
+
+    /// In some attributes, references should not be expanded into components, but
+    /// should instead keep the data they have about their referent.
+    /// This function returns the (local) indices of the attributes whose references should be preserved.
+    fn get_preserve_ref_attribute_indices(&self) -> &[usize] {
+        &[]
+    }
 }
 
 /// Trait that creates props from attribute variants.

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/core/component_builder.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/core/component_builder.rs
@@ -320,7 +320,9 @@ impl ComponentBuilder {
             .take(normalized_root.nodes.len())
             .collect();
 
-        // Creating the nodes lowest-index first should lead to less queueing than the other way around.
+        // Creating the nodes lowest-index first. This
+        //  1. is assumed by the algorithm which specializes the `extend` expansion/resolution, and
+        //  2. should lead to less queueing than the other way around.
         let mut queue: Vec<usize> = Vec::from_iter((0..components.len()).rev());
 
         while let Some(idx) = queue.pop() {
@@ -377,7 +379,7 @@ impl ComponentBuilder {
                     },
                 );
 
-                // A some of a component's attributes may specify that refs in those attributes should not be expanded.
+                // Some of a component's attributes may specify that refs in those attributes should not be expanded.
                 // We mark the corresponding components.
                 // Because the component's attributes have not been processed yet, we need to look up the corresponding
                 // attributes from `node`
@@ -417,6 +419,7 @@ impl ComponentBuilder {
                         };
                         if ref_resolution.unresolved_path.is_some() {
                             // XXX: this should result in the component being converted into an error, not a hard panic.
+                            // TODO: Not only should this not be an error, but sometimes it is valid. For example `<point name="p">(3,2)</point><updateValue target="$p.x" newValue="$p.x+1" />`
                             panic!("Cannot preserve_refs if there is a remaining path part. Remaining: {:?}", ref_resolution.unresolved_path);
                         }
                         // If we made it here, we are a ref pointing to a component and we should not actually be expanded

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/core/component_builder.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/core/component_builder.rs
@@ -13,7 +13,7 @@ use crate::{
         },
         types::{PropDefinitionIdx, PropPointer},
         Component, ComponentAttributes, ComponentCommon, ComponentCommonData, ComponentEnum,
-        ComponentNode, ComponentProps,
+        ComponentNode, ComponentProps, _Ref,
     },
     dast::{
         flat_dast::{Index, NormalizedNode, NormalizedRoot, Source},
@@ -36,6 +36,10 @@ pub struct ComponentBuilder {
     /// The reified components. These can be queried for information about their attributes/props/state
     /// as well as asked to calculate/recalculate props.
     pub components: TiVec<ComponentIdx, Component>,
+    /// Some components should not be expanded when they are extending something else. Instead they should be
+    /// turned into the internal `_ref` component. This vec stores whether an _extend_ing component should be
+    /// turned into a `_ref` component.
+    component_preserve_refs: TiVec<ComponentIdx, bool>,
     /// A list of all strings in the document. Strings are stored here once and referenced when they appear as children.
     pub strings: StringCache,
     /// A counter for the number of virtual nodes created. Every virtual node needs to be unique (so that
@@ -56,6 +60,7 @@ impl ComponentBuilder {
         ComponentBuilder {
             structure_graph: DirectedGraph::new(),
             components: TiVec::new(),
+            component_preserve_refs: TiVec::new(),
             strings: StringCache::new(),
             props: TiVec::new(),
             virtual_node_count: 0,
@@ -98,8 +103,13 @@ impl ComponentBuilder {
                 continue;
             }
 
-            let ref_source = elm.extending.clone().unwrap();
             let component = &self.components[component_idx];
+            if matches!(component.variant, ComponentEnum::_Ref(_)) {
+                // The `_Ref` component is special, keeping a pointer to its referent
+                // but never getting connected to it.
+                continue;
+            }
+            let ref_source = elm.extending.clone().unwrap();
             let referent = &self.components[ComponentIdx::from(ref_source.idx())];
 
             match Self::determine_extending(ref_source, component, referent) {
@@ -300,6 +310,10 @@ impl ComponentBuilder {
     /// Creates all `components` but sets all their `extending` fields to `None`.
     /// This is an intermediate step that needs to be done before resolving references in `extending`.
     fn init_normalized_root_without_extending(&mut self, normalized_root: &NormalizedRoot) {
+        // Keep track of special expanding behavior for components with `extend`.
+        self.component_preserve_refs =
+            TiVec::from_iter(std::iter::repeat(false).take(normalized_root.nodes.len()));
+
         // We are going to create components possibly out of order. We will track which components are created
         // and which are in the process of being created.
         let mut components: Vec<Option<Component>> = std::iter::repeat_with(|| None)
@@ -362,7 +376,60 @@ impl ComponentBuilder {
                         unrecognized_attributes: HashMap::new(),
                     },
                 );
-                if let Some(Source::Ref(ref_resolution)) = &elm.extending {
+
+                // A some of a component's attributes may specify that refs in those attributes should not be expanded.
+                // We mark the corresponding components.
+                // Because the component's attributes have not been processed yet, we need to look up the corresponding
+                // attributes from `node`
+                for preserve_ref_attr_name in component
+                    .get_preserve_ref_attribute_indices()
+                    .iter()
+                    .map(|idx| component.get_attribute_names()[*idx])
+                {
+                    let attr = elm
+                        .attributes
+                        .iter()
+                        .find(|a| a.name == preserve_ref_attr_name);
+                    if attr.is_none() {
+                        continue;
+                    }
+                    let attr = attr.unwrap();
+                    for child in &attr.children {
+                        match child {
+                            UntaggedContent::Ref(idx) => {
+                                self.component_preserve_refs[ComponentIdx::from(*idx)] = true;
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+
+                if self.component_preserve_refs[component.get_idx()] {
+                    // If we're here, we have special expanding behavior.
+                    // We want to expand _most_ components that are marked with `extending`, but not all.
+                    // Components that are children of an attribute that has the `preserve_refs` flag set
+                    // are protected and should be converted into a special `_ref` component instead of being linked
+                    // to their extend referent.
+                    if let Some(ref_source) = &elm.extending {
+                        let ref_resolution = match ref_source {
+                            Source::Ref(ref_resolution) => ref_resolution,
+                            _ => unreachable!("Encountered an extend of style <foo extend='$xxx' /> inside of an attribute. It should be syntactically impossible to parse such an element in an attribute."),
+                        };
+                        if ref_resolution.unresolved_path.is_some() {
+                            // XXX: this should result in the component being converted into an error, not a hard panic.
+                            panic!("Cannot preserve_refs if there is a remaining path part. Remaining: {:?}", ref_resolution.unresolved_path);
+                        }
+                        // If we made it here, we are a ref pointing to a component and we should not actually be expanded
+                        // to a copy of our referent. Instead we should be replaced with a special `_ref` component that preserves the pointer.
+                        let referent_idx = ComponentIdx::from(ref_resolution.node_idx);
+
+                        // The new component!
+                        component = Component {
+                            common: component.common,
+                            variant: ComponentEnum::_Ref(_Ref { referent_idx }),
+                        };
+                    }
+                } else if let Some(Source::Ref(ref_resolution)) = &elm.extending {
                     // Some components specify that when they are referenced with the `$foo` syntax,
                     // a different component should be created in their place. E.g., `<textInput name="i" />$i`
                     // should become `<textInput name="i" /><text extend="$i` />`.

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/core/document_model/debug/mermaid.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/core/document_model/debug/mermaid.rs
@@ -255,11 +255,19 @@ impl Core {
                 .iter()
                 .enumerate()
             {
-                mermaid.push_str(&format!(
-                    "{}([\"@{}\"])\n",
-                    attr_virtual_node.to_mermaid_id(),
-                    component.get_attribute_names()[i]
-                ));
+                if let Some(attr_name) = component.get_attribute_names().get(i) {
+                    mermaid.push_str(&format!(
+                        "{}([\"@{}\"])\n",
+                        attr_virtual_node.to_mermaid_id(),
+                        attr_name
+                    ));
+                } else {
+                    mermaid.push_str(&format!(
+                        "{}([\"@{}\"])\n",
+                        attr_virtual_node.to_mermaid_id(),
+                        "ERROR_MISSING_ATTRIBUTE"
+                    ));
+                }
             }
 
             // Props

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/core/general_prop/component_ref_prop.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/core/general_prop/component_ref_prop.rs
@@ -84,7 +84,7 @@ impl PropUpdater for ComponentRefProp {
     }
 
     fn calculate(&self, data: DataQueryResults) -> PropCalcResult<Self::PropType> {
-        // There are two options based on the data query that created us.
+        // There are different options based on the data query that created us.
         match self.data_query {
             DataQuery::ComponentRefs { .. } => {
                 let required_data = RequiredData::try_from_data_query_results(data).unwrap();

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/core/general_prop/component_ref_prop.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/core/general_prop/component_ref_prop.rs
@@ -65,12 +65,26 @@ impl PropFromAttribute<prop_type::ComponentRef> for ComponentRefProp {
 }
 
 /// Structure to hold data generated from the data queries
+/// This is used for the `DataQuery::ComponentRefs` variant.
 #[derive(TryFromDataQueryResults, Debug)]
-#[data_query(query_trait = DataQueries, pass_data = &DataQuery)]
-struct RequiredData {
+#[data_query(query_trait = DataQueriesRefs, pass_data = &DataQuery)]
+struct RequiredDataRefs {
     refs: PropView<prop_type::ContentRefs>,
 }
-impl DataQueries for RequiredData {
+impl DataQueriesRefs for RequiredDataRefs {
+    fn refs_query(query: &DataQuery) -> DataQuery {
+        query.clone()
+    }
+}
+
+/// Structure to hold data generated from the data queries
+/// This is used for the `DataQuery::SelfRef` and `DataQuery::Attribute` variants.
+#[derive(TryFromDataQueryResults, Debug)]
+#[data_query(query_trait = DataQueriesRef, pass_data = &DataQuery)]
+struct RequiredDataRef {
+    refs: PropView<prop_type::ComponentRef>,
+}
+impl DataQueriesRef for RequiredDataRef {
     fn refs_query(query: &DataQuery) -> DataQuery {
         query.clone()
     }
@@ -80,14 +94,14 @@ impl PropUpdater for ComponentRefProp {
     type PropType = prop_type::ComponentRef;
 
     fn data_queries(&self) -> Vec<DataQuery> {
-        RequiredData::data_queries_vec(&self.data_query)
+        RequiredDataRefs::data_queries_vec(&self.data_query)
     }
 
     fn calculate(&self, data: DataQueryResults) -> PropCalcResult<Self::PropType> {
         // There are different options based on the data query that created us.
         match self.data_query {
             DataQuery::ComponentRefs { .. } => {
-                let required_data = RequiredData::try_from_data_query_results(data).unwrap();
+                let required_data = RequiredDataRefs::try_from_data_query_results(data).unwrap();
                 let content_refs = required_data.refs;
 
                 if content_refs.value.is_empty() {
@@ -110,14 +124,12 @@ impl PropUpdater for ComponentRefProp {
                 PropCalcResult::Calculated(component)
             }
             DataQuery::SelfRef => {
-                let component_ref: PropView<prop_type::ComponentRef> =
-                    data.vec[0].values[0].to_owned().into_prop_view();
-                PropCalcResult::Calculated(component_ref.value)
+                let required_data = RequiredDataRef::try_from_data_query_results(data).unwrap();
+                PropCalcResult::Calculated(required_data.refs.value)
             }
             DataQuery::Attribute { .. } => {
-                let component_ref: PropView<prop_type::ComponentRef> =
-                    data.vec[0].values[0].to_owned().into_prop_view();
-                PropCalcResult::Calculated(component_ref.value)
+                let required_data = RequiredDataRef::try_from_data_query_results(data).unwrap();
+                PropCalcResult::Calculated(required_data.refs.value)
             }
             _ => {
                 panic!("ComponentRefProp should only be created with a FilteredChildren data query")

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/core/general_prop/component_ref_prop.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/core/general_prop/component_ref_prop.rs
@@ -52,6 +52,18 @@ impl ComponentRefProp {
     }
 }
 
+impl PropFromAttribute<prop_type::ComponentRef> for ComponentRefProp {
+    fn new_from_attribute(attr_name: &'static str, _default: prop_type::ComponentRef) -> Self {
+        Self {
+            data_query: DataQuery::Attribute {
+                attribute_name: attr_name,
+                match_profiles: vec![PropProfile::_Ref],
+            },
+            component_to_select: None,
+        }
+    }
+}
+
 /// Structure to hold data generated from the data queries
 #[derive(TryFromDataQueryResults, Debug)]
 #[data_query(query_trait = DataQueries, pass_data = &DataQuery)]
@@ -98,6 +110,11 @@ impl PropUpdater for ComponentRefProp {
                 PropCalcResult::Calculated(component)
             }
             DataQuery::SelfRef => {
+                let component_ref: PropView<prop_type::ComponentRef> =
+                    data.vec[0].values[0].to_owned().into_prop_view();
+                PropCalcResult::Calculated(component_ref.value)
+            }
+            DataQuery::Attribute { .. } => {
                 let component_ref: PropView<prop_type::ComponentRef> =
                     data.vec[0].values[0].to_owned().into_prop_view();
                 PropCalcResult::Calculated(component_ref.value)

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/core/general_prop/independent_prop.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/core/general_prop/independent_prop.rs
@@ -11,13 +11,27 @@ use crate::{components::prelude::*, props::UpdaterObject};
 /// - `new(default_value)`: create an independent prop with the given default value.
 #[derive(Debug, Default)]
 pub struct IndependentProp<T: Default + Clone> {
+    /// The default value of the prop.
     default: T,
+    /// Whether or not the prop can be changed.
+    frozen: bool,
 }
 
 impl<T: Default + Clone> IndependentProp<T> {
     /// Create an independent prop with the given default value.
     pub fn new(default: T) -> Self {
-        IndependentProp { default }
+        IndependentProp {
+            default,
+            frozen: false,
+        }
+    }
+
+    /// Create a new instance of the prop with the specified value. The value cannot be changed.
+    pub fn new_frozen(value: T) -> Self {
+        IndependentProp {
+            default: value,
+            frozen: true,
+        }
     }
 }
 
@@ -87,6 +101,9 @@ where
         requested_value: Self::PropType,
         _is_direct_change_from_action: bool,
     ) -> Result<DataQueryResults, InvertError> {
+        if self.frozen {
+            return Err(InvertError::CouldNotUpdate);
+        }
         let mut desired = RequiredData::try_new_desired(&data).unwrap();
 
         desired.independent_state.change_to(requested_value);

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/core/props/prop_profile.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/core/props/prop_profile.rs
@@ -50,6 +50,8 @@ pub enum PropProfile {
     Renderable,
     /// Matches the RenderedChildren prop
     RenderedChildren,
+    /// Matches a prop that stores a reference to another component.
+    _Ref,
 }
 
 // TODO: implement with macro?
@@ -71,6 +73,7 @@ impl PropProfile {
             }
             PropProfile::SerialNumber => PropValue::Integer(i64::default()),
             PropProfile::DivisionDepth => PropValue::Integer(i64::default()),
+            PropProfile::_Ref => PropValue::ComponentRef(None),
         }
     }
 }

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast.rs
@@ -37,6 +37,14 @@ impl<T> Source<T> {
             Source::Ref(m) => Source::Attribute(m),
         }
     }
+    /// Returns whether `self` is an `Attribute` variant.
+    pub fn is_attribute(&self) -> bool {
+        matches!(self, Source::Attribute(_))
+    }
+    /// Returns whether `self` is a `Ref` variant.
+    pub fn is_ref(&self) -> bool {
+        matches!(self, Source::Ref(_))
+    }
 }
 
 impl Source<RefResolution> {

--- a/packages/doenetml-worker-rust/lib-doenetml-core/tests/by_component/mod.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/tests/by_component/mod.rs
@@ -3,5 +3,6 @@ mod p;
 mod section;
 mod text;
 mod text_input;
+mod xref;
 
 use super::*;

--- a/packages/doenetml-worker-rust/lib-doenetml-core/tests/by_component/xref.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/tests/by_component/xref.rs
@@ -27,3 +27,25 @@ fn xref_ref_attribute_refs_dont_expand() {
     let pv: PropView<prop_type::ComponentRef> = prop.into_prop_view();
     assert_eq!(pv.value.unwrap(), ComponentRef(section_idx));
 }
+
+#[test]
+fn xref_referring_to_itself_wont_crash_the_system() {
+    let dast_root = dast_root_no_position(r#"<xref name="foo" ref="$foo" />"#);
+
+    //attach_codelldb_debugger();
+
+    let mut core = TestCore::new();
+    core.init_from_dast_root(&dast_root);
+    core.to_flat_dast();
+
+    // the document tag will be index 0.
+    let xref_idx = ComponentIdx::from(1);
+    let _ref_idx = ComponentIdx::from(2);
+
+    // The `$foo` should be expanded into a `<_ref />` component
+    assert_eq!(core.get_component(_ref_idx).get_component_type(), "_ref");
+
+    let prop = core.get_prop(xref_idx, XrefProps::Referent.local_idx());
+    let pv: PropView<prop_type::ComponentRef> = prop.into_prop_view();
+    assert_eq!(pv.value.unwrap(), ComponentRef(xref_idx));
+}

--- a/packages/doenetml-worker-rust/lib-doenetml-core/tests/by_component/xref.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/tests/by_component/xref.rs
@@ -1,0 +1,29 @@
+use super::*;
+
+use doenetml_core::{
+    components::{doenet::xref::XrefProps, ComponentNode},
+    props::{prop_type, traits::IntoPropView, PropView},
+    state::types::component_refs::ComponentRef,
+};
+
+#[test]
+fn xref_ref_attribute_refs_dont_expand() {
+    let dast_root = dast_root_no_position(r#"<section name="foo"/><xref ref="$foo" />"#);
+
+    //attach_codelldb_debugger();
+
+    let mut core = TestCore::new();
+    core.init_from_dast_root(&dast_root);
+
+    // the document tag will be index 0.
+    let section_idx = ComponentIdx::from(1);
+    let xref_idx = ComponentIdx::from(2);
+    let _ref_idx = ComponentIdx::from(3);
+
+    // The `$foo` should be expanded into a `<_ref />` component
+    assert_eq!(core.get_component(_ref_idx).get_component_type(), "_ref");
+
+    let prop = core.get_prop(xref_idx, XrefProps::Referent.local_idx());
+    let pv: PropView<prop_type::ComponentRef> = prop.into_prop_view();
+    assert_eq!(pv.value.unwrap(), ComponentRef(section_idx));
+}

--- a/packages/doenetml-worker-rust/lib-rust-macros/src/component_module/generate_component_module.test.rs
+++ b/packages/doenetml-worker-rust/lib-rust-macros/src/component_module/generate_component_module.test.rs
@@ -91,6 +91,24 @@ fn test_can_parse_empty_module() {
 }
 
 #[test]
+fn test_can_parse_preserve_ref() {
+    let input = r#"
+        #[component(name = Document, ref_transmutes_to = Text)]
+        mod component {
+            enum Attributes {
+                MyAttr,
+                #[attribute(preserve_refs)]
+                YourAttr
+            }
+        }
+    "#;
+    let result = generate_component_module(syn::parse_str(input).unwrap());
+    println!("\n{}\n", pretty_print_result(&result));
+    //dbg!(syn::parse_str::<ItemMod>(input).unwrap());
+    // dbg!(result.to_string());
+}
+
+#[test]
 fn test_can_parse_module3() {
     let input = r#"
 #[component(name = Text, extend_via_default_prop)]

--- a/packages/doenetml-worker-rust/lib-rust-macros/src/component_module/items/attributes.rs
+++ b/packages/doenetml-worker-rust/lib-rust-macros/src/component_module/items/attributes.rs
@@ -99,6 +99,23 @@ impl AttributesEnum {
             .collect()
     }
 
+    /// Get a list of indices of attributes annotated with `preserve_refs = true`
+    pub fn get_preserve_ref_attribute_indices(&self) -> Vec<usize> {
+        self.get_variants()
+            .iter()
+            .enumerate()
+            .filter_map(
+                |(i, variant)| {
+                    if variant.preserve_refs {
+                        Some(i)
+                    } else {
+                        None
+                    }
+                },
+            )
+            .collect()
+    }
+
     fn generate_variant_doc_comment(&self, variant_idx: usize) -> String {
         let variant = &self.get_variants()[variant_idx];
         let existing_doc = variant.doc.clone().unwrap_or_default();
@@ -185,6 +202,9 @@ pub struct AttributesVariant {
     /// The explicit type for the attribute. This can be auto-computed if using one of the standard
     /// prop types.
     pub explicit_type: Option<Path>,
+    /// Whether or not to preserve/expand references that are children in this attribute.
+    #[darling(default)]
+    pub preserve_refs: bool,
     pub attrs: Vec<syn::Attribute>,
     #[darling(default)]
     pub doc: Option<String>,

--- a/packages/doenetml-worker-rust/lib-rust-macros/src/component_module/items/component.rs
+++ b/packages/doenetml-worker-rust/lib-rust-macros/src/component_module/items/component.rs
@@ -56,6 +56,7 @@ impl ComponentModule {
 
         let action_names = self.actions.get_action_names();
         let attribute_names = self.attributes.get_attribute_names();
+        let preserve_ref_attribute_indices = self.attributes.get_preserve_ref_attribute_indices();
         let prop_names = self.props.get_prop_names();
         let prop_profiles = self
             .props
@@ -96,6 +97,8 @@ impl ComponentModule {
                 const REF_TRANSMUTES_TO: Option<&'static str> = #ref_transmutes_to;
 
                 pub const ATTRIBUTE_NAMES: &'static [&'static str] = &[#(#attribute_names),*];
+
+                const PRESERVE_REF_ATTRIBUTE_INDICES: &'static [usize] = &[#(#preserve_ref_attribute_indices),*];
 
                 const ACTION_NAMES: &'static [&'static str] = &[#(#action_names),*];
 
@@ -187,6 +190,10 @@ impl ComponentModule {
             impl ComponentAttributes for Component {
                 fn get_attribute_names(&self) -> Vec<AttributeName> {
                     Component::ATTRIBUTE_NAMES.iter().map(|x| *x).collect()
+                }
+
+                fn get_preserve_ref_attribute_indices(&self) -> &[usize] {
+                    Component::PRESERVE_REF_ATTRIBUTE_INDICES
                 }
             }
         }

--- a/packages/doenetml-worker-rust/lib-rust-macros/src/lib.rs
+++ b/packages/doenetml-worker-rust/lib-rust-macros/src/lib.rs
@@ -90,6 +90,8 @@ mod try_from_ref;
 /// - `default = ...` - Required; the default value of the attribute. For strings use `String::new()`, for other types, you can specify
 /// their value literally.
 /// - `explicit_type = ...` - Optional; the type of the attribute. If not provided, the type will be inferred from the `prop` attribute.
+/// - `preserve_refs` - Optional; if set, the references in this attribute will not be expanded into components. Instead, they will become
+/// an internal-use-only `_ref` component which preserves a pointer back to the referent component.
 ///
 /// ### `#[prop(...)]`
 ///


### PR DESCRIPTION
Attributes can now be annotated with `preserve_refs`. If so, any `$foo` refs that appear in the specified attribute will not be expanded to clones of their referent. Instead, they will be converted to special `_ref` components which hold the `idx` of their referent.