### PR TITLE
check work buttons are not tab stops when disabled

### DIFF
--- a/packages/doenetml-worker/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker/src/components/abstract/BaseComponent.js
@@ -532,7 +532,9 @@ export default class BaseComponent {
                 if (!usedDefault.disabledPreliminary) {
                     return {
                         setValue: {
-                            disabled: dependencyValues.disabledPreliminary,
+                            disabled: Boolean(
+                                dependencyValues.disabledPreliminary,
+                            ),
                         },
                     };
                 }

--- a/packages/doenetml/src/Viewer/renderers/answer.jsx
+++ b/packages/doenetml/src/Viewer/renderers/answer.jsx
@@ -87,12 +87,14 @@ export default React.memo(function Answer(props) {
             padding: "1px 6px 1px 6px",
         };
 
+        let checkWorkTabIndex = "0";
         if (disabled) {
             checkWorkStyle.backgroundColor = getComputedStyle(
                 document.documentElement,
             ).getPropertyValue("--mainGray");
             checkWorkStyle.color = "black";
             checkWorkStyle.cursor = "not-allowed";
+            checkWorkTabIndex = "-1";
         }
 
         let checkWorkText = SVs.submitLabel;
@@ -102,7 +104,7 @@ export default React.memo(function Answer(props) {
         let checkworkComponent = (
             <Button
                 id={id + "_submit"}
-                tabIndex="0"
+                tabIndex={checkWorkTabIndex}
                 disabled={disabled}
                 style={checkWorkStyle}
                 onClick={submitAnswer}
@@ -133,7 +135,11 @@ export default React.memo(function Answer(props) {
                     document.documentElement,
                 ).getPropertyValue("--mainGreen");
                 checkworkComponent = (
-                    <Button id={id + "_correct"} style={checkWorkStyle}>
+                    <Button
+                        id={id + "_correct"}
+                        style={checkWorkStyle}
+                        tabIndex={checkWorkTabIndex}
+                    >
                         <FontAwesomeIcon icon={faCheck} />
                         &nbsp; Correct
                     </Button>
@@ -143,7 +149,11 @@ export default React.memo(function Answer(props) {
                     document.documentElement,
                 ).getPropertyValue("--mainRed");
                 checkworkComponent = (
-                    <Button id={id + "_incorrect"} style={checkWorkStyle}>
+                    <Button
+                        id={id + "_incorrect"}
+                        style={checkWorkStyle}
+                        tabIndex={checkWorkTabIndex}
+                    >
                         <FontAwesomeIcon icon={faTimes} />
                         &nbsp; Incorrect
                     </Button>
@@ -154,7 +164,11 @@ export default React.memo(function Answer(props) {
                 let partialCreditContents = `${percent}% Correct`;
 
                 checkworkComponent = (
-                    <Button id={id + "_partial"} style={checkWorkStyle}>
+                    <Button
+                        id={id + "_partial"}
+                        style={checkWorkStyle}
+                        tabIndex={checkWorkTabIndex}
+                    >
                         {partialCreditContents}
                     </Button>
                 );
@@ -164,7 +178,11 @@ export default React.memo(function Answer(props) {
             if (validationState !== "unvalidated") {
                 checkWorkStyle.backgroundColor = "rgb(74, 3, 217)";
                 checkworkComponent = (
-                    <Button id={id + "_saved"} style={checkWorkStyle}>
+                    <Button
+                        id={id + "_saved"}
+                        style={checkWorkStyle}
+                        tabIndex={checkWorkTabIndex}
+                    >
                         <FontAwesomeIcon icon={faCloud} />
                         &nbsp; Response Saved
                     </Button>

--- a/packages/doenetml/src/Viewer/renderers/booleanInput.jsx
+++ b/packages/doenetml/src/Viewer/renderers/booleanInput.jsx
@@ -468,6 +468,7 @@ export default React.memo(function BooleanInput(props) {
         cursor: "pointer",
         padding: "1px 6px 1px 6px",
     };
+    let checkWorkTabIndex = "0";
 
     if (disabled) {
         // Disable the checkWorkButton
@@ -476,6 +477,7 @@ export default React.memo(function BooleanInput(props) {
         ).getPropertyValue("--mainGray");
         checkWorkStyle.color = "black";
         checkWorkStyle.cursor = "not-allowed";
+        checkWorkTabIndex = "-1";
     }
 
     //Assume we don't have a check work button
@@ -497,7 +499,7 @@ export default React.memo(function BooleanInput(props) {
             checkWorkButton = (
                 <Button
                     id={id + "_submit"}
-                    tabIndex="0"
+                    tabIndex={checkWorkTabIndex}
                     disabled={disabled}
                     // ref={c => { this.target = c && ReactDOM.findDOMNode(c); }}
                     style={checkWorkStyle}
@@ -537,7 +539,11 @@ export default React.memo(function BooleanInput(props) {
                         document.documentElement,
                     ).getPropertyValue("--mainGreen");
                     checkWorkButton = (
-                        <Button id={id + "_correct"} style={checkWorkStyle}>
+                        <Button
+                            id={id + "_correct"}
+                            style={checkWorkStyle}
+                            tabIndex={checkWorkTabIndex}
+                        >
                             <FontAwesomeIcon icon={faCheck} />
                         </Button>
                     );
@@ -550,7 +556,11 @@ export default React.memo(function BooleanInput(props) {
 
                     checkWorkStyle.backgroundColor = "#efab34";
                     checkWorkButton = (
-                        <Button id={id + "_partial"} style={checkWorkStyle}>
+                        <Button
+                            id={id + "_partial"}
+                            style={checkWorkStyle}
+                            tabIndex={checkWorkTabIndex}
+                        >
                             {partialCreditContents}
                         </Button>
                     );
@@ -560,7 +570,11 @@ export default React.memo(function BooleanInput(props) {
                         document.documentElement,
                     ).getPropertyValue("--mainRed");
                     checkWorkButton = (
-                        <Button id={id + "_incorrect"} style={checkWorkStyle}>
+                        <Button
+                            id={id + "_incorrect"}
+                            style={checkWorkStyle}
+                            tabIndex={checkWorkTabIndex}
+                        >
                             <FontAwesomeIcon icon={faTimes} />
                         </Button>
                     );
@@ -570,7 +584,11 @@ export default React.memo(function BooleanInput(props) {
                 checkWorkStyle.backgroundColor = "rgb(74, 3, 217)";
                 checkWorkStyle.padding = "1px 8px 1px 4px"; // To center the faCloud icon
                 checkWorkButton = (
-                    <Button id={id + "_saved"} style={checkWorkStyle}>
+                    <Button
+                        id={id + "_saved"}
+                        style={checkWorkStyle}
+                        tabIndex={checkWorkTabIndex}
+                    >
                         <FontAwesomeIcon icon={faCloud} />
                     </Button>
                 );

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.jsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.jsx
@@ -157,6 +157,9 @@ export default React.memo(function ChoiceInput(props) {
             padding: "1px 6px 1px 6px",
             width: "24px",
         };
+        let checkWorkTabIndex = "0";
+
+        let selectStyle = {};
 
         if (disabled) {
             // Disable the checkWorkButton
@@ -165,6 +168,11 @@ export default React.memo(function ChoiceInput(props) {
             ).getPropertyValue("--mainGray");
             checkWorkStyle.color = "black";
             checkWorkStyle.cursor = "not-allowed";
+            checkWorkTabIndex = "-1";
+            selectStyle.cursor = "not-allowed";
+            selectStyle.borderColor = getComputedStyle(
+                document.documentElement,
+            ).getPropertyValue("--mainGray");
         }
 
         //Assume we don't have a check work button
@@ -180,7 +188,7 @@ export default React.memo(function ChoiceInput(props) {
                     <Button
                         id={id + "_submit"}
                         disabled={disabled}
-                        tabIndex="0"
+                        tabIndex={checkWorkTabIndex}
                         // ref={c => { this.target = c && ReactDOM.findDOMNode(c); }}
                         style={checkWorkStyle}
                         onClick={() =>
@@ -219,7 +227,11 @@ export default React.memo(function ChoiceInput(props) {
                             document.documentElement,
                         ).getPropertyValue("--mainGreen");
                         checkWorkButton = (
-                            <Button id={id + "_correct"} style={checkWorkStyle}>
+                            <Button
+                                id={id + "_correct"}
+                                style={checkWorkStyle}
+                                tabIndex={checkWorkTabIndex}
+                            >
                                 <FontAwesomeIcon icon={faCheck} />
                             </Button>
                         );
@@ -232,7 +244,11 @@ export default React.memo(function ChoiceInput(props) {
 
                         checkWorkStyle.backgroundColor = "#efab34";
                         checkWorkButton = (
-                            <Button id={id + "_partial"} style={checkWorkStyle}>
+                            <Button
+                                id={id + "_partial"}
+                                style={checkWorkStyle}
+                                tabIndex={checkWorkTabIndex}
+                            >
                                 {partialCreditContents}
                             </Button>
                         );
@@ -245,6 +261,7 @@ export default React.memo(function ChoiceInput(props) {
                             <Button
                                 id={id + "_incorrect"}
                                 style={checkWorkStyle}
+                                tabIndex={checkWorkTabIndex}
                             >
                                 <FontAwesomeIcon icon={faTimes} />
                             </Button>
@@ -255,7 +272,11 @@ export default React.memo(function ChoiceInput(props) {
                     checkWorkStyle.backgroundColor = "rgb(74, 3, 217)";
                     checkWorkStyle.padding = "1px 8px 1px 4px"; // To center the faCloud icon
                     checkWorkButton = (
-                        <Button id={id + "_saved"} style={checkWorkStyle}>
+                        <Button
+                            id={id + "_saved"}
+                            style={checkWorkStyle}
+                            tabIndex={checkWorkTabIndex}
+                        >
                             <FontAwesomeIcon icon={faCloud} />
                         </Button>
                     );
@@ -328,6 +349,7 @@ export default React.memo(function ChoiceInput(props) {
                         value={value}
                         disabled={disabled}
                         multiple={SVs.selectMultiple}
+                        style={selectStyle}
                     >
                         <option hidden={true} value="">
                             {SVs.placeHolder}
@@ -346,6 +368,7 @@ export default React.memo(function ChoiceInput(props) {
             cursor: "pointer",
             // fontWeight: "bold",
         };
+        let checkWorkTabIndex = "0";
 
         if (disabled) {
             // Disable the checkWorkButton
@@ -354,6 +377,7 @@ export default React.memo(function ChoiceInput(props) {
             ).getPropertyValue("--mainGray");
             checkWorkStyle.color = "black";
             checkWorkStyle.cursor = "not-allowed";
+            checkWorkTabIndex = "-1";
         }
 
         let checkworkComponent = null;
@@ -372,7 +396,7 @@ export default React.memo(function ChoiceInput(props) {
                 checkworkComponent = (
                     <Button
                         id={id + "_submit"}
-                        tabIndex="0"
+                        tabIndex={checkWorkTabIndex}
                         disabled={disabled}
                         style={checkWorkStyle}
                         onClick={() =>
@@ -413,7 +437,11 @@ export default React.memo(function ChoiceInput(props) {
                             document.documentElement,
                         ).getPropertyValue("--mainGreen");
                         checkworkComponent = (
-                            <Button id={id + "_correct"} style={checkWorkStyle}>
+                            <Button
+                                id={id + "_correct"}
+                                style={checkWorkStyle}
+                                tabIndex={checkWorkTabIndex}
+                            >
                                 <FontAwesomeIcon icon={faCheck} />
                                 &nbsp; Correct
                             </Button>
@@ -426,6 +454,7 @@ export default React.memo(function ChoiceInput(props) {
                             <Button
                                 id={id + "_incorrect"}
                                 style={checkWorkStyle}
+                                tabIndex={checkWorkTabIndex}
                             >
                                 <FontAwesomeIcon icon={faTimes} />
                                 &nbsp; Incorrect
@@ -437,7 +466,11 @@ export default React.memo(function ChoiceInput(props) {
                         let partialCreditContents = `${percent}% Correct`;
 
                         checkworkComponent = (
-                            <Button id={id + "_partial"} style={checkWorkStyle}>
+                            <Button
+                                id={id + "_partial"}
+                                style={checkWorkStyle}
+                                tabIndex={checkWorkTabIndex}
+                            >
                                 {partialCreditContents}
                             </Button>
                         );
@@ -445,7 +478,11 @@ export default React.memo(function ChoiceInput(props) {
                 } else {
                     checkWorkStyle.backgroundColor = "rgb(74, 3, 217)";
                     checkworkComponent = (
-                        <Button id={id + "_saved"} style={checkWorkStyle}>
+                        <Button
+                            id={id + "_saved"}
+                            style={checkWorkStyle}
+                            tabIndex={checkWorkTabIndex}
+                        >
                             <FontAwesomeIcon icon={faCloud} />
                             &nbsp; Response Saved
                         </Button>

--- a/packages/doenetml/src/Viewer/renderers/mathInput.jsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.jsx
@@ -249,6 +249,7 @@ export default function MathInput(props) {
     }
 
     let mathInputWrapperCursor = "allowed";
+    let checkWorkTabIndex = "0";
     if (SVs.disabled) {
         // Disable the checkWorkButton
         checkWorkStyle.backgroundColor = getComputedStyle(
@@ -256,6 +257,7 @@ export default function MathInput(props) {
         ).getPropertyValue("--mainGray");
         checkWorkStyle.color = "black";
         checkWorkStyle.cursor = "not-allowed";
+        checkWorkTabIndex = "-1";
 
         // Disable the mathInput
         mathInputStyle.borderColor = getComputedStyle(
@@ -278,7 +280,7 @@ export default function MathInput(props) {
             checkWorkButton = (
                 <Button
                     id={id + "_submit"}
-                    tabIndex="0"
+                    tabIndex={checkWorkTabIndex}
                     disabled={SVs.disabled}
                     style={checkWorkStyle}
                     onClick={() =>
@@ -312,7 +314,11 @@ export default function MathInput(props) {
                         document.documentElement,
                     ).getPropertyValue("--mainGreen");
                     checkWorkButton = (
-                        <Button id={id + "_correct"} style={checkWorkStyle}>
+                        <Button
+                            id={id + "_correct"}
+                            style={checkWorkStyle}
+                            tabIndex={checkWorkTabIndex}
+                        >
                             <FontAwesomeIcon icon={faCheck} />
                         </Button>
                     );
@@ -325,7 +331,11 @@ export default function MathInput(props) {
 
                     checkWorkStyle.backgroundColor = "#efab34";
                     checkWorkButton = (
-                        <Button id={id + "_partial"} style={checkWorkStyle}>
+                        <Button
+                            id={id + "_partial"}
+                            style={checkWorkStyle}
+                            tabIndex={checkWorkTabIndex}
+                        >
                             {partialCreditContents}
                         </Button>
                     );
@@ -335,7 +345,11 @@ export default function MathInput(props) {
                         document.documentElement,
                     ).getPropertyValue("--mainRed");
                     checkWorkButton = (
-                        <Button id={id + "_incorrect"} style={checkWorkStyle}>
+                        <Button
+                            id={id + "_incorrect"}
+                            style={checkWorkStyle}
+                            tabIndex={checkWorkTabIndex}
+                        >
                             <FontAwesomeIcon icon={faTimes} />
                         </Button>
                     );
@@ -345,7 +359,11 @@ export default function MathInput(props) {
                 checkWorkStyle.backgroundColor = "rgb(74, 3, 217)";
                 checkWorkStyle.padding = "1px 8px 1px 4px"; // To center the faCloud icon
                 checkWorkButton = (
-                    <Button id={id + "_saved"} style={checkWorkStyle}>
+                    <Button
+                        id={id + "_saved"}
+                        style={checkWorkStyle}
+                        tabIndex={checkWorkTabIndex}
+                    >
                         <FontAwesomeIcon icon={faCloud} />
                     </Button>
                 );

--- a/packages/doenetml/src/Viewer/renderers/matrixInput.jsx
+++ b/packages/doenetml/src/Viewer/renderers/matrixInput.jsx
@@ -111,6 +111,7 @@ export default React.memo(function MatrixInput(props) {
         cursor: "pointer",
         padding: "1px 6px 1px 6px",
     };
+    let checkWorkTabIndex = "0";
 
     if (disabled) {
         // Disable the checkWorkButton
@@ -119,6 +120,7 @@ export default React.memo(function MatrixInput(props) {
         ).getPropertyValue("--mainGray");
         checkWorkStyle.color = "black";
         checkWorkStyle.cursor = "not-allowed";
+        checkWorkTabIndex = "-1";
     }
 
     //Assume we don't have a check work button
@@ -128,7 +130,7 @@ export default React.memo(function MatrixInput(props) {
             checkWorkButton = (
                 <Button
                     id={id + "_submit"}
-                    tabIndex="0"
+                    tabIndex={checkWorkTabIndex}
                     disabled={disabled}
                     style={checkWorkStyle}
                     onClick={() =>
@@ -162,7 +164,11 @@ export default React.memo(function MatrixInput(props) {
                         document.documentElement,
                     ).getPropertyValue("--mainGreen");
                     checkWorkButton = (
-                        <Button id={id + "_correct"} style={checkWorkStyle}>
+                        <Button
+                            id={id + "_correct"}
+                            style={checkWorkStyle}
+                            tabIndex={checkWorkTabIndex}
+                        >
                             <FontAwesomeIcon icon={faCheck} />
                         </Button>
                     );
@@ -175,7 +181,11 @@ export default React.memo(function MatrixInput(props) {
 
                     checkWorkStyle.backgroundColor = "#efab34";
                     checkWorkButton = (
-                        <Button id={id + "_partial"} style={checkWorkStyle}>
+                        <Button
+                            id={id + "_partial"}
+                            style={checkWorkStyle}
+                            tabIndex={checkWorkTabIndex}
+                        >
                             {partialCreditContents}
                         </Button>
                     );
@@ -185,7 +195,11 @@ export default React.memo(function MatrixInput(props) {
                         document.documentElement,
                     ).getPropertyValue("--mainRed");
                     checkWorkButton = (
-                        <Button id={id + "_incorrect"} style={checkWorkStyle}>
+                        <Button
+                            id={id + "_incorrect"}
+                            style={checkWorkStyle}
+                            tabIndex={checkWorkTabIndex}
+                        >
                             <FontAwesomeIcon icon={faTimes} />
                         </Button>
                     );
@@ -195,7 +209,11 @@ export default React.memo(function MatrixInput(props) {
                 checkWorkStyle.backgroundColor = "rgb(74, 3, 217)";
                 checkWorkStyle.padding = "1px 8px 1px 4px"; // To center the faCloud icon
                 checkWorkButton = (
-                    <Button id={id + "_saved"} style={checkWorkStyle}>
+                    <Button
+                        id={id + "_saved"}
+                        style={checkWorkStyle}
+                        tabIndex={checkWorkTabIndex}
+                    >
                         <FontAwesomeIcon icon={faCloud} />
                     </Button>
                 );
@@ -260,7 +278,7 @@ export default React.memo(function MatrixInput(props) {
                                 args: { numRows: SVs.numRows - 1 },
                             })
                         }
-                        disabled={SVs.numRows < 2}
+                        disabled={SVs.numRows < 2 || disabled}
                     >
                         r-
                     </ActionButton>
@@ -273,6 +291,7 @@ export default React.memo(function MatrixInput(props) {
                                 args: { numRows: SVs.numRows + 1 },
                             })
                         }
+                        disabled={disabled}
                     >
                         r+
                     </ActionButton>
@@ -294,7 +313,7 @@ export default React.memo(function MatrixInput(props) {
                                 args: { numColumns: SVs.numColumns - 1 },
                             })
                         }
-                        disabled={SVs.numColumns < 2}
+                        disabled={SVs.numColumns < 2 || disabled}
                     >
                         c-
                     </ActionButton>
@@ -307,6 +326,7 @@ export default React.memo(function MatrixInput(props) {
                                 args: { numColumns: SVs.numColumns + 1 },
                             })
                         }
+                        disabled={disabled}
                     >
                         c+
                     </ActionButton>

--- a/packages/doenetml/src/Viewer/renderers/textInput.jsx
+++ b/packages/doenetml/src/Viewer/renderers/textInput.jsx
@@ -606,6 +606,7 @@ export default function TextInput(props) {
         cursor: "pointer",
         padding: "1px 6px 1px 6px",
     };
+    let checkWorkTabIndex = "0";
 
     if (disabled) {
         checkWorkStyle.backgroundColor = getComputedStyle(
@@ -613,6 +614,7 @@ export default function TextInput(props) {
         ).getPropertyValue("--mainGray");
         checkWorkStyle.cursor = "not-allowed";
         checkWorkStyle.color = "black";
+        checkWorkTabIndex = "-1";
     }
 
     // Assume we don't have a check work button
@@ -622,7 +624,7 @@ export default function TextInput(props) {
             checkWorkButton = (
                 <Button
                     id={id + "_submit"}
-                    tabIndex="0"
+                    tabIndex={checkWorkTabIndex}
                     disabled={disabled}
                     style={checkWorkStyle}
                     onClick={() =>
@@ -661,7 +663,11 @@ export default function TextInput(props) {
                         document.documentElement,
                     ).getPropertyValue("--mainGreen");
                     checkWorkButton = (
-                        <Button id={id + "_correct"} style={checkWorkStyle}>
+                        <Button
+                            id={id + "_correct"}
+                            style={checkWorkStyle}
+                            tabIndex={checkWorkTabIndex}
+                        >
                             <FontAwesomeIcon icon={faCheck} />
                         </Button>
                     );
@@ -673,7 +679,11 @@ export default function TextInput(props) {
 
                     checkWorkStyle.backgroundColor = "#efab34";
                     checkWorkButton = (
-                        <Button id={id + "_partial"} style={checkWorkStyle}>
+                        <Button
+                            id={id + "_partial"}
+                            style={checkWorkStyle}
+                            tabIndex={checkWorkTabIndex}
+                        >
                             {partialCreditContents}
                         </Button>
                     );
@@ -683,7 +693,11 @@ export default function TextInput(props) {
                         document.documentElement,
                     ).getPropertyValue("--mainRed");
                     checkWorkButton = (
-                        <Button id={id + "_incorrect"} style={checkWorkStyle}>
+                        <Button
+                            id={id + "_incorrect"}
+                            style={checkWorkStyle}
+                            tabIndex={checkWorkTabIndex}
+                        >
                             <FontAwesomeIcon icon={faTimes} />
                         </Button>
                     );
@@ -693,7 +707,11 @@ export default function TextInput(props) {
                 checkWorkStyle.backgroundColor = "rgb(74, 3, 217)";
                 checkWorkStyle.padding = "1px 8px 1px 4px"; // To center the faCloud icon
                 checkWorkButton = (
-                    <Button id={id + "_saved"} style={checkWorkStyle}>
+                    <Button
+                        id={id + "_saved"}
+                        style={checkWorkStyle}
+                        tabIndex={checkWorkTabIndex}
+                    >
                         <FontAwesomeIcon icon={faCloud} />
                     </Button>
                 );


### PR DESCRIPTION
This PR makes sure that all variations of check work buttons and answer status buttons are not tab stops when disabled.

It also updates the section-wide check work button to current styling.

Fixes #221