### PR TITLE
Make a DoenetMLIframe component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20442,7 +20442,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "*",
+            "version": "0.7.0-alpha7",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {
                 "vite": "^4.5.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1879,6 +1879,10 @@
             "resolved": "packages/doenetml",
             "link": true
         },
+        "node_modules/@doenet/doenetml-iframe": {
+            "resolved": "packages/doenetml-iframe",
+            "link": true
+        },
         "node_modules/@doenet/doenetml-worker": {
             "resolved": "packages/doenetml-worker",
             "link": true
@@ -19434,6 +19438,18 @@
                 "styled-components": "^5.3.11"
             }
         },
+        "packages/doenetml-iframe": {
+            "version": "0.7.0-alpha7",
+            "license": "AGPL-3.0-or-later",
+            "devDependencies": {
+                "vite": "^4.5.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0",
+                "react-dom": "^18.2.0",
+                "styled-components": "^5.3.11"
+            }
+        },
         "packages/doenetml-worker": {
             "name": "@doenet/doenetml-worker",
             "version": "*",
@@ -19682,7 +19698,7 @@
         },
         "packages/vscode-extension": {
             "name": "@doenet/vscode-extension",
-            "version": "0.7.7",
+            "version": "0.7.8",
             "license": "AGPL",
             "devDependencies": {
                 "@types/vscode": "^1.76.0",

--- a/packages/doenetml-iframe/README.md
+++ b/packages/doenetml-iframe/README.md
@@ -1,0 +1,10 @@
+# DoenetML IFrame Renderer
+
+This workspace contains a DoenetML renderer that renders inside of an iframe. This allows DoenetML
+to be used without affecting the surrounding page. It also allows multiple versions of DoenetML to
+be used at the same time.
+
+## Development
+
+Source code in `src/iframe-index.ts` is pre-compiled and included directly in the generated iframe.
+Source code in `src/index.tsx` is compiled into the `DoenetMLIframe` component.

--- a/packages/doenetml-iframe/index.html
+++ b/packages/doenetml-iframe/index.html
@@ -13,31 +13,5 @@
             <div id="root"></div>
         </div>
         <script type="module" src="/src/test-main.tsx"></script>
-        <!--
-        <script></script>
-        <div class="doenetml-applet">
-            <script type="text/doenetml">
-                <p>Use this to test DoenetML</p>
-                <graph showNavigation="false">
-
-                  <line through="(-8,8) (9,6)" />
-                  <line through="(0,4)" slope="1/2" styleNumber="2" />
-
-                  <line equation="y=2x-8" styleNumber="3" />
-                  <line equation="x=-6" styleNumber="4" />
-
-                </graph>
-            </script>
-        </div>
-        <div class="doenetml-applet" data-doenet-read-only="true">
-            <script type="text/doenetml">
-                <p>Use this to test DoenetML</p>
-                <graph showNavigation="false">
-
-                  <line through="(0,4)" slope="1/2" styleNumber="2" />
-
-                </graph>
-            </script>
-        </div>
-    --></body>
+      </body>
 </html>

--- a/packages/doenetml-iframe/index.html
+++ b/packages/doenetml-iframe/index.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <link rel="shortcut icon" href="/favicon.ico" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>DoenetML Viewer</title>
+        <script src="https://www.youtube.com/iframe_api"></script>
+    </head>
+    <body>
+        <h1>Below is DoenetML rendered in an iframe</h1>
+        <div style="border: 1px dashed black; padding: 0px;">
+            <div id="root"></div>
+        </div>
+        <script type="module" src="/src/test-main.tsx"></script>
+        <!--
+        <script></script>
+        <div class="doenetml-applet">
+            <script type="text/doenetml">
+                <p>Use this to test DoenetML</p>
+                <graph showNavigation="false">
+
+                  <line through="(-8,8) (9,6)" />
+                  <line through="(0,4)" slope="1/2" styleNumber="2" />
+
+                  <line equation="y=2x-8" styleNumber="3" />
+                  <line equation="x=-6" styleNumber="4" />
+
+                </graph>
+            </script>
+        </div>
+        <div class="doenetml-applet" data-doenet-read-only="true">
+            <script type="text/doenetml">
+                <p>Use this to test DoenetML</p>
+                <graph showNavigation="false">
+
+                  <line through="(0,4)" slope="1/2" styleNumber="2" />
+
+                </graph>
+            </script>
+        </div>
+    --></body>
+</html>

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -1,0 +1,62 @@
+{
+    "name": "@doenet/doenetml-iframe",
+    "type": "module",
+    "description": "A renderer for DoenetML contained in an iframe",
+    "version": "0.7.0-alpha7",
+    "license": "AGPL-3.0-or-later",
+    "homepage": "https://github.com/Doenet/DoenetML#readme",
+    "private": true,
+    "repository": "github:Doenet/DoenetML",
+    "files": [
+        "/dist"
+    ],
+    "exports": {
+        ".": {
+            "import": "./dist/component/index.js"
+        }
+    },
+    "scripts": {
+        "dev": "npm run build:iframe && vite",
+        "build": "npm run build:iframe && npm run build:component",
+        "build:component": "wireit",
+        "build:iframe": "wireit",
+        "test": "echo \"No tests \""
+    },
+    "wireit": {
+        "build:iframe": {
+            "command": "vite -c vite.config-iframe.ts build",
+            "files": [
+                "src/iframe-index.ts",
+                "vite.config-iframe.ts",
+                "tsconfig.json"
+            ],
+            "output": [
+                "dist/iframe/*"
+            ]
+        },
+        "build:component": {
+            "command": "vite build",
+            "files": [
+                "src/**/*.ts",
+                "src/**/*.tsx",
+                "tsconfig.json",
+                "vite.config.ts",
+                "dist/iframe/*"
+            ],
+            "output": [
+                "dist/component/*"
+            ],
+            "dependencies": [
+                "../doenetml:build"
+            ]
+        }
+    },
+    "peerDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+    },
+    "dependencies": {},
+    "devDependencies": {
+        "vite": "^4.5.0"
+    }
+}

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -20,6 +20,7 @@
         "build": "npm run build:iframe && npm run build:component",
         "build:component": "wireit",
         "build:iframe": "wireit",
+        "publish": "npm run build && cd dist/component && npm publish",
         "test": "echo \"No tests \""
     },
     "wireit": {

--- a/packages/doenetml-iframe/src/iframe-index.ts
+++ b/packages/doenetml-iframe/src/iframe-index.ts
@@ -1,0 +1,38 @@
+declare const id: string;
+declare const doenetMLProps: object;
+interface Window {
+    renderDoenetToContainer: (
+        container: Element,
+        doenetMLSource?: string,
+        config?: object,
+    ) => void;
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    window.renderDoenetToContainer(
+        document.getElementById("root")!,
+        undefined,
+        {
+            ...doenetMLProps,
+            // Callbacks have to be explicitly overridden here so that they
+            // can message the parent React component (outside the iframe).
+            generatedVariantCallback: (variant: unknown) => {
+                messageParent({ generatedVariantCallback: variant });
+            },
+        },
+    );
+});
+
+/**
+ * Send a message to the parent React component.
+ * @param data
+ */
+function messageParent(data: any) {
+    window.parent.postMessage(
+        {
+            origin: id,
+            data,
+        },
+        window.parent.origin,
+    );
+}

--- a/packages/doenetml-iframe/src/iframe-index.ts
+++ b/packages/doenetml-iframe/src/iframe-index.ts
@@ -1,3 +1,5 @@
+// All code in this file will be executed in the context of an iframe
+// created by DoenetMLIframe.
 declare const id: string;
 declare const doenetMLProps: object;
 interface Window {

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -1,0 +1,137 @@
+/*
+ * This file is for running a dev test of the codemirror component.
+ * It does not show up in the bundled package.
+ */
+
+import React from "react";
+import type { DoenetML } from "@doenet/doenetml";
+// @ts-ignore
+import iframeJsSource from "../dist/iframe/iframe-index.iife.js?raw";
+import { watchForResize } from "./resize-watcher";
+
+type DoenetMLProps = React.ComponentProps<typeof DoenetML>;
+
+/**
+ * A message that is sent from an iframe to the parent window.
+ */
+type IframeMessage = {
+    origin: string;
+    data: Record<string, unknown>;
+};
+
+export type DoenetMLIframeProps = {
+    doenetML: string;
+    doenetMLProps: DoenetMLProps;
+    /**
+     * The URL of a standalone DoenetML bundle. This may be from the CDN.
+     */
+    standaloneUrl: string;
+    /**
+     * The URL of a CSS file that styles the standalone DoenetML bundle.
+     */
+    cssUrl: string;
+    /**
+     * Callback that is called when a message is received from the DoenetML component embedded in the iframe.
+     */
+    onMessage?: (message: any) => void;
+};
+
+/**
+ * Render DoenetML constrained to an iframe. A URL pointing to a version of DoenetML
+ * standalone must be provided (along with a URL to the corresponding CSS file).
+ *
+ * Parameters being passed to the underlying DoenetML component are passed via the `doenetMLProps` prop.
+ * However, only serializable parameters may be passed. E.g., callbacks **cannot** be passed to the underlying
+ * DoenetML component. Instead you must use the message passing interface of `DoenetMLIframe` to communicate
+ * with the underlying DoenetML component.
+ */
+export function DoenetMLIframe({
+    doenetML,
+    doenetMLProps,
+    standaloneUrl,
+    cssUrl,
+    onMessage,
+}: DoenetMLIframeProps) {
+    const [id, _] = React.useState(() => Math.random().toString(36).slice(2));
+    const ref = React.useRef<HTMLIFrameElement>(null);
+    const [height, setHeight] = React.useState("0px");
+
+    React.useEffect(() => {
+        const listener = (event: MessageEvent<IframeMessage>) => {
+            if (
+                event.origin !== window.location.origin ||
+                event.data?.origin !== id
+            ) {
+                return;
+            }
+            if (onMessage) {
+                onMessage(event.data.data);
+            }
+        };
+        if (ref.current) {
+            window.addEventListener("message", listener);
+        }
+        const clearResize = watchForResize(ref, () => height, setHeight);
+
+        return () => {
+            window.removeEventListener("message", listener);
+            clearResize();
+        };
+    }, []);
+
+    return (
+        <iframe
+            ref={ref}
+            srcDoc={createHtmlForDoenetML(
+                id,
+                doenetML,
+                doenetMLProps,
+                standaloneUrl,
+                cssUrl,
+            )}
+            style={{
+                width: "100%",
+                boxSizing: "border-box",
+                overflow: "hidden",
+                border: "none",
+                minHeight: 200,
+            }}
+            height={height}
+        />
+    );
+}
+
+/**
+ * Create HTML for a single page document that renders the given DoenetML.
+ */
+function createHtmlForDoenetML(
+    id: string,
+    doenetML: string,
+    doenetMLProps: DoenetMLProps,
+    standaloneUrl: string,
+    cssUrl: string,
+) {
+    return `
+    <html>
+    <head>
+        <script type="module" src="${standaloneUrl}"></script>
+        <link rel="stylesheet" href="${cssUrl}">
+    </head>
+    <body>
+        <script type="module">
+            const id = "${id}";
+            const doenetMLProps = ${JSON.stringify(doenetMLProps)};
+            
+            // This source code has been compiled by vite and should be directly included.
+            // It assumes that id and doenetMLProps are defined in the global scope.
+            ${iframeJsSource}
+        </script>
+        <div id="root">
+            <script type="text/doenetml">
+                ${doenetML}
+            </script>
+        </div>
+    </body>
+    </html>
+    `;
+}

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -1,8 +1,3 @@
-/*
- * This file is for running a dev test of the codemirror component.
- * It does not show up in the bundled package.
- */
-
 import React from "react";
 import type { DoenetML } from "@doenet/doenetml";
 // @ts-ignore

--- a/packages/doenetml-iframe/src/resize-watcher.ts
+++ b/packages/doenetml-iframe/src/resize-watcher.ts
@@ -1,0 +1,42 @@
+import React from "react";
+
+/**
+ * Watch `ref` for any changes in size and update `setHeight` accordingly.
+ */
+export function watchForResize(
+    ref: React.RefObject<HTMLIFrameElement>,
+    getHeight: () => string,
+    setHeight: React.Dispatch<React.SetStateAction<string>>
+): () => void {
+    const iframe = ref.current?.contentWindow?.document?.body?.parentElement;
+    if (!iframe) {
+        return () => { };
+    }
+    setHeight(iframe.scrollHeight + "px");
+
+    const updateHeight = () => {
+        const iframe = ref.current?.contentWindow?.document?.body?.parentElement;
+        if (!iframe) {
+            return;
+        }
+        const newHeight = iframe.scrollHeight + "px";
+        if (newHeight !== getHeight()) {
+            setHeight(newHeight);
+        }
+    };
+
+    const observer = new MutationObserver(updateHeight);
+    observer.observe(iframe, {
+        attributes: true,
+        childList: true,
+        subtree: true,
+    });
+
+    // The mutation observer might not catch all resize changes, so we poll as well.
+    const interval = setInterval(updateHeight, 200);
+
+    return () => {
+        observer.disconnect();
+        clearInterval(interval);
+    };
+}

--- a/packages/doenetml-iframe/src/test-main.tsx
+++ b/packages/doenetml-iframe/src/test-main.tsx
@@ -1,0 +1,52 @@
+/*
+ * This file is for running a dev test.
+ * It does not show up in the bundled package.
+ */
+
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { DoenetMLIframe } from "./index";
+
+const root = ReactDOM.createRoot(document.getElementById("root")!);
+root.render(
+    <React.Fragment>
+        <h4>DoenetML 0.6:</h4>
+        <DoenetMLIframe
+            doenetML={`<p>Use this to test DoenetML</p>
+                <graph showNavigation="false">
+
+                  <line through="(-8,8) (9,6)" />
+                  <line through="(0,4)" slope="1/2" styleNumber="2" />
+
+                  <line equation="y=2x-8" styleNumber="3" />
+                  <line equation="x=-6" styleNumber="4" />
+
+                </graph>`}
+            doenetMLProps={{} as any}
+            standaloneUrl="https://cdn.jsdelivr.net/npm/@doenet/standalone@0.6.4/doenet-standalone.js"
+            cssUrl="https://cdn.jsdelivr.net/npm/@doenet/standalone@0.6.4/style.css"
+            onMessage={(message) => {
+                console.log("Got message (0.6): ", message);
+            }}
+        />
+        <h4>DoenetML 0.7:</h4>
+        <DoenetMLIframe
+            doenetML={`<p>Use this to test DoenetML</p>
+                <graph showNavigation="false">
+
+                  <line through="(-8,8) (9,6)" />
+                  <line through="(0,4)" slope="1/2" styleNumber="2" />
+
+                  <line equation="y=2x-8" styleNumber="3" />
+                  <line equation="x=-6" styleNumber="4" />
+
+                </graph>`}
+            doenetMLProps={{} as any}
+            standaloneUrl="https://cdn.jsdelivr.net/npm/@doenet/standalone@0.7.0-alpha7/doenet-standalone.js"
+            cssUrl="https://cdn.jsdelivr.net/npm/@doenet/standalone@0.7.0-alpha7/style.css"
+            onMessage={(message) => {
+                console.log("Got message (0.7): ", message);
+            }}
+        />
+    </React.Fragment>,
+);

--- a/packages/doenetml-iframe/tsconfig.json
+++ b/packages/doenetml-iframe/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist/",
+        "rootDir": "./src"
+    },
+    "include": ["./**/*.ts", "./**/*.tsx", "./**/*.js", "./**/*.jsx"],
+    "exclude": ["vite.config.ts", "vite.config-iframe.ts", "dist/**/*"],
+    "references": []
+}

