### PR TITLE
temporarily remove vertexConstraints and edgeConstraints components

### DIFF
--- a/packages/doenetml-worker/src/ComponentTypes.js
+++ b/packages/doenetml-worker/src/ComponentTypes.js
@@ -92,7 +92,7 @@ import ConstrainTo from "./components/ConstrainTo";
 import AttractTo from "./components/AttractTo";
 import ConstraintUnion from "./components/ConstraintUnion";
 import AttractToConstraint from "./components/AttractToConstraint";
-import AttractSegmentTo from "./components/AttractSegmentTo";
+// import AttractSegmentTo from "./components/AttractSegmentTo";
 import Intersection from "./components/Intersection";
 import Panel from "./components/Panel";
 import ConstrainToAngles from "./components/ConstrainToAngles";
@@ -169,8 +169,8 @@ import EigenDecomposition from "./components/linearAlgebra/EigenDecomposition";
 import Latex from "./components/Latex";
 import BlockQuote from "./components/BlockQuote";
 import ContentPicker from "./components/ContentPicker";
-import VertexConstraints from "./components/VertexConstraints";
-import EdgeConstraints from "./components/EdgeConstraints";
+// import VertexConstraints from "./components/VertexConstraints";
+// import EdgeConstraints from "./components/EdgeConstraints";
 import StickyGroup from "./components/StickyGroup";
 
 //Extended
