### PR TITLE
Nextra path does not include github repository name

### DIFF
--- a/packages/docs-nextra/next.config.mjs
+++ b/packages/docs-nextra/next.config.mjs
@@ -118,18 +118,9 @@ const withNextra = nextraConfig({
 //     latex: true
 //   });
 //
-const isGithubActions = process.env.GITHUB_ACTIONS || false;
 
 let assetPrefix = "";
 let basePath = "";
-
-if (isGithubActions) {
-    // trim off `<owner>/`
-    const repo = process.env.GITHUB_REPOSITORY.replace(/.*?\//, "");
-
-    assetPrefix = `/${repo}/`;
-    basePath = `/${repo}`;
-}
 
 export default withNextra({
     output: "export",


### PR DESCRIPTION
Since we will use the domain `docs.doenet.org`  rather than `doenet.github.io/DoenetML` for the docs, we no longer want to include `/DoenetML/` in the path for Nextra links.