### PR TITLE
Make open keyboard button more visible

### DIFF
--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.css
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.css
@@ -23,7 +23,6 @@ Tailwind base is purposely not included because we want all styles to be prefixe
      * Some styles from tailwind preflight need to be included here
      */
     box-sizing: border-box;
-    border-stylke: solid;
     --tw-border-spacing-x: 0;
     --tw-border-spacing-y: 0;
     --tw-translate-x: 0;
@@ -64,6 +63,8 @@ Tailwind base is purposely not included because we want all styles to be prefixe
         @apply border-b-black border-b;
         @apply hover:bg-slate-300 active:bg-slate-400;
         @apply w-12 h-[1.5rem] flex items-center justify-center;
+        background-color: white;
+        border-width: 1px;
     }
 
     .virtual-keyboard-tab-list {

--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.css
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.css
@@ -63,8 +63,7 @@ Tailwind base is purposely not included because we want all styles to be prefixe
         @apply border-b-black border-b;
         @apply hover:bg-slate-300 active:bg-slate-400;
         @apply w-12 h-[1.5rem] flex items-center justify-center;
-        background-color: white;
-        border-width: 1px;
+        @apply bg-white border
     }
 
     .virtual-keyboard-tab-list {

--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.css
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.css
@@ -63,7 +63,7 @@ Tailwind base is purposely not included because we want all styles to be prefixe
         @apply border-b-black border-b;
         @apply hover:bg-slate-300 active:bg-slate-400;
         @apply w-12 h-[1.5rem] flex items-center justify-center;
-        @apply bg-white border
+        @apply bg-white border;
     }
 
     .virtual-keyboard-tab-list {

--- a/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.tsx
+++ b/packages/virtual-keyboard/src/virtual-keyboard/keyboard-tray.tsx
@@ -52,6 +52,7 @@ export function KeyboardTray({ onClick }: { onClick: OnClick }) {
                 className="open-keyboard-button"
                 onClick={() => setOpen((old) => !old)}
                 title={open ? "Close Keyboard" : "Open Keyboard"}
+                aria-label={open ? "Close Keyboard" : "Open Keyboard"}
             >
                 <KeyboardIcon />
             </button>
@@ -60,6 +61,7 @@ export function KeyboardTray({ onClick }: { onClick: OnClick }) {
                     className="close-keyboard-button"
                     onClick={() => setOpen(false)}
                     title="Close Keyboard"
+                    aria-label="Close Keyboard"
                 >
                     &times;
                 </button>


### PR DESCRIPTION
This PR makes the open keyboard button be white with a black border to make it more visible, especially when it is in front of a dark background.