### PR TITLE
tweak packaging and fix font issue

### DIFF
--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -5,7 +5,7 @@
     "version": "0.7.0-alpha7",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
-    "private": false,
+    "private": true,
     "repository": "github:Doenet/DoenetML",
     "files": [
         "/dist"
@@ -25,7 +25,8 @@
         "build": "wireit",
         "preview": "vite preview",
         "test": "echo \"No tests \"",
-        "lint": "eslint src --ext js,jsx --report-unused-disable-directives --max-warnings 0"
+        "lint": "eslint src --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+        "publish": "npm run build && cd dist && npm publish"
     },
     "wireit": {
         "build": {

--- a/packages/doenetml/src/DoenetML.css
+++ b/packages/doenetml/src/DoenetML.css
@@ -5,8 +5,8 @@
     src:
 /* url(OpenSansRegularWoffTwo) format('woff2'),
 url(OpenSansRegularWoff) format('woff'); */
-        url("/fonts/files/open-sans-v18-latin-regular.woff2") format("woff2"),
-        url("/fonts/files/open-sans-v18-latin-regular.woff") format("woff");
+        url("./fonts/files/open-sans-v18-latin-regular.woff2") format("woff2"),
+        url("./fonts/files/open-sans-v18-latin-regular.woff") format("woff");
 }
 
 @font-face {
@@ -14,8 +14,8 @@ url(OpenSansRegularWoff) format('woff'); */
     font-style: italic;
     font-weight: normal;
     src:
-        url("/fonts/files/open-sans-v18-latin-italic.woff2") format("woff2"),
-        url("/fonts/files/open-sans-v18-latin-italic.woff") format("woff");
+        url("./fonts/files/open-sans-v18-latin-italic.woff2") format("woff2"),
+        url("./fonts/files/open-sans-v18-latin-italic.woff") format("woff");
 }
 
 @font-face {
@@ -23,8 +23,8 @@ url(OpenSansRegularWoff) format('woff'); */
     font-style: normal;
     font-weight: 700;
     src:
-        url("/fonts/files/open-sans-v18-latin-700.woff2") format("woff2"),
-        url("/fonts/files/open-sans-v18-latin-700.woff") format("woff");
+        url("./fonts/files/open-sans-v18-latin-700.woff2") format("woff2"),
+        url("./fonts/files/open-sans-v18-latin-700.woff") format("woff");
 }
 
 @font-face {
@@ -32,8 +32,8 @@ url(OpenSansRegularWoff) format('woff'); */
     font-style: normal;
     font-weight: 300;
     src:
-        url("/fonts/files/open-sans-v18-latin-light.woff2") format("woff2"),
-        url("/fonts/files/open-sans-v18-latin-light.woff") format("woff");
+        url("./fonts/files/open-sans-v18-latin-light.woff2") format("woff2"),
+        url("./fonts/files/open-sans-v18-latin-light.woff") format("woff");
 }
 
 @font-face {
@@ -41,9 +41,9 @@ url(OpenSansRegularWoff) format('woff'); */
     font-style: italic;
     font-weight: 300;
     src:
-        url("/fonts/files/open-sans-v18-latin-light-italic.woff2")
+        url("./fonts/files/open-sans-v18-latin-light-italic.woff2")
             format("woff2"),
-        url("/fonts/files/open-sans-v18-latin-light-italic.woff") format("woff");
+        url("./fonts/files/open-sans-v18-latin-light-italic.woff") format("woff");
 }
 
 @font-face {
@@ -51,8 +51,8 @@ url(OpenSansRegularWoff) format('woff'); */
     font-style: italic;
     font-weight: 700;
     src:
-        url("/fonts/files/open-sans-v18-latin-700italic.woff2") format("woff2"),
-        url("/fonts/files/open-sans-v18-latin-700italic.woff") format("woff");
+        url("./fonts/files/open-sans-v18-latin-700italic.woff2") format("woff2"),
+        url("./fonts/files/open-sans-v18-latin-700italic.woff") format("woff");
 }
 html {
     font-family: "Open Sans" !important;

--- a/packages/doenetml/vite.config.ts
+++ b/packages/doenetml/vite.config.ts
@@ -76,9 +76,12 @@ function transformPackageJson(contents: string, filePath: string) {
     delete pkg.peerDependencies;
     delete pkg.dependencies;
     delete pkg.prettier;
+    delete pkg.wireit;
+
+    pkg.private = false;
 
     // Everything that is externalized should be a peer dependency
-    pkg.devDependencies = {};
+    pkg.peerDependencies = {};
     for (const dep of EXTERNAL_DEPS) {
         if (!allDeps[dep]) {
             console.warn(
@@ -87,7 +90,7 @@ function transformPackageJson(contents: string, filePath: string) {
             );
             continue;
         }
-        pkg.devDependencies[dep] = allDeps[dep];
+        pkg.peerDependencies[dep] = allDeps[dep];
     }
 
     // Fix up the paths. The existing package.json refers to files in the `./dist` directory. But

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "*",
+    "version": "0.7.0-alpha7",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,
@@ -10,12 +10,17 @@
     "files": [
         "/dist"
     ],
-    "main": "dist/doenet-standalone.js",
+    "exports": {
+        ".": {
+            "import": "./dist/doenet-standalone.js"
+        }
+    },
     "scripts": {
         "dev": "vite",
         "build": "wireit",
         "test": "echo \"No tests \"",
-        "preview": "vite preview"
+        "preview": "vite preview",
+        "publish": "npm run build && cd dist && npm publish"
     },
     "wireit": {
         "build": {

--- a/packages/standalone/vite.config.ts
+++ b/packages/standalone/vite.config.ts
@@ -5,6 +5,9 @@ import * as path from "node:path";
 import { createRequire } from "module";
 const require = createRequire(import.meta.url);
 
+// These are the dependencies that will not be bundled into the library.
+const EXTERNAL_DEPS = [];
+
 // https://vitejs.dev/config/
 export default defineConfig({
     base: "./",
@@ -18,6 +21,11 @@ export default defineConfig({
                         "../fonts/*",
                     ),
                     dest: "fonts/",
+                },
+                {
+                    src: "package.json",
+                    dest: "./",
+                    transform: transformPackageJson,
                 },
             ],
         }),
@@ -42,3 +50,72 @@ export default defineConfig({
         "process.env.NODE_ENV": '"production"',
     },
 });
+
+/**
+ * Trim and modify the `package.json` file so that it is suitable for publishing.
+ */
+function transformPackageJson(contents: string, filePath: string) {
+    const pkg = JSON.parse(contents);
+    const allDeps = {
+        ...pkg.dependencies,
+        ...pkg.peerDependencies,
+        ...pkg.devDependencies,
+    };
+    // Delete unneeded entries
+    delete pkg.private;
+    delete pkg.scripts;
+    delete pkg.devDependencies;
+    delete pkg.peerDependencies;
+    delete pkg.dependencies;
+    delete pkg.prettier;
+    delete pkg.wireit;
+
+    pkg.private = false;
+
+    // Everything that is externalized should be a peer dependency
+    pkg.peerDependencies = {};
+    for (const dep of EXTERNAL_DEPS) {
+        if (!allDeps[dep]) {
+            console.warn(
+                dep,
+                "is listed as a dependency for vite to externalize, but a version is not specified in package.json.",
+            );
+            continue;
+        }
+        pkg.peerDependencies[dep] = allDeps[dep];
+    }
+
+    // Fix up the paths. The existing package.json refers to files in the `./dist` directory. But
+    // the new package.json will be in the ./dist directory itself, so we need to remove any `./dist`
+    // prefix from the paths.
+    const outputPackageJsonPath = path.join(
+        path.dirname(filePath),
+        "./dist/package.json",
+    );
+    if (Array.isArray(pkg.files)) {
+        pkg.files = pkg.files.map((file) =>
+            getPathRelativeToPackageJson(file, outputPackageJsonPath),
+        );
+    }
+    for (const exp of Object.values(pkg.exports ?? {}) as Record<
+        string,
+        string
+    >[]) {
+        for (const [format, path] of Object.entries(exp)) {
+            exp[format] = getPathRelativeToPackageJson(
+                path,
+                outputPackageJsonPath,
+            );
+        }
+    }
+
+    return JSON.stringify(pkg, null, 4);
+}
+
+function getPathRelativeToPackageJson(
+    relPath: string,
+    packageJsonPath: string,
+) {
+    const packageJsonDir = path.dirname(packageJsonPath);
+    return "./" + path.relative(packageJsonDir, path.join(__dirname, relPath));
+}


### PR DESCRIPTION
With this PR, building the `doenetml` and `standalone` packages  creates pared-down `package.json` files in the dist directory. A new `npm run publish` script in each packge publishes to npm from the dist directories using those `package.json` files.

The PR also changes how fonts were included in `doenetml` so that they can be found by the `standalone` package.