--- a/packages/doenetml-iframe/vite.config-iframe.ts
+++ b/packages/doenetml-iframe/vite.config-iframe.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from "vite";
+import { viteStaticCopy } from "vite-plugin-static-copy";
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+
+// These are the dependencies that will not be bundled into the library.
+const EXTERNAL_DEPS = [];
+
+// https://vitejs.dev/config/
+export default defineConfig({
+    base: "./",
+    plugins: [],
+    build: {
+        minify: false,
+        sourcemap: false,
+        assetsInlineLimit: 0,
+        outDir: "dist/iframe",
+        lib: {
+            entry: { "iframe-index": "./src/iframe-index.ts" },
+            fileName: "iframe-index",
+            name: "doenetIframe",
+            formats: ["iife"],
+        },
+        rollupOptions: {
+            output: {
+                // Make sure everything is bundled as a single file
+                inlineDynamicImports: true,
+            },
+        },
+    },
+    define: {
+        "process.env.NODE_ENV": '"production"',
+    },
+});

--- a/packages/doenetml-iframe/vite.config.ts
+++ b/packages/doenetml-iframe/vite.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
+import { viteStaticCopy } from "vite-plugin-static-copy";
+import { createPackageJsonTransformer } from "../../scripts/transform-package-json";
 
 // These are the dependencies that will not be bundled into the library.
 const EXTERNAL_DEPS = ["react", "react-dom"];
@@ -7,7 +9,22 @@ const EXTERNAL_DEPS = ["react", "react-dom"];
 // https://vitejs.dev/config/
 export default defineConfig({
     base: "./",
-    plugins: [dts({ rollupTypes: true })],
+    plugins: [
+        dts({ rollupTypes: true }),
+        viteStaticCopy({
+            targets: [
+                {
+                    src: "package.json",
+                    dest: "./",
+                    transform: createPackageJsonTransformer({
+                        externalDeps: EXTERNAL_DEPS,
+                        targetDir: "dist/component",
+
+                    }),
+                },
+            ],
+        }),
+    ],
     build: {
         minify: false,
         outDir: "dist/component",

--- a/packages/doenetml-iframe/vite.config.ts
+++ b/packages/doenetml-iframe/vite.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from "vite";
+import dts from "vite-plugin-dts";
+
+// These are the dependencies that will not be bundled into the library.
+const EXTERNAL_DEPS = ["react", "react-dom"];
+
+// https://vitejs.dev/config/
+export default defineConfig({
+    base: "./",
+    plugins: [dts({ rollupTypes: true })],
+    build: {
+        minify: false,
+        outDir: "dist/component",
+        sourcemap: true,
+        assetsInlineLimit: 0,
+        lib: {
+            entry: "./src/index.tsx",
+            fileName: "index",
+            formats: ["es"],
+        },
+        rollupOptions: {
+            external: EXTERNAL_DEPS,
+            output: {
+                globals: Object.fromEntries(
+                    EXTERNAL_DEPS.map((dep) => [dep, dep]),
+                ),
+            },
+        },
+    },
+    define: {
+        "process.env.NODE_ENV": '"production"',
+    },
+});

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -37,7 +37,8 @@
                 "src/**/*.js",
                 "src/**/*.jsx",
                 "src/**/*.css",
-                "tsconfig.json"
+                "tsconfig.json",
+                "vite.config.ts"
             ],
             "output": [
                 "dist/**/*.js",

--- a/packages/doenetml/vite.config.ts
+++ b/packages/doenetml/vite.config.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { createRequire } from "module";
 const require = createRequire(import.meta.url);
 import dts from "vite-plugin-dts";
+import { createPackageJsonTransformer } from "../../scripts/transform-package-json";
 
 // These are the dependencies that will not be bundled into the library.
 const EXTERNAL_DEPS = ["react", "react-dom", "styled-components"];
@@ -31,7 +32,9 @@ export default defineConfig({
                 {
                     src: "package.json",
                     dest: "./",
-                    transform: transformPackageJson,
+                    transform: createPackageJsonTransformer({
+                        externalDeps: EXTERNAL_DEPS,
+                    }),
                 },
             ],
         }),

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -28,7 +28,8 @@
             "files": [
                 "src/**/*.ts",
                 "src/**/*.tsx",
-                "tsconfig.json"
+                "tsconfig.json",
+                "vite.config.ts"
             ],
             "output": [
                 "dist/**/*.js",

--- a/packages/standalone/vite.config.ts
+++ b/packages/standalone/vite.config.ts
@@ -1,10 +1,7 @@
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 import { viteStaticCopy } from "vite-plugin-static-copy";
-import * as path from "node:path";
-import { createRequire } from "module";
 import { createPackageJsonTransformer } from "../../scripts/transform-package-json";
-const require = createRequire(import.meta.url);
 
 // These are the dependencies that will not be bundled into the library.
 const EXTERNAL_DEPS = [];

--- a/packages/standalone/vite.config.ts
+++ b/packages/standalone/vite.config.ts
@@ -3,6 +3,7 @@ import dts from "vite-plugin-dts";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import * as path from "node:path";
 import { createRequire } from "module";
+import { createPackageJsonTransformer } from "../../scripts/transform-package-json";
 const require = createRequire(import.meta.url);
 
 // These are the dependencies that will not be bundled into the library.
@@ -16,16 +17,9 @@ export default defineConfig({
         viteStaticCopy({
             targets: [
                 {
-                    src: path.join(
-                        require.resolve("@doenet/doenetml"),
-                        "../fonts/*",
-                    ),
-                    dest: "fonts/",
-                },
-                {
                     src: "package.json",
                     dest: "./",
-                    transform: transformPackageJson,
+                    transform: createPackageJsonTransformer(),
                 },
             ],
         }),
@@ -50,72 +44,3 @@ export default defineConfig({
         "process.env.NODE_ENV": '"production"',
     },
 });
-
-/**
- * Trim and modify the `package.json` file so that it is suitable for publishing.
- */
-function transformPackageJson(contents: string, filePath: string) {
-    const pkg = JSON.parse(contents);
-    const allDeps = {
-        ...pkg.dependencies,
-        ...pkg.peerDependencies,
-        ...pkg.devDependencies,
-    };
-    // Delete unneeded entries
-    delete pkg.private;
-    delete pkg.scripts;
-    delete pkg.devDependencies;
-    delete pkg.peerDependencies;
-    delete pkg.dependencies;
-    delete pkg.prettier;
-    delete pkg.wireit;
-
-    pkg.private = false;
-
-    // Everything that is externalized should be a peer dependency
-    pkg.peerDependencies = {};
-    for (const dep of EXTERNAL_DEPS) {
-        if (!allDeps[dep]) {
-            console.warn(
-                dep,
-                "is listed as a dependency for vite to externalize, but a version is not specified in package.json.",
-            );
-            continue;
-        }
-        pkg.peerDependencies[dep] = allDeps[dep];
-    }
-
-    // Fix up the paths. The existing package.json refers to files in the `./dist` directory. But
-    // the new package.json will be in the ./dist directory itself, so we need to remove any `./dist`
-    // prefix from the paths.
-    const outputPackageJsonPath = path.join(
-        path.dirname(filePath),
-        "./dist/package.json",
-    );
-    if (Array.isArray(pkg.files)) {
-        pkg.files = pkg.files.map((file) =>
-            getPathRelativeToPackageJson(file, outputPackageJsonPath),
-        );
-    }
-    for (const exp of Object.values(pkg.exports ?? {}) as Record<
-        string,
-        string
-    >[]) {
-        for (const [format, path] of Object.entries(exp)) {
-            exp[format] = getPathRelativeToPackageJson(
-                path,
-                outputPackageJsonPath,
-            );
-        }
-    }
-
-    return JSON.stringify(pkg, null, 4);
-}
-
-function getPathRelativeToPackageJson(
-    relPath: string,
-    packageJsonPath: string,
-) {
-    const packageJsonDir = path.dirname(packageJsonPath);
-    return "./" + path.relative(packageJsonDir, path.join(__dirname, relPath));
-}

--- a/scripts/transform-package-json.ts
+++ b/scripts/transform-package-json.ts
@@ -1,0 +1,144 @@
+import path from "node:path";
+import fs from "node:fs";
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+
+/**
+ * Create a transformer that will modify the contents of a package.json file
+ * so that it is suitable for publishing. This function returns a `transformer`
+ * that can be used by `viteStaticCopy` to transform a `package.json` file.
+ *
+ * @param externalDeps An array of dependencies that should be externalized.
+ * @param targetDir The directory where the `package.json` file will be written. This is usually `./dist`, but it may be a different subdirectory. Any paths in the exports field of package.json are rewritten to be relative to this directory instead.
+ */
+export function createPackageJsonTransformer({
+    externalDeps = [],
+    targetDir = "./dist",
+}: {
+    /**
+     * A list of external dependencies. These dependencies will be listed as peer dependencies in the final package.json file.
+     */
+    externalDeps?: string[];
+    /**
+     * The directory where the final `package.json` file will be placed. Default is `./dist`.
+     */
+    targetDir?: string;
+} = {}) {
+    /**
+     * Trim and modify the `package.json` file so that it is suitable for publishing.
+     */
+    return function transformPackageJson(contents: string, filePath: string) {
+        const pkg = JSON.parse(contents);
+        const allDeps = {
+            ...pkg.dependencies,
+            ...pkg.peerDependencies,
+            ...pkg.devDependencies,
+        };
+        // Delete unneeded entries
+        delete pkg.private;
+        delete pkg.scripts;
+        delete pkg.devDependencies;
+        delete pkg.peerDependencies;
+        delete pkg.dependencies;
+        delete pkg.prettier;
+        delete pkg.wireit;
+
+        pkg.private = false;
+
+        const pkgRootDir = path.dirname(findPackageJsonPath(pkg.name));
+
+        // Everything that is externalized should be a peer dependency
+        pkg.peerDependencies = {};
+        for (const dep of externalDeps) {
+            if (!allDeps[dep]) {
+                console.warn(
+                    dep,
+                    "is listed as a dependency for vite to externalize, but a version is not specified in package.json.",
+                );
+                continue;
+            }
+            pkg.peerDependencies[dep] = allDeps[dep];
+        }
+
+        // Fix up the paths. The existing package.json refers to files in the `./dist` directory. But
+        // the new package.json will be in the ./dist directory itself, so we need to remove any `./dist`
+        // prefix from the paths.
+        const outputPackageJsonPath = path.join(
+            path.dirname(filePath),
+            targetDir,
+            "/package.json",
+        );
+        if (Array.isArray(pkg.files)) {
+            pkg.files = pkg.files.map((file) => {
+                let filePath = getPathRelativeToPackageJson(
+                    file,
+                    outputPackageJsonPath,
+                    pkgRootDir,
+                );
+
+                // Make sure we don't try to escape our current directory
+                // We do this by resolving our path relative to `/` and then trimming the excess slash.
+                filePath = path.resolve("/", filePath);
+                filePath = path.relative("/", filePath);
+                if (filePath === "") {
+                    filePath = "./";
+                }
+                return filePath;
+            });
+        }
+        for (const exp of Object.values(pkg.exports ?? {}) as Record<
+            string,
+            string
+        >[]) {
+            for (const [format, filePath] of Object.entries(exp)) {
+                exp[format] = getPathRelativeToPackageJson(
+                    filePath,
+                    outputPackageJsonPath,
+                    pkgRootDir,
+                );
+            }
+        }
+
+        return JSON.stringify(pkg, null, 4);
+    };
+}
+
+/**
+ * Find the location of the package.json file for a given package name.
+ * @param pkgName
+ */
+function findPackageJsonPath(pkgName: string): string {
+    const MAX_WALK = 10;
+
+    let basePath = path.dirname(import.meta.url);
+    try {
+        basePath = path.dirname(import.meta.resolve(pkgName));
+    } catch (e) {
+        basePath = require.resolve(pkgName);
+    }
+    if (basePath.startsWith("file://")) {
+        basePath = basePath.slice("file://".length);
+    }
+
+    // Walk up the directory structure looking for the first package.json file.
+    // We assume there aren't more than MAX_WALK directories we walk up.
+    for (let i = 0; i < MAX_WALK; i++) {
+        if (fs.existsSync(path.join(basePath, "package.json"))) {
+            return path.join(basePath, "package.json");
+        }
+        basePath = path.join(basePath, "..");
+    }
+    throw new Error("Could not find package.json for " + pkgName);
+}
+
+function getPathRelativeToPackageJson(
+    relPath: string,
+    packageJsonPath: string,
+    rootPackagePath: string,
+) {
+    const packageJsonDir = path.dirname(packageJsonPath);
+    return (
+        "./" +
+        path.relative(packageJsonDir, path.join(rootPackagePath, relPath))
+    );
+}


### PR DESCRIPTION
This PR creates a `DoenetMLIframe` component. When using this component, you specify a copy of `standalone` to use (e.g., from a CDN URL). Its contents are completely isolated inside of an iframe. This means, using `DoementMLIframe`, you can run multiple versions of DoenetML at the same time on the same page.

One drawback of this approach is that you cannot directly pass the React component the usual callbacks. Instead, you have to use the provided `onMessage(...)` prop to receive messages coming from the `<DoenetML ... />` component that is rendered in the iframe.