### PR TITLE
Move virtual keyboard outside iframe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19679,7 +19679,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.0-alpha16",
+            "version": "0.7.0-alpha17",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@chakra-ui/icons": "^2.0.19",
@@ -19724,7 +19724,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.0-alpha16",
+            "version": "0.7.0-alpha17",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -19798,7 +19798,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.0-alpha16",
+            "version": "0.7.0-alpha17",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19679,7 +19679,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.0-alpha14",
+            "version": "0.7.0-alpha15",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@chakra-ui/icons": "^2.0.19",
@@ -19724,7 +19724,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.0-alpha14",
+            "version": "0.7.0-alpha15",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -19798,7 +19798,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.0-alpha14",
+            "version": "0.7.0-alpha15",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19679,7 +19679,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.0-alpha15",
+            "version": "0.7.0-alpha16",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@chakra-ui/icons": "^2.0.19",
@@ -19724,7 +19724,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.0-alpha15",
+            "version": "0.7.0-alpha16",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -19798,7 +19798,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.0-alpha15",
+            "version": "0.7.0-alpha16",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml-iframe",
     "type": "module",
     "description": "A renderer for DoenetML contained in an iframe",
-    "version": "0.7.0-alpha14",
+    "version": "0.7.0-alpha15",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml-iframe",
     "type": "module",
     "description": "A renderer for DoenetML contained in an iframe",
-    "version": "0.7.0-alpha15",
+    "version": "0.7.0-alpha16",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml-iframe",
     "type": "module",
     "description": "A renderer for DoenetML contained in an iframe",
