### PR TITLE
regionBetweenCurves component

### DIFF
--- a/packages/doenetml-worker/src/ComponentTypes.js
+++ b/packages/doenetml-worker/src/ComponentTypes.js
@@ -153,6 +153,7 @@ import SubsetOfReals from "./components/SubsetOfReals";
 import Split from "./components/Split";
 import BestFitLine from "./components/BestFitLine";
 import RegionBetweenCurveXAxis from "./components/RegionBetweenCurveXAxis";
+import RegionBetweenCurves from "./components/RegionBetweenCurves";
 import RegionHalfPlane from "./components/RegionHalfPlane";
 import CodeEditor from "./components/CodeEditor";
 import CodeViewer from "./components/CodeViewer";
@@ -348,6 +349,7 @@ const componentTypeArray = [
     Split,
     BestFitLine,
     RegionBetweenCurveXAxis,
+    RegionBetweenCurves,
     RegionHalfPlane,
     CodeEditor,
     CodeViewer,

--- a/packages/doenetml-worker/src/components/RegionBetweenCurves.js
+++ b/packages/doenetml-worker/src/components/RegionBetweenCurves.js
@@ -14,6 +14,14 @@ export default class RegionBetweenCurves extends GraphicalComponent {
             public: true,
         };
 
+        attributes.flipFunctions = {
+            createComponentOfType: "boolean",
+            createStateVariable: "flipFunctions",
+            defaultValue: false,
+            public: true,
+            forRenderer: true,
+        };
+
         return attributes;
     }
 

