### PR TITLE
Do not remove blank string children on <row> before sugar

### DIFF
--- a/packages/doenetml-worker/src/components/Row.js
+++ b/packages/doenetml-worker/src/components/Row.js
@@ -1,10 +1,12 @@
 import BaseComponent from "./abstract/BaseComponent";
-import { normalizeIndex } from "../utils/table";
 
 export default class Row extends BaseComponent {
     static componentType = "row";
     static rendererType = "row";
     static renderChildren = true;
+
+    static includeBlankStringChildren = true;
+    static removeBlankStringChildrenPostSugar = true;
 
     static createAttributesObject() {
         let attributes = super.createAttributesObject();


### PR DESCRIPTION
Needed so that the sugar of a `<row>` inside a `<matrix>` works properly.