@@ -299,7 +299,7 @@ const componentTypeArray = [
     AttractTo,
     ConstraintUnion,
     AttractToConstraint,
-    AttractSegmentTo,
+    // AttractSegmentTo,
     Intersection,
     ConstrainToAngles,
     AttractToAngles,
@@ -365,8 +365,8 @@ const componentTypeArray = [
     Latex,
     BlockQuote,
     ContentPicker,
-    VertexConstraints,
-    EdgeConstraints,
+    // VertexConstraints,
+    // EdgeConstraints,
     StickyGroup,
 
     BaseComponent,

--- a/packages/doenetml-worker/src/components/Polyline.js
+++ b/packages/doenetml-worker/src/components/Polyline.js
@@ -118,14 +118,14 @@ export default class Polyline extends GraphicalComponent {
 
     static returnChildGroups() {
         let groups = super.returnChildGroups();
-        groups.push({
-            group: "vertexConstraints",
-            componentTypes: ["vertexConstraints"],
-        });
-        groups.push({
-            group: "edgeConstraints",
-            componentTypes: ["edgeConstraints"],
-        });
+        // groups.push({
+        //     group: "vertexConstraints",
+        //     componentTypes: ["vertexConstraints"],
+        // });
+        // groups.push({
+        //     group: "edgeConstraints",
+        //     componentTypes: ["edgeConstraints"],
+        // });
 
         return groups;
     }
@@ -810,14 +810,14 @@ export default class Polyline extends GraphicalComponent {
 
         stateVariableDefinitions.haveConstrainedVertices = {
             returnDependencies: () => ({
-                vertexConstraintsChild: {
-                    dependencyType: "child",
-                    childGroups: ["vertexConstraints"],
-                },
-                edgeConstraintsChild: {
-                    dependencyType: "child",
-                    childGroups: ["edgeConstraints"],
-                },
+                // vertexConstraintsChild: {
+                //     dependencyType: "child",
+                //     childGroups: ["vertexConstraints"],
+                // },
+                // edgeConstraintsChild: {
+                //     dependencyType: "child",
+                //     childGroups: ["edgeConstraints"],
+                // },
                 inStickyGroup: {
                     dependencyType: "stateVariable",
                     variableName: "inStickyGroup",
@@ -827,9 +827,9 @@ export default class Polyline extends GraphicalComponent {
                 return {
                     setValue: {
                         haveConstrainedVertices:
-                            dependencyValues.vertexConstraintsChild.length >
-                                0 ||
-                            dependencyValues.edgeConstraintsChild.length > 0 ||
+                            // dependencyValues.vertexConstraintsChild.length >
+                            //     0 ||
+                            // dependencyValues.edgeConstraintsChild.length > 0 ||
                             dependencyValues.inStickyGroup,
                     },
                 };
@@ -1032,16 +1032,16 @@ export default class Polyline extends GraphicalComponent {
                         dependencyType: "stateVariable",
                         variableName: "unconstrainedVertices",
                     };
-                    globalDependencies.vertexConstraintsChild = {
-                        dependencyType: "child",
-                        childGroups: ["vertexConstraints"],
-                        variableNames: ["constraintFunction"],
-                    };
-                    globalDependencies.edgeConstraintsChild = {
-                        dependencyType: "child",
-                        childGroups: ["edgeConstraints"],
-                        variableNames: ["constraintFunction"],
-                    };
+                    // globalDependencies.vertexConstraintsChild = {
+                    //     dependencyType: "child",
+                    //     childGroups: ["vertexConstraints"],
+                    //     variableNames: ["constraintFunction"],
+                    // };
+                    // globalDependencies.edgeConstraintsChild = {
+                    //     dependencyType: "child",
+                    //     childGroups: ["edgeConstraints"],
+                    //     variableNames: ["constraintFunction"],
+                    // };
                 } else {
                     for (let arrayKey of arrayKeys) {
                         let [pointInd, dim] = arrayKey.split(",");
@@ -1077,28 +1077,28 @@ export default class Polyline extends GraphicalComponent {
                     let constrainedVertices =
                         globalDependencyValues.unconstrainedVertices;
 
-                    if (
-                        globalDependencyValues.edgeConstraintsChild.length > 0
-                    ) {
-                        constrainedVertices =
-                            globalDependencyValues.edgeConstraintsChild[0].stateValues.constraintFunction(
-                                {
-                                    unconstrainedVertices: constrainedVertices,
-                                    closed: globalDependencyValues.closed,
-                                    enforceRigid: true,
-                                    allowRotation: false,
-                                },
-                            );
-                    }
-                    if (
-                        globalDependencyValues.vertexConstraintsChild.length > 0
-                    ) {
-                        constrainedVertices =
-                            globalDependencyValues.vertexConstraintsChild[0].stateValues.constraintFunction(
-                                constrainedVertices,
-                                true,
-                            );
-                    }
+                    // if (
+                    //     globalDependencyValues.edgeConstraintsChild.length > 0
+                    // ) {
+                    //     constrainedVertices =
+                    //         globalDependencyValues.edgeConstraintsChild[0].stateValues.constraintFunction(
+                    //             {
+                    //                 unconstrainedVertices: constrainedVertices,
+                    //                 closed: globalDependencyValues.closed,
+                    //                 enforceRigid: true,
+                    //                 allowRotation: false,
+                    //             },
+                    //         );
+                    // }
+                    // if (
+                    //     globalDependencyValues.vertexConstraintsChild.length > 0
+                    // ) {
+                    //     constrainedVertices =
+                    //         globalDependencyValues.vertexConstraintsChild[0].stateValues.constraintFunction(
+                    //             constrainedVertices,
+                    //             true,
+                    //         );
+                    // }
 
                     for (
                         let pointInd = 0;
@@ -1412,31 +1412,31 @@ export default class Polyline extends GraphicalComponent {
                         }
 
                         if (globalDependencyValues.haveConstrainedVertices) {
-                            if (
-                                globalDependencyValues.edgeConstraintsChild
-                                    .length > 0
-                            ) {
-                                desired_vertices =
-                                    globalDependencyValues.edgeConstraintsChild[0].stateValues.constraintFunction(
-                                        {
-                                            unconstrainedVertices:
-                                                desired_vertices,
-                                            closed: globalDependencyValues.closed,
-                                            enforceRigid: true,
-                                            allowRotation,
-                                        },
-                                    );
-                            }
-                            if (
-                                globalDependencyValues.vertexConstraintsChild
-                                    .length > 0
-                            ) {
-                                desired_vertices =
-                                    globalDependencyValues.vertexConstraintsChild[0].stateValues.constraintFunction(
-                                        desired_vertices,
-                                        true,
-                                    );
-                            }
+                            // if (
+                            //     globalDependencyValues.edgeConstraintsChild
+                            //         .length > 0
+                            // ) {
+                            //     desired_vertices =
+                            //         globalDependencyValues.edgeConstraintsChild[0].stateValues.constraintFunction(
+                            //             {
+                            //                 unconstrainedVertices:
+                            //                     desired_vertices,
+                            //                 closed: globalDependencyValues.closed,
+                            //                 enforceRigid: true,
+                            //                 allowRotation,
+                            //             },
+                            //         );
+                            // }
+                            // if (
+                            //     globalDependencyValues.vertexConstraintsChild
+                            //         .length > 0
+                            // ) {
+                            //     desired_vertices =
+                            //         globalDependencyValues.vertexConstraintsChild[0].stateValues.constraintFunction(
+                            //             desired_vertices,
+                            //             true,
+                            //         );
+                            // }
 
                             if (await stateValues.inStickyGroup) {
                                 let stickyObjectIndex =
@@ -1538,31 +1538,31 @@ export default class Polyline extends GraphicalComponent {
                         }
 
                         if (globalDependencyValues.haveConstrainedVertices) {
-                            if (
-                                globalDependencyValues.edgeConstraintsChild
-                                    .length > 0
-                            ) {
-                                desired_vertices =
-                                    globalDependencyValues.edgeConstraintsChild[0].stateValues.constraintFunction(
-                                        {
-                                            unconstrainedVertices:
-                                                desired_vertices,
-                                            closed: globalDependencyValues.closed,
-                                            enforceRigid: true,
-                                            allowRotation: false,
-                                        },
-                                    );
-                            }
-                            if (
-                                globalDependencyValues.vertexConstraintsChild
-                                    .length > 0
-                            ) {
-                                desired_vertices =
-                                    globalDependencyValues.vertexConstraintsChild[0].stateValues.constraintFunction(
-                                        desired_vertices,
-                                        true,
-                                    );
-                            }
+                            // if (
+                            //     globalDependencyValues.edgeConstraintsChild
+                            //         .length > 0
+                            // ) {
+                            //     desired_vertices =
+                            //         globalDependencyValues.edgeConstraintsChild[0].stateValues.constraintFunction(
+                            //             {
+                            //                 unconstrainedVertices:
+                            //                     desired_vertices,
+                            //                 closed: globalDependencyValues.closed,
+                            //                 enforceRigid: true,
+                            //                 allowRotation: false,
+                            //             },
+                            //         );
+                            // }
+                            // if (
+                            //     globalDependencyValues.vertexConstraintsChild
+                            //         .length > 0
+                            // ) {
+                            //     desired_vertices =
+                            //         globalDependencyValues.vertexConstraintsChild[0].stateValues.constraintFunction(
+                            //             desired_vertices,
+                            //             true,
+                            //         );
+                            // }
 
                             if (await stateValues.inStickyGroup) {
                                 let stickyObjectIndex =
@@ -1632,30 +1632,30 @@ export default class Polyline extends GraphicalComponent {
                         let enforceRigid = !movedJustOneVertex;
                         let allowRotation = movedJustOneVertex;
 
-                        if (
-                            globalDependencyValues.edgeConstraintsChild.length >
-                            0
-                        ) {
-                            desired_vertices =
-                                globalDependencyValues.edgeConstraintsChild[0].stateValues.constraintFunction(
-                                    {
-                                        unconstrainedVertices: desired_vertices,
-                                        closed: globalDependencyValues.closed,
-                                        enforceRigid,
-                                        allowRotation,
-                                    },
-                                );
-                        }
-                        if (
-                            globalDependencyValues.vertexConstraintsChild
-                                .length > 0
-                        ) {
-                            desired_vertices =
-                                globalDependencyValues.vertexConstraintsChild[0].stateValues.constraintFunction(
-                                    desired_vertices,
-                                    enforceRigid,
-                                );
-                        }
+                        // if (
+                        //     globalDependencyValues.edgeConstraintsChild.length >
+                        //     0
+                        // ) {
+                        //     desired_vertices =
+                        //         globalDependencyValues.edgeConstraintsChild[0].stateValues.constraintFunction(
+                        //             {
+                        //                 unconstrainedVertices: desired_vertices,
+                        //                 closed: globalDependencyValues.closed,
+                        //                 enforceRigid,
+                        //                 allowRotation,
+                        //             },
+                        //         );
+                        // }
+                        // if (
+                        //     globalDependencyValues.vertexConstraintsChild
+                        //         .length > 0
+                        // ) {
+                        //     desired_vertices =
+                        //         globalDependencyValues.vertexConstraintsChild[0].stateValues.constraintFunction(
+                        //             desired_vertices,
+                        //             enforceRigid,
+                        //         );
+                        // }
 
                         if (await stateValues.inStickyGroup) {
                             let stickyObjectIndex =

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -1265,8 +1265,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -2305,8 +2303,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -2644,8 +2640,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -2983,8 +2977,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -3377,6 +3369,11 @@
                 {
                     "name": "value",
                     "type": "topic",
+                    "isArray": false
+                },
+                {
+                    "name": "numCharacters",
+                    "type": "integer",
                     "isArray": false
                 },
                 {
@@ -20399,6 +20396,11 @@
                     "isArray": false
                 },
                 {
+                    "name": "numCharacters",
+                    "type": "integer",
+                    "isArray": false
+                },
+                {
                     "name": "text",
                     "type": "text",
                     "isArray": false
@@ -24217,8 +24219,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -24724,8 +24724,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -25231,8 +25229,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -25738,8 +25734,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -26245,8 +26239,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -26771,8 +26763,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -27278,8 +27268,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -27785,8 +27773,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -28292,8 +28278,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -28799,8 +28783,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -29306,8 +29288,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -29813,8 +29793,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -30320,8 +30298,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -30827,8 +30803,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -31334,8 +31308,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -31851,8 +31823,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -32349,8 +32319,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -33117,8 +33085,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -33581,9 +33547,7 @@
             "children": [
                 "xlabel",
                 "ylabel",
-                "label",
-                "vertexConstraints",
-                "edgeConstraints"
+                "label"
             ],
             "attributes": [
                 {
@@ -38228,8 +38192,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -38625,6 +38587,11 @@
                 {
                     "name": "value",
                     "type": "h",
+                    "isArray": false
+                },
+                {
+                    "name": "numCharacters",
+                    "type": "integer",
                     "isArray": false
                 },
                 {
@@ -39054,8 +39021,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -39393,8 +39358,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -39732,8 +39695,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -40071,8 +40032,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -40430,8 +40389,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -41542,8 +41499,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -41947,6 +41902,11 @@
                 {
                     "name": "value",
                     "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "numCharacters",
+                    "type": "integer",
                     "isArray": false
                 },
                 {
@@ -44925,8 +44885,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -46966,9 +46924,7 @@
             "children": [
                 "xlabel",
                 "ylabel",
-                "label",
-                "vertexConstraints",
-                "edgeConstraints"
+                "label"
             ],
             "attributes": [
                 {
@@ -47322,9 +47278,7 @@
             "children": [
                 "xlabel",
                 "ylabel",
-                "label",
-                "vertexConstraints",
-                "edgeConstraints"
+                "label"
             ],
             "attributes": [
                 {
@@ -47710,9 +47664,7 @@
             "children": [
                 "xlabel",
                 "ylabel",
-                "label",
-                "vertexConstraints",
-                "edgeConstraints"
+                "label"
             ],
             "attributes": [
                 {
@@ -48098,9 +48050,7 @@
             "children": [
                 "xlabel",
                 "ylabel",
-                "label",
-                "vertexConstraints",
-                "edgeConstraints"
+                "label"
             ],
             "attributes": [
                 {
@@ -48517,9 +48467,7 @@
             "children": [
                 "xlabel",
                 "ylabel",
-                "label",
-                "vertexConstraints",
-                "edgeConstraints"
+                "label"
             ],
             "attributes": [
                 {
@@ -54711,8 +54659,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -57924,8 +57870,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -58282,8 +58226,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -59425,8 +59367,6 @@
                 "eigenDecomposition",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -61533,8 +61473,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -63140,218 +63078,6 @@
             "acceptsStringChildren": false
         },
         {
-            "name": "attractSegmentTo",
-            "children": [
-                "rightHandSide",
-                "sum",
-                "product",
-                "clampNumber",
-                "wrapNumberPeriodic",
-                "round",
-                "setSmallToZero",
-                "convertSetToList",
-                "ceil",
-                "floor",
-                "abs",
-                "sign",
-                "mean",
-                "median",
-                "variance",
-                "standardDeviation",
-                "count",
-                "min",
-                "max",
-                "mod",
-                "gcd",
-                "extractMath",
-                "clampFunction",
-                "wrapFunctionPeriodic",
-                "derivative",
-                "cobwebPolyline",
-                "equilibriumPoint",
-                "equilibriumLine",
-                "equilibriumCurve",
-                "electronConfiguration",
-                "idx",
-                "math",
-                "collect",
-                "point",
-                "coords",
-                "line",
-                "lineSegment",
-                "ray",
-                "polyline",
-                "polygon",
-                "triangle",
-                "rectangle",
-                "regularPolygon",
-                "circle",
-                "parabola",
-                "curve",
-                "vector",
-                "angle",
-                "function",
-                "piecewiseFunction",
-                "interval",
-                "sequence",
-                "map",
-                "pegboard",
-                "intersection",
-                "conditionalContent",
-                "selectFromSequence",
-                "select",
-                "group",
-                "evaluate",
-                "substitute",
-                "periodicSet",
-                "module",
-                "endpoint",
-                "sort",
-                "shuffle",
-                "subsetOfReals",
-                "split",
-                "bestFitLine",
-                "regionBetweenCurveXAxis",
-                "regionBetweenCurves",
-                "regionHalfPlane",
-                "legend",
-                "matrix",
-                "stickyGroup"
-            ],
-            "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
-                {
-                    "name": "hide",
-                    "values": [
-                        "true",
-                        "false"
-                    ]
-                },
-                {
-                    "name": "disabled",
-                    "values": [
-                        "true",
-                        "false"
-                    ]
-                },
-                {
-                    "name": "fixed",
-                    "values": [
-                        "true",
-                        "false"
-                    ]
-                },
-                {
-                    "name": "fixLocation",
-                    "values": [
-                        "true",
-                        "false"
-                    ]
-                },
-                {
-                    "name": "styleNumber"
-                },
-                {
-                    "name": "isResponse",
-                    "values": [
-                        "true",
-                        "false"
-                    ]
-                },
-                {
-                    "name": "newNamespace",
-                    "values": [
-                        "true",
-                        "false"
-                    ]
-                },
-                {
-                    "name": "relativeToGraphScales",
-                    "values": [
-                        "true",
-                        "false"
-                    ]
-                },
-                {
-                    "name": "threshold"
-                }
-            ],
-            "properties": [
-                {
-                    "name": "hide",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "styleNumber",
-                    "type": "integer",
-                    "isArray": false
-                },
-                {
-                    "name": "isResponse",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "newNamespace",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false
-                },
-                {
-                    "name": "relativeToGraphScales",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "hidden",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "disabled",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "fixed",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "fixLocation",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "doenetML",
-                    "type": "text",
-                    "isArray": false
-                },
-                {
-                    "name": "threshold",
-                    "type": "number",
-                    "isArray": false
-                }
-            ],
-            "top": false,
-            "acceptsStringChildren": false
-        },
-        {
             "name": "intersection",
             "children": [
                 "equilibriumLine",
@@ -63711,8 +63437,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -64823,8 +64547,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -66686,8 +66408,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -68101,8 +67821,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -68503,6 +68221,11 @@
                     "isArray": false
                 },
                 {
+                    "name": "numCharacters",
+                    "type": "integer",
+                    "isArray": false
+                },
+                {
                     "name": "text",
                     "type": "text",
                     "isArray": false
@@ -68822,6 +68545,11 @@
                     "isArray": false
                 },
                 {
+                    "name": "numCharacters",
+                    "type": "integer",
+                    "isArray": false
+                },
+                {
                     "name": "text",
                     "type": "text",
                     "isArray": false
@@ -69072,8 +68800,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -69409,8 +69135,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -69748,8 +69472,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -71145,8 +70867,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -71625,8 +71345,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup",
                 "customAttribute"
             ],
@@ -72982,8 +72700,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -73360,8 +73076,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -74681,8 +74395,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -75940,8 +75652,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -79371,6 +79081,11 @@
                     "isArray": false
                 },
                 {
+                    "name": "numCharacters",
+                    "type": "integer",
+                    "isArray": false
+                },
+                {
                     "name": "text",
                     "type": "text",
                     "isArray": false
@@ -79616,8 +79331,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -79955,8 +79668,6 @@
                 "latex",
                 "blockQuote",
                 "contentPicker",
-                "vertexConstraints",
-                "edgeConstraints",
                 "stickyGroup"
             ],
             "attributes": [
@@ -80089,258 +79800,6 @@
             ],
             "top": true,
             "acceptsStringChildren": true
-        },
-        {
-            "name": "vertexConstraints",
-            "children": [
-                "constrainToGrid",
-                "constrainToGraph",
-                "attractToGrid",
-                "constrainTo",
-                "attractTo",
-                "constraintUnion",
-                "attractToConstraint"
-            ],
-            "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
-                {
-                    "name": "hide",
-                    "values": [
-                        "true",
-                        "false"
-                    ]
-                },
-                {
-                    "name": "disabled",
-                    "values": [
-                        "true",
-                        "false"
-                    ]
-                },
-                {
-                    "name": "fixed",
-                    "values": [
-                        "true",
-                        "false"
-                    ]
-                },
-                {
-                    "name": "fixLocation",
-                    "values": [
-                        "true",
-                        "false"
-                    ]
-                },
-                {
-                    "name": "styleNumber"
-                },
-                {
-                    "name": "isResponse",
-                    "values": [
-                        "true",
-                        "false"
-                    ]
-                },
-                {
-                    "name": "newNamespace",
-                    "values": [
-                        "true",
-                        "false"
-                    ]
-                }
-            ],
-            "properties": [
-                {
-                    "name": "hide",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "styleNumber",
-                    "type": "integer",
-                    "isArray": false
-                },
-                {
-                    "name": "isResponse",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "newNamespace",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false
-                },
-                {
-                    "name": "hidden",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "disabled",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "fixed",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "fixLocation",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "doenetML",
-                    "type": "text",
-                    "isArray": false
-                },
-                {
-                    "name": "scales",
-                    "type": "number",
-                    "isArray": false
-                }
-            ],
-            "top": true,
-            "acceptsStringChildren": false
-        },
-        {
-            "name": "edgeConstraints",
-            "children": [
-                "attractSegmentTo"
-            ],
-            "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
-                {
-                    "name": "hide",
-                    "values": [
-                        "true",
-                        "false"
-                    ]
-                },
-                {
-                    "name": "disabled",
-                    "values": [
-                        "true",
-                        "false"
-                    ]
-                },
-                {
-                    "name": "fixed",
-                    "values": [
-                        "true",
-                        "false"
-                    ]
-                },
-                {
-                    "name": "fixLocation",
-                    "values": [
-                        "true",
-                        "false"
-                    ]
-                },
-                {
-                    "name": "styleNumber"
-                },
-                {
-                    "name": "isResponse",
-                    "values": [
-                        "true",
-                        "false"
-                    ]
-                },
-                {
-                    "name": "newNamespace",
-                    "values": [
-                        "true",
-                        "false"
-                    ]
-                }
-            ],
-            "properties": [
-                {
-                    "name": "hide",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "styleNumber",
-                    "type": "integer",
-                    "isArray": false
-                },
-                {
-                    "name": "isResponse",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "newNamespace",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false
-                },
-                {
-                    "name": "hidden",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "disabled",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "fixed",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "fixLocation",
-                    "type": "boolean",
-                    "isArray": false
-                },
-                {
-                    "name": "doenetML",
-                    "type": "text",
-                    "isArray": false
-                },
-                {
-                    "name": "scales",
-                    "type": "number",
-                    "isArray": false
-                }
-            ],
-            "top": true,
-            "acceptsStringChildren": false
         },
         {
             "name": "stickyGroup",

--- a/packages/test-cypress/cypress/e2e/tagSpecific/polygon.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/polygon.cy.js
@@ -5627,729 +5627,729 @@ describe("Polygon Tag Tests", function () {
         });
     });
 
-    it("Rigid polygon, vertex constraint", () => {
-        cy.window().then(async (win) => {
-            win.postMessage(
-                {
-                    doenetML: `
-  <text>a</text>
-  <graph name="g1" newNamespace>
-    <point>(3,7)</point>
-    <point>(-4,-1)</point>
-    <point>(8,2)</point>
-    <point>(-3,4)</point>
-
-    <point styleNumber="2" name="a1">(1,9)</point>
-    <polygon vertices="$_point1 $_point2 $_point3 $_point4" name="pg" rigid >
-        <vertexConstraints>
-            <attractTo threshold="2">$a1</attractTo>
-        </vertexConstraints>
-    </polygon>
-  </graph>
-  <graph name="g2" newNamespace>
-    $(../g1/pg{name="pg"})
-  </graph>
-  $g2{name="g3"}
-  $(g1/pg.vertices{assignNames="p1 p2 p3 p4"})
-  `,
-                },
-                "*",
-            );
-        });
-        cy.get(cesc("#\\/_text1")).should("have.text", "a"); //wait for page to load
-
-        let vertices = [
-            [3, 7],
-            [-4, -1],
-            [8, 2],
-            [-3, 4],
-        ];
-
-        let centroid = vertices.reduce(
-            (a, c) => [a[0] + c[0], a[1] + c[1]],
-            [0, 0],
-        );
-        centroid[0] /= 4;
-        centroid[1] /= 4;
-
-        testPolygonCopiedTwice({ vertices });
-
-        cy.log("move individual vertex rotates, attracts to point");
-        cy.window().then(async (win) => {
-            // rotate by 90 degrees counterclockwise around centroid
-            // (shrinking by 1/2, but that will be ignored)
-            let requested_vertex_1 = [
-                -0.5 * (vertices[1][1] - centroid[1]) + centroid[0],
-                0.5 * (vertices[1][0] - centroid[0]) + centroid[1],
-            ];
-            vertices = vertices.map((v) => [
-                -(v[1] - centroid[1]) + centroid[0],
-                v[0] - centroid[0] + centroid[1],
-            ]);
-            // since attracted to point, moves down one and to the left
-            vertices = vertices.map((v) => [v[0] - 1, v[1] - 1]);
-
-            win.callAction1({
-                actionName: "movePolygon",
-                componentName: "/g1/pg",
-                args: {
-                    pointCoords: { 1: requested_vertex_1 },
-                },
-            });
-
-            testPolygonCopiedTwice({ vertices });
-        });
-
-        cy.log("rotating further so no attraction preserves old centroid");
-        cy.window().then(async (win) => {
-            // location of vertices if weren't attracted to point, moves up one and to the right
-            vertices = vertices.map((v) => [v[0] + 1, v[1] + 1]);
-
-            // rotate by another 90 degrees counterclockwise around centroid
-            // (doubling but that will be ignored)
-            let requested_vertex_1 = [
-                -2 * (vertices[1][1] - centroid[1]) + centroid[0],
-                2 * (vertices[1][0] - centroid[0]) + centroid[1],
-            ];
-            vertices = vertices.map((v) => [
-                -(v[1] - centroid[1]) + centroid[0],
-                v[0] - centroid[0] + centroid[1],
-            ]);
-
-            win.callAction1({
-                actionName: "movePolygon",
-                componentName: "/g1/pg",
-                args: {
-                    pointCoords: { 1: requested_vertex_1 },
-                },
-            });
-
-            testPolygonCopiedTwice({ vertices });
-        });
-
-        cy.log(
-            "move copied polygon up and to the left chooses minimum moved and gets attracted",
-        );
-        cy.window().then(async (win) => {
-            let moveX = -4;
-            let moveY = 1;
-
-            // add extra movement to requested vertices, which will be ignored
-            let requested_vertices = [];
-            for (let i = 0; i < vertices.length; i++) {
-                vertices[i][0] = vertices[i][0] + moveX;
-                vertices[i][1] = vertices[i][1] + moveY;
-                requested_vertices.push([
-                    vertices[i][0] - i,
-                    vertices[i][1] + 2 * i,
-                ]);
-            }
-
-            // since attracted to point, moves up one and to the left
-            vertices = vertices.map((v) => [v[0] - 1, v[1] + 1]);
-
-            win.callAction1({
-                actionName: "movePolygon",
-                componentName: "/g2/pg",
-                args: {
-                    pointCoords: requested_vertices,
-                },
-            });
-
-            testPolygonCopiedTwice({ vertices });
-        });
-
-        cy.log(
-            "move double copied individual vertex, getting rotation around new centroid",
-        );
-        cy.window().then(async (win) => {
-            let centroid = vertices.reduce(
-                (a, c) => [a[0] + c[0], a[1] + c[1]],
-                [0, 0],
-            );
-            centroid[0] /= 4;
-            centroid[1] /= 4;
-
-            // rotate by 180 degrees around centroid
-            // (doubling length, but that will be ignored)
-            let requested_vertex_2 = [
-                -2 * (vertices[2][0] - centroid[0]) + centroid[0],
-                -2 * (vertices[2][1] - centroid[1]) + centroid[1],
-            ];
-            vertices = vertices.map((v) => [
-                -(v[0] - centroid[0]) + centroid[0],
-                -(v[1] - centroid[1]) + centroid[1],
-            ]);
-
-            win.callAction1({
-                actionName: "movePolygon",
-                componentName: "/g3/pg",
-                args: {
-                    pointCoords: { 2: requested_vertex_2 },
-                },
-            });
-
-            testPolygonCopiedTwice({ vertices });
-        });
-    });
-
-    it("Rigid polygon, three vertex constraints", () => {
-        cy.window().then(async (win) => {
-            win.postMessage(
-                {
-                    doenetML: `
-  <text>a</text>
-  <graph name="g1" newNamespace>
-    <point>(3,7)</point>
-    <point>(-4,-1)</point>
-    <point>(8,2)</point>
-    <point>(-3,4)</point>
-
-    <point styleNumber="2" name="a1">(1,9)</point>
-    <point styleNumber="2" name="a2">(5,-1)</point>
-    <point styleNumber="2" name="a3">(-9,5)</point>
-    <polygon vertices="$_point1 $_point2 $_point3 $_point4" name="pg" rigid >
-    <vertexConstraints>
-      <attractTo threshold="2">$a1$a2$a3</attractTo>
-    </vertexConstraints>
-    </polygon>
-  </graph>
-  <graph name="g2" newNamespace>
-    $(../g1/pg{name="pg"})
-  </graph>
-  $g2{name="g3"}
-  $(g1/pg.vertices{assignNames="p1 p2 p3 p4"})
-  `,
-                },
-                "*",
-            );
-        });
-        cy.get(cesc("#\\/_text1")).should("have.text", "a"); //wait for page to load
-
-        let vertices = [
-            [3, 7],
-            [-4, -1],
-            [8, 2],
-            [-3, 4],
-        ];
-
-        let centroid = vertices.reduce(
-            (a, c) => [a[0] + c[0], a[1] + c[1]],
-            [0, 0],
-        );
-        centroid[0] /= 4;
-        centroid[1] /= 4;
-
-        testPolygonCopiedTwice({ vertices });
-
-        cy.log("move individual vertex rotates, attracts to closest point");
-        cy.window().then(async (win) => {
-            // rotate by 90 degrees counterclockwise around centroid
-            // (shrinking by 1/2, but that will be ignored)
-            let requested_vertex_1 = [
-                -0.5 * (vertices[1][1] - centroid[1]) + centroid[0],
-                0.5 * (vertices[1][0] - centroid[0]) + centroid[1],
-            ];
-            vertices = vertices.map((v) => [
-                -(v[1] - centroid[1]) + centroid[0],
-                v[0] - centroid[0] + centroid[1],
-            ]);
-            // since attracted to closest point (5,-2), moves up one
-            vertices = vertices.map((v) => [v[0], v[1] + 1]);
-
-            win.callAction1({
-                actionName: "movePolygon",
-                componentName: "/g1/pg",
-                args: {
-                    pointCoords: { 1: requested_vertex_1 },
-                },
-            });
-
-            testPolygonCopiedTwice({ vertices });
-        });
-
-        cy.log("rotating further so no attraction preserves old centroid");
-        cy.window().then(async (win) => {
-            // location of vertices if weren't attracted to point, moves down one
-            vertices = vertices.map((v) => [v[0], v[1] - 1]);
-
-            // rotate by another 90 degrees counterclockwise around centroid
-            // (doubling but that will be ignored)
-            let requested_vertex_1 = [
-                -2 * (vertices[1][1] - centroid[1]) + centroid[0],
-                2 * (vertices[1][0] - centroid[0]) + centroid[1],
-            ];
-            vertices = vertices.map((v) => [
-                -(v[1] - centroid[1]) + centroid[0],
-                v[0] - centroid[0] + centroid[1],
-            ]);
-
-            win.callAction1({
-                actionName: "movePolygon",
-                componentName: "/g1/pg",
-                args: {
-                    pointCoords: { 1: requested_vertex_1 },
-                },
-            });
-
-            testPolygonCopiedTwice({ vertices });
-        });
-
-        cy.log(
-            "move copied polygon up and to the left chooses minimum moved and gets attracted",
-        );
-        cy.window().then(async (win) => {
-            let moveX = -4;
-            let moveY = 1;
-
-            // add extra movement to requested vertices, which will be ignored
-            let requested_vertices = [];
-            for (let i = 0; i < vertices.length; i++) {
-                vertices[i][0] = vertices[i][0] + moveX;
-                vertices[i][1] = vertices[i][1] + moveY;
-                requested_vertices.push([
-                    vertices[i][0] - i,
-                    vertices[i][1] + 2 * i,
-                ]);
-            }
-
-            // since attracted to point (-9,5), moves one to the right
-            vertices = vertices.map((v) => [v[0] + 1, v[1]]);
-
-            win.callAction1({
-                actionName: "movePolygon",
-                componentName: "/g2/pg",
-                args: {
-                    pointCoords: requested_vertices,
-                },
-            });
-
-            testPolygonCopiedTwice({ vertices });
-        });
-
-        cy.log(
-            "move double copied individual vertex, getting rotation around new centroid, then attracted to point",
-        );
-        cy.window().then(async (win) => {
-            let centroid = vertices.reduce(
-                (a, c) => [a[0] + c[0], a[1] + c[1]],
-                [0, 0],
-            );
-            centroid[0] /= 4;
-            centroid[1] /= 4;
-
-            // rotate by 180 degrees around centroid
-            // (doubling length, but that will be ignored)
-            let requested_vertex_2 = [
-                -2 * (vertices[2][0] - centroid[0]) + centroid[0],
-                -2 * (vertices[2][1] - centroid[1]) + centroid[1],
-            ];
-            vertices = vertices.map((v) => [
-                -(v[0] - centroid[0]) + centroid[0],
-                -(v[1] - centroid[1]) + centroid[1],
-            ]);
-
-            // since a different vertex is attracted to point (1,9), moves one up and to the right
-            vertices = vertices.map((v) => [v[0] + 1, v[1] + 1]);
-
-            win.callAction1({
-                actionName: "movePolygon",
-                componentName: "/g3/pg",
-                args: {
-                    pointCoords: { 2: requested_vertex_2 },
-                },
-            });
-
-            testPolygonCopiedTwice({ vertices });
-        });
-    });
-
-    it("Non-rigid polygon, three vertex constraints", () => {
-        cy.window().then(async (win) => {
-            win.postMessage(
-                {
-                    doenetML: `
-<text>a</text>
-<graph name="g1" newNamespace>
-  <point>(3,7)</point>
-  <point>(-4,-1)</point>
-  <point>(8,2)</point>
-  <point>(-3,4)</point>
-
-  <point styleNumber="2" name="a1">(1,9)</point>
-  <point styleNumber="2" name="a2">(5,-1)</point>
-  <point styleNumber="2" name="a3">(-9,5)</point>
-  <polygon vertices="$_point1 $_point2 $_point3 $_point4" name="pg" >
-  <vertexConstraints>
-    <attractTo threshold="2">$a1$a2$a3</attractTo>
-  </vertexConstraints>
-  </polygon>
-</graph>
-<graph name="g2" newNamespace>
-  $(../g1/pg{name="pg"})
-  $pg.vertices{assignNames="v1 v2 v3 v4"}
-</graph>
-$g2{name="g3"}
-$(g1/pg.vertices{assignNames="p1 p2 p3 p4"})
-`,
-                },
-                "*",
-            );
-        });
-        cy.get(cesc("#\\/_text1")).should("have.text", "a"); //wait for page to load
-
-        let vertices = [
-            [3, 7],
-            [-4, -1],
-            [8, 2],
-            [-3, 4],
-        ];
-
-        testPolygonCopiedTwice({ vertices });
-
-        cy.log("move individual vertex, attracts to closest point");
-        cy.window().then(async (win) => {
-            let requested_vertex_1 = [-10, 6];
-
-            vertices[1] = [-9, 5];
-            win.callAction1({
-                actionName: "movePolygon",
-                componentName: "/g1/pg",
-                args: {
-                    pointCoords: { 1: requested_vertex_1 },
-                },
-            });
-
-            testPolygonCopiedTwice({ vertices });
-        });
-
-        cy.log("Moving entire polygon up attract to another point");
-
-        cy.window().then(async (win) => {
-            let moveX = -1;
-            let moveY = 1;
-
-            let requested_vertices = [];
-            for (let i = 0; i < vertices.length; i++) {
-                vertices[i][0] = vertices[i][0] + moveX;
-                vertices[i][1] = vertices[i][1] + moveY;
-                requested_vertices.push([vertices[i][0], vertices[i][1]]);
-            }
-
-            // since attracted to point (1,9), moves one up and to the left
-            vertices = vertices.map((v) => [v[0] - 1, v[1] + 1]);
-
-            win.callAction1({
-                actionName: "movePolygon",
-                componentName: "/g2/pg",
-                args: {
-                    pointCoords: requested_vertices,
-                },
-            });
-
-            testPolygonCopiedTwice({ vertices });
-        });
-
-        cy.log("move double copied individual vertex");
-        cy.window().then(async (win) => {
-            vertices[2] = [2, 1];
-
-            win.callAction1({
-                actionName: "movePolygon",
-                componentName: "/g3/pg",
-                args: {
-                    pointCoords: { 2: vertices[2] },
-                },
-            });
-
-            testPolygonCopiedTwice({ vertices });
-        });
-
-        cy.log("Moving entire polygon near two points, attracts to just one");
-        cy.window().then(async (win) => {
-            let moveX = 2.6;
-            let moveY = -2;
-
-            let requested_vertices = [];
-            for (let i = 0; i < vertices.length; i++) {
-                vertices[i][0] = vertices[i][0] + moveX;
-                vertices[i][1] = vertices[i][1] + moveY;
-                requested_vertices.push([vertices[i][0], vertices[i][1]]);
-            }
-
-            // since attracted to point (5,-1), moves 0.4 to the right
-            vertices = vertices.map((v) => [v[0] + 0.4, v[1]]);
-
-            win.callAction1({
-                actionName: "movePolygon",
-                componentName: "/g2/pg",
-                args: {
-                    pointCoords: requested_vertices,
-                },
-            });
-
-            testPolygonCopiedTwice({ vertices });
-        });
-
-        cy.log(
-            "Moving just one vertex attracts to other nearby vertex to attractor",
-        );
-        cy.window().then(async (win) => {
-            let requested_vertex_0 = [0, 10];
-            vertices[0] = [1, 9];
-            vertices[1] = [-9, 5];
-
-            win.callAction1({
-                actionName: "movePoint",
-                componentName: "/g2/v1",
-                args: { x: requested_vertex_0[0], y: requested_vertex_0[1] },
-            });
-
-            testPolygonCopiedTwice({ vertices });
-        });
-    });
-
-    it("Rigid polygon, vertices attracted to polygon", () => {
-        cy.window().then(async (win) => {
-            win.postMessage(
-                {
-                    doenetML: `
-  <text>a</text>
-  <graph name="g1" newNamespace>
-    <polygon name="pa" vertices="(0,0) (12,0) (6,9)" stylenumber="2" />
-
-    <point name="v1">(-1,0)</point>
-    <point name="v2">(3,0)</point>
-    <point name="v3">(1,-3)</point>
-    <polygon name="pg" vertices="$v1 $v2 $v3" rigid layer="2">
-       <vertexConstraints>
-         <attractTo threshold="2">$pa</attractTo>
-      </vertexConstraints>
-    </polygon>
-  </graph>
-  <graph name="g2" newNamespace>
-    $(../g1/pg{name="pg"})
-  </graph>
-  $g2{name="g3"}
-  $(g1/pg.vertices{assignNames="p1 p2 p3 p4"})
-  `,
-                },
-                "*",
-            );
-        });
-        cy.get(cesc("#\\/_text1")).should("have.text", "a"); //wait for page to load
-
-        cy.log("start shifted so that two vertices are attracted");
-
-        let vertices = [
-            [0, 0],
-            [4, 0],
-            [2, -3],
-        ];
-
-        testPolygonCopiedTwice({ vertices });
-
-        cy.log("move individual vertex rotates, attracts to edge of polygon");
-
-        let centroid = vertices.reduce(
-            (a, c) => [a[0] + c[0], a[1] + c[1]],
-            [0, 0],
-        );
-        centroid[0] /= 3;
-        centroid[1] /= 3;
-
-        cy.window().then(async (win) => {
-            // shift 1 to left to give original before attraction
-            centroid[0] -= 1;
-            vertices = vertices.map((v) => [v[0] - 1, v[1]]);
-
-            // rotate by 90 degrees clockwise around centroid
-            // (shrinking by 1/2, but that will be ignored)
-            let requested_vertex_1 = [
-                0.5 * (vertices[1][1] - centroid[1]) + centroid[0],
-                -0.5 * (vertices[1][0] - centroid[0]) + centroid[1],
-            ];
-            vertices = vertices.map((v) => [
-                v[1] - centroid[1] + centroid[0],
-                -(v[0] - centroid[0]) + centroid[1],
-            ]);
-            // since attracted to edge, moves down one and to the left
-            vertices = vertices.map((v) => [v[0], v[1] - 1]);
-
-            win.callAction1({
-                actionName: "movePolygon",
-                componentName: "/g1/pg",
-                args: {
-                    pointCoords: { 1: requested_vertex_1 },
-                },
-            });
-
-            testPolygonCopiedTwice({ vertices });
-        });
-
-        cy.log("move copied polygon up and to the right");
-        cy.window().then(async (win) => {
-            // Move so that bottom right gets attracted to (4,6).
-            // Slope of orthogonal to attractor edge is -6/9.
-            // So move bottom right to (4,6) + (9,-6)/10
-
-            let requested_bottom_right = [4 + 0.9, 6 - 0.6];
-            let actual_bottom_right = [4, 6];
-
-            let moveX = requested_bottom_right[0] - vertices[1][0];
-            let moveY = requested_bottom_right[1] - vertices[1][1];
-
-            // add extra movement to requested vertices, which will be ignored
-            let requested_vertices = [];
-            for (let i = 0; i < vertices.length; i++) {
-                vertices[i][0] = vertices[i][0] + moveX;
-                vertices[i][1] = vertices[i][1] + moveY;
-                requested_vertices.push([
-                    vertices[i][0] + i,
-                    vertices[i][1] + 2 * i,
-                ]);
-            }
-
-            // since attracted to point, moves up one and to the left
-            vertices = vertices.map((v) => [
-                v[0] + actual_bottom_right[0] - requested_bottom_right[0],
-                v[1] + actual_bottom_right[1] - requested_bottom_right[1],
-            ]);
-
-            win.callAction1({
-                actionName: "movePolygon",
-                componentName: "/g2/pg",
-                args: {
-                    pointCoords: requested_vertices,
-                },
-            });
-
-            testPolygonCopiedTwice({ vertices });
-        });
-    });
-
-    it("Rigid polygon, vertices attracted to polyline", () => {
-        cy.window().then(async (win) => {
-            win.postMessage(
-                {
-                    doenetML: `
-  <text>a</text>
-  <graph name="g1" newNamespace>
-    <polyline name="pa" vertices="(0,0) (12,0) (6,9)" stylenumber="2" />
-
-    <point name="v1">(-1,0)</point>
-    <point name="v2">(3,0)</point>
-    <point name="v3">(1,-3)</point>
-    <polygon name="pg" vertices="$v1 $v2 $v3" rigid layer="2">
-       <vertexConstraints>
-         <attractTo threshold="2">$pa</attractTo>
-      </vertexConstraints>
-    </polygon>
-  </graph>
-  <graph name="g2" newNamespace>
-    $(../g1/pg{name="pg"})
-  </graph>
-  $g2{name="g3"}
-  $(g1/pg.vertices{assignNames="p1 p2 p3 p4"})
-  `,
-                },
-                "*",
-            );
-        });
-        cy.get(cesc("#\\/_text1")).should("have.text", "a"); //wait for page to load
-
-        cy.log("start shifted so that two vertices are attracted");
-
-        let vertices = [
-            [0, 0],
-            [4, 0],
-            [2, -3],
-        ];
-
-        testPolygonCopiedTwice({ vertices });
-
-        cy.log("move individual vertex rotates, attracts to edge of polygon");
-
-        let centroid = vertices.reduce(
-            (a, c) => [a[0] + c[0], a[1] + c[1]],
-            [0, 0],
-        );
-        centroid[0] /= 3;
-        centroid[1] /= 3;
-
-        cy.window().then(async (win) => {
-            // shift 1 to left to give original before attraction
-            centroid[0] -= 1;
-            vertices = vertices.map((v) => [v[0] - 1, v[1]]);
-
-            // rotate by 90 degrees clockwise around centroid
-            // (shrinking by 1/2, but that will be ignored)
-            let requested_vertex_1 = [
-                0.5 * (vertices[1][1] - centroid[1]) + centroid[0],
-                -0.5 * (vertices[1][0] - centroid[0]) + centroid[1],
-            ];
-            vertices = vertices.map((v) => [
-                v[1] - centroid[1] + centroid[0],
-                -(v[0] - centroid[0]) + centroid[1],
-            ]);
-            // since attracted to edge, moves down one and to the left
-            vertices = vertices.map((v) => [v[0], v[1] - 1]);
-
-            win.callAction1({
-                actionName: "movePolygon",
-                componentName: "/g1/pg",
-                args: {
-                    pointCoords: { 1: requested_vertex_1 },
-                },
-            });
-
-            testPolygonCopiedTwice({ vertices });
-        });
-
-        cy.log("move copied polygon up and to the right");
-        cy.window().then(async (win) => {
-            // Move so that bottom right would get attracted to (4,6) if it where a polygon.
-            // But since it is a polyline, that edge doesn't exist
-            // and instead the upper right gets attracted to other edge.
-
-            // If had polygon,
-            // slope of orthogonal to attractor edge would be -6/9.
-            // So move bottom right to (4,6) + (9,-6)/10
-
-            let requested_bottom_right = [4 + 0.9, 6 - 0.6];
-            let actual_bottom_right = [6, 5];
-
-            let moveX = requested_bottom_right[0] - vertices[1][0];
-            let moveY = requested_bottom_right[1] - vertices[1][1];
-
-            // add extra movement to requested vertices, which will be ignored
-            let requested_vertices = [];
-            for (let i = 0; i < vertices.length; i++) {
-                vertices[i][0] = vertices[i][0] + moveX;
-                vertices[i][1] = vertices[i][1] + moveY;
-                requested_vertices.push([
-                    vertices[i][0] + i,
-                    vertices[i][1] + 2 * i,
-                ]);
-            }
-
-            // since attracted to point, moves up one and to the left
-            vertices = vertices.map((v) => [
-                v[0] + actual_bottom_right[0] - requested_bottom_right[0],
-                v[1] + actual_bottom_right[1] - requested_bottom_right[1],
-            ]);
-
-            win.callAction1({
-                actionName: "movePolygon",
-                componentName: "/g2/pg",
-                args: {
-                    pointCoords: requested_vertices,
-                },
-            });
-
-            testPolygonCopiedTwice({ vertices });
-        });
-    });
+    //     it("Rigid polygon, vertex constraint", () => {
+    //         cy.window().then(async (win) => {
+    //             win.postMessage(
+    //                 {
+    //                     doenetML: `
+    //   <text>a</text>
+    //   <graph name="g1" newNamespace>
+    //     <point>(3,7)</point>
+    //     <point>(-4,-1)</point>
+    //     <point>(8,2)</point>
+    //     <point>(-3,4)</point>
+
+    //     <point styleNumber="2" name="a1">(1,9)</point>
+    //     <polygon vertices="$_point1 $_point2 $_point3 $_point4" name="pg" rigid >
+    //         <vertexConstraints>
+    //             <attractTo threshold="2">$a1</attractTo>
+    //         </vertexConstraints>
+    //     </polygon>
+    //   </graph>
+    //   <graph name="g2" newNamespace>
+    //     $(../g1/pg{name="pg"})
+    //   </graph>
+    //   $g2{name="g3"}
+    //   $(g1/pg.vertices{assignNames="p1 p2 p3 p4"})
+    //   `,
+    //                 },
+    //                 "*",
+    //             );
+    //         });
+    //         cy.get(cesc("#\\/_text1")).should("have.text", "a"); //wait for page to load
+
+    //         let vertices = [
+    //             [3, 7],
+    //             [-4, -1],
+    //             [8, 2],
+    //             [-3, 4],
+    //         ];
+
+    //         let centroid = vertices.reduce(
+    //             (a, c) => [a[0] + c[0], a[1] + c[1]],
+    //             [0, 0],
+    //         );
+    //         centroid[0] /= 4;
+    //         centroid[1] /= 4;
+
+    //         testPolygonCopiedTwice({ vertices });
+
+    //         cy.log("move individual vertex rotates, attracts to point");
+    //         cy.window().then(async (win) => {
+    //             // rotate by 90 degrees counterclockwise around centroid
+    //             // (shrinking by 1/2, but that will be ignored)
+    //             let requested_vertex_1 = [
+    //                 -0.5 * (vertices[1][1] - centroid[1]) + centroid[0],
+    //                 0.5 * (vertices[1][0] - centroid[0]) + centroid[1],
+    //             ];
+    //             vertices = vertices.map((v) => [
+    //                 -(v[1] - centroid[1]) + centroid[0],
+    //                 v[0] - centroid[0] + centroid[1],
+    //             ]);
+    //             // since attracted to point, moves down one and to the left
+    //             vertices = vertices.map((v) => [v[0] - 1, v[1] - 1]);
+
+    //             win.callAction1({
+    //                 actionName: "movePolygon",
+    //                 componentName: "/g1/pg",
+    //                 args: {
+    //                     pointCoords: { 1: requested_vertex_1 },
+    //                 },
+    //             });
+
+    //             testPolygonCopiedTwice({ vertices });
+    //         });
+
+    //         cy.log("rotating further so no attraction preserves old centroid");
+    //         cy.window().then(async (win) => {
+    //             // location of vertices if weren't attracted to point, moves up one and to the right
+    //             vertices = vertices.map((v) => [v[0] + 1, v[1] + 1]);
+
+    //             // rotate by another 90 degrees counterclockwise around centroid
+    //             // (doubling but that will be ignored)
+    //             let requested_vertex_1 = [
+    //                 -2 * (vertices[1][1] - centroid[1]) + centroid[0],
+    //                 2 * (vertices[1][0] - centroid[0]) + centroid[1],
+    //             ];
+    //             vertices = vertices.map((v) => [
+    //                 -(v[1] - centroid[1]) + centroid[0],
+    //                 v[0] - centroid[0] + centroid[1],
+    //             ]);
+
+    //             win.callAction1({
+    //                 actionName: "movePolygon",
+    //                 componentName: "/g1/pg",
+    //                 args: {
+    //                     pointCoords: { 1: requested_vertex_1 },
+    //                 },
+    //             });
+
+    //             testPolygonCopiedTwice({ vertices });
+    //         });
+
+    //         cy.log(
+    //             "move copied polygon up and to the left chooses minimum moved and gets attracted",
+    //         );
+    //         cy.window().then(async (win) => {
+    //             let moveX = -4;
+    //             let moveY = 1;
+
+    //             // add extra movement to requested vertices, which will be ignored
+    //             let requested_vertices = [];
+    //             for (let i = 0; i < vertices.length; i++) {
+    //                 vertices[i][0] = vertices[i][0] + moveX;
+    //                 vertices[i][1] = vertices[i][1] + moveY;
+    //                 requested_vertices.push([
+    //                     vertices[i][0] - i,
+    //                     vertices[i][1] + 2 * i,
+    //                 ]);
+    //             }
+
+    //             // since attracted to point, moves up one and to the left
+    //             vertices = vertices.map((v) => [v[0] - 1, v[1] + 1]);
+
+    //             win.callAction1({
+    //                 actionName: "movePolygon",
+    //                 componentName: "/g2/pg",
+    //                 args: {
+    //                     pointCoords: requested_vertices,
+    //                 },
+    //             });
+
+    //             testPolygonCopiedTwice({ vertices });
+    //         });
+
+    //         cy.log(
+    //             "move double copied individual vertex, getting rotation around new centroid",
+    //         );
+    //         cy.window().then(async (win) => {
+    //             let centroid = vertices.reduce(
+    //                 (a, c) => [a[0] + c[0], a[1] + c[1]],
+    //                 [0, 0],
+    //             );
+    //             centroid[0] /= 4;
+    //             centroid[1] /= 4;
+
+    //             // rotate by 180 degrees around centroid
+    //             // (doubling length, but that will be ignored)
+    //             let requested_vertex_2 = [
+    //                 -2 * (vertices[2][0] - centroid[0]) + centroid[0],
+    //                 -2 * (vertices[2][1] - centroid[1]) + centroid[1],
+    //             ];
+    //             vertices = vertices.map((v) => [
+    //                 -(v[0] - centroid[0]) + centroid[0],
+    //                 -(v[1] - centroid[1]) + centroid[1],
+    //             ]);
+
+    //             win.callAction1({
+    //                 actionName: "movePolygon",
+    //                 componentName: "/g3/pg",
+    //                 args: {
+    //                     pointCoords: { 2: requested_vertex_2 },
+    //                 },
+    //             });
+
+    //             testPolygonCopiedTwice({ vertices });
+    //         });
+    //     });
+
+    //     it("Rigid polygon, three vertex constraints", () => {
+    //         cy.window().then(async (win) => {
+    //             win.postMessage(
+    //                 {
+    //                     doenetML: `
+    //   <text>a</text>
+    //   <graph name="g1" newNamespace>
+    //     <point>(3,7)</point>
+    //     <point>(-4,-1)</point>
+    //     <point>(8,2)</point>
+    //     <point>(-3,4)</point>
+
+    //     <point styleNumber="2" name="a1">(1,9)</point>
+    //     <point styleNumber="2" name="a2">(5,-1)</point>
+    //     <point styleNumber="2" name="a3">(-9,5)</point>
+    //     <polygon vertices="$_point1 $_point2 $_point3 $_point4" name="pg" rigid >
+    //     <vertexConstraints>
+    //       <attractTo threshold="2">$a1$a2$a3</attractTo>
+    //     </vertexConstraints>
+    //     </polygon>
+    //   </graph>
+    //   <graph name="g2" newNamespace>
+    //     $(../g1/pg{name="pg"})
+    //   </graph>
+    //   $g2{name="g3"}
+    //   $(g1/pg.vertices{assignNames="p1 p2 p3 p4"})
+    //   `,
+    //                 },
+    //                 "*",
+    //             );
+    //         });
+    //         cy.get(cesc("#\\/_text1")).should("have.text", "a"); //wait for page to load
+
+    //         let vertices = [
+    //             [3, 7],
+    //             [-4, -1],
+    //             [8, 2],
+    //             [-3, 4],
+    //         ];
+
+    //         let centroid = vertices.reduce(
+    //             (a, c) => [a[0] + c[0], a[1] + c[1]],
+    //             [0, 0],
+    //         );
+    //         centroid[0] /= 4;
+    //         centroid[1] /= 4;
+
+    //         testPolygonCopiedTwice({ vertices });
+
+    //         cy.log("move individual vertex rotates, attracts to closest point");
+    //         cy.window().then(async (win) => {
+    //             // rotate by 90 degrees counterclockwise around centroid
+    //             // (shrinking by 1/2, but that will be ignored)
+    //             let requested_vertex_1 = [
+    //                 -0.5 * (vertices[1][1] - centroid[1]) + centroid[0],
+    //                 0.5 * (vertices[1][0] - centroid[0]) + centroid[1],
+    //             ];
+    //             vertices = vertices.map((v) => [
+    //                 -(v[1] - centroid[1]) + centroid[0],
+    //                 v[0] - centroid[0] + centroid[1],
+    //             ]);
+    //             // since attracted to closest point (5,-2), moves up one
+    //             vertices = vertices.map((v) => [v[0], v[1] + 1]);
+
+    //             win.callAction1({
+    //                 actionName: "movePolygon",
+    //                 componentName: "/g1/pg",
+    //                 args: {
+    //                     pointCoords: { 1: requested_vertex_1 },
+    //                 },
+    //             });
+
+    //             testPolygonCopiedTwice({ vertices });
+    //         });
+
+    //         cy.log("rotating further so no attraction preserves old centroid");
+    //         cy.window().then(async (win) => {
+    //             // location of vertices if weren't attracted to point, moves down one
+    //             vertices = vertices.map((v) => [v[0], v[1] - 1]);
+
+    //             // rotate by another 90 degrees counterclockwise around centroid
+    //             // (doubling but that will be ignored)
+    //             let requested_vertex_1 = [
+    //                 -2 * (vertices[1][1] - centroid[1]) + centroid[0],
+    //                 2 * (vertices[1][0] - centroid[0]) + centroid[1],
+    //             ];
+    //             vertices = vertices.map((v) => [
+    //                 -(v[1] - centroid[1]) + centroid[0],
+    //                 v[0] - centroid[0] + centroid[1],
+    //             ]);
+
+    //             win.callAction1({
+    //                 actionName: "movePolygon",
+    //                 componentName: "/g1/pg",
+    //                 args: {
+    //                     pointCoords: { 1: requested_vertex_1 },
+    //                 },
+    //             });
+
+    //             testPolygonCopiedTwice({ vertices });
+    //         });
+
+    //         cy.log(
+    //             "move copied polygon up and to the left chooses minimum moved and gets attracted",
+    //         );
+    //         cy.window().then(async (win) => {
+    //             let moveX = -4;
+    //             let moveY = 1;
+
+    //             // add extra movement to requested vertices, which will be ignored
+    //             let requested_vertices = [];
+    //             for (let i = 0; i < vertices.length; i++) {
+    //                 vertices[i][0] = vertices[i][0] + moveX;
+    //                 vertices[i][1] = vertices[i][1] + moveY;
+    //                 requested_vertices.push([
+    //                     vertices[i][0] - i,
+    //                     vertices[i][1] + 2 * i,
+    //                 ]);
+    //             }
+
+    //             // since attracted to point (-9,5), moves one to the right
+    //             vertices = vertices.map((v) => [v[0] + 1, v[1]]);
+
+    //             win.callAction1({
+    //                 actionName: "movePolygon",
+    //                 componentName: "/g2/pg",
+    //                 args: {
+    //                     pointCoords: requested_vertices,
+    //                 },
+    //             });
+
+    //             testPolygonCopiedTwice({ vertices });
+    //         });
+
+    //         cy.log(
+    //             "move double copied individual vertex, getting rotation around new centroid, then attracted to point",
+    //         );
+    //         cy.window().then(async (win) => {
+    //             let centroid = vertices.reduce(
+    //                 (a, c) => [a[0] + c[0], a[1] + c[1]],
+    //                 [0, 0],
+    //             );
+    //             centroid[0] /= 4;
+    //             centroid[1] /= 4;
+
+    //             // rotate by 180 degrees around centroid
+    //             // (doubling length, but that will be ignored)
+    //             let requested_vertex_2 = [
+    //                 -2 * (vertices[2][0] - centroid[0]) + centroid[0],
+    //                 -2 * (vertices[2][1] - centroid[1]) + centroid[1],
+    //             ];
+    //             vertices = vertices.map((v) => [
+    //                 -(v[0] - centroid[0]) + centroid[0],
+    //                 -(v[1] - centroid[1]) + centroid[1],
+    //             ]);
+
+    //             // since a different vertex is attracted to point (1,9), moves one up and to the right
+    //             vertices = vertices.map((v) => [v[0] + 1, v[1] + 1]);
+
+    //             win.callAction1({
+    //                 actionName: "movePolygon",
+    //                 componentName: "/g3/pg",
+    //                 args: {
+    //                     pointCoords: { 2: requested_vertex_2 },
+    //                 },
+    //             });
+
+    //             testPolygonCopiedTwice({ vertices });
+    //         });
+    //     });
+
+    //     it("Non-rigid polygon, three vertex constraints", () => {
+    //         cy.window().then(async (win) => {
+    //             win.postMessage(
+    //                 {
+    //                     doenetML: `
+    // <text>a</text>
+    // <graph name="g1" newNamespace>
+    //   <point>(3,7)</point>
+    //   <point>(-4,-1)</point>
+    //   <point>(8,2)</point>
+    //   <point>(-3,4)</point>
+
+    //   <point styleNumber="2" name="a1">(1,9)</point>
+    //   <point styleNumber="2" name="a2">(5,-1)</point>
+    //   <point styleNumber="2" name="a3">(-9,5)</point>
+    //   <polygon vertices="$_point1 $_point2 $_point3 $_point4" name="pg" >
+    //   <vertexConstraints>
+    //     <attractTo threshold="2">$a1$a2$a3</attractTo>
+    //   </vertexConstraints>
+    //   </polygon>
+    // </graph>
+    // <graph name="g2" newNamespace>
+    //   $(../g1/pg{name="pg"})
+    //   $pg.vertices{assignNames="v1 v2 v3 v4"}
+    // </graph>
+    // $g2{name="g3"}
+    // $(g1/pg.vertices{assignNames="p1 p2 p3 p4"})
+    // `,
+    //                 },
+    //                 "*",
+    //             );
+    //         });
+    //         cy.get(cesc("#\\/_text1")).should("have.text", "a"); //wait for page to load
+
+    //         let vertices = [
+    //             [3, 7],
+    //             [-4, -1],
+    //             [8, 2],
+    //             [-3, 4],
+    //         ];
+
+    //         testPolygonCopiedTwice({ vertices });
+
+    //         cy.log("move individual vertex, attracts to closest point");
+    //         cy.window().then(async (win) => {
+    //             let requested_vertex_1 = [-10, 6];
+
+    //             vertices[1] = [-9, 5];
+    //             win.callAction1({
+    //                 actionName: "movePolygon",
+    //                 componentName: "/g1/pg",
+    //                 args: {
+    //                     pointCoords: { 1: requested_vertex_1 },
+    //                 },
+    //             });
+
+    //             testPolygonCopiedTwice({ vertices });
+    //         });
+
+    //         cy.log("Moving entire polygon up attract to another point");
+
+    //         cy.window().then(async (win) => {
+    //             let moveX = -1;
+    //             let moveY = 1;
+
+    //             let requested_vertices = [];
+    //             for (let i = 0; i < vertices.length; i++) {
+    //                 vertices[i][0] = vertices[i][0] + moveX;
+    //                 vertices[i][1] = vertices[i][1] + moveY;
+    //                 requested_vertices.push([vertices[i][0], vertices[i][1]]);
+    //             }
+
+    //             // since attracted to point (1,9), moves one up and to the left
+    //             vertices = vertices.map((v) => [v[0] - 1, v[1] + 1]);
+
+    //             win.callAction1({
+    //                 actionName: "movePolygon",
+    //                 componentName: "/g2/pg",
+    //                 args: {
+    //                     pointCoords: requested_vertices,
+    //                 },
+    //             });
+
+    //             testPolygonCopiedTwice({ vertices });
+    //         });
+
+    //         cy.log("move double copied individual vertex");
+    //         cy.window().then(async (win) => {
+    //             vertices[2] = [2, 1];
+
+    //             win.callAction1({
+    //                 actionName: "movePolygon",
+    //                 componentName: "/g3/pg",
+    //                 args: {
+    //                     pointCoords: { 2: vertices[2] },
+    //                 },
+    //             });
+
+    //             testPolygonCopiedTwice({ vertices });
+    //         });
+
+    //         cy.log("Moving entire polygon near two points, attracts to just one");
+    //         cy.window().then(async (win) => {
+    //             let moveX = 2.6;
+    //             let moveY = -2;
+
+    //             let requested_vertices = [];
+    //             for (let i = 0; i < vertices.length; i++) {
+    //                 vertices[i][0] = vertices[i][0] + moveX;
+    //                 vertices[i][1] = vertices[i][1] + moveY;
+    //                 requested_vertices.push([vertices[i][0], vertices[i][1]]);
+    //             }
+
+    //             // since attracted to point (5,-1), moves 0.4 to the right
+    //             vertices = vertices.map((v) => [v[0] + 0.4, v[1]]);
+
+    //             win.callAction1({
+    //                 actionName: "movePolygon",
+    //                 componentName: "/g2/pg",
+    //                 args: {
+    //                     pointCoords: requested_vertices,
+    //                 },
+    //             });
+
+    //             testPolygonCopiedTwice({ vertices });
+    //         });
+
+    //         cy.log(
+    //             "Moving just one vertex attracts to other nearby vertex to attractor",
+    //         );
+    //         cy.window().then(async (win) => {
+    //             let requested_vertex_0 = [0, 10];
+    //             vertices[0] = [1, 9];
+    //             vertices[1] = [-9, 5];
+
+    //             win.callAction1({
+    //                 actionName: "movePoint",
+    //                 componentName: "/g2/v1",
+    //                 args: { x: requested_vertex_0[0], y: requested_vertex_0[1] },
+    //             });
+
+    //             testPolygonCopiedTwice({ vertices });
+    //         });
+    //     });
+
+    //     it("Rigid polygon, vertices attracted to polygon", () => {
+    //         cy.window().then(async (win) => {
+    //             win.postMessage(
+    //                 {
+    //                     doenetML: `
+    //   <text>a</text>
+    //   <graph name="g1" newNamespace>
+    //     <polygon name="pa" vertices="(0,0) (12,0) (6,9)" stylenumber="2" />
+
+    //     <point name="v1">(-1,0)</point>
+    //     <point name="v2">(3,0)</point>
+    //     <point name="v3">(1,-3)</point>
+    //     <polygon name="pg" vertices="$v1 $v2 $v3" rigid layer="2">
+    //        <vertexConstraints>
+    //          <attractTo threshold="2">$pa</attractTo>
+    //       </vertexConstraints>
+    //     </polygon>
+    //   </graph>
+    //   <graph name="g2" newNamespace>
+    //     $(../g1/pg{name="pg"})
+    //   </graph>
+    //   $g2{name="g3"}
+    //   $(g1/pg.vertices{assignNames="p1 p2 p3 p4"})
+    //   `,
+    //                 },
+    //                 "*",
+    //             );
+    //         });
+    //         cy.get(cesc("#\\/_text1")).should("have.text", "a"); //wait for page to load
+
+    //         cy.log("start shifted so that two vertices are attracted");
+
+    //         let vertices = [
+    //             [0, 0],
+    //             [4, 0],
+    //             [2, -3],
+    //         ];
+
+    //         testPolygonCopiedTwice({ vertices });
+
+    //         cy.log("move individual vertex rotates, attracts to edge of polygon");
+
+    //         let centroid = vertices.reduce(
+    //             (a, c) => [a[0] + c[0], a[1] + c[1]],
+    //             [0, 0],
+    //         );
+    //         centroid[0] /= 3;
+    //         centroid[1] /= 3;
+
+    //         cy.window().then(async (win) => {
+    //             // shift 1 to left to give original before attraction
+    //             centroid[0] -= 1;
+    //             vertices = vertices.map((v) => [v[0] - 1, v[1]]);
+
+    //             // rotate by 90 degrees clockwise around centroid
+    //             // (shrinking by 1/2, but that will be ignored)
+    //             let requested_vertex_1 = [
+    //                 0.5 * (vertices[1][1] - centroid[1]) + centroid[0],
+    //                 -0.5 * (vertices[1][0] - centroid[0]) + centroid[1],
+    //             ];
+    //             vertices = vertices.map((v) => [
+    //                 v[1] - centroid[1] + centroid[0],
+    //                 -(v[0] - centroid[0]) + centroid[1],
+    //             ]);
+    //             // since attracted to edge, moves down one and to the left
+    //             vertices = vertices.map((v) => [v[0], v[1] - 1]);
+
+    //             win.callAction1({
+    //                 actionName: "movePolygon",
+    //                 componentName: "/g1/pg",
+    //                 args: {
+    //                     pointCoords: { 1: requested_vertex_1 },
+    //                 },
+    //             });
+
+    //             testPolygonCopiedTwice({ vertices });
+    //         });
+
+    //         cy.log("move copied polygon up and to the right");
+    //         cy.window().then(async (win) => {
+    //             // Move so that bottom right gets attracted to (4,6).
+    //             // Slope of orthogonal to attractor edge is -6/9.
+    //             // So move bottom right to (4,6) + (9,-6)/10
+
+    //             let requested_bottom_right = [4 + 0.9, 6 - 0.6];
+    //             let actual_bottom_right = [4, 6];
+
+    //             let moveX = requested_bottom_right[0] - vertices[1][0];
+    //             let moveY = requested_bottom_right[1] - vertices[1][1];
+
+    //             // add extra movement to requested vertices, which will be ignored
+    //             let requested_vertices = [];
+    //             for (let i = 0; i < vertices.length; i++) {
+    //                 vertices[i][0] = vertices[i][0] + moveX;
+    //                 vertices[i][1] = vertices[i][1] + moveY;
+    //                 requested_vertices.push([
+    //                     vertices[i][0] + i,
+    //                     vertices[i][1] + 2 * i,
+    //                 ]);
+    //             }
+
+    //             // since attracted to point, moves up one and to the left
+    //             vertices = vertices.map((v) => [
+    //                 v[0] + actual_bottom_right[0] - requested_bottom_right[0],
+    //                 v[1] + actual_bottom_right[1] - requested_bottom_right[1],
+    //             ]);
+
+    //             win.callAction1({
+    //                 actionName: "movePolygon",
+    //                 componentName: "/g2/pg",
+    //                 args: {
+    //                     pointCoords: requested_vertices,
+    //                 },
+    //             });
+
+    //             testPolygonCopiedTwice({ vertices });
+    //         });
+    //     });
+
+    //     it("Rigid polygon, vertices attracted to polyline", () => {
+    //         cy.window().then(async (win) => {
+    //             win.postMessage(
+    //                 {
+    //                     doenetML: `
+    //   <text>a</text>
+    //   <graph name="g1" newNamespace>
+    //     <polyline name="pa" vertices="(0,0) (12,0) (6,9)" stylenumber="2" />
+
+    //     <point name="v1">(-1,0)</point>
+    //     <point name="v2">(3,0)</point>
+    //     <point name="v3">(1,-3)</point>
+    //     <polygon name="pg" vertices="$v1 $v2 $v3" rigid layer="2">
+    //        <vertexConstraints>
+    //          <attractTo threshold="2">$pa</attractTo>
+    //       </vertexConstraints>
+    //     </polygon>
+    //   </graph>
+    //   <graph name="g2" newNamespace>
+    //     $(../g1/pg{name="pg"})
+    //   </graph>
+    //   $g2{name="g3"}
+    //   $(g1/pg.vertices{assignNames="p1 p2 p3 p4"})
+    //   `,
+    //                 },
+    //                 "*",
+    //             );
+    //         });
+    //         cy.get(cesc("#\\/_text1")).should("have.text", "a"); //wait for page to load
+
+    //         cy.log("start shifted so that two vertices are attracted");
+
+    //         let vertices = [
+    //             [0, 0],
+    //             [4, 0],
+    //             [2, -3],
+    //         ];
+
+    //         testPolygonCopiedTwice({ vertices });
+
+    //         cy.log("move individual vertex rotates, attracts to edge of polygon");
+
+    //         let centroid = vertices.reduce(
+    //             (a, c) => [a[0] + c[0], a[1] + c[1]],
+    //             [0, 0],
+    //         );
+    //         centroid[0] /= 3;
+    //         centroid[1] /= 3;
+
+    //         cy.window().then(async (win) => {
+    //             // shift 1 to left to give original before attraction
+    //             centroid[0] -= 1;
+    //             vertices = vertices.map((v) => [v[0] - 1, v[1]]);
+
+    //             // rotate by 90 degrees clockwise around centroid
+    //             // (shrinking by 1/2, but that will be ignored)
+    //             let requested_vertex_1 = [
+    //                 0.5 * (vertices[1][1] - centroid[1]) + centroid[0],
+    //                 -0.5 * (vertices[1][0] - centroid[0]) + centroid[1],
+    //             ];
+    //             vertices = vertices.map((v) => [
+    //                 v[1] - centroid[1] + centroid[0],
+    //                 -(v[0] - centroid[0]) + centroid[1],
+    //             ]);
+    //             // since attracted to edge, moves down one and to the left
+    //             vertices = vertices.map((v) => [v[0], v[1] - 1]);
+
+    //             win.callAction1({
+    //                 actionName: "movePolygon",
+    //                 componentName: "/g1/pg",
+    //                 args: {
+    //                     pointCoords: { 1: requested_vertex_1 },
+    //                 },
+    //             });
+
+    //             testPolygonCopiedTwice({ vertices });
+    //         });
+
+    //         cy.log("move copied polygon up and to the right");
+    //         cy.window().then(async (win) => {
+    //             // Move so that bottom right would get attracted to (4,6) if it where a polygon.
+    //             // But since it is a polyline, that edge doesn't exist
+    //             // and instead the upper right gets attracted to other edge.
+
+    //             // If had polygon,
+    //             // slope of orthogonal to attractor edge would be -6/9.
+    //             // So move bottom right to (4,6) + (9,-6)/10
+
+    //             let requested_bottom_right = [4 + 0.9, 6 - 0.6];
+    //             let actual_bottom_right = [6, 5];
+
+    //             let moveX = requested_bottom_right[0] - vertices[1][0];
+    //             let moveY = requested_bottom_right[1] - vertices[1][1];
+
+    //             // add extra movement to requested vertices, which will be ignored
+    //             let requested_vertices = [];
+    //             for (let i = 0; i < vertices.length; i++) {
+    //                 vertices[i][0] = vertices[i][0] + moveX;
+    //                 vertices[i][1] = vertices[i][1] + moveY;
+    //                 requested_vertices.push([
+    //                     vertices[i][0] + i,
+    //                     vertices[i][1] + 2 * i,
+    //                 ]);
+    //             }
+
+    //             // since attracted to point, moves up one and to the left
+    //             vertices = vertices.map((v) => [
+    //                 v[0] + actual_bottom_right[0] - requested_bottom_right[0],
+    //                 v[1] + actual_bottom_right[1] - requested_bottom_right[1],
+    //             ]);
+
+    //             win.callAction1({
+    //                 actionName: "movePolygon",
+    //                 componentName: "/g2/pg",
+    //                 args: {
+    //                     pointCoords: requested_vertices,
+    //                 },
+    //             });
+
+    //             testPolygonCopiedTwice({ vertices });
+    //         });
+    //     });
 
     it("Preserve similarity", () => {
         cy.window().then(async (win) => {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/triangle.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/triangle.cy.js
@@ -2169,159 +2169,159 @@ describe("Triangle Tag Tests", function () {
         });
     });
 
-    it("Rigid triangle, vertex constraints", () => {
-        cy.window().then(async (win) => {
-            win.postMessage(
-                {
-                    doenetML: `
-  <text>a</text>
-  <graph>
+    //     it("Rigid triangle, vertex constraints", () => {
+    //         cy.window().then(async (win) => {
+    //             win.postMessage(
+    //                 {
+    //                     doenetML: `
+    //   <text>a</text>
+    //   <graph>
 
-  <point styleNumber="2" name="a1">(1,9)</point>
-  <point styleNumber="2" name="a2">(5,8)</point>
-    <triangle vertices="(0,6) (3,0)" rigid >
-        <vertexConstraints>
-            <attractTo threshold="2">$a1$a2</attractTo>
-        </vertexConstraints>
-    </triangle>
-    $_triangle1.vertex1{name="vertex1"}
-    $_triangle1.vertex2{name="vertex2"}
-    $_triangle1.vertex3{name="vertex3"}
-  </graph>
-  `,
-                },
-                "*",
-            );
-        });
-        cy.get(cesc("#\\/_text1")).should("have.text", "a"); //wait for page to load
+    //   <point styleNumber="2" name="a1">(1,9)</point>
+    //   <point styleNumber="2" name="a2">(5,8)</point>
+    //     <triangle vertices="(0,6) (3,0)" rigid >
+    //         <vertexConstraints>
+    //             <attractTo threshold="2">$a1$a2</attractTo>
+    //         </vertexConstraints>
+    //     </triangle>
+    //     $_triangle1.vertex1{name="vertex1"}
+    //     $_triangle1.vertex2{name="vertex2"}
+    //     $_triangle1.vertex3{name="vertex3"}
+    //   </graph>
+    //   `,
+    //                 },
+    //                 "*",
+    //             );
+    //         });
+    //         cy.get(cesc("#\\/_text1")).should("have.text", "a"); //wait for page to load
 
-        cy.window().then(async (win) => {
-            let stateVariables = await win.returnAllStateVariables1();
-            let v1x = 0,
-                v1y = 6;
-            let v2x = 3,
-                v2y = 0;
-            let v3x = 0,
-                v3y = 0;
+    //         cy.window().then(async (win) => {
+    //             let stateVariables = await win.returnAllStateVariables1();
+    //             let v1x = 0,
+    //                 v1y = 6;
+    //             let v2x = 3,
+    //                 v2y = 0;
+    //             let v3x = 0,
+    //                 v3y = 0;
 
-            let vertices = [
-                stateVariables["/vertex1"].replacements[0],
-                stateVariables["/vertex2"].replacements[0],
-                stateVariables["/vertex3"].replacements[0],
-            ];
+    //             let vertices = [
+    //                 stateVariables["/vertex1"].replacements[0],
+    //                 stateVariables["/vertex2"].replacements[0],
+    //                 stateVariables["/vertex3"].replacements[0],
+    //             ];
 
-            cy.window().then(async (win) => {
-                let pxs = [v1x, v2x, v3x];
-                let pys = [v1y, v2y, v3y];
+    //             cy.window().then(async (win) => {
+    //                 let pxs = [v1x, v2x, v3x];
+    //                 let pys = [v1y, v2y, v3y];
 
-                for (let i = 0; i < 3; i++) {
-                    expect(
-                        stateVariables["/_triangle1"].stateValues.vertices[i],
-                    ).eqls([pxs[i], pys[i]]);
-                    expect(
-                        stateVariables[vertices[i].componentName].stateValues
-                            .coords,
-                    ).eqls(["vector", pxs[i], pys[i]]);
-                }
-            });
+    //                 for (let i = 0; i < 3; i++) {
+    //                     expect(
+    //                         stateVariables["/_triangle1"].stateValues.vertices[i],
+    //                     ).eqls([pxs[i], pys[i]]);
+    //                     expect(
+    //                         stateVariables[vertices[i].componentName].stateValues
+    //                             .coords,
+    //                     ).eqls(["vector", pxs[i], pys[i]]);
+    //                 }
+    //             });
 
-            cy.log("move triangle up and to the right, attracts to one point");
-            cy.window().then(async (win) => {
-                let stateVariables = await win.returnAllStateVariables1();
+    //             cy.log("move triangle up and to the right, attracts to one point");
+    //             cy.window().then(async (win) => {
+    //                 let stateVariables = await win.returnAllStateVariables1();
 
-                let moveX = 2;
-                let moveY = 2;
+    //                 let moveX = 2;
+    //                 let moveY = 2;
 
-                let desiredVertices = [];
-                for (
-                    let i = 0;
-                    i < stateVariables["/_triangle1"].stateValues.numVertices;
-                    i++
-                ) {
-                    desiredVertices.push([
-                        me
-                            .fromAst(
-                                stateVariables["/_triangle1"].stateValues
-                                    .vertices[i][0],
-                            )
-                            .add(moveX).tree,
-                        me
-                            .fromAst(
-                                stateVariables["/_triangle1"].stateValues
-                                    .vertices[i][1],
-                            )
-                            .add(moveY).tree,
-                    ]);
-                }
+    //                 let desiredVertices = [];
+    //                 for (
+    //                     let i = 0;
+    //                     i < stateVariables["/_triangle1"].stateValues.numVertices;
+    //                     i++
+    //                 ) {
+    //                     desiredVertices.push([
+    //                         me
+    //                             .fromAst(
+    //                                 stateVariables["/_triangle1"].stateValues
+    //                                     .vertices[i][0],
+    //                             )
+    //                             .add(moveX).tree,
+    //                         me
+    //                             .fromAst(
+    //                                 stateVariables["/_triangle1"].stateValues
+    //                                     .vertices[i][1],
+    //                             )
+    //                             .add(moveY).tree,
+    //                     ]);
+    //                 }
 
-                await win.callAction1({
-                    actionName: "movePolygon",
-                    componentName: "/_triangle1",
-                    args: { pointCoords: desiredVertices },
-                });
+    //                 await win.callAction1({
+    //                     actionName: "movePolygon",
+    //                     componentName: "/_triangle1",
+    //                     args: { pointCoords: desiredVertices },
+    //                 });
 
-                // shifts one up and to the left being attracted by (1,9)
-                v1x += moveX - 1;
-                v2x += moveX - 1;
-                v3x += moveX - 1;
-                v1y += moveY + 1;
-                v2y += moveY + 1;
-                v3y += moveY + 1;
+    //                 // shifts one up and to the left being attracted by (1,9)
+    //                 v1x += moveX - 1;
+    //                 v2x += moveX - 1;
+    //                 v3x += moveX - 1;
+    //                 v1y += moveY + 1;
+    //                 v2y += moveY + 1;
+    //                 v3y += moveY + 1;
 
-                let pxs = [v1x, v2x, v3x];
-                let pys = [v1y, v2y, v3y];
+    //                 let pxs = [v1x, v2x, v3x];
+    //                 let pys = [v1y, v2y, v3y];
 
-                cy.window().then(async (win) => {
-                    let stateVariables = await win.returnAllStateVariables1();
+    //                 cy.window().then(async (win) => {
+    //                     let stateVariables = await win.returnAllStateVariables1();
 
-                    for (let i = 0; i < vertices.length; i++) {
-                        expect(
-                            stateVariables["/_triangle1"].stateValues.vertices[
-                                i
-                            ],
-                        ).eqls([pxs[i], pys[i]]);
-                        expect(
-                            stateVariables[vertices[i].componentName]
-                                .stateValues.coords,
-                        ).eqls(["vector", pxs[i], pys[i]]);
-                    }
-                });
-            });
+    //                     for (let i = 0; i < vertices.length; i++) {
+    //                         expect(
+    //                             stateVariables["/_triangle1"].stateValues.vertices[
+    //                                 i
+    //                             ],
+    //                         ).eqls([pxs[i], pys[i]]);
+    //                         expect(
+    //                             stateVariables[vertices[i].componentName]
+    //                                 .stateValues.coords,
+    //                         ).eqls(["vector", pxs[i], pys[i]]);
+    //                     }
+    //                 });
+    //             });
 
-            cy.log("move a point rotates, attracts to other point");
-            cy.window().then(async (win) => {
-                (v1x = -1), (v2x = 5), (v3x = 5);
-                (v1y = 5), (v2y = 8), (v3y = 5);
+    //             cy.log("move a point rotates, attracts to other point");
+    //             cy.window().then(async (win) => {
+    //                 (v1x = -1), (v2x = 5), (v3x = 5);
+    //                 (v1y = 5), (v2y = 8), (v3y = 5);
 
-                let pxs = [v1x, v2x, v3x];
-                let pys = [v1y, v2y, v3y];
+    //                 let pxs = [v1x, v2x, v3x];
+    //                 let pys = [v1y, v2y, v3y];
 
-                await win.callAction1({
-                    actionName: "movePoint",
-                    componentName: vertices[0].componentName,
-                    args: { x: -18, y: 0 },
-                });
-                cy.window().then(async (win) => {
-                    let stateVariables = await win.returnAllStateVariables1();
+    //                 await win.callAction1({
+    //                     actionName: "movePoint",
+    //                     componentName: vertices[0].componentName,
+    //                     args: { x: -18, y: 0 },
+    //                 });
+    //                 cy.window().then(async (win) => {
+    //                     let stateVariables = await win.returnAllStateVariables1();
 
-                    for (let i = 0; i < 3; i++) {
-                        expect(
-                            stateVariables["/_triangle1"].stateValues.vertices[
-                                i
-                            ].map((x) => Math.round(x * 1e10) / 1e10),
-                        ).eqls([pxs[i], pys[i]]);
-                        expect(
-                            stateVariables[
-                                vertices[i].componentName
-                            ].stateValues.coords.map((x) =>
-                                Number.isFinite(x)
-                                    ? Math.round(x * 1e10) / 1e10
-                                    : x,
-                            ),
-                        ).eqls(["vector", pxs[i], pys[i]]);
-                    }
-                });
-            });
-        });
-    });
+    //                     for (let i = 0; i < 3; i++) {
+    //                         expect(
+    //                             stateVariables["/_triangle1"].stateValues.vertices[
+    //                                 i
+    //                             ].map((x) => Math.round(x * 1e10) / 1e10),
+    //                         ).eqls([pxs[i], pys[i]]);
+    //                         expect(
+    //                             stateVariables[
+    //                                 vertices[i].componentName
+    //                             ].stateValues.coords.map((x) =>
+    //                                 Number.isFinite(x)
+    //                                     ? Math.round(x * 1e10) / 1e10
+    //                                     : x,
+    //                             ),
+    //                         ).eqls(["vector", pxs[i], pys[i]]);
+    //                     }
+    //                 });
+    //             });
+    //         });
+    //     });
 });


### PR DESCRIPTION
This PR temporarily removes the `<vertexConstraints>`, `<edgeConstraints>`, and `<attractSegmentTo>` components until we can dedicate time to fix and revive them.

The main use case for these components was superseded by the `<stickyGroup>` component. However, these components could give authors more control over how vertices and edges are constrained.