-    "version": "0.7.0-alpha16",
+    "version": "0.7.0-alpha17",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,
@@ -13,6 +13,9 @@
     "exports": {
         ".": {
             "import": "./dist/component/index.js"
+        },
+        "./*": {
+            "import": "./dist/component/*"
         }
     },
     "scripts": {

--- a/packages/doenetml-iframe/src/iframe-editor-index.ts
+++ b/packages/doenetml-iframe/src/iframe-editor-index.ts
@@ -21,7 +21,7 @@ document.addEventListener("DOMContentLoaded", () => {
         undefined,
         {
             ...doenetEditorProps,
-            keyboardIsOutsideIframe: true,
+            externalVirtualKeyboardProvided: true,
             // Callbacks have to be explicitly overridden here so that they
             // can message the parent React component (outside the iframe).
             doenetmlChangeCallback: (args: unknown) => {

--- a/packages/doenetml-iframe/src/iframe-editor-index.ts
+++ b/packages/doenetml-iframe/src/iframe-editor-index.ts
@@ -21,6 +21,7 @@ document.addEventListener("DOMContentLoaded", () => {
         undefined,
         {
             ...doenetEditorProps,
+            keyboardIsOutsideIframe: true,
             // Callbacks have to be explicitly overridden here so that they
             // can message the parent React component (outside the iframe).
             doenetmlChangeCallback: (args: unknown) => {

--- a/packages/doenetml-iframe/src/iframe-viewer-index.ts
+++ b/packages/doenetml-iframe/src/iframe-viewer-index.ts
@@ -21,6 +21,7 @@ document.addEventListener("DOMContentLoaded", () => {
         undefined,
         {
             ...doenetViewerProps,
+            keyboardIsOutsideIframe: true,
             // Callbacks have to be explicitly overridden here so that they
             // can message the parent React component (outside the iframe).
             updateCreditAchievedCallback: (args: unknown) => {

--- a/packages/doenetml-iframe/src/iframe-viewer-index.ts
+++ b/packages/doenetml-iframe/src/iframe-viewer-index.ts
@@ -21,7 +21,7 @@ document.addEventListener("DOMContentLoaded", () => {
         undefined,
         {
             ...doenetViewerProps,
-            keyboardIsOutsideIframe: true,
+            externalVirtualKeyboardProvided: true,
             // Callbacks have to be explicitly overridden here so that they
             // can message the parent React component (outside the iframe).
             updateCreditAchievedCallback: (args: unknown) => {

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -55,11 +55,6 @@ export type DoenetViewerIframeProps = DoenetViewerProps & {
      * overwriting any doenetmlVersion or urls provided
      */
     autodetectVersion?: boolean;
-    /**
-     * Added to remove the scrollableContainer attribute from DoenetViewerProps
-     * that will be stringified (as it has circular structure)
-     */
-    scrollableContainer?: any;
 };
 
 export type DoenetEditorIframeProps = DoenetEditorProps & {
@@ -110,7 +105,6 @@ export function DoenetViewer({
     cssUrl: specifiedCssUrl,
     doenetmlVersion: specifiedDoenetmlVersion,
     autodetectVersion = true,
-    scrollableContainer: _scrollableContainer,
     ...doenetViewerProps
 }: DoenetViewerIframeProps) {
     const [id, _] = React.useState(() => Math.random().toString(36).slice(2));

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -20,7 +20,7 @@ const latestDoenetmlVersion: string = version;
 export { mathjaxConfig } from "@doenet/utils";
 export type { ErrorDescription, WarningDescription };
 
-import { OutsideIframeKeyboard } from "@doenet/virtual-keyboard";
+import { ExternalVirtualKeyboard } from "@doenet/virtual-keyboard";
 import "@doenet/virtual-keyboard/style.css";
 
 /**
@@ -242,7 +242,7 @@ export function DoenetViewer({
 
     return (
         <React.Fragment>
-            <OutsideIframeKeyboard />
+            <ExternalVirtualKeyboard />
             <iframe
                 ref={ref}
                 srcDoc={createHtmlForDoenetViewer(
@@ -411,7 +411,7 @@ export function DoenetEditor({
 
     return (
         <React.Fragment>
-            <OutsideIframeKeyboard />
+            <ExternalVirtualKeyboard />
             <iframe
                 ref={ref}
                 srcDoc={createHtmlForDoenetEditor(

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -20,6 +20,9 @@ const latestDoenetmlVersion: string = version;
 export { mathjaxConfig } from "@doenet/utils";
 export type { ErrorDescription, WarningDescription };
 
+import { OutsideIframeKeyboard } from "@doenet/virtual-keyboard";
+import "@doenet/virtual-keyboard/style.css";
+
 /**
  * A message that is sent from an iframe to the parent window.
  */
@@ -244,24 +247,27 @@ export function DoenetViewer({
     }
 
     return (
-        <iframe
-            ref={ref}
-            srcDoc={createHtmlForDoenetViewer(
-                id,
-                doenetML,
-                doenetViewerProps,
-                standaloneUrl,
-                cssUrl,
-            )}
-            style={{
-                width: "100%",
-                boxSizing: "border-box",
-                overflow: "hidden",
-                border: "none",
-                minHeight: 200,
-            }}
-            height={height}
-        />
+        <React.Fragment>
+            <OutsideIframeKeyboard />
+            <iframe
+                ref={ref}
+                srcDoc={createHtmlForDoenetViewer(
+                    id,
+                    doenetML,
+                    doenetViewerProps,
+                    standaloneUrl,
+                    cssUrl,
+                )}
+                style={{
+                    width: "100%",
+                    boxSizing: "border-box",
+                    overflow: "hidden",
+                    border: "none",
+                    minHeight: 200,
+                }}
+                height={height}
+            />
+        </React.Fragment>
     );
 }
 
@@ -410,23 +416,26 @@ export function DoenetEditor({
     }
 
     return (
-        <iframe
-            ref={ref}
-            srcDoc={createHtmlForDoenetEditor(
-                id,
-                doenetML,
-                width,
-                augmentedDoenetEditorProps,
-                standaloneUrl,
-                cssUrl,
-            )}
-            style={{
-                width,
-                boxSizing: "content-box",
-                overflow: "hidden",
-                border: "none",
-                height,
-            }}
-        />
+        <React.Fragment>
+            <OutsideIframeKeyboard />
+            <iframe
+                ref={ref}
+                srcDoc={createHtmlForDoenetEditor(
+                    id,
+                    doenetML,
+                    width,
+                    augmentedDoenetEditorProps,
+                    standaloneUrl,
+                    cssUrl,
+                )}
+                style={{
+                    width,
+                    boxSizing: "content-box",
+                    overflow: "hidden",
+                    border: "none",
+                    height,
+                }}
+            />
+        </React.Fragment>
     );
 }

--- a/packages/doenetml-iframe/src/test-main.tsx
+++ b/packages/doenetml-iframe/src/test-main.tsx
@@ -31,57 +31,32 @@ function App() {
 
     return (
         <React.Fragment>
-            <h4>DoenetML {DOENET_LEGACY_VERSION}:</h4>
-
-            <DoenetViewer
-                doenetML={`<p>Use this to test DoenetML</p>
-                <graph showNavigation="false">
-
-                  <line through="(-8,8) (9,6)" />
-                  <line through="(0,4)" slope="1/2" styleNumber="2" />
-
-                  <line equation="y=2x-8" styleNumber="3" />
-                  <line equation="x=-6" styleNumber="4" />
-
-                </graph>`}
-                doenetmlVersion={DOENET_LEGACY_VERSION}
-            />
             <h4>DoenetML {STANDALONE_VERSION} (locally-built copy):</h4>
             <DoenetViewer
-                doenetML={`<p>Use this to test DoenetML</p>
-                <graph showNavigation="false">
-
-                  <line through="(-8,8) (9,6)" />
-                  <line through="(0,4)" slope="1/2" styleNumber="2" />
-
-                  <line equation="y=2x-8" styleNumber="3" />
-                  <line equation="x=-6" styleNumber="4" />
-
-                </graph>`}
+                doenetML={`<mathInput /><p><mathInput />Use this to test DoenetML<mathInput /></p>
+                <graph />
+                <graph />
+                <graph />
+               <mathInput />`}
                 generatedVariantCallback={(variant: any) =>
                     console.log("found variant", variant)
                 }
-                flags={{ readOnly: true }}
                 standaloneUrl={STANDALONE_BLOB_URL}
                 cssUrl={STANDALONE_CSS_BLOB_URL}
             />
-            <h4>DoenetML {STANDALONE_VERSION} (locally-built copy) editor:</h4>
-            <DoenetEditor
-                doenetML={`<p>Use this to test DoenetML</p>
-                <graph showNavigation="false">
 
-                  <line through="(-8,8) (9,6)" />
-                  <line through="(0,4)" slope="1/2" styleNumber="2" />
-
-                  <line equation="y=2x-8" styleNumber="3" />
-                  <line equation="x=-6" styleNumber="4" />
-
-                </graph>`}
+            <h4>DoenetML {STANDALONE_VERSION} (locally-built copy):</h4>
+            <DoenetViewer
+                doenetML={`<mathInput /><p><mathInput />Use this to test DoenetML<mathInput /></p>
+                <graph />
+                <graph />
+                <graph />
+               <mathInput />`}
+                generatedVariantCallback={(variant: any) =>
+                    console.log("found variant", variant)
+                }
                 standaloneUrl={STANDALONE_BLOB_URL}
                 cssUrl={STANDALONE_CSS_BLOB_URL}
-                doenetmlChangeCallback={(doenetml: any) =>
-                    console.log("new doenetml", doenetml)
-                }
             />
         </React.Fragment>
     );

--- a/packages/doenetml-iframe/src/utils.ts
+++ b/packages/doenetml-iframe/src/utils.ts
@@ -10,11 +10,11 @@ import { parseAndCompile } from "@doenet/parser";
 
 export type DoenetViewerProps = Omit<
     React.ComponentProps<typeof DoenetViewerOrig>,
-    "doenetML" | "scrollableContainer" | "keyboardIsOutsideIframe"
+    "doenetML" | "scrollableContainer" | "externalVirtualKeyboardProvided"
 >;
 export type DoenetEditorProps = Omit<
     React.ComponentProps<typeof DoenetEditorOrig>,
-    "doenetML" | "width" | "height" | "keyboardIsOutsideIframe"
+    "doenetML" | "width" | "height" | "externalVirtualKeyboardProvided"
 >;
 
 /**

--- a/packages/doenetml-iframe/src/utils.ts
+++ b/packages/doenetml-iframe/src/utils.ts
@@ -10,11 +10,11 @@ import { parseAndCompile } from "@doenet/parser";
 
 export type DoenetViewerProps = Omit<
     React.ComponentProps<typeof DoenetViewerOrig>,
-    "doenetML" | "scrollableContainer"
+    "doenetML" | "scrollableContainer" | "keyboardIsOutsideIframe"
 >;
 export type DoenetEditorProps = Omit<
     React.ComponentProps<typeof DoenetEditorOrig>,
-    "doenetML" | "width" | "height"
+    "doenetML" | "width" | "height" | "keyboardIsOutsideIframe"
 >;
 
 /**

--- a/packages/doenetml-iframe/vite.config.ts
+++ b/packages/doenetml-iframe/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import { createPackageJsonTransformer } from "../../scripts/transform-package-json";
+import { version } from "./package.json";
 
 // These are the dependencies that will not be bundled into the library.
 const EXTERNAL_DEPS = ["react", "react-dom"];
@@ -46,6 +47,6 @@ export default defineConfig({
     },
     define: {
         "process.env.NODE_ENV": '"production"',
-        IFRAME_VERSION: JSON.stringify(process.env.npm_package_version),
+        IFRAME_VERSION: JSON.stringify(version),
     },
 });

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.7.0-alpha15",
+    "version": "0.7.0-alpha16",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.7.0-alpha14",
+    "version": "0.7.0-alpha15",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.7.0-alpha16",
+    "version": "0.7.0-alpha17",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/src/Viewer/ActivityViewer.tsx
+++ b/packages/doenetml/src/Viewer/ActivityViewer.tsx
@@ -749,7 +749,7 @@ export function ActivityViewer({
         // we need to check if the page has a doneetML attribute,
         // and load the doenetML if needed
 
-        let newOrder = [];
+        let newOrder: any[] = [];
 
         for (let page of order) {
             if (page.doenetML === undefined) {
@@ -1177,7 +1177,7 @@ export function ActivityViewer({
     async function submitAllAndFinishAssessment() {
         setProcessingSubmitAll(true);
 
-        let submitAndSavePromises = [];
+        let submitAndSavePromises: Promise<unknown>[] = [];
 
         for (let [
             pageInd,
@@ -1260,7 +1260,7 @@ export function ActivityViewer({
     }
 
     async function terminateAllCores() {
-        let terminatePromises = [];
+        let terminatePromises: Promise<unknown>[] = [];
 
         for (let [
             pageInd,
@@ -1322,7 +1322,7 @@ export function ActivityViewer({
     function collateErrorsAndWarnings() {
         let allErrors = [...errorsActivitySpecific.current];
 
-        let allWarnings = [];
+        let allWarnings: WarningDescription[] = [];
 
         for (let errWarn of errorsAndWarningsByPage.current) {
             if (errWarn) {
@@ -1497,7 +1497,7 @@ export function ActivityViewer({
 
     let title = <h1>{activityDefinition.title}</h1>;
 
-    let pages = [];
+    let pages: React.JSX.Element[] = [];
 
     if (order && variantsByPage) {
         for (let [ind, page] of order.entries()) {
@@ -1603,8 +1603,8 @@ export function ActivityViewer({
         }
     }
 
-    let pageControlsTop = null;
-    let pageControlsBottom = null;
+    let pageControlsTop: React.JSX.Element | null = null;
+    let pageControlsBottom: React.JSX.Element | null = null;
     if (paginate && nPages > 1) {
         pageControlsTop = (
             <div
@@ -1661,7 +1661,7 @@ export function ActivityViewer({
         }
     }
 
-    let finishAssessmentPrompt = null;
+    let finishAssessmentPrompt: React.JSX.Element | null = null;
 
     if (showFinishButton) {
         if (finishAssessmentMessageOpen) {
@@ -1749,19 +1749,19 @@ export function ActivityViewer({
         paddingStyle.paddingBottom = "50vh";
     }
 
-    let activityErrors = null;
+    let activityErrors: React.JSX.Element[] | null = null;
     if (errorsActivitySpecific.current.length > 0) {
         const errorsToDisplay = errorsActivitySpecific.current.filter(
             (x) => x.displayInActivity,
         );
         let errorStyle = {
             backgroundColor: "#ff9999",
-            textAlign: "center",
+            textAlign: "center" as const,
             borderWidth: 3,
             borderStyle: "solid",
         };
         activityErrors = errorsToDisplay.map((err, i) => {
-            let rangeMessage = null;
+            let rangeMessage: React.JSX.Element | null = null;
             if (err.doenetMLrange?.lineBegin !== undefined) {
                 rangeMessage = (
                     <>

--- a/packages/doenetml/src/Viewer/renderers/graph.jsx
+++ b/packages/doenetml/src/Viewer/renderers/graph.jsx
@@ -3,6 +3,7 @@ import { sizeToCSS } from "./utils/css";
 import useDoenetRenderer from "../useDoenetRenderer";
 import me from "math-expressions";
 import VisibilitySensor from "react-visibility-sensor-v2";
+//@ts-ignore
 import JXG from "./jsxgraph-distrib/jsxgraphcore.mjs";
 // import JXG from './jsxgraph';
 import { cesc } from "@doenet/utils";

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -118,7 +118,7 @@ export function DoenetViewer({
     forceShowSolution = false,
     forceUnsuppressCheckwork = false,
     addVirtualKeyboard = true,
-    keyboardIsOutsideIframe = false,
+    externalVirtualKeyboardProvided = false,
     addBottomPadding = false,
     location,
     navigate,
@@ -155,7 +155,7 @@ export function DoenetViewer({
     forceShowSolution?: boolean;
     forceUnsuppressCheckwork?: boolean;
     addVirtualKeyboard?: boolean;
-    keyboardIsOutsideIframe?: boolean;
+    externalVirtualKeyboardProvided?: boolean;
     addBottomPadding?: boolean;
     location?: any;
     navigate?: any;
@@ -252,7 +252,9 @@ export function DoenetViewer({
     }
 
     const keyboard = addVirtualKeyboard ? (
-        <VirtualKeyboard keyboardIsOutsideIframe={keyboardIsOutsideIframe} />
+        <VirtualKeyboard
+            externalVirtualKeyboardProvided={externalVirtualKeyboardProvided}
+        />
     ) : null;
 
     const viewer = (
@@ -316,7 +318,7 @@ export function DoenetEditor({
     activityId,
     paginate = false,
     addVirtualKeyboard = true,
-    keyboardIsOutsideIframe = false,
+    externalVirtualKeyboardProvided = false,
     addBottomPadding = false,
     location,
     navigate,
@@ -343,7 +345,7 @@ export function DoenetEditor({
     activityId?: string;
     paginate?: boolean;
     addVirtualKeyboard?: boolean;
-    keyboardIsOutsideIframe?: boolean;
+    externalVirtualKeyboardProvided?: boolean;
     addBottomPadding?: boolean;
     location?: any;
     navigate?: any;
@@ -367,7 +369,9 @@ export function DoenetEditor({
     initialWarnings?: WarningDescription[];
 }) {
     const keyboard = addVirtualKeyboard ? (
-        <VirtualKeyboard keyboardIsOutsideIframe={keyboardIsOutsideIframe} />
+        <VirtualKeyboard
+            externalVirtualKeyboardProvided={externalVirtualKeyboardProvided}
+        />
     ) : null;
 
     const editor = (

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -9,7 +9,6 @@ import { mathjaxConfig } from "@doenet/utils";
 import type { ErrorDescription, WarningDescription } from "@doenet/utils";
 import { VirtualKeyboard } from "@doenet/virtual-keyboard";
 import { Box, ChakraProvider, extendTheme } from "@chakra-ui/react";
-import "@doenet/virtual-keyboard/style.css";
 import { EditorViewer } from "./EditorViewer/EditorViewer.js";
 import VariantSelect from "./EditorViewer/VariantSelect";
 

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -9,6 +9,7 @@ import { mathjaxConfig } from "@doenet/utils";
 import type { ErrorDescription, WarningDescription } from "@doenet/utils";
 import { VirtualKeyboard } from "@doenet/virtual-keyboard";
 import { Box, ChakraProvider, extendTheme } from "@chakra-ui/react";
+import "@doenet/virtual-keyboard/style.css";
 import { EditorViewer } from "./EditorViewer/EditorViewer.js";
 import VariantSelect from "./EditorViewer/VariantSelect";
 
@@ -117,6 +118,7 @@ export function DoenetViewer({
     forceShowSolution = false,
     forceUnsuppressCheckwork = false,
     addVirtualKeyboard = true,
+    keyboardIsOutsideIframe = false,
     addBottomPadding = false,
     location,
     navigate,
@@ -153,6 +155,7 @@ export function DoenetViewer({
     forceShowSolution?: boolean;
     forceUnsuppressCheckwork?: boolean;
     addVirtualKeyboard?: boolean;
+    keyboardIsOutsideIframe?: boolean;
     addBottomPadding?: boolean;
     location?: any;
     navigate?: any;
@@ -248,7 +251,9 @@ export function DoenetViewer({
         }
     }
 
-    const keyboard = addVirtualKeyboard ? <VirtualKeyboard /> : null;
+    const keyboard = addVirtualKeyboard ? (
+        <VirtualKeyboard keyboardIsOutsideIframe={keyboardIsOutsideIframe} />
+    ) : null;
 
     const viewer = (
         <ActivityViewer
@@ -311,6 +316,7 @@ export function DoenetEditor({
     activityId,
     paginate = false,
     addVirtualKeyboard = true,
+    keyboardIsOutsideIframe = false,
     addBottomPadding = false,
     location,
     navigate,
@@ -337,6 +343,7 @@ export function DoenetEditor({
     activityId?: string;
     paginate?: boolean;
     addVirtualKeyboard?: boolean;
+    keyboardIsOutsideIframe?: boolean;
     addBottomPadding?: boolean;
     location?: any;
     navigate?: any;
@@ -359,7 +366,9 @@ export function DoenetEditor({
     initialErrors?: ErrorDescription[];
     initialWarnings?: WarningDescription[];
 }) {
-    const keyboard = addVirtualKeyboard ? <VirtualKeyboard /> : null;
+    const keyboard = addVirtualKeyboard ? (
+        <VirtualKeyboard keyboardIsOutsideIframe={keyboardIsOutsideIframe} />
+    ) : null;
 
     const editor = (
         <EditorViewer

--- a/packages/doenetml/tsconfig.json
+++ b/packages/doenetml/tsconfig.json
@@ -5,6 +5,12 @@
         "rootDir": "./src"
     },
     "include": ["./**/*.ts", "./**/*.tsx", "./**/*.js", "./**/*.jsx"],
-    "exclude": ["vite.config.ts"],
+    "exclude": [
+        "vite.config.ts",
+        "node_modules",
+        "runner-results",
+        ".wireit",
+        "**/dist/**/*"
+    ],
     "references": []
 }

--- a/packages/doenetml/vite.config.ts
+++ b/packages/doenetml/vite.config.ts
@@ -6,6 +6,7 @@ import { createRequire } from "module";
 const require = createRequire(import.meta.url);
 import dts from "vite-plugin-dts";
 import { createPackageJsonTransformer } from "../../scripts/transform-package-json";
+import { version } from "./package.json";
 
 // These are the dependencies that will not be bundled into the library.
 const EXTERNAL_DEPS = ["react", "react-dom", "styled-components"];
@@ -40,7 +41,7 @@ export default defineConfig({
         }),
     ],
     define: {
-        DOENETML_VERSION: JSON.stringify(process.env.npm_package_version),
+        DOENETML_VERSION: JSON.stringify(version),
     },
     server: {
         port: 8012,

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.7.0-alpha16",
+    "version": "0.7.0-alpha17",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.7.0-alpha15",
+    "version": "0.7.0-alpha16",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.7.0-alpha14",
+    "version": "0.7.0-alpha15",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/standalone/tsconfig.json
+++ b/packages/standalone/tsconfig.json
@@ -5,6 +5,12 @@
         "rootDir": "./src"
     },
     "include": ["./**/*.ts", "./**/*.tsx", "./**/*.js", "./**/*.jsx"],
-    "exclude": ["vite.config.ts"],
+    "exclude": [
+        "vite.config.ts",
+        "node_modules",
+        "runner-results",
+        ".wireit",
+        "**/dist/**/*"
+    ],
     "references": []
 }

--- a/packages/standalone/vite.config.ts
+++ b/packages/standalone/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import { createPackageJsonTransformer } from "../../scripts/transform-package-json";
+import { version } from "./package.json";
 
 // These are the dependencies that will not be bundled into the library.
 const EXTERNAL_DEPS = [];
@@ -39,6 +40,6 @@ export default defineConfig({
     },
     define: {
         "process.env.NODE_ENV": '"production"',
-        STANDALONE_VERSION: JSON.stringify(process.env.npm_package_version),
+        STANDALONE_VERSION: JSON.stringify(version),
     },
 });

--- a/packages/test-cypress/tsconfig.json
+++ b/packages/test-cypress/tsconfig.json
@@ -5,6 +5,12 @@
         "rootDir": "./src"
     },
     "include": ["./**/*.ts", "./**/*.tsx", "./**/*.js", "./**/*.jsx"],
-    "exclude": ["vite.config.ts"],
+    "exclude": [
+        "vite.config.ts",
+        "node_modules",
+        "runner-results",
+        ".wireit",
+        "**/dist/**/*"
+    ],
     "references": []
 }

--- a/packages/test-viewer/tsconfig.json
+++ b/packages/test-viewer/tsconfig.json
@@ -5,6 +5,12 @@
         "rootDir": "./src"
     },
     "include": ["./**/*.ts", "./**/*.tsx", "./**/*.js", "./**/*.jsx"],
-    "exclude": ["vite.config.ts"],
+    "exclude": [
+        "vite.config.ts",
+        "node_modules",
+        "runner-results",
+        ".wireit",
+        "**/dist/**/*"
+    ],
     "references": []
 }

--- a/packages/virtual-keyboard/src/virtual-keyboard/external-virtual-keyboard.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/external-virtual-keyboard.tsx
@@ -14,7 +14,7 @@ export type IframeMessage = {
 /**
  * Virtual keyboard that is connected via Recoil to math elements.
  */
-export function OutsideIframeKeyboard() {
+export function ExternalVirtualKeyboard() {
     return (
         <UniqueKeyboardTray
             onClick={(events) => {

--- a/packages/virtual-keyboard/src/virtual-keyboard/index.ts
+++ b/packages/virtual-keyboard/src/virtual-keyboard/index.ts
@@ -2,4 +2,6 @@ export * from "./keyboard";
 export * from "./managed-keyboard";
 export * from "./unique-keyboard-tray";
 export * from "./recoil-virtual-keyboard";
+export * from "./outside-iframe-keyboard";
+
 export { RecoilVirtualKeyboard as VirtualKeyboard } from "./recoil-virtual-keyboard";

--- a/packages/virtual-keyboard/src/virtual-keyboard/index.ts
+++ b/packages/virtual-keyboard/src/virtual-keyboard/index.ts
@@ -2,6 +2,6 @@ export * from "./keyboard";
 export * from "./managed-keyboard";
 export * from "./unique-keyboard-tray";
 export * from "./recoil-virtual-keyboard";
-export * from "./outside-iframe-keyboard";
+export * from "./external-virtual-keyboard";
 
 export { RecoilVirtualKeyboard as VirtualKeyboard } from "./recoil-virtual-keyboard";

--- a/packages/virtual-keyboard/src/virtual-keyboard/keys.ts
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keys.ts
@@ -23,7 +23,7 @@ export const TEX_NAMES_LOWER = [
     "upsilon",
     "theta",
     "iota",
-    "omicron",
+    null,
     "pi",
     "alpha",
     "sigma",
@@ -92,7 +92,12 @@ export const KEYS = {
     greek_lower: [..."ϕ𝜍ερτυθιοπασδφγηξκλζχψωβνμ,'"].map((c, i) => ({
         displayName: c,
         name: c,
-        commands: [{ type: "write", command: `\\${TEX_NAMES_LOWER[i]}` }],
+        commands: [
+            {
+                type: "write",
+                command: TEX_NAMES_LOWER[i] ? `\\${TEX_NAMES_LOWER[i]}` : c,
+            },
+        ],
     })),
     // upper-case greek letters in QWERTY order
     greek_upper: [..."ΦΣΕΡΤΥΘΙΟΠΑΣΔΦΓΗΞΚΛΖΧΨΩΒΝΜ,'"].map((c, i) => ({
@@ -147,7 +152,7 @@ export const OPERATOR_KEYS = {
     times: {
         displayName: "×",
         name: "times",
-        commands: [{ type: "type", command: "\\times" }],
+        commands: [{ type: "write", command: "\\times" }],
     },
     divide: {
         displayName: "÷",
@@ -353,12 +358,12 @@ export const OTHER_SYMBOLS = {
     langle: {
         displayName: "⟨",
         name: "langle",
-        commands: [{ type: "write", command: "\\langle" }],
+        commands: [{ type: "cmd", command: "\\langle" }],
     },
     rangle: {
         displayName: "⟩",
         name: "rangle",
-        commands: [{ type: "write", command: "\\rangle" }],
+        commands: [{ type: "cmd", command: "\\rangle" }],
     },
     cdot: {
         displayName: "⋅",
@@ -373,7 +378,7 @@ export const OTHER_SYMBOLS = {
     conj: {
         displayName: "a\u0304",
         name: "conj",
-        commands: [{ type: "write", command: "overline{a}" }],
+        commands: [{ type: "cmd", command: "\\overline" }],
     },
     perp: {
         displayName: "⊥",
@@ -539,12 +544,12 @@ export const FUNCTION_KEYS = {
     nPr: {
         displayName: "nPr",
         name: "nPr",
-        commands: [{ type: "write", command: "nPr(" }],
+        commands: [{ type: "type", command: "nPr(" }],
     },
     nCr: {
         displayName: "nCr",
         name: "nCr",
-        commands: [{ type: "write", command: "nCr(" }],
+        commands: [{ type: "type", command: "nCr(" }],
     },
     factorial: {
         displayName: "n!",

--- a/packages/virtual-keyboard/src/virtual-keyboard/outside-iframe-keyboard.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/outside-iframe-keyboard.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+import { UniqueKeyboardTray } from "./unique-keyboard-tray";
+import { KeyCommand } from "./keys";
+
+/**
+ * A message that is sent from the parent window to the iframe
+ */
+export type IframeMessage = {
+    keyCommands: KeyCommand[];
+    subject: "keyboard";
+};
+
+/**
+ * Virtual keyboard that is connected via Recoil to math elements.
+ */
+export function OutsideIframeKeyboard() {
+    return (
+        <UniqueKeyboardTray
+            onClick={(events) => {
+                window.postMessage({
+                    keyCommands: events,
+                    subject: "keyboard",
+                } satisfies IframeMessage);
+            }}
+        />
+    );
+}

--- a/packages/virtual-keyboard/src/virtual-keyboard/recoil-virtual-keyboard.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/recoil-virtual-keyboard.tsx
@@ -4,11 +4,16 @@ import { useRecoilValue } from "recoil";
 import { focusedMathField, focusedMathFieldReturn } from "../MathInputSelector";
 import { translateKeyboardEvent } from "./translate-events";
 import { IframeMessage } from "./outside-iframe-keyboard";
+import { UniqueKeyboardTray } from "./unique-keyboard-tray";
 
 /**
  * Virtual keyboard that is connected via Recoil to math elements.
  */
-export function RecoilVirtualKeyboard() {
+export function RecoilVirtualKeyboard({
+    keyboardIsOutsideIframe = false,
+}: {
+    keyboardIsOutsideIframe: boolean;
+}) {
     const callback = useRecoilValue(focusedMathField);
     const returnCallback = useRecoilValue(focusedMathFieldReturn);
     const [recoilEvents, setRecoilEvents] = React.useState<
@@ -36,23 +41,38 @@ export function RecoilVirtualKeyboard() {
     }, [recoilEvents]);
 
     React.useEffect(() => {
-        const listener = (event: MessageEvent<IframeMessage | undefined>) => {
-            if (
-                event.origin !== window.parent.location.origin ||
-                event.data?.subject !== "keyboard"
-            ) {
-                return;
-            }
+        if (keyboardIsOutsideIframe) {
+            // If the keyboard is outside the iframe,
+            // then the keyboard events will be sent via messages on the parent.
+            const listener = (
+                event: MessageEvent<IframeMessage | undefined>,
+            ) => {
+                if (
+                    event.origin !== window.parent.location.origin ||
+                    event.data?.subject !== "keyboard"
+                ) {
+                    return;
+                }
 
-            setRecoilEvents(translateKeyboardEvent(event.data.keyCommands));
-        };
+                setRecoilEvents(translateKeyboardEvent(event.data.keyCommands));
+            };
 
-        window.parent.addEventListener("message", listener);
+            window.parent.addEventListener("message", listener);
 
-        return () => {
-            window.parent.removeEventListener("message", listener);
-        };
+            return () => {
+                window.parent.removeEventListener("message", listener);
+            };
+        }
     }, []);
 
-    return null;
+    // If the keyboard is not outside the iframe,
+    // then we add a reference to the keyboard here
+    // that will return the events via a callback.
+    return keyboardIsOutsideIframe ? null : (
+        <UniqueKeyboardTray
+            onClick={(events) => {
+                setRecoilEvents(translateKeyboardEvent(events));
+            }}
+        />
+    );
 }

--- a/packages/virtual-keyboard/src/virtual-keyboard/recoil-virtual-keyboard.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/recoil-virtual-keyboard.tsx
@@ -3,16 +3,16 @@ import { useRecoilValue } from "recoil";
 
 import { focusedMathField, focusedMathFieldReturn } from "../MathInputSelector";
 import { translateKeyboardEvent } from "./translate-events";
-import { IframeMessage } from "./outside-iframe-keyboard";
+import { IframeMessage } from "./external-virtual-keyboard";
 import { UniqueKeyboardTray } from "./unique-keyboard-tray";
 
 /**
  * Virtual keyboard that is connected via Recoil to math elements.
  */
 export function RecoilVirtualKeyboard({
-    keyboardIsOutsideIframe = false,
+    externalVirtualKeyboardProvided = false,
 }: {
-    keyboardIsOutsideIframe: boolean;
+    externalVirtualKeyboardProvided: boolean;
 }) {
     const callback = useRecoilValue(focusedMathField);
     const returnCallback = useRecoilValue(focusedMathFieldReturn);
@@ -41,9 +41,9 @@ export function RecoilVirtualKeyboard({
     }, [recoilEvents]);
 
     React.useEffect(() => {
-        if (keyboardIsOutsideIframe) {
-            // If the keyboard is outside the iframe,
-            // then the keyboard events will be sent via messages on the parent.
+        if (externalVirtualKeyboardProvided) {
+            // If an external keyboard is provided,
+            // then we expect that the keyboard events will be sent via messages on the parent.
             const listener = (
                 event: MessageEvent<IframeMessage | undefined>,
             ) => {
@@ -65,10 +65,10 @@ export function RecoilVirtualKeyboard({
         }
     }, []);
 
-    // If the keyboard is not outside the iframe,
+    // If an external keyboard is not provided,
     // then we add a reference to the keyboard here
     // that will return the events via a callback.
-    return keyboardIsOutsideIframe ? null : (
+    return externalVirtualKeyboardProvided ? null : (
         <UniqueKeyboardTray
             onClick={(events) => {
                 setRecoilEvents(translateKeyboardEvent(events));

--- a/packages/virtual-keyboard/src/virtual-keyboard/unique-keyboard-tray.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/unique-keyboard-tray.tsx
@@ -3,13 +3,24 @@ import { createRoot, Root } from "react-dom/client";
 import { OnClick } from "./keyboard";
 import { KeyboardTray } from "./keyboard-tray";
 
-const virtualKeyboardState = {
-    count: 0,
-    keyboardDomNode: null as HTMLElement | null,
-    keyboardReactRoot: null as Root | null,
-    callbacks: [] as OnClick[],
+let virtualKeyboardState: {
+    count: number;
+    keyboardDomNode: HTMLElement | null;
+    keyboardReactRoot: Root | null;
+    callbacks: OnClick[];
 };
-(window as any).virtualKeyboardState = virtualKeyboardState;
+
+if ((window as any).virtualKeyboardState) {
+    virtualKeyboardState = (window as any).virtualKeyboardState;
+} else {
+    virtualKeyboardState = {
+        count: 0,
+        keyboardDomNode: null as HTMLElement | null,
+        keyboardReactRoot: null as Root | null,
+        callbacks: [] as OnClick[],
+    };
+    (window as any).virtualKeyboardState = virtualKeyboardState;
+}
 
 /**
  * An expandable keyboard tray that is unique among the document. If multiple instances of `UniqueKeyboardTray` are used,

--- a/packages/virtual-keyboard/src/virtual-keyboard/unique-keyboard-tray.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/unique-keyboard-tray.tsx
@@ -3,24 +3,21 @@ import { createRoot, Root } from "react-dom/client";
 import { OnClick } from "./keyboard";
 import { KeyboardTray } from "./keyboard-tray";
 
-let virtualKeyboardState: {
+type VirtualKeyboardState = {
     count: number;
     keyboardDomNode: HTMLElement | null;
     keyboardReactRoot: Root | null;
     callbacks: OnClick[];
 };
 
-if ((window as any).virtualKeyboardState) {
-    virtualKeyboardState = (window as any).virtualKeyboardState;
-} else {
-    virtualKeyboardState = {
-        count: 0,
-        keyboardDomNode: null as HTMLElement | null,
-        keyboardReactRoot: null as Root | null,
-        callbacks: [] as OnClick[],
-    };
-    (window as any).virtualKeyboardState = virtualKeyboardState;
-}
+const virtualKeyboardState: VirtualKeyboardState = (window as any)
+    .virtualKeyboardState || {
+    count: 0,
+    keyboardDomNode: null,
+    keyboardReactRoot: null,
+    callbacks: [],
+};
+(window as any).virtualKeyboardState = virtualKeyboardState;
 
 /**
  * An expandable keyboard tray that is unique among the document. If multiple instances of `UniqueKeyboardTray` are used,

--- a/packages/virtual-keyboard/vite.config.ts
+++ b/packages/virtual-keyboard/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
             external: [
                 "react",
                 "react-dom",
+                "react-dom/client",
                 "styled-components",
                 "recoil",
                 "@chakra-ui/react",


### PR DESCRIPTION
This PR moves the virtual keyboard outside the iframe if DoenetViewer or DoenetEditor are access via `doenetml-iframe`. This allows the keyboard to placed at the bottom of the browser window regardless of the size of the iframe.