### PR TITLE
send a SPLICE.recordSolutionViewed message when solution is viewed

### DIFF
--- a/packages/doenetml-worker/src/Core.js
+++ b/packages/doenetml-worker/src/Core.js
@@ -13242,7 +13242,7 @@ export default class Core {
             };
         }
 
-        if (this.apiUrls.postMessages) {
+        if (this.apiURLs.postMessages) {
             postMessage({
                 messageType: "recordSolutionView",
                 activityId: this.activityId,

--- a/packages/doenetml-worker/src/Core.js
+++ b/packages/doenetml-worker/src/Core.js
@@ -13242,6 +13242,22 @@ export default class Core {
             };
         }
 
+        if (this.apiUrls.postMessages) {
+            postMessage({
+                messageType: "recordSolutionView",
+                activityId: this.activityId,
+                itemNumber: this.itemNumber,
+                pageNumber: this.pageNumber,
+                attemptNumber: this.attemptNumber,
+            });
+
+            return {
+                allowView: true,
+                message: "",
+                scoredComponent: this.documentName,
+            };
+        }
+
         try {
             const resp = await axios.post(this.apiURLs.reportSolutionViewed, {
                 activityId: this.activityId,

--- a/packages/doenetml/src/Viewer/PageViewer.jsx
+++ b/packages/doenetml/src/Viewer/PageViewer.jsx
@@ -316,6 +316,11 @@ export function PageViewer({
                     ...e.data,
                     subject: "SPLICE.reportScoreAndState",
                 });
+            } else if (e.data.messageType === "recordSolutionViewed") {
+                window.postMessage({
+                    ...e.data,
+                    subject: "SPLICE.recordSolutionViewed",
+                });
             } else if (e.data.messageType === "sendEvent") {
                 window.postMessage({
                     ...e.data,

--- a/packages/doenetml/src/Viewer/PageViewer.jsx
+++ b/packages/doenetml/src/Viewer/PageViewer.jsx
@@ -316,10 +316,10 @@ export function PageViewer({
                     ...e.data,
                     subject: "SPLICE.reportScoreAndState",
                 });
-            } else if (e.data.messageType === "recordSolutionViewed") {
+            } else if (e.data.messageType === "recordSolutionView") {
                 window.postMessage({
                     ...e.data,
-                    subject: "SPLICE.recordSolutionViewed",
+                    subject: "SPLICE.recordSolutionView",
                 });
             } else if (e.data.messageType === "sendEvent") {
                 window.postMessage({


### PR DESCRIPTION
This PR adds the feature where if the `postMessages` parameter is set, then a `SPLICE.recordSolutionViewed` is posted to `window` giving information about which solution was viewed.