### PR TITLE
Math expression refinements and tests

### DIFF
--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/core/core.test.browser.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/core/core.test.browser.rs
@@ -30,6 +30,12 @@ macro_rules! embed_test {
 /// Run a test matching `test_name`. As well, return a list of all tests that can be run.
 #[cfg(debug_assertions)]
 pub fn run_test(test_name: &str) -> Vec<String> {
+    use std::collections::HashMap;
+
+    use crate::state::types::math_expr::{
+        MathArg, MathExpr, MathSimplify, NormalizeParams, ToTextParams,
+    };
+
     let mut all_tests = Vec::new();
 
     embed_test!(all_tests, test_name, fn test_always_passes() {});
@@ -43,6 +49,267 @@ pub fn run_test(test_name: &str) -> Vec<String> {
                 math_to_latex(&expr, ToLatexParams::default()).unwrap(),
                 "x + y"
             );
+        }
+    );
+
+    embed_test!(
+        all_tests,
+        test_name,
+        fn substitute_into_math_expr() {
+            let expr1 = MathExpr::from_text("x+y", true, &["f"]);
+
+            let substitutions =
+                HashMap::from([("y".to_string(), MathArg::Symbol("z".to_string()))]);
+            let expr2 = expr1.substitute(&substitutions);
+            assert_eq!(expr2.to_latex(ToLatexParams::default()), "x + z");
+
+            let substitutions = HashMap::from([(
+                "y".to_string(),
+                MathArg::Math(MathExpr::from_text("q", true, &["f"])),
+            )]);
+            let expr2 = expr1.substitute(&substitutions);
+            assert_eq!(expr2.to_latex(ToLatexParams::default()), "x + q");
+
+            let substitutions = HashMap::from([("y".to_string(), MathArg::Number(3.14))]);
+            let expr2 = expr1.substitute(&substitutions);
+            assert_eq!(expr2.to_latex(ToLatexParams::default()), "x + 3.14");
+
+            let substitutions = HashMap::from([("y".to_string(), MathArg::Integer(-4))]);
+            let expr2 = expr1.substitute(&substitutions);
+            assert_eq!(expr2.to_latex(ToLatexParams::default()), "x - 4");
+        }
+    );
+
+    embed_test!(
+        all_tests,
+        test_name,
+        fn math_expr_from_number() {
+            let expr = MathExpr::from_number(3.4);
+            assert_eq!(expr.to_latex(ToLatexParams::default()), "3.4");
+        }
+    );
+
+    embed_test!(
+        all_tests,
+        test_name,
+        fn math_expr_from_text() {
+            // `x` times `y`
+            let expr = MathExpr::from_text("xy", true, &["f"]);
+            assert_eq!(expr.to_text(ToTextParams::default()), r#"x y"#);
+
+            // the multi-character symbol `xy`
+            let expr = MathExpr::from_text("xy", false, &["f"]);
+            assert_eq!(expr.to_text(ToTextParams::default()), r#"xy"#);
+
+            // the function `g` evaluated at `x`.
+            let expr = MathExpr::from_text("g(x)", true, &["f", "g"]);
+            assert_eq!(expr.to_text(ToTextParams::default()), r#"g(x)"#);
+
+            // `g` times `x`
+            let expr = MathExpr::from_text("g(x)", true, &["f"]);
+            assert_eq!(expr.to_text(ToTextParams::default()), r#"g x"#);
+        }
+    );
+
+    embed_test!(
+        all_tests,
+        test_name,
+        fn math_expr_to_text() {
+            let expr = MathExpr::from_text("123 / 0.05", true, &["f"]);
+
+            assert_eq!(expr.to_text(ToTextParams::default()), r#"123/0.05"#);
+
+            let pad_three_decimals = ToTextParams {
+                pad_to_decimals: Some(3),
+                ..Default::default()
+            };
+            assert_eq!(expr.to_text(pad_three_decimals), r#"123.000/0.050"#);
+
+            let pad_four_digits = ToTextParams {
+                pad_to_digits: Some(4),
+                ..Default::default()
+            };
+            assert_eq!(expr.to_text(pad_four_digits), r#"123.0/0.05000"#);
+
+            let expr_with_blanks = MathExpr::from_text("x + ()", true, &["f"]);
+
+            assert_eq!(
+                expr_with_blanks.to_text(ToTextParams::default()),
+                "x + \u{FF3F}"
+            );
+
+            let hide_blanks = ToTextParams {
+                show_blanks: false,
+                ..Default::default()
+            };
+            assert_eq!(expr_with_blanks.to_text(hide_blanks), "x + ");
+        }
+    );
+
+    embed_test!(
+        all_tests,
+        test_name,
+        fn math_expr_from_latex() {
+            // `x` times `y`
+            let expr = MathExpr::from_latex("xy", true, &["f"]);
+            assert_eq!(expr.to_latex(ToLatexParams::default()), r#"x y"#);
+
+            // the multi-character symbol `xy`
+            let expr = MathExpr::from_latex("xy", false, &["f"]);
+            assert_eq!(
+                expr.to_latex(ToLatexParams::default()),
+                r#"\operatorname{xy}"#
+            );
+
+            // the function `g` evaluated at `x`.
+            let expr = MathExpr::from_latex("g(x)", true, &["f", "g"]);
+            assert_eq!(
+                expr.to_latex(ToLatexParams::default()),
+                r#"g\left(x\right)"#
+            );
+
+            // `g` times `x`
+            let expr = MathExpr::from_latex("g(x)", true, &["f"]);
+            assert_eq!(expr.to_latex(ToLatexParams::default()), r#"g x"#);
+        }
+    );
+
+    embed_test!(
+        all_tests,
+        test_name,
+        fn math_expr_tolatex() {
+            let expr = MathExpr::from_text("123 / 0.05", true, &["f"]);
+
+            assert_eq!(
+                expr.to_latex(ToLatexParams::default()),
+                r#"\frac{123}{0.05}"#
+            );
+
+            let pad_three_decimals = ToLatexParams {
+                pad_to_decimals: Some(3),
+                ..Default::default()
+            };
+            assert_eq!(
+                expr.to_latex(pad_three_decimals),
+                r#"\frac{123.000}{0.050}"#
+            );
+
+            let pad_four_digits = ToLatexParams {
+                pad_to_digits: Some(4),
+                ..Default::default()
+            };
+            assert_eq!(expr.to_latex(pad_four_digits), r#"\frac{123.0}{0.05000}"#);
+
+            let expr_with_blanks = MathExpr::from_text("x + ()", true, &["f"]);
+
+            assert_eq!(
+                expr_with_blanks.to_latex(ToLatexParams::default()),
+                "x + \u{FF3F}"
+            );
+
+            let hide_blanks = ToLatexParams {
+                show_blanks: false,
+                ..Default::default()
+            };
+            assert_eq!(expr_with_blanks.to_latex(hide_blanks), "x + ");
+        }
+    );
+
+    embed_test!(
+        all_tests,
+        test_name,
+        fn simplify_math() {
+            let expr = MathExpr::from_text("x+2+x+3+4", true, &["f"]);
+
+            let expr_none = expr.normalize(NormalizeParams {
+                simplify: MathSimplify::None,
+                ..Default::default()
+            });
+            assert_eq!(expr_none, expr);
+
+            let expr_numbers = expr.normalize(NormalizeParams {
+                simplify: MathSimplify::Numbers,
+                ..Default::default()
+            });
+            assert_eq!(expr_numbers.to_text(ToTextParams::default()), "x + x + 9");
+
+            let expr_numbers_order = expr.normalize(NormalizeParams {
+                simplify: MathSimplify::NumbersPreserveOrder,
+                ..Default::default()
+            });
+            assert_eq!(
+                expr_numbers_order.to_text(ToTextParams::default()),
+                "x + 2 + x + 7"
+            );
+
+            let expr_simplify = expr.normalize(NormalizeParams {
+                simplify: MathSimplify::Full,
+                ..Default::default()
+            });
+            assert_eq!(expr_simplify.to_text(ToTextParams::default()), "2 x + 9");
+
+            let expr_simplify2 = expr.normalize(NormalizeParams::default());
+            assert_eq!(expr_simplify2, expr_simplify);
+        }
+    );
+
+    embed_test!(
+        all_tests,
+        test_name,
+        fn expand_math() {
+            let expr = MathExpr::from_text("(x+1)(x-1)", true, &["f"]);
+
+            let expr_simplify = expr.normalize(NormalizeParams::default());
+
+            assert_eq!(
+                expr_simplify.to_text(ToTextParams::default()),
+                "(x - 1) (x + 1)"
+            );
+
+            let expr_expand = expr.normalize(NormalizeParams {
+                expand: true,
+                ..Default::default()
+            });
+
+            assert_eq!(expr_expand.to_text(ToTextParams::default()), "x^2 - 1");
+        }
+    );
+
+    embed_test!(
+        all_tests,
+        test_name,
+        fn arithmetic_on_math() {
+            let expr = MathExpr::from_text("3", true, &["f"]);
+
+            let expr_add = expr.add(MathArg::Integer(4));
+            let expr_add_simplify = expr_add.normalize(NormalizeParams::default());
+
+            assert_eq!(expr_add.to_text(ToTextParams::default()), "3 + 4");
+            assert_eq!(expr_add_simplify.to_text(ToTextParams::default()), "7");
+
+            let expr_subtract = expr.subtract(MathArg::Integer(4));
+            let expr_subtract_simplify = expr_subtract.normalize(NormalizeParams::default());
+
+            assert_eq!(expr_subtract.to_text(ToTextParams::default()), "3 - 4");
+            assert_eq!(
+                expr_subtract_simplify.to_text(ToTextParams::default()),
+                "-1"
+            );
+
+            let expr_multiply = expr.multiply(MathArg::Integer(4));
+            let expr_multiply_simplify = expr_multiply.normalize(NormalizeParams::default());
+
+            assert_eq!(expr_multiply.to_text(ToTextParams::default()), "3 * 4");
+            assert_eq!(
+                expr_multiply_simplify.to_text(ToTextParams::default()),
+                "12"
+            );
+
+            let expr_divide = expr.divide(MathArg::Integer(6));
+            let expr_divide_simplify = expr_divide.normalize(NormalizeParams::default());
+
+            assert_eq!(expr_divide.to_text(ToTextParams::default()), "3/6");
+            assert_eq!(expr_divide_simplify.to_text(ToTextParams::default()), "1/2");
         }
     );
 

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/core/core.test.browser.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/core/core.test.browser.rs
@@ -70,6 +70,7 @@ pub fn run_test(test_name: &str) -> Vec<String> {
             let expr2 = expr1.substitute(&substitutions);
             assert_eq!(expr2.to_latex(ToLatexParams::default()), "x + q");
 
+            #[allow(clippy::approx_constant)]
             let substitutions = HashMap::from([("y".to_string(), MathArg::Number(3.14))]);
             let expr2 = expr1.substitute(&substitutions);
             assert_eq!(expr2.to_latex(ToLatexParams::default()), "x + 3.14");

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/core/core.test.browser.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/core/core.test.browser.rs
@@ -84,15 +84,6 @@ pub fn run_test(test_name: &str) -> Vec<String> {
     embed_test!(
         all_tests,
         test_name,
-        fn math_expr_from_number() {
-            let expr = MathExpr::from_number(3.4);
-            assert_eq!(expr.to_latex(ToLatexParams::default()), "3.4");
-        }
-    );
-
-    embed_test!(
-        all_tests,
-        test_name,
         fn math_expr_from_text() {
             // `x` times `y`
             let expr = MathExpr::from_text("xy", true, &["f"]);
@@ -311,6 +302,46 @@ pub fn run_test(test_name: &str) -> Vec<String> {
 
             assert_eq!(expr_divide.to_text(ToTextParams::default()), "3/6");
             assert_eq!(expr_divide_simplify.to_text(ToTextParams::default()), "1/2");
+        }
+    );
+
+    embed_test!(
+        all_tests,
+        test_name,
+        fn math_expr_converted_to_number() {
+            let expr1 = MathExpr::from_text("3/e^0", true, &["f"]);
+
+            let num1 = expr1.to_number();
+            assert_eq!(num1, 3.0);
+
+            let num1 = expr1.try_to_number().unwrap();
+            assert_eq!(num1, 3.0);
+
+            let num1: f64 = expr1.into();
+            assert_eq!(num1, 3.0);
+
+            let expr2 = MathExpr::from_text("x", true, &["f"]);
+
+            let num2 = expr2.to_number();
+            assert!(num2.is_nan());
+
+            let num2_result = expr2.try_to_number();
+            assert!(num2_result.is_err());
+
+            let num2: f64 = expr2.into();
+            assert!(num2.is_nan());
+        }
+    );
+
+    embed_test!(
+        all_tests,
+        test_name,
+        fn math_expr_from_numbers() {
+            let expr1: MathExpr = 5.into();
+            assert_eq!(expr1.to_text(ToTextParams::default()), "5");
+
+            let expr2: MathExpr = 5.5.into();
+            assert_eq!(expr2.to_text(ToTextParams::default()), "5.5");
         }
     );
 

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/core/general_prop/math_prop.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/core/general_prop/math_prop.rs
@@ -335,7 +335,7 @@ impl PropUpdater for MathProp {
 
                 if string_changed || split_symbols.changed {
                     // Either a string child has changed or split_symbols changed
-                    // (the latter condition will catch the first time calculate_old() is called).
+                    // (the latter condition will catch the first time calculate() is called).
                     // We need to recalculate the expression template.
 
                     // Create the expression template from concatenating all values

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/core/state/types/math_expr.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/core/state/types/math_expr.rs
@@ -42,7 +42,7 @@ impl MathExpr {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
 #[cfg_attr(feature = "web", derive(tsify_next::Tsify))]
 pub struct JsMathExpr(pub String);
 
@@ -390,7 +390,7 @@ impl serde::Serialize for MathArg {
         // one still has to call JSON.parse() to finish the hydration,
         // given that this last step is required for the Math variant
         match self {
-            Self::Math(math_expr) => math_expr.serialize(serializer),
+            Self::Math(math_expr) => math_expr.math_object.serialize(serializer),
             Self::Number(num) => serializer.serialize_str(&num.to_string()),
             Self::Integer(num) => serializer.serialize_str(&num.to_string()),
             Self::Symbol(var_name) => {

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/core/state/types/math_expr.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/core/state/types/math_expr.rs
@@ -1,3 +1,4 @@
+use serde::ser::SerializeStruct;
 use std::collections::HashMap;
 use strum_macros::Display;
 
@@ -68,7 +69,9 @@ impl serde::Serialize for MathExpr {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&self.math_object.0)
+        let mut m = serializer.serialize_struct("MathExpr", 1)?;
+        m.serialize_field("math_object", &self.math_object.0)?;
+        m.end()
     }
 }
 

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/core/state/types/math_expr.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/core/state/types/math_expr.rs
@@ -5,9 +5,12 @@ use strum_macros::Display;
 #[cfg(all(not(feature = "testing"), feature = "web"))]
 use web_sys::js_sys::JsString;
 
-use crate::math_via_wasm::{
-    eval_js, math_to_latex, math_to_text, normalize_math, parse_latex_into_math,
-    parse_text_into_math, substitute_into_math,
+use crate::{
+    math_via_wasm::{
+        eval_js, math_to_latex, math_to_text, normalize_math, parse_latex_into_math,
+        parse_text_into_math, substitute_into_math,
+    },
+    props::prop_type,
 };
 
 const BLANK_MATH_OBJECT: &str = "{\"objectType\":\"math-expression\",\"tree\":\"\u{ff3f}\"}";
@@ -69,6 +72,7 @@ impl serde::Serialize for MathExpr {
     where
         S: serde::Serializer,
     {
+        // Serialize as a struct named `MathExpr` with `1` field: `math_object`
         let mut m = serializer.serialize_struct("MathExpr", 1)?;
         m.serialize_field("math_object", &self.math_object.0)?;
         m.end()
@@ -231,6 +235,15 @@ impl MathExpr {
         match math_to_latex(&self.math_object, params) {
             Ok(res) => res,
             Err(_) => "\u{FF3f}".to_string(),
+        }
+    }
+
+    pub fn from_number(x: prop_type::Number) -> Self {
+        MathExpr {
+            math_object: JsMathExpr(format!(
+                "{{\"objectType\":\"math-expression\",\"tree\":{} }}",
+                x,
+            )),
         }
     }
 

--- a/packages/doenetml-worker-rust/lib-js-wasm-binding/src/eval-math.ts
+++ b/packages/doenetml-worker-rust/lib-js-wasm-binding/src/eval-math.ts
@@ -132,7 +132,7 @@ export function parseLatexIntoMath(
  * Return a LaTeX string that corresponds to a mathematical expression.
  *
  * Arguments:
- * @mathObject - the stringify math expression
+ * @mathObject - the stringified math expression
  * @padToDecimals - If present, then pad numbers with zeros so they have at least
  *    this many decimal places after the decimal point displayed.
  * @padToDigits - If present, then pad numbers with zeros so they have at least
@@ -159,7 +159,7 @@ export function toLatex(
  * Create a new mathematical expression formed by substituting variables with new expressions
  *
  * Arguments:
- * @mathObject - the stringify math expression
+ * @mathObject - the stringified math expression
  * @substitutions - a mapping of variable names and the values to substitute for those variables
  */
 export function substituteIntoMath(
@@ -183,7 +183,7 @@ export function substituteIntoMath(
  * Return a normalize mathematical expression as specified by the parameters
  *
  * Arguments:
- * @mathObject - the stringify math expression
+ * @mathObject - the stringified math expression
  * @simplify - We currently support four options for `simplify`:
  * - `"none"`: no simplification
  * - `"numberspreserveorder"`: simplify numbers within the expression, such as simplify `1+1` to 2,
@@ -217,4 +217,18 @@ export function normalizeMath(
     });
 
     return JSON.stringify(newExpr, serializedComponentsReplacer);
+}
+
+/**
+ * Attempts to evaluate the math expression to a constant number, returning NaN if failure
+ *
+ * Arguments:
+ * @mathObject - the stringified math expression
+ */
+export function evaluateToNumber(mathObject: string) {
+    let mathExpr = JSON.parse(mathObject, serializedComponentsReviver);
+
+    let newNumber = mathExpr.evaluate_to_constant();
+
+    return newNumber;
 }

--- a/packages/doenetml-worker-rust/lib-js-wasm-binding/src/index.ts
+++ b/packages/doenetml-worker-rust/lib-js-wasm-binding/src/index.ts
@@ -6,6 +6,7 @@ import {
     toText,
     substituteIntoMath,
     normalizeMath,
+    evaluateToNumber,
 } from "./eval-math";
 import { globalThis } from "./global-this";
 
@@ -22,6 +23,7 @@ declare global {
             toText: typeof toText;
             substituteIntoMath: typeof substituteIntoMath;
             normalizeMath: typeof normalizeMath;
+            evaluateToNumber: typeof evaluateToNumber;
         };
     }
 }
@@ -35,4 +37,5 @@ globalThis.__forDoenetWorker = {
     toText,
     substituteIntoMath,
     normalizeMath,
+    evaluateToNumber,
 };


### PR DESCRIPTION
This PR fixes the serialization of `MathExpr` in rust so that it matches the TypeScript type, fixes a regression, and adds regression tests. It also adds conversion functions between `MathExpr` and numbers.