### PR TITLE
Normalize xml:id and ref attributes to be doenet compatible

### DIFF
--- a/packages/doenetml-prototype/src/state/redux-slices/dast/utils/convert-pretext-attributes.ts
+++ b/packages/doenetml-prototype/src/state/redux-slices/dast/utils/convert-pretext-attributes.ts
@@ -1,0 +1,82 @@
+import { Plugin } from "unified";
+import {
+    DastAttribute,
+    DastElement,
+    DastElementContent,
+    DastMacro,
+    DastRoot,
+    DastRootContent,
+    isDastElement,
+    visit,
+} from "@doenet/parser";
+import { unified } from "unified";
+import { ELEMENT_EXPANSIONS } from "./element-expansions";
+
+/**
+ * PreTeXt follows some different conventions from DoenetML. For instance, it uses `xml:id` instead of `name`.
+ * It also uses `<xref ref="name" />` instead of `<xref ref="$name" />`. This plugin converts PreTeXt style
+ * attributes to DoenetML style attributes.
+ */
+export const pluginConvertPretextAttributes: Plugin<
+    [],
+    DastRoot,
+    DastRoot
+> = () => {
+    return (tree) => {
+        visit(tree, (node) => {
+            if (!isDastElement(node)) {
+                return;
+            }
+            if (node.attributes["xml:id"]) {
+                // Convert `xml:id` to `name`
+                const attr = node.attributes["xml:id"];
+                attr.name = "name";
+                delete node.attributes["xml:id"];
+                node.attributes.name = attr;
+            }
+
+            if (node.name === "xref") {
+                // Test if the ref is a `$ref` or a `ref`.
+                const refAttr = node.attributes.ref;
+                if (!refAttr) {
+                    return;
+                }
+
+                const hasMacroChild = refAttr.children.some(
+                    (child) => child.type === "macro",
+                );
+                const hasNonWhitespaceTextChild = refAttr.children.some(
+                    (child) =>
+                        child.type === "text" && child.value.trim() !== "",
+                );
+                if (hasMacroChild || !hasNonWhitespaceTextChild) {
+                    // No need to convert. If we're in this case we already have a `$ref` or
+                    // for some reason the ref field is empty.
+                    return;
+                }
+
+                // Get the text value of the ref attribute
+                const refText = refAttr.children
+                    .map((child) => (child.type === "text" ? child.value : ""))
+                    .join("");
+                const position = refAttr.position!;
+
+                let macro: DastMacro = {
+                    type: "macro",
+                    attributes: {},
+                    path: [
+                        {
+                            type: "pathPart",
+                            index: [],
+                            name: refText,
+                        },
+                    ],
+                };
+
+                // Replace the ref attribute with a macro
+                refAttr.children.length = 0;
+                refAttr.children.push(macro);
+            }
+        });
+    };
+};

--- a/packages/doenetml-prototype/src/state/redux-slices/dast/utils/normalize-dast.ts
+++ b/packages/doenetml-prototype/src/state/redux-slices/dast/utils/normalize-dast.ts
@@ -10,6 +10,7 @@ import {
 } from "@doenet/parser";
 import { unified } from "unified";
 import { ELEMENT_EXPANSIONS } from "./element-expansions";
+import { pluginConvertPretextAttributes } from "./convert-pretext-attributes";
 
 /**
  * Normalize the DAST tree so that it is contained in a single `<document>` element.
@@ -20,6 +21,7 @@ export function normalizeDocumentDast(dast: DastRoot) {
         .use(pluginRemoveCommentsInstructionsAndDocStrings)
         .use(pluginChangeCdataToText)
         .use(pluginEnsureDocumentElement)
+        .use(pluginConvertPretextAttributes)
         .use(pluginExpandAliasedElements);
     return processor.runSync(dast);
 }

--- a/packages/doenetml-prototype/test/normalize-dast.test.ts
+++ b/packages/doenetml-prototype/test/normalize-dast.test.ts
@@ -113,7 +113,7 @@ describe("Normalize dast", async () => {
         expect(toXml(normalizeDocumentDast(dast))).toEqual(
             '<document><xref ref="$(foo-bar)" /></document>',
         );
-        
+
         source = `<xref ref="foo-bar" />`;
         dast = lezerToDast(source);
         expect(toXml(normalizeDocumentDast(dast))).toEqual(

--- a/packages/doenetml-prototype/test/normalize-dast.test.ts
+++ b/packages/doenetml-prototype/test/normalize-dast.test.ts
@@ -94,4 +94,30 @@ describe("Normalize dast", async () => {
             `<document id="foo"><p>hi</p></document>`,
         );
     });
+    it("converts xml:id to name", () => {
+        let source: string;
+        let dast: ReturnType<typeof lezerToDast>;
+
+        source = `<p xml:id="foo-bar">hi</p>`;
+        dast = lezerToDast(source);
+        expect(toXml(normalizeDocumentDast(dast))).toEqual(
+            '<document><p name="foo-bar">hi</p></document>',
+        );
+    });
+    it("converts xref ref to dollar-sign form", () => {
+        let source: string;
+        let dast: ReturnType<typeof lezerToDast>;
+
+        source = `<xref ref="$(foo-bar)" />`;
+        dast = lezerToDast(source);
+        expect(toXml(normalizeDocumentDast(dast))).toEqual(
+            '<document><xref ref="$(foo-bar)" /></document>',
+        );
+        
+        source = `<xref ref="foo-bar" />`;
+        dast = lezerToDast(source);
+        expect(toXml(normalizeDocumentDast(dast))).toEqual(
+            '<document><xref ref="$(foo-bar)" /></document>',
+        );
+    });
 });

--- a/packages/parser/src/macros/types.ts
+++ b/packages/parser/src/macros/types.ts
@@ -28,7 +28,7 @@ export type SimplePathPart = {
     };
 };
 export type PathPart = { type: "pathPart"; name: Ident; index: PropIndex[] } & {
-    position: {
+    position?: {
         start: { offset: number; line: number; column: number };
         end: { offset: number; line: number; column: number };
     };
@@ -37,13 +37,13 @@ export type SimplePath = [SimplePathPart, ...SimplePathPart[]];
 export type Path = [PathPart, ...PathPart[]];
 export type Macro =
     | (FullAddressMacro & {
-          position: {
+          position?: {
               start: { offset: number; line: number; column: number };
               end: { offset: number; line: number; column: number };
           };
       })
     | (SimpleAddressMacro & {
-          position: {
+          position?: {
               start: { offset: number; line: number; column: number };
               end: { offset: number; line: number; column: number };
           };
@@ -53,7 +53,7 @@ export type SimpleAddressMacro = {
     path: SimplePath;
     attributes: PropAttrs;
 } & {
-    position: {
+    position?: {
         start: { offset: number; line: number; column: number };
         end: { offset: number; line: number; column: number };
     };
@@ -63,7 +63,7 @@ export type FullAddressMacro = {
     path: Path;
     attributes: PropAttrs;
 } & {
-    position: {
+    position?: {
         start: { offset: number; line: number; column: number };
         end: { offset: number; line: number; column: number };
     };


### PR DESCRIPTION
PreTeXt uses `xml:id` instead of `name`, and allows for xrefs of the form `<xref ref="ref" />`. This PR changes `xml:id` to `name` before processing. It also converts `<xref ref="ref" />` to `<xref ref="$ref" />`