--- a/packages/doenetml-worker/src/components/RegionBetweenCurves.js
+++ b/packages/doenetml-worker/src/components/RegionBetweenCurves.js
@@ -111,7 +111,6 @@ export default class RegionBetweenCurves extends GraphicalComponent {
                 },
             }),
             definition({ dependencyValues }) {
-                console.log({ dependencyValues });
                 if (
                     dependencyValues.functions.length < 2 ||
                     dependencyValues.functions[0].stateValues.numInputs !== 1 ||

--- a/packages/doenetml-worker/src/components/RegionBetweenCurves.js
+++ b/packages/doenetml-worker/src/components/RegionBetweenCurves.js
@@ -1,0 +1,146 @@
+import GraphicalComponent from "./abstract/GraphicalComponent";
+
+export default class RegionBetweenCurves extends GraphicalComponent {
+    static componentType = "regionBetweenCurves";
+
+    static createAttributesObject() {
+        let attributes = super.createAttributesObject();
+
+        attributes.boundaryValues = {
+            createComponentOfType: "numberList",
+            createStateVariable: "boundaryValues",
+            defaultValue: [0, 1],
+            forRenderer: true,
+            public: true,
+        };
+
+        return attributes;
+    }
+
+    static returnChildGroups() {
+        let groups = super.returnChildGroups();
+        groups.push({
+            group: "functions",
+            componentTypes: ["function"],
+        });
+
+        return groups;
+    }
+
+    static returnStateVariableDefinitions() {
+        let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        stateVariableDefinitions.styleDescription = {
+            public: true,
+            shadowingInstructions: {
+                createComponentOfType: "text",
+            },
+            returnDependencies: () => ({
+                selectedStyle: {
+                    dependencyType: "stateVariable",
+                    variableName: "selectedStyle",
+                },
+                document: {
+                    dependencyType: "ancestor",
+                    componentType: "document",
+                    variableNames: ["theme"],
+                },
+            }),
+            definition: function ({ dependencyValues }) {
+                let fillColorWord;
+                if (dependencyValues.document?.stateValues.theme === "dark") {
+                    fillColorWord =
+                        dependencyValues.selectedStyle.fillColorWordDarkMode;
+                } else {
+                    fillColorWord =
+                        dependencyValues.selectedStyle.fillColorWord;
+                }
+
+                return { setValue: { styleDescription: fillColorWord } };
+            },
+        };
+
+        stateVariableDefinitions.styleDescriptionWithNoun = {
+            public: true,
+            shadowingInstructions: {
+                createComponentOfType: "text",
+            },
+            returnDependencies: () => ({
+                styleDescription: {
+                    dependencyType: "stateVariable",
+                    variableName: "styleDescription",
+                },
+            }),
+            definition: function ({ dependencyValues }) {
+                let styleDescriptionWithNoun =
+                    dependencyValues.styleDescription + " region";
+
+                return { setValue: { styleDescriptionWithNoun } };
+            },
+        };
+
+        stateVariableDefinitions.functions = {
+            additionalStateVariablesDefined: [
+                {
+                    variableName: "haveFunctions",
+                    forRenderer: true,
+                },
+                {
+                    variableName: "fDefinitions",
+                    forRenderer: true,
+                },
+            ],
+            returnDependencies: () => ({
+                functions: {
+                    dependencyType: "child",
+                    childGroups: ["functions"],
+                    variableNames: [
+                        "numericalfs",
+                        "numInputs",
+                        "numOutputs",
+                        "fDefinition",
+                    ],
+                },
+            }),
+            definition({ dependencyValues }) {
+                console.log({ dependencyValues });
+                if (
+                    dependencyValues.functions.length < 2 ||
+                    dependencyValues.functions[0].stateValues.numInputs !== 1 ||
+                    dependencyValues.functions[0].stateValues.numOutputs !==
+                        1 ||
+                    dependencyValues.functions[1].stateValues.numInputs !== 1 ||
+                    dependencyValues.functions[1].stateValues.numOutputs !== 1
+                ) {
+                    return {
+                        setValues: {
+                            function: [() => NaN, () => NaN],
+                            haveFunctions: false,
+                            fDefinitions: [{}, {}],
+                        },
+                    };
+                }
+
+                return {
+                    setValue: {
+                        functions: [
+                            dependencyValues.functions[0].stateValues
+                                .numericalfs[0],
+                            dependencyValues.functions[1].stateValues
+                                .numericalfs[0],
+                        ],
+                        haveFunctions: true,
+                        fDefinitions: [
+                            dependencyValues.functions[0].stateValues
+                                .fDefinition,
+                            dependencyValues.functions[1].stateValues
+                                .fDefinition,
+                        ],
+                    },
+                };
+            },
+        };
+
+        return stateVariableDefinitions;
+    }
+}

--- a/packages/doenetml/src/Viewer/renderers/regionBetweenCurves.jsx
+++ b/packages/doenetml/src/Viewer/renderers/regionBetweenCurves.jsx
@@ -62,10 +62,6 @@ export default React.memo(function RegionBetweenCurves(props) {
             fillColor,
             fillOpacity: SVs.selectedStyle.fillOpacity,
             highlight: false,
-
-            // don't display points at left and right endpoints along function
-            // curveLeft: { visible: false },
-            // curveRight: { visible: false },
         };
 
         jsxAttributes.label = {
@@ -81,6 +77,8 @@ export default React.memo(function RegionBetweenCurves(props) {
             visible: false,
         });
 
+        // based on https://jsfiddle.net/migerh/u95pL/
+        // as described in https://groups.google.com/g/jsxgraph/c/umlhu6CkGD0
         var region = board.create("curve", [[], []], jsxAttributes);
 
         region.updateDataArray = function () {

--- a/packages/doenetml/src/Viewer/renderers/regionBetweenCurves.jsx
+++ b/packages/doenetml/src/Viewer/renderers/regionBetweenCurves.jsx
@@ -125,8 +125,13 @@ export default React.memo(function RegionBetweenCurves(props) {
             x.push(left.current);
             y.push(c1.Y(left.current));
 
-            this.dataX = x;
-            this.dataY = y;
+            if (SVs.flipFunctions) {
+                this.dataX = y;
+                this.dataY = x;
+            } else {
+                this.dataX = x;
+                this.dataY = y;
+            }
         };
 
         return region;

--- a/packages/doenetml/src/Viewer/renderers/regionBetweenCurves.jsx
+++ b/packages/doenetml/src/Viewer/renderers/regionBetweenCurves.jsx
@@ -1,0 +1,260 @@
+import React, { useContext, useEffect, useState, useRef } from "react";
+import useDoenetRenderer from "../useDoenetRenderer";
+import { BoardContext, LINE_LAYER_OFFSET } from "./graph";
+import { createFunctionFromDefinition } from "@doenet/utils";
+import { PageContext } from "../PageViewer";
+
+export default React.memo(function RegionBetweenCurves(props) {
+    let { name, id, SVs } = useDoenetRenderer(props);
+
+    RegionBetweenCurves.ignoreActionsWithoutCore = () => true;
+
+    const board = useContext(BoardContext);
+
+    let curve1JXG = useRef(null);
+    let curve2JXG = useRef(null);
+    let regionJXG = useRef(null);
+    let left = useRef(null);
+    let right = useRef(null);
+
+    const { darkMode } = useContext(PageContext) || {};
+
+    useEffect(() => {
+        //On unmount
+        return () => {
+            deleteRegion();
+        };
+    }, []);
+
+    function createRegion() {
+        if (
+            !SVs.haveFunctions ||
+            SVs.boundaryValues.length !== 2 ||
+            !SVs.boundaryValues.every(Number.isFinite)
+        ) {
+            return null;
+        }
+
+        [left.current, right.current] = SVs.boundaryValues.toSorted();
+
+        let lineColor =
+            darkMode === "dark"
+                ? SVs.selectedStyle.lineColorDarkMode
+                : SVs.selectedStyle.lineColor;
+
+        let fillColor =
+            darkMode === "dark"
+                ? SVs.selectedStyle.fillColorDarkMode
+                : SVs.selectedStyle.fillColor;
+
+        let jsxAttributes = {
+            name: SVs.labelForGraph,
+            visible: !SVs.hidden,
+            withLabel: SVs.labelForGraph !== "",
+            fixed: true,
+            layer: 10 * SVs.layer + LINE_LAYER_OFFSET,
+
+            strokeColor: lineColor,
+            strokeOpacity: SVs.selectedStyle.lineOpacity,
+            strokeWidth: SVs.selectedStyle.lineWidth,
+            dash: styleToDash(SVs.selectedStyle.lineStyle, SVs.dashed),
+
+            fillColor,
+            fillOpacity: SVs.selectedStyle.fillOpacity,
+            highlight: false,
+
+            // don't display points at left and right endpoints along function
+            // curveLeft: { visible: false },
+            // curveRight: { visible: false },
+        };
+
+        jsxAttributes.label = {
+            highlight: false,
+        };
+
+        let f1 = createFunctionFromDefinition(SVs.fDefinitions[0]);
+        let f2 = createFunctionFromDefinition(SVs.fDefinitions[1]);
+        curve1JXG.current = board.create("functiongraph", f1, {
+            visible: false,
+        });
+        curve2JXG.current = board.create("functiongraph", f2, {
+            visible: false,
+        });
+
+        var region = board.create("curve", [[], []], jsxAttributes);
+
+        region.updateDataArray = function () {
+            // start and end
+            var x, y;
+
+            const c1 = curve1JXG.current;
+            const c2 = curve2JXG.current;
+
+            x = [left.current];
+            y = [c1.Y(left.current)];
+
+            // go through c1 forwards, push all of c1's data points into the data array for region
+            for (let pt of c1.points) {
+                if (
+                    left.current <= pt.usrCoords[1] &&
+                    pt.usrCoords[1] <= right.current
+                ) {
+                    x.push(pt.usrCoords[1]);
+                    y.push(pt.usrCoords[2]);
+                }
+            }
+            x.push(right.current);
+            y.push(c1.Y(right.current));
+
+            x.push(right.current);
+            y.push(c2.Y(right.current));
+
+            // walk backwards through c2
+            for (let pt of c2.points.toReversed()) {
+                if (
+                    left.current <= pt.usrCoords[1] &&
+                    pt.usrCoords[1] <= right.current
+                ) {
+                    x.push(pt.usrCoords[1]);
+                    y.push(pt.usrCoords[2]);
+                }
+            }
+
+            x.push(left.current);
+            y.push(c2.Y(left.current));
+
+            // close the curve
+            x.push(left.current);
+            y.push(c1.Y(left.current));
+
+            this.dataX = x;
+            this.dataY = y;
+        };
+
+        return region;
+    }
+
+    function deleteRegion() {
+        if (regionJXG.current) {
+            board.removeObject(regionJXG.current);
+            regionJXG.current = null;
+
+            board.removeObject(curve1JXG.current);
+            curve1JXG.current = null;
+            board.removeObject(curve2JXG.current);
+            curve2JXG.current = null;
+        }
+    }
+
+    if (board) {
+        if (regionJXG.current === null) {
+            regionJXG.current = createRegion();
+        } else if (
+            !SVs.haveFunctions ||
+            SVs.boundaryValues.length !== 2 ||
+            !SVs.boundaryValues.every(Number.isFinite)
+        ) {
+            deleteRegion();
+        } else {
+            let f1 = createFunctionFromDefinition(SVs.fDefinitions[0]);
+            let f2 = createFunctionFromDefinition(SVs.fDefinitions[1]);
+
+            curve1JXG.current.Y = f1;
+            curve2JXG.current.Y = f2;
+
+            regionJXG.current.visProp["visible"] = !SVs.hidden;
+            regionJXG.current.visPropCalc["visible"] = !SVs.hidden;
+
+            [left.current, right.current] = SVs.boundaryValues.toSorted();
+
+            let layer = 10 * SVs.layer + LINE_LAYER_OFFSET;
+            let layerChanged = regionJXG.current.visProp.layer !== layer;
+
+            if (layerChanged) {
+                regionJXG.current.setAttribute({ layer });
+            }
+
+            let lineColor =
+                darkMode === "dark"
+                    ? SVs.selectedStyle.lineColorDarkMode
+                    : SVs.selectedStyle.lineColor;
+
+            if (regionJXG.current.visProp.strokecolor !== lineColor) {
+                regionJXG.current.visProp.strokecolor = lineColor;
+                regionJXG.current.visProp.highlightstrokecolor = lineColor;
+            }
+            if (
+                regionJXG.current.visProp.strokeopacity !==
+                SVs.selectedStyle.lineOpacity
+            ) {
+                regionJXG.current.visProp.strokeopacity =
+                    SVs.selectedStyle.lineOpacity;
+            }
+            let newDash = styleToDash(SVs.selectedStyle.lineStyle, SVs.dashed);
+            if (regionJXG.current.visProp.dash !== newDash) {
+                regionJXG.current.visProp.dash = newDash;
+            }
+            if (
+                regionJXG.current.visProp.strokewidth !==
+                SVs.selectedStyle.lineWidth
+            ) {
+                regionJXG.current.visProp.strokewidth =
+                    SVs.selectedStyle.lineWidth;
+            }
+
+            let fillColor =
+                darkMode === "dark"
+                    ? SVs.selectedStyle.fillColorDarkMode
+                    : SVs.selectedStyle.fillColor;
+
+            if (regionJXG.current.visProp.fillcolor !== fillColor) {
+                regionJXG.current.visProp.fillcolor = fillColor;
+            }
+
+            if (
+                regionJXG.current.visProp.fillopacity !==
+                SVs.selectedStyle.fillOpacity
+            ) {
+                regionJXG.current.visProp.fillopacity =
+                    SVs.selectedStyle.fillOpacity;
+            }
+
+            regionJXG.current.needsUpdate = true;
+            regionJXG.current.fullUpdate();
+
+            board.update();
+            board.fullUpdate();
+
+            board.updateRenderer();
+        }
+
+        return (
+            <>
+                <a name={id} />
+            </>
+        );
+    }
+
+    if (SVs.hidden) {
+        return null;
+    }
+
+    // don't think we want to return anything if not in board
+    return (
+        <>
+            <a name={id} />
+        </>
+    );
+});
+
+function styleToDash(style, dash) {
+    if (style === "dashed" || dash) {
+        return 2;
+    } else if (style === "solid") {
+        return 0;
+    } else if (style === "dotted") {
+        return 1;
+    } else {
+        return 0;
+    }
+}

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -1249,6 +1249,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -2288,6 +2289,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -2626,6 +2628,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -2964,6 +2967,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -24197,6 +24201,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -24703,6 +24708,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -25209,6 +25215,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -25715,6 +25722,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -26221,6 +26229,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -26746,6 +26755,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -27252,6 +27262,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -27758,6 +27769,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -28264,6 +28276,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -28770,6 +28783,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -29276,6 +29290,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -29782,6 +29797,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -30288,6 +30304,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -30794,6 +30811,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -31300,6 +31318,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -31816,6 +31835,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -32313,6 +32333,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -33080,6 +33101,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -38190,6 +38212,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -39015,6 +39038,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -39353,6 +39377,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -39691,6 +39716,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -40029,6 +40055,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -40387,6 +40414,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -41498,6 +41526,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -44880,6 +44909,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -54665,6 +54695,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -55619,6 +55650,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "legend",
                 "matrix",
@@ -57876,6 +57908,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -58233,6 +58266,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -59377,6 +59411,7 @@
                 "subsetOfRealsInput",
                 "split",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -61482,6 +61517,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -62504,6 +62540,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "legend",
                 "matrix",
@@ -62707,6 +62744,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "legend",
                 "matrix",
@@ -63174,6 +63212,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "legend",
                 "matrix",
@@ -63656,6 +63695,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -64767,6 +64807,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -66629,6 +66670,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -68043,6 +68085,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -69013,6 +69056,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -69349,6 +69393,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -69687,6 +69732,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -71083,6 +71129,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -71562,6 +71609,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -72918,6 +72966,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -73295,6 +73344,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -74615,6 +74665,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -75287,6 +75338,186 @@
             "acceptsStringChildren": false
         },
         {
+            "name": "regionBetweenCurves",
+            "children": [
+                "xlabel",
+                "ylabel",
+                "label",
+                "clampFunction",
+                "wrapFunctionPeriodic",
+                "derivative",
+                "function",
+                "piecewiseFunction"
+            ],
+            "attributes": [
+                {
+                    "name": "name"
+                },
+                {
+                    "name": "copySource"
+                },
+                {
+                    "name": "hide",
+                    "values": [
+                        "true",
+                        "false"
+                    ]
+                },
+                {
+                    "name": "disabled",
+                    "values": [
+                        "true",
+                        "false"
+                    ]
+                },
+                {
+                    "name": "fixed",
+                    "values": [
+                        "true",
+                        "false"
+                    ]
+                },
+                {
+                    "name": "fixLocation",
+                    "values": [
+                        "true",
+                        "false"
+                    ]
+                },
+                {
+                    "name": "styleNumber"
+                },
+                {
+                    "name": "isResponse",
+                    "values": [
+                        "true",
+                        "false"
+                    ]
+                },
+                {
+                    "name": "newNamespace",
+                    "values": [
+                        "true",
+                        "false"
+                    ]
+                },
+                {
+                    "name": "labelIsName",
+                    "values": [
+                        "true",
+                        "false"
+                    ]
+                },
+                {
+                    "name": "applyStyleToLabel",
+                    "values": [
+                        "true",
+                        "false"
+                    ]
+                },
+                {
+                    "name": "layer"
+                },
+                {
+                    "name": "boundaryValues"
+                }
+            ],
+            "properties": [
+                {
+                    "name": "hide",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "modifyIndirectly",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "styleNumber",
+                    "type": "integer",
+                    "isArray": false
+                },
+                {
+                    "name": "isResponse",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "newNamespace",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "permid",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "labelIsName",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "applyStyleToLabel",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "layer",
+                    "type": "integer",
+                    "isArray": false
+                },
+                {
+                    "name": "boundaryValues",
+                    "type": "numberList",
+                    "isArray": false
+                },
+                {
+                    "name": "hidden",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "disabled",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "fixed",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "fixLocation",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "doenetML",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "label",
+                    "type": "label",
+                    "isArray": false
+                },
+                {
+                    "name": "styleDescription",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "styleDescriptionWithNoun",
+                    "type": "text",
+                    "isArray": false
+                }
+            ],
+            "top": true,
+            "acceptsStringChildren": false
+        },
+        {
             "name": "regionHalfPlane",
             "children": [
                 "xlabel",
@@ -75681,6 +75912,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -79356,6 +79588,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -79694,6 +79927,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "codeEditor",
                 "codeViewer",
@@ -80172,6 +80406,7 @@
                 "split",
                 "bestFitLine",
                 "regionBetweenCurveXAxis",
+                "regionBetweenCurves",
                 "regionHalfPlane",
                 "legend",
                 "matrix",

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -75420,6 +75420,13 @@
                 },
                 {
                     "name": "boundaryValues"
+                },
+                {
+                    "name": "flipFunctions",
+                    "values": [
+                        "true",
+                        "false"
+                    ]
                 }
             ],
             "properties": [
@@ -75471,6 +75478,11 @@
                 {
                     "name": "boundaryValues",
                     "type": "numberList",
+                    "isArray": false
+                },
+                {
+                    "name": "flipFunctions",
+                    "type": "boolean",
                     "isArray": false
                 },
                 {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/regionBetweenCurves.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/regionBetweenCurves.cy.js
@@ -1,0 +1,38 @@
+import { cesc2 } from "@doenet/utils";
+
+describe("RegionBetweenCurves Tag Tests", function () {
+    beforeEach(() => {
+        cy.clearIndexedDB();
+        cy.visit("/");
+    });
+
+    it("region between two curves", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <text>a</text>
+  <graph name="g1" newNamespace>
+    <function name="f1">sin(x)</function>
+    <function name="f2">cos(x)</function>
+    <regionBetweenCurves name="r" boundaryValues="-3 5">$f1 $f2</regionBetweenCurves>
+  </graph>
+
+  <graph name="g2" newNamespace>
+    $(../g1/r{name="r"})
+  </graph>
+
+  $g2{name="g3"}
+
+
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc2("#/_text1")).should("have.text", "a"); // to wait for page to load
+
+        // Not sure what to test until can test jsxgraph output
+    });
+});

--- a/packages/test-cypress/cypress/e2e/tagSpecific/regionBetweenCurves.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/regionBetweenCurves.cy.js
@@ -35,4 +35,34 @@ describe("RegionBetweenCurves Tag Tests", function () {
 
         // Not sure what to test until can test jsxgraph output
     });
+
+    it("region between two curves, flipped", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <text>a</text>
+  <graph name="g1" newNamespace>
+    <curve flipFunction><function name="f1">sin(x)</function></curve>
+    <curve flipFunction><function name="f2">cos(x)</function></curve>
+    <regionBetweenCurves name="r" boundaryValues="-3 5" flipFunctions>$f1 $f2</regionBetweenCurves>
+  </graph>
+
+  <graph name="g2" newNamespace>
+    $(../g1/r{name="r"})
+  </graph>
+
+  $g2{name="g3"}
+
+
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc2("#/_text1")).should("have.text", "a"); // to wait for page to load
+
+        // Not sure what to test until can test jsxgraph output
+    });
 });


### PR DESCRIPTION
This PR creates a new DoenetML component `<regionBetweenCurves>` that displays the region between two functions, optionally flipping the functions across "x=y" before displaying the region.