### PR TITLE
create a graph component

### DIFF
--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/components/component_enum.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/components/component_enum.rs
@@ -8,6 +8,7 @@ pub use super::doenet::_fragment::_Fragment;
 pub use super::doenet::boolean::Boolean;
 pub use super::doenet::division::Division;
 pub use super::doenet::document::Document;
+pub use super::doenet::graph::Graph;
 pub use super::doenet::li::Li;
 pub use super::doenet::math::Math;
 pub use super::doenet::ol::Ol;
@@ -46,6 +47,7 @@ pub enum ComponentEnum {
     Ol(Ol),
     Ul(Ul),
     Li(Li),
+    Graph(Graph),
     _Error(_Error),
     _External(_External),
     _Fragment(_Fragment),

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/components/doenet/graph.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/components/doenet/graph.rs
@@ -1,0 +1,42 @@
+use crate::components::prelude::*;
+use crate::general_prop::RenderedChildrenPassthroughProp;
+use crate::props::UpdaterObject;
+
+#[component(name = Graph)]
+mod component {
+
+    use crate::general_prop::BooleanProp;
+
+    enum Props {
+        /// Whether the `<graph>` should be hidden.
+        #[prop(value_type = PropValueType::Boolean, profile = PropProfile::Hidden)]
+        Hidden,
+        #[prop(value_type = PropValueType::AnnotatedContentRefs, profile = PropProfile::RenderedChildren)]
+        RenderedChildren,
+    }
+
+    enum Attributes {
+        /// Whether the `<graph>` should be hidden.
+        #[attribute(prop = BooleanProp, default = false)]
+        Hide,
+    }
+}
+
+pub use component::Graph;
+pub use component::GraphActions;
+pub use component::GraphAttributes;
+pub use component::GraphProps;
+
+impl PropGetUpdater for GraphProps {
+    fn get_updater(&self) -> UpdaterObject {
+        match self {
+            GraphProps::Hidden => as_updater_object::<_, component::props::types::Hidden>(
+                component::attrs::Hide::get_prop_updater(),
+            ),
+            GraphProps::RenderedChildren => as_updater_object::<
+                _,
+                component::props::types::RenderedChildren,
+            >(RenderedChildrenPassthroughProp::new()),
+        }
+    }
+}

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/components/doenet/mod.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/components/doenet/mod.rs
@@ -4,6 +4,7 @@ pub mod _fragment;
 pub mod boolean;
 pub mod division;
 pub mod document;
+pub mod graph;
 pub mod li;
 pub mod math;
 pub mod ol;


### PR DESCRIPTION
This PR adds a `<graph>` component to the 0.9 rust worker.