### PR TITLE
give warning when an answer's award depends on its submitted response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22819,7 +22819,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.0-alpha19",
+            "version": "0.7.0-alpha20",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@chakra-ui/icons": "^2.0.19",
@@ -22861,7 +22861,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.0-alpha19",
+            "version": "0.7.0-alpha20",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -22939,7 +22939,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.0-alpha19",
+            "version": "0.7.0-alpha20",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml-iframe",
     "type": "module",
     "description": "A renderer for DoenetML contained in an iframe",
-    "version": "0.7.0-alpha19",
+    "version": "0.7.0-alpha20",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml-worker/src/Core.js
+++ b/packages/doenetml-worker/src/Core.js
@@ -227,7 +227,6 @@ export default class Core {
         };
 
         this.finishCoreConstruction().catch((e) => {
-            // throw e;
             this.rejectInitialized(e);
         });
     }

--- a/packages/doenetml-worker/src/CoreWorker.js
+++ b/packages/doenetml-worker/src/CoreWorker.js
@@ -174,13 +174,21 @@ async function createCore(args) {
         Object.assign(coreArgs, args);
 
         core = new Core(coreArgs);
-        core.getInitializedPromise().then(() => {
+
+        try {
+            await core.getInitializedPromise();
             // console.log('actions to process', queuedRequestActions)
             for (let action of queuedRequestActions) {
                 core.requestAction(action);
             }
             queuedRequestActions = [];
-        });
+        } catch (e) {
+            postMessage({
+                messageType: "inErrorState",
+                coreId: coreArgs.coreId,
+                args: { errMsg: e.message },
+            });
+        }
     } else {
         let errMsg =
             initializeResult.success === false

--- a/packages/doenetml-worker/src/test/tagSpecific/answer.test.ts
+++ b/packages/doenetml-worker/src/test/tagSpecific/answer.test.ts
@@ -1428,6 +1428,123 @@ describe("Answer tag tests", async () => {
         expect(stateVariables["/answer1"].stateValues.creditAchieved).eq(1);
     });
 
+    async function check_award_based_on_submitted_response(
+        core: any,
+        eventually_correct = true,
+    ) {
+        let errorWarnings = core.errorWarnings;
+
+        expect(errorWarnings.errors.length).eq(0);
+        expect(errorWarnings.warnings.length).eq(1);
+
+        expect(errorWarnings.warnings[0].message).contain(
+            "An award for this answer is based on the answer's own submitted response",
+        );
+        expect(errorWarnings.warnings[0].level).eq(1);
+        expect(errorWarnings.warnings[0].doenetMLrange.lineBegin).eq(2);
+        expect(errorWarnings.warnings[0].doenetMLrange.charBegin).eq(5);
+        expect(errorWarnings.warnings[0].doenetMLrange.lineEnd).eq(5);
+        expect(errorWarnings.warnings[0].doenetMLrange.charEnd).eq(13);
+
+        let stateVariables = await returnAllStateVariables(core);
+        let mathInputName =
+            stateVariables["/ans"].stateValues.inputChildren[0].componentName;
+
+        // have to submit the correct answer twice before it is marked correct
+        await updateMathInputValue({
+            latex: "5",
+            componentName: mathInputName,
+            core,
+        });
+        await core.requestAction({
+            componentName: "/ans",
+            actionName: "submitAnswer",
+            args: {},
+            event: null,
+        });
+        stateVariables = await returnAllStateVariables(core);
+
+        // answer is not correct because the submitted response was initially blank
+        expect(stateVariables["/ans"].stateValues.creditAchieved).eq(0);
+        // justSubmitted becomes false at the criteria (based on submitted response)
+        // change when the answer is submitted
+        expect(stateVariables["/ans"].stateValues.justSubmitted).eq(false);
+
+        await core.requestAction({
+            componentName: "/ans",
+            actionName: "submitAnswer",
+            args: {},
+            event: null,
+        });
+        stateVariables = await returnAllStateVariables(core);
+
+        // if `eventually correct` is set to `true`, then
+        // the second time, the answer is marked correct and justSubmitted stays true
+        // because the submitted response starts off correct and doesn't change
+        expect(stateVariables["/ans"].stateValues.creditAchieved).eq(
+            eventually_correct ? 1 : 0,
+        );
+        expect(stateVariables["/ans"].stateValues.justSubmitted).eq(true);
+    }
+
+    it("warning for award depending on submitted response", async () => {
+        const doenetMLs = [
+            `
+    <answer name="ans">
+        <mathInput />
+        <award><when>$ans</when></award>
+    </answer>`,
+            `
+    <answer name="ans">
+        <mathInput />
+        <award><when>$ans.submittedResponse=5</when></award>
+    </answer>`,
+            `
+    <answer name="ans">
+        <mathInput />
+        <award><when>$ans.submittedResponse1=5</when></award>
+    </answer>`,
+            `
+    <answer name="ans">
+        <mathInput />
+        <award><when>$ans.submittedResponses=5</when></award>
+    </answer>`,
+        ];
+
+        for (let doenetML of doenetMLs) {
+            let core = await createTestCore({
+                doenetML,
+            });
+            await check_award_based_on_submitted_response(core);
+        }
+
+        let doenetML = `
+    <answer name="ans">
+        <mathInput />
+        <award><when>$ans.submittedResponse2=5</when></award>
+    </answer>`;
+
+        let core = await createTestCore({
+            doenetML,
+        });
+        await check_award_based_on_submitted_response(core, false);
+    });
+
+    it("award depending on current response throws error", async () => {
+        const doenetMLs = [
+            `<answer name="ans"><mathInput /><award><when>$ans.currentResponse=5</when></award></answer>`,
+            `<answer name="ans"><mathInput /><award><when>$ans.currentResponse1=5</when></award></answer>`,
+            `<answer name="ans"><mathInput /><award><when>$ans.currentResponse2=5</when></award></answer>`,
+            `<answer name="ans"><mathInput /><award><when>$ans.currentResponses=5</when></award></answer>`,
+        ];
+
+        for (let doenetML of doenetMLs) {
+            await expect(createTestCore({ doenetML })).rejects.toThrow(
+                "Circular dependency",
+            );
+        }
+    });
+
     it("answer award with math", async () => {
         const doenetML = `
     <answer name="answer1"><award><math>x+y</math></award></answer>

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.7.0-alpha19",
+    "version": "0.7.0-alpha20",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.7.0-alpha19",
+    "version": "0.7.0-alpha20",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,


### PR DESCRIPTION
This PR creates a warning if one writes an answer such as
```
<answer name="ans">
    <mathInput />
    <award><when>$ans</when></award>
</answer>
```
where the award depends on the answer's submitted response.

Creating such an answer is an easy mistake when learning DoenetML, but it leads to requiring that one submits an answer twice before it is properly validated.