### PR TITLE
fix regression from recent math-expression changes

### DIFF
--- a/packages/doenetml-worker/src/utils/extrema.js
+++ b/packages/doenetml-worker/src/utils/extrema.js
@@ -1030,7 +1030,7 @@ export function find_minima_of_piecewise({
 
         for (let domainPiece of childDomainPieces) {
             let thisDomain;
-            if (domainPiece === "∅") {
+            if (domainPiece === "emptyset") {
                 continue;
             } else if (domainPiece === "R") {
                 thisDomain = null;


### PR DESCRIPTION
Recent improvements to `math-expressions` updated how subsets of reals are encoded. This PR fixes a regression introduced by those changes.