### PR TITLE
Fix flaw in passing state variable changes to core

### DIFF
--- a/packages/doenetml-worker/src/Core.js
+++ b/packages/doenetml-worker/src/Core.js
@@ -65,7 +65,7 @@ export default class Core {
         previousComponentTypeCounts = {},
         theme,
         prerender = false,
-        stateVariableChanges = {},
+        stateVariableChanges: stateVariableChangesString,
         coreId,
         updateDataOnContentChange,
         apiURLs = {},
@@ -106,7 +106,12 @@ export default class Core {
 
         this.previousComponentTypeCounts = previousComponentTypeCounts;
 
-        // Note: this changes the stateVariableChanges passed into core as an argument
+        const stateVariableChanges = stateVariableChangesString
+            ? JSON.parse(
+                  stateVariableChangesString,
+                  serializedComponentsReviver,
+              )
+            : {};
         for (let cName in stateVariableChanges) {
             let componentSVChanges = stateVariableChanges[cName];
             for (let varName in componentSVChanges) {

--- a/packages/doenetml-worker/src/utils/math.ts
+++ b/packages/doenetml-worker/src/utils/math.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
 import me from "math-expressions";
 
-import { vectorOperators } from "@doenet/utils";
+import { subsets, vectorOperators } from "@doenet/utils";
 
 export var appliedFunctionSymbolsDefault = [
     "abs",
@@ -929,7 +929,12 @@ export function removeFunctionsMathExpressionClass(value: any) {
         value = undefined;
     } else if (Array.isArray(value)) {
         value = value.map((x) => removeFunctionsMathExpressionClass(x));
-    } else if (typeof value === "object" && value !== null) {
+    } else if (
+        typeof value === "object" &&
+        value !== null &&
+        //@ts-ignore
+        !(value instanceof subsets.Subset)
+    ) {
         let valueCopy: any = {};
         for (let key in value) {
             valueCopy[key] = removeFunctionsMathExpressionClass(value[key]);

--- a/packages/doenetml/src/Viewer/PageViewer.jsx
+++ b/packages/doenetml/src/Viewer/PageViewer.jsx
@@ -1222,7 +1222,10 @@ export function PageViewer({
                 activityVariantIndex,
                 requestedVariant: initialCoreData.current.requestedVariant,
                 stateVariableChanges: initialCoreData.current.coreState
-                    ? initialCoreData.current.coreState
+                    ? JSON.stringify(
+                          initialCoreData.current.coreState,
+                          serializedComponentsReplacer,
+                      )
                     : undefined,
                 apiURLs: apiURLs,
             },


### PR DESCRIPTION
State variable changes to the core web worker were sent a Javascript object. However, in the transition to the web worker, the subset class information was lost. To preserve subset class information, serialize the state changes before passing to the web worker.