### PR TITLE
add lcm math operator

### DIFF
--- a/packages/doenetml-worker/src/components/BooleanList.js
+++ b/packages/doenetml-worker/src/components/BooleanList.js
@@ -155,9 +155,6 @@ export default class BooleanList extends CompositeComponent {
         };
 
         stateVariableDefinitions.booleans = {
-            shadowingInstructions: {
-                createComponentOfType: "boolean",
-            },
             isArray: true,
             entryPrefixes: ["boolean"],
             stateVariablesDeterminingDependencies: ["childNameByComponent"],

--- a/packages/doenetml-worker/src/components/MathList.js
+++ b/packages/doenetml-worker/src/components/MathList.js
@@ -277,9 +277,6 @@ export default class MathList extends CompositeComponent {
         };
 
         stateVariableDefinitions.maths = {
-            shadowingInstructions: {
-                createComponentOfType: "math",
-            },
             isArray: true,
             entryPrefixes: ["math"],
             stateVariablesDeterminingDependencies: [

--- a/packages/doenetml-worker/src/components/MathOperators.js
+++ b/packages/doenetml-worker/src/components/MathOperators.js
@@ -1118,6 +1118,45 @@ export class Gcd extends MathBaseOperator {
     }
 }
 
+export class Lcm extends MathBaseOperator {
+    static componentType = "lcm";
+
+    static returnStateVariableDefinitions() {
+        let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        stateVariableDefinitions.numericOperator = {
+            returnDependencies: () => ({}),
+            definition: () => ({
+                setValue: {
+                    numericOperator: function (inputs) {
+                        if (inputs.every(Number.isInteger)) {
+                            return lcm(...inputs);
+                        }
+                        return NaN;
+                    },
+                },
+            }),
+        };
+
+        stateVariableDefinitions.mathOperator = {
+            returnDependencies: () => ({}),
+            definition: () => ({
+                setValue: {
+                    mathOperator: function (inputs) {
+                        return me.fromAst([
+                            "apply",
+                            "lcm",
+                            ["tuple", ...inputs.map((x) => x.tree)],
+                        ]);
+                    },
+                },
+            }),
+        };
+
+        return stateVariableDefinitions;
+    }
+}
+
 export class ExtractMath extends MathBaseOperatorOneInput {
     static componentType = "extractMath";
 
@@ -1334,4 +1373,14 @@ function gcd(x, y, ...z) {
         return x;
     }
     return gcd(y, x % y, ...z);
+}
+
+function lcm(...z) {
+    let prod = z.reduce((a, c) => a * c, 1);
+
+    let gcdArgs = z.map((v) => prod / v);
+
+    let g = gcd(...gcdArgs);
+
+    return prod / g;
 }

--- a/packages/doenetml-worker/src/components/NumberList.js
+++ b/packages/doenetml-worker/src/components/NumberList.js
@@ -120,10 +120,6 @@ export default class NumberList extends CompositeComponent {
         };
 
         stateVariableDefinitions.mergeMathLists = {
-            public: true,
-            shadowingInstructions: {
-                createComponentOfType: "boolean",
-            },
             returnDependencies: () => ({
                 mergeMathListsAttr: {
                     dependencyType: "attributeComponent",
@@ -253,9 +249,6 @@ export default class NumberList extends CompositeComponent {
         };
 
         stateVariableDefinitions.numbers = {
-            shadowingInstructions: {
-                createComponentOfType: "number",
-            },
             isArray: true,
             entryPrefixes: ["number"],
             stateVariablesDeterminingDependencies: [

--- a/packages/doenetml-worker/src/components/TextList.js
+++ b/packages/doenetml-worker/src/components/TextList.js
@@ -158,9 +158,6 @@ export default class TextList extends CompositeComponent {
         };
 
         stateVariableDefinitions.texts = {
-            shadowingInstructions: {
-                createComponentOfType: "text",
-            },
             isArray: true,
             entryPrefixes: ["text"],
             stateVariablesDeterminingDependencies: ["childNameByComponent"],

--- a/packages/doenetml-worker/src/test/tagSpecific/mathoperators.test.ts
+++ b/packages/doenetml-worker/src/test/tagSpecific/mathoperators.test.ts
@@ -7569,19 +7569,39 @@ describe("Math operator tests", async () => {
     it("gcd", async () => {
         let core = await createTestCore({
             doenetML: `
-      <gcd><number>135</number><number>81</number></gcd>
-      <gcd>135 81 63</gcd>
-      <gcd>x y z</gcd>
+      <gcd name="gcd1"><number>135</number><number>81</number></gcd>
+      <gcd name="gcd2">135 81 63</gcd>
+      <gcd name="gcd3">x y z</gcd>
       `,
         });
 
         let stateVariables = await returnAllStateVariables(core);
 
-        expect(stateVariables["/_gcd1"].stateValues.value.tree).eq(27);
-        expect(stateVariables["/_gcd2"].stateValues.value.tree).eq(9);
-        expect(stateVariables["/_gcd3"].stateValues.value.tree).eqls([
+        expect(stateVariables["/gcd1"].stateValues.value.tree).eq(27);
+        expect(stateVariables["/gcd2"].stateValues.value.tree).eq(9);
+        expect(stateVariables["/gcd3"].stateValues.value.tree).eqls([
             "apply",
             "gcd",
+            ["tuple", "x", "y", "z"],
+        ]);
+    });
+
+    it("lcm", async () => {
+        let core = await createTestCore({
+            doenetML: `
+      <lcm name="lcm1"><number>135</number><number>81</number></lcm>
+      <lcm name="lcm2">135 81 63</lcm>
+      <lcm name="lcm3">x y z</lcm>
+      `,
+        });
+
+        let stateVariables = await returnAllStateVariables(core);
+
+        expect(stateVariables["/lcm1"].stateValues.value.tree).eq(405);
+        expect(stateVariables["/lcm2"].stateValues.value.tree).eq(2835);
+        expect(stateVariables["/lcm3"].stateValues.value.tree).eqls([
+            "apply",
+            "lcm",
             ["tuple", "x", "y", "z"],
         ]);
     });

--- a/packages/doenetml-worker/src/test/tagSpecific/selectsamplerandomnumbers.test.ts
+++ b/packages/doenetml-worker/src/test/tagSpecific/selectsamplerandomnumbers.test.ts
@@ -548,7 +548,7 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests", async () => {
                 numRepetitions: 80,
                 validValues: vals,
                 allowedMeanMid: mean,
-                allowedMeanSpread: 0.5,
+                allowedMeanSpread: 0.6,
                 allowedVarianceMid: variance,
                 allowedVarianceSpread: 1,
                 expectedMean: mean,

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -303,8 +303,6 @@ export function getSchema() {
                     }),
                 );
             } else {
-                let foundMatch = false;
-
                 for (let prefix of arrayEntryPrefixesLongestToShortest) {
                     if (
                         aliasTargetName.substring(0, prefix.length) === prefix
@@ -338,17 +336,8 @@ export function getSchema() {
                             }),
                         );
 
-                        foundMatch = true;
                         break;
                     }
-                }
-
-                if (!foundMatch) {
-                    properties.push({
-                        name: aliasName,
-                        type: "unknown",
-                        isArray: false,
-                    });
                 }
             }
         }

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -42,6 +42,7 @@
         "max",
         "mod",
         "gcd",
+        "lcm",
         "extractMath",
         "clampFunction",
         "wrapFunctionPeriodic",
@@ -378,6 +379,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -933,6 +937,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -1295,6 +1302,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -1338,6 +1358,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -1500,6 +1525,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -2043,6 +2071,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -2825,6 +2856,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -3414,6 +3448,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -3980,6 +4017,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -4741,6 +4781,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -5500,6 +5543,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -6256,6 +6302,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -6571,7 +6620,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "listItems",
+                    "name": "list",
                     "type": "text",
                     "isArray": true,
                     "numDimensions": 1,
@@ -6769,6 +6818,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -7346,6 +7398,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -7919,6 +7974,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -8857,6 +8915,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -9406,6 +9467,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -10641,6 +10705,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -11060,6 +11127,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -11489,6 +11559,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -11972,6 +12045,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -12332,6 +12408,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -12375,6 +12464,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -12584,6 +12678,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -12946,6 +13043,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -12989,6 +13099,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -13198,6 +13313,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -13572,6 +13690,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -13615,6 +13746,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -13824,6 +13960,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -14198,6 +14337,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -14241,6 +14393,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -14450,6 +14607,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -14824,6 +14984,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -14867,6 +15040,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -15072,6 +15250,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -15441,6 +15622,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -15484,6 +15678,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -15681,6 +15880,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -16040,6 +16242,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -16083,6 +16298,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -16284,6 +16504,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -16648,6 +16871,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -16691,6 +16927,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -16892,6 +17133,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -17256,6 +17500,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -17299,6 +17556,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -17500,6 +17762,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -17864,6 +18129,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -17907,6 +18185,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -18108,6 +18391,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -18472,6 +18758,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -18515,6 +18814,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -18724,6 +19028,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -19086,6 +19393,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -19129,6 +19449,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -19338,6 +19663,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -19700,6 +20028,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -19743,6 +20084,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -19956,6 +20302,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -20323,6 +20672,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -20366,6 +20728,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -20579,6 +20946,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -20946,6 +21316,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -20989,6 +21372,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -21198,6 +21586,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -21560,6 +21951,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -21603,6 +22007,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -21812,6 +22221,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -22174,6 +22586,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -22217,6 +22642,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -22426,6 +22856,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -22788,6 +23221,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -22831,6 +23277,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -23040,6 +23491,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -23402,6 +23856,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -23445,6 +23912,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -23654,6 +24126,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -24016,6 +24491,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -24059,6 +24547,646 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
+                }
+            ]
+        },
+        "lcm": {
+            "type": "element",
+            "name": "lcm",
+            "attributes": {
+                "name": {
+                    "optional": true,
+                    "type": ["string"]
+                },
+                "copySource": {
+                    "optional": true,
+                    "type": ["string"]
+                },
+                "hide": {
+                    "optional": true,
+                    "type": ["true", "false"]
+                },
+                "disabled": {
+                    "optional": true,
+                    "type": ["true", "false"]
+                },
+                "fixed": {
+                    "optional": true,
+                    "type": ["true", "false"]
+                },
+                "fixLocation": {
+                    "optional": true,
+                    "type": ["true", "false"]
+                },
+                "styleNumber": {
+                    "optional": true,
+                    "type": ["string"]
+                },
+                "isResponse": {
+                    "optional": true,
+                    "type": ["true", "false"]
+                },
+                "newNamespace": {
+                    "optional": true,
+                    "type": ["true", "false"]
+                },
+                "format": {
+                    "optional": true,
+                    "type": ["text", "latex"]
+                },
+                "simplify": {
+                    "optional": true,
+                    "type": ["none", "full", "numbers", "numberspreserveorder"]
+                },
+                "expand": {
+                    "optional": true,
+                    "type": ["true", "false"]
+                },
+                "displayDigits": {
+                    "optional": true,
+                    "type": ["string"]
+                },
+                "displayDecimals": {
+                    "optional": true,
+                    "type": ["string"]
+                },
+                "displaySmallAsZero": {
+                    "optional": true,
+                    "type": ["string"]
+                },
+                "padZeros": {
+                    "optional": true,
+                    "type": ["true", "false"]
+                },
+                "renderMode": {
+                    "optional": true,
+                    "type": ["string"]
+                },
+                "unordered": {
+                    "optional": true,
+                    "type": ["true", "false"]
+                },
+                "createVectors": {
+                    "optional": true,
+                    "type": ["true", "false"]
+                },
+                "createIntervals": {
+                    "optional": true,
+                    "type": ["true", "false"]
+                },
+                "functionSymbols": {
+                    "optional": true,
+                    "type": ["string"]
+                },
+                "sourcesAreFunctionSymbols": {
+                    "optional": true,
+                    "type": ["string"]
+                },
+                "splitSymbols": {
+                    "optional": true,
+                    "type": ["true", "false"]
+                },
+                "parseScientificNotation": {
+                    "optional": true,
+                    "type": ["true", "false"]
+                },
+                "displayBlanks": {
+                    "optional": true,
+                    "type": ["true", "false"]
+                },
+                "draggable": {
+                    "optional": true,
+                    "type": ["true", "false"]
+                },
+                "layer": {
+                    "optional": true,
+                    "type": ["string"]
+                },
+                "anchor": {
+                    "optional": true,
+                    "type": ["string"]
+                },
+                "positionFromAnchor": {
+                    "optional": true,
+                    "type": [
+                        "upperright",
+                        "upperleft",
+                        "lowerright",
+                        "lowerleft",
+                        "top",
+                        "bottom",
+                        "left",
+                        "right",
+                        "center"
+                    ]
+                },
+                "forceSymbolic": {
+                    "optional": true,
+                    "type": ["true", "false"]
+                },
+                "forceNumeric": {
+                    "optional": true,
+                    "type": ["true", "false"]
+                }
+            },
+            "children": [
+                {
+                    "ref": "rightHandSide"
+                },
+                {
+                    "ref": "topic"
+                },
+                {
+                    "ref": "sum"
+                },
+                {
+                    "ref": "product"
+                },
+                {
+                    "ref": "clampNumber"
+                },
+                {
+                    "ref": "wrapNumberPeriodic"
+                },
+                {
+                    "ref": "round"
+                },
+                {
+                    "ref": "setSmallToZero"
+                },
+                {
+                    "ref": "convertSetToList"
+                },
+                {
+                    "ref": "ceil"
+                },
+                {
+                    "ref": "floor"
+                },
+                {
+                    "ref": "abs"
+                },
+                {
+                    "ref": "sign"
+                },
+                {
+                    "ref": "mean"
+                },
+                {
+                    "ref": "median"
+                },
+                {
+                    "ref": "variance"
+                },
+                {
+                    "ref": "standardDeviation"
+                },
+                {
+                    "ref": "count"
+                },
+                {
+                    "ref": "min"
+                },
+                {
+                    "ref": "max"
+                },
+                {
+                    "ref": "mod"
+                },
+                {
+                    "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
+                },
+                {
+                    "ref": "extractMath"
+                },
+                {
+                    "ref": "clampFunction"
+                },
+                {
+                    "ref": "wrapFunctionPeriodic"
+                },
+                {
+                    "ref": "derivative"
+                },
+                {
+                    "ref": "extractMathOperator"
+                },
+                {
+                    "ref": "equilibriumPoint"
+                },
+                {
+                    "ref": "equilibriumLine"
+                },
+                {
+                    "ref": "atom"
+                },
+                {
+                    "ref": "ion"
+                },
+                {
+                    "ref": "ionicCompound"
+                },
+                {
+                    "ref": "electronConfiguration"
+                },
+                {
+                    "ref": "h"
+                },
+                {
+                    "ref": "matrixInput"
+                },
+                {
+                    "ref": "text"
+                },
+                {
+                    "ref": "math"
+                },
+                {
+                    "ref": "point"
+                },
+                {
+                    "ref": "coords"
+                },
+                {
+                    "ref": "line"
+                },
+                {
+                    "ref": "vector"
+                },
+                {
+                    "ref": "angle"
+                },
+                {
+                    "ref": "mathInput"
+                },
+                {
+                    "ref": "choice"
+                },
+                {
+                    "ref": "number"
+                },
+                {
+                    "ref": "integer"
+                },
+                {
+                    "ref": "function"
+                },
+                {
+                    "ref": "piecewiseFunction"
+                },
+                {
+                    "ref": "interval"
+                },
+                {
+                    "ref": "sequence"
+                },
+                {
+                    "ref": "cell"
+                },
+                {
+                    "ref": "selectFromSequence"
+                },
+                {
+                    "ref": "evaluate"
+                },
+                {
+                    "ref": "selectRandomNumbers"
+                },
+                {
+                    "ref": "sampleRandomNumbers"
+                },
+                {
+                    "ref": "selectPrimeNumbers"
+                },
+                {
+                    "ref": "samplePrimeNumbers"
+                },
+                {
+                    "ref": "substitute"
+                },
+                {
+                    "ref": "periodicSet"
+                },
+                {
+                    "ref": "intcomma"
+                },
+                {
+                    "ref": "pluralize"
+                },
+                {
+                    "ref": "lorem"
+                },
+                {
+                    "ref": "endpoint"
+                },
+                {
+                    "ref": "subsetOfReals"
+                },
+                {
+                    "ref": "bestFitLine"
+                },
+                {
+                    "ref": "matrix"
+                },
+                {
+                    "ref": "latex"
+                }
+            ],
+            "textChildrenAllowed": true,
+            "properties": [
+                {
+                    "name": "hide",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "modifyIndirectly",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "styleNumber",
+                    "type": "integer",
+                    "isArray": false
+                },
+                {
+                    "name": "isResponse",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "newNamespace",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "permid",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "format",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "simplify",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "expand",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "renderMode",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "createVectors",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "createIntervals",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "functionSymbols",
+                    "type": "textList",
+                    "isArray": false
+                },
+                {
+                    "name": "splitSymbols",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "parseScientificNotation",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "displayBlanks",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "draggable",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "layer",
+                    "type": "number",
+                    "isArray": false
+                },
+                {
+                    "name": "positionFromAnchor",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "forceSymbolic",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "forceNumeric",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "hidden",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "disabled",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "fixed",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "fixLocation",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "doenetML",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "textColor",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "backgroundColor",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "textStyleDescription",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "anchor",
+                    "type": "point",
+                    "isArray": false
+                },
+                {
+                    "name": "displayDigits",
+                    "type": "integer",
+                    "isArray": false
+                },
+                {
+                    "name": "displayDecimals",
+                    "type": "integer",
+                    "isArray": false
+                },
+                {
+                    "name": "displaySmallAsZero",
+                    "type": "number",
+                    "isArray": false
+                },
+                {
+                    "name": "padZeros",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "unordered",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "value",
+                    "type": "lcm",
+                    "isArray": false
+                },
+                {
+                    "name": "number",
+                    "type": "number",
+                    "isArray": false
+                },
+                {
+                    "name": "isNumber",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "isNumeric",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "latex",
+                    "type": "latex",
+                    "isArray": false
+                },
+                {
+                    "name": "text",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "numDimensions",
+                    "type": "integer",
+                    "isArray": false
+                },
+                {
+                    "name": "vector",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": false,
+                            "type": "vector"
+                        }
+                    ]
+                },
+                {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "matrixSize",
+                    "type": "numberList",
+                    "isArray": false
+                },
+                {
+                    "name": "numRows",
+                    "type": "integer",
+                    "isArray": false
+                },
+                {
+                    "name": "numColumns",
+                    "type": "integer",
+                    "isArray": false
+                },
+                {
+                    "name": "matrix",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 2,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        },
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        }
+                    ]
+                },
+                {
+                    "name": "x",
+                    "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "y",
+                    "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "z",
+                    "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -24277,6 +25405,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -24651,6 +25782,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -24694,6 +25838,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -24920,6 +26069,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -25394,21 +26546,6 @@
                 {
                     "name": "variable",
                     "type": "_variableName",
-                    "isArray": false
-                },
-                {
-                    "name": "symbolicf",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
-                    "name": "fDefinition",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
-                    "name": "f",
-                    "type": "unknown",
                     "isArray": false
                 }
             ]
@@ -25635,6 +26772,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -26110,21 +27250,6 @@
                     "name": "variable",
                     "type": "_variableName",
                     "isArray": false
-                },
-                {
-                    "name": "symbolicf",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
-                    "name": "fDefinition",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
-                    "name": "f",
-                    "type": "unknown",
-                    "isArray": false
                 }
             ]
         },
@@ -26348,6 +27473,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -26833,21 +27961,6 @@
                     "name": "variable",
                     "type": "_variableName",
                     "isArray": false
-                },
-                {
-                    "name": "symbolicf",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
-                    "name": "fDefinition",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
-                    "name": "f",
-                    "type": "unknown",
-                    "isArray": false
                 }
             ]
         },
@@ -26988,6 +28101,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -27284,7 +28400,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "listItems",
+                    "name": "list",
                     "type": "text",
                     "isArray": true,
                     "numDimensions": 1,
@@ -27456,6 +28572,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -27967,6 +29086,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -28474,6 +29596,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -28985,6 +30110,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -29492,6 +30620,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -30003,6 +31134,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -30510,6 +31644,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -31021,6 +32158,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -31530,6 +32670,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -32037,6 +33180,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -33467,6 +34613,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -34370,6 +35519,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -35277,6 +36429,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -36180,6 +37335,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -37095,6 +38253,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -38005,6 +39166,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -38908,6 +40072,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -39815,6 +40982,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -40718,6 +41888,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -41625,6 +42798,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -42528,6 +43704,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -43435,6 +44614,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -44340,6 +45522,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -45243,6 +46428,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -46158,6 +47346,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -47063,6 +48254,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -47961,6 +49155,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -49051,6 +50248,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -50612,6 +51812,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -51154,6 +52357,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -51749,6 +52955,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -53022,6 +54231,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -53384,6 +54596,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -53427,6 +54652,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -53548,6 +54778,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -55115,6 +56348,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -55875,6 +57111,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -56190,7 +57429,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "listItems",
+                    "name": "list",
                     "type": "text",
                     "isArray": true,
                     "numDimensions": 1,
@@ -56341,6 +57580,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -56668,6 +57910,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -57429,6 +58674,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -58188,6 +59436,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -58945,6 +60196,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -59728,6 +60982,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -60902,6 +62159,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -61580,6 +62840,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -62352,6 +63615,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -62667,7 +63933,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "listItems",
+                    "name": "list",
                     "type": "text",
                     "isArray": true,
                     "numDimensions": 1,
@@ -62827,6 +64093,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -63002,11 +64271,6 @@
                     "name": "numValues",
                     "type": "number",
                     "isArray": false
-                },
-                {
-                    "name": "values",
-                    "type": "unknown",
-                    "isArray": false
                 }
             ]
         },
@@ -63168,6 +64432,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -63682,6 +64949,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -64153,11 +65423,6 @@
                     "name": "numValues",
                     "type": "number",
                     "isArray": false
-                },
-                {
-                    "name": "values",
-                    "type": "unknown",
-                    "isArray": false
                 }
             ]
         },
@@ -64358,6 +65623,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -64722,6 +65990,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -64765,6 +66046,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -64926,6 +66212,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -65149,35 +66438,9 @@
                     "isArray": false
                 },
                 {
-                    "name": "maths",
-                    "type": "math",
-                    "isArray": true,
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": true,
-                            "type": "math",
-                            "numDimensions": 1
-                        }
-                    ]
-                },
-                {
                     "name": "numValues",
                     "type": "number",
                     "isArray": false
-                },
-                {
-                    "name": "values",
-                    "type": "math",
-                    "isArray": true,
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": true,
-                            "type": "math",
-                            "numDimensions": 1
-                        }
-                    ]
                 }
             ]
         },
@@ -65338,6 +66601,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -65561,35 +66827,9 @@
                     "isArray": false
                 },
                 {
-                    "name": "maths",
-                    "type": "math",
-                    "isArray": true,
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": true,
-                            "type": "math",
-                            "numDimensions": 1
-                        }
-                    ]
-                },
-                {
                     "name": "numValues",
                     "type": "number",
                     "isArray": false
-                },
-                {
-                    "name": "values",
-                    "type": "math",
-                    "isArray": true,
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": true,
-                            "type": "math",
-                            "numDimensions": 1
-                        }
-                    ]
                 }
             ]
         },
@@ -65730,6 +66970,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -65806,6 +67049,63 @@
                 },
                 {
                     "ref": "latex"
+                },
+                {
+                    "ref": "clampFunction"
+                },
+                {
+                    "ref": "wrapFunctionPeriodic"
+                },
+                {
+                    "ref": "derivative"
+                },
+                {
+                    "ref": "equilibriumPoint"
+                },
+                {
+                    "ref": "equilibriumLine"
+                },
+                {
+                    "ref": "atom"
+                },
+                {
+                    "ref": "ion"
+                },
+                {
+                    "ref": "ionicCompound"
+                },
+                {
+                    "ref": "matrixInput"
+                },
+                {
+                    "ref": "point"
+                },
+                {
+                    "ref": "line"
+                },
+                {
+                    "ref": "vector"
+                },
+                {
+                    "ref": "angle"
+                },
+                {
+                    "ref": "mathInput"
+                },
+                {
+                    "ref": "choice"
+                },
+                {
+                    "ref": "function"
+                },
+                {
+                    "ref": "piecewiseFunction"
+                },
+                {
+                    "ref": "endpoint"
+                },
+                {
+                    "ref": "bestFitLine"
                 }
             ],
             "textChildrenAllowed": true,
@@ -65878,11 +67178,6 @@
                 {
                     "name": "numValues",
                     "type": "number",
-                    "isArray": false
-                },
-                {
-                    "name": "values",
-                    "type": "unknown",
                     "isArray": false
                 }
             ]
@@ -66195,6 +67490,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -66995,6 +68293,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -67533,6 +68834,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -67890,6 +69194,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -67938,6 +69255,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -68123,6 +69445,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -71013,6 +72338,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -71593,6 +72921,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -71943,11 +73274,6 @@
                     "name": "equation",
                     "type": "math",
                     "isArray": false
-                },
-                {
-                    "name": "f",
-                    "type": "unknown",
-                    "isArray": false
                 }
             ]
         },
@@ -72182,6 +73508,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -72775,6 +74104,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -73086,6 +74418,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -73484,6 +74819,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -74017,6 +75355,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -74543,6 +75884,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -75211,6 +76555,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -75749,6 +77096,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -76258,6 +77608,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -76578,6 +77931,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -76621,6 +77987,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -76808,6 +78179,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -77083,7 +78457,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "listItems",
+                    "name": "list",
                     "type": "text",
                     "isArray": true,
                     "numDimensions": 1,
@@ -77284,6 +78658,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -77811,11 +79188,6 @@
                     ]
                 },
                 {
-                    "name": "numValues",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
                     "name": "selectedIndex",
                     "type": "number",
                     "isArray": false
@@ -77847,11 +79219,6 @@
                             "numDimensions": 1
                         }
                     ]
-                },
-                {
-                    "name": "valueRecordedAtSubmit",
-                    "type": "unknown",
-                    "isArray": false
                 }
             ]
         },
@@ -78038,6 +79405,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -78833,6 +80203,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -79313,6 +80686,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -79861,6 +81237,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -80595,6 +81974,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -81060,21 +82442,6 @@
                     "name": "variable",
                     "type": "_variableName",
                     "isArray": false
-                },
-                {
-                    "name": "symbolicf",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
-                    "name": "fDefinition",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
-                    "name": "f",
-                    "type": "unknown",
-                    "isArray": false
                 }
             ]
         },
@@ -81534,21 +82901,6 @@
                     "name": "variable",
                     "type": "_variableName",
                     "isArray": false
-                },
-                {
-                    "name": "symbolicf",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
-                    "name": "fDefinition",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
-                    "name": "f",
-                    "type": "unknown",
-                    "isArray": false
                 }
             ]
         },
@@ -81745,6 +83097,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -82104,6 +83459,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -82152,6 +83520,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -82343,6 +83716,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -83130,6 +84506,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -84054,6 +85433,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -84730,6 +86112,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -86219,6 +87604,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -86896,6 +88284,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -87535,6 +88926,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -88011,6 +89405,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -89484,6 +90881,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -89822,6 +91222,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -90426,6 +91829,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -90979,6 +92385,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -91729,6 +93138,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -92724,6 +94136,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -93894,6 +95309,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -93942,6 +95370,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -94913,6 +96346,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -95946,6 +97382,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -96004,6 +97453,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -96601,6 +98055,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -97369,6 +98826,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -97679,7 +99139,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "listItems",
+                    "name": "list",
                     "type": "text",
                     "isArray": true,
                     "numDimensions": 1,
@@ -97875,6 +99335,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -98197,7 +99660,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "listItems",
+                    "name": "list",
                     "type": "text",
                     "isArray": true,
                     "numDimensions": 1,
@@ -98392,6 +99855,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -99146,6 +100612,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -99929,6 +101398,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -101671,6 +103143,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -102548,6 +104023,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -103301,6 +104779,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -103813,6 +105294,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -104507,6 +105991,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -105055,6 +106542,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -105842,6 +107332,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -106557,6 +108050,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -107242,6 +108738,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -107609,6 +109108,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -107704,6 +109216,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -107891,6 +109408,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -109545,6 +111065,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -110502,6 +112025,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -111508,6 +113034,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -112090,6 +113619,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -112770,6 +114302,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -112813,6 +114358,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ]
@@ -112940,6 +114490,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -113352,6 +114905,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -113733,7 +115289,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "listItems",
+                    "name": "list",
                     "type": "text",
                     "isArray": true,
                     "numDimensions": 1,
@@ -113919,6 +115475,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"
@@ -114692,6 +116251,9 @@
                     "ref": "gcd"
                 },
                 {
+                    "ref": "lcm"
+                },
+                {
                     "ref": "extractMath"
                 },
                 {
@@ -115424,6 +116986,9 @@
                 },
                 {
                     "ref": "gcd"
+                },
+                {
+                    "ref": "lcm"
                 },
                 {
                     "ref": "extractMath"

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -42,6 +42,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -268,6 +269,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -654,6 +656,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -697,6 +712,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ],
@@ -745,6 +765,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -991,6 +1012,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -1322,6 +1344,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -1637,6 +1660,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -1955,6 +1979,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -2273,6 +2298,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -2591,6 +2617,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -2898,6 +2925,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "extractMathOperator",
                 "atom",
@@ -3172,7 +3200,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "listItems",
+                    "name": "list",
                     "type": "text",
                     "isArray": true,
                     "numDimensions": 1,
@@ -3230,6 +3258,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -3532,6 +3561,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -3834,6 +3864,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -4475,6 +4506,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -4769,6 +4801,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -5766,6 +5799,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -6052,6 +6086,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -6338,6 +6373,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -6641,6 +6677,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -7041,6 +7078,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -7085,6 +7135,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -7115,6 +7170,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -7515,6 +7571,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -7559,6 +7628,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -7589,6 +7663,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -7991,6 +8066,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -8035,6 +8123,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -8065,6 +8158,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -8467,6 +8561,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -8511,6 +8618,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -8541,6 +8653,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -8943,6 +9056,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -8987,6 +9113,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -9017,6 +9148,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -9411,6 +9543,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -9455,6 +9600,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -9485,6 +9635,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -9862,6 +10013,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -9906,6 +10070,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -9936,6 +10105,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -10322,6 +10492,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -10366,6 +10549,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -10396,6 +10584,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -10782,6 +10971,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -10826,6 +11028,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -10856,6 +11063,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -11242,6 +11450,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -11286,6 +11507,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -11316,6 +11542,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -11702,6 +11929,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -11746,6 +11986,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -11776,6 +12021,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -12176,6 +12422,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -12220,6 +12479,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -12250,6 +12514,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -12650,6 +12915,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -12694,6 +12972,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -12724,6 +13007,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -13133,6 +13417,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -13177,6 +13474,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -13207,6 +13509,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -13616,6 +13919,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -13660,6 +13976,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -13690,6 +14011,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -14090,6 +14412,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -14134,6 +14469,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -14164,6 +14504,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -14564,6 +14905,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -14608,6 +14962,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -14638,6 +14997,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -15038,6 +15398,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -15082,6 +15455,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -15112,6 +15490,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -15512,6 +15891,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -15556,6 +15948,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -15586,6 +15983,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -15986,6 +16384,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -16030,6 +16441,504 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
+                }
+            ],
+            "top": true,
+            "acceptsStringChildren": true
+        },
+        {
+            "name": "lcm",
+            "children": [
+                "rightHandSide",
+                "topic",
+                "sum",
+                "product",
+                "clampNumber",
+                "wrapNumberPeriodic",
+                "round",
+                "setSmallToZero",
+                "convertSetToList",
+                "ceil",
+                "floor",
+                "abs",
+                "sign",
+                "mean",
+                "median",
+                "variance",
+                "standardDeviation",
+                "count",
+                "min",
+                "max",
+                "mod",
+                "gcd",
+                "lcm",
+                "extractMath",
+                "clampFunction",
+                "wrapFunctionPeriodic",
+                "derivative",
+                "extractMathOperator",
+                "equilibriumPoint",
+                "equilibriumLine",
+                "atom",
+                "ion",
+                "ionicCompound",
+                "electronConfiguration",
+                "h",
+                "matrixInput",
+                "text",
+                "math",
+                "point",
+                "coords",
+                "line",
+                "vector",
+                "angle",
+                "mathInput",
+                "choice",
+                "number",
+                "integer",
+                "function",
+                "piecewiseFunction",
+                "interval",
+                "sequence",
+                "cell",
+                "selectFromSequence",
+                "evaluate",
+                "selectRandomNumbers",
+                "sampleRandomNumbers",
+                "selectPrimeNumbers",
+                "samplePrimeNumbers",
+                "substitute",
+                "periodicSet",
+                "intcomma",
+                "pluralize",
+                "lorem",
+                "endpoint",
+                "subsetOfReals",
+                "bestFitLine",
+                "matrix",
+                "latex"
+            ],
+            "attributes": [
+                {
+                    "name": "name"
+                },
+                {
+                    "name": "copySource"
+                },
+                {
+                    "name": "hide",
+                    "values": ["true", "false"]
+                },
+                {
+                    "name": "disabled",
+                    "values": ["true", "false"]
+                },
+                {
+                    "name": "fixed",
+                    "values": ["true", "false"]
+                },
+                {
+                    "name": "fixLocation",
+                    "values": ["true", "false"]
+                },
+                {
+                    "name": "styleNumber"
+                },
+                {
+                    "name": "isResponse",
+                    "values": ["true", "false"]
+                },
+                {
+                    "name": "newNamespace",
+                    "values": ["true", "false"]
+                },
+                {
+                    "name": "format",
+                    "values": ["text", "latex"]
+                },
+                {
+                    "name": "simplify",
+                    "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numberspreserveorder"
+                    ]
+                },
+                {
+                    "name": "expand",
+                    "values": ["true", "false"]
+                },
+                {
+                    "name": "displayDigits"
+                },
+                {
+                    "name": "displayDecimals"
+                },
+                {
+                    "name": "displaySmallAsZero"
+                },
+                {
+                    "name": "padZeros",
+                    "values": ["true", "false"]
+                },
+                {
+                    "name": "renderMode"
+                },
+                {
+                    "name": "unordered",
+                    "values": ["true", "false"]
+                },
+                {
+                    "name": "createVectors",
+                    "values": ["true", "false"]
+                },
+                {
+                    "name": "createIntervals",
+                    "values": ["true", "false"]
+                },
+                {
+                    "name": "functionSymbols"
+                },
+                {
+                    "name": "sourcesAreFunctionSymbols"
+                },
+                {
+                    "name": "splitSymbols",
+                    "values": ["true", "false"]
+                },
+                {
+                    "name": "parseScientificNotation",
+                    "values": ["true", "false"]
+                },
+                {
+                    "name": "displayBlanks",
+                    "values": ["true", "false"]
+                },
+                {
+                    "name": "draggable",
+                    "values": ["true", "false"]
+                },
+                {
+                    "name": "layer"
+                },
+                {
+                    "name": "anchor"
+                },
+                {
+                    "name": "positionFromAnchor",
+                    "values": [
+                        "upperright",
+                        "upperleft",
+                        "lowerright",
+                        "lowerleft",
+                        "top",
+                        "bottom",
+                        "left",
+                        "right",
+                        "center"
+                    ]
+                },
+                {
+                    "name": "forceSymbolic",
+                    "values": ["true", "false"]
+                },
+                {
+                    "name": "forceNumeric",
+                    "values": ["true", "false"]
+                }
+            ],
+            "properties": [
+                {
+                    "name": "hide",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "modifyIndirectly",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "styleNumber",
+                    "type": "integer",
+                    "isArray": false
+                },
+                {
+                    "name": "isResponse",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "newNamespace",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "permid",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "format",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "simplify",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "expand",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "renderMode",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "createVectors",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "createIntervals",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "functionSymbols",
+                    "type": "textList",
+                    "isArray": false
+                },
+                {
+                    "name": "splitSymbols",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "parseScientificNotation",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "displayBlanks",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "draggable",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "layer",
+                    "type": "number",
+                    "isArray": false
+                },
+                {
+                    "name": "positionFromAnchor",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "forceSymbolic",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "forceNumeric",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "hidden",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "disabled",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "fixed",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "fixLocation",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "doenetML",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "textColor",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "backgroundColor",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "textStyleDescription",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "anchor",
+                    "type": "point",
+                    "isArray": false
+                },
+                {
+                    "name": "displayDigits",
+                    "type": "integer",
+                    "isArray": false
+                },
+                {
+                    "name": "displayDecimals",
+                    "type": "integer",
+                    "isArray": false
+                },
+                {
+                    "name": "displaySmallAsZero",
+                    "type": "number",
+                    "isArray": false
+                },
+                {
+                    "name": "padZeros",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "unordered",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "value",
+                    "type": "lcm",
+                    "isArray": false
+                },
+                {
+                    "name": "number",
+                    "type": "number",
+                    "isArray": false
+                },
+                {
+                    "name": "isNumber",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "isNumeric",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "latex",
+                    "type": "latex",
+                    "isArray": false
+                },
+                {
+                    "name": "text",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
+                    "name": "numDimensions",
+                    "type": "integer",
+                    "isArray": false
+                },
+                {
+                    "name": "vector",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": false,
+                            "type": "vector"
+                        }
+                    ]
+                },
+                {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "matrixSize",
+                    "type": "numberList",
+                    "isArray": false
+                },
+                {
+                    "name": "numRows",
+                    "type": "integer",
+                    "isArray": false
+                },
+                {
+                    "name": "numColumns",
+                    "type": "integer",
+                    "isArray": false
+                },
+                {
+                    "name": "matrix",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 2,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        },
+                        {
+                            "isArray": false,
+                            "type": "matrix"
+                        }
+                    ]
+                },
+                {
+                    "name": "x",
+                    "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "y",
+                    "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "z",
+                    "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -16060,6 +16969,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -16471,6 +17381,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -16515,6 +17438,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -16545,6 +17473,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -17058,21 +17987,6 @@
                 {
                     "name": "variable",
                     "type": "_variableName",
-                    "isArray": false
-                },
-                {
-                    "name": "symbolicf",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
-                    "name": "fDefinition",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
-                    "name": "f",
-                    "type": "unknown",
                     "isArray": false
                 }
             ],
@@ -17104,6 +18018,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -17618,21 +18533,6 @@
                     "name": "variable",
                     "type": "_variableName",
                     "isArray": false
-                },
-                {
-                    "name": "symbolicf",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
-                    "name": "fDefinition",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
-                    "name": "f",
-                    "type": "unknown",
-                    "isArray": false
                 }
             ],
             "top": true,
@@ -17663,6 +18563,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -18185,21 +19086,6 @@
                     "name": "variable",
                     "type": "_variableName",
                     "isArray": false
-                },
-                {
-                    "name": "symbolicf",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
-                    "name": "fDefinition",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
-                    "name": "f",
-                    "type": "unknown",
-                    "isArray": false
                 }
             ],
             "top": true,
@@ -18230,6 +19116,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -18497,7 +19384,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "listItems",
+                    "name": "list",
                     "type": "text",
                     "isArray": true,
                     "numDimensions": 1,
@@ -18555,6 +19442,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -18793,6 +19681,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -19031,6 +19920,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -19269,6 +20159,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -19507,6 +20398,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -19745,6 +20637,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -19983,6 +20876,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -20221,6 +21115,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -20459,6 +21354,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -20697,6 +21593,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -21764,6 +22661,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -22223,6 +23121,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -22682,6 +23581,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -23141,6 +24041,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -23600,6 +24501,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -24072,6 +24974,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -24531,6 +25434,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -24990,6 +25894,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -25449,6 +26354,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -25908,6 +26814,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -26367,6 +27274,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -26826,6 +27734,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -27285,6 +28194,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -27744,6 +28654,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -28203,6 +29114,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -28669,6 +29581,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -29122,6 +30035,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -29803,6 +30717,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -30829,6 +31744,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "equilibriumPoint",
                 "electronConfiguration",
@@ -31225,6 +32141,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -31623,6 +32540,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "extractMathOperator",
                 "equilibriumPoint",
@@ -32741,6 +33659,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -33127,6 +34046,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -33171,6 +34103,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -33203,6 +34140,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -34395,6 +35333,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -34702,6 +35641,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "extractMathOperator",
                 "atom",
@@ -34979,7 +35919,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "listItems",
+                    "name": "list",
                     "type": "text",
                     "isArray": true,
                     "numDimensions": 1,
@@ -35030,6 +35970,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "extractMathOperator",
                 "atom",
@@ -35204,6 +36145,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -35522,6 +36464,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -35840,6 +36783,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -36158,6 +37102,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -36496,6 +37441,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -37212,6 +38158,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -37509,6 +38456,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -37834,6 +38782,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "extractMathOperator",
                 "atom",
@@ -38108,7 +39057,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "listItems",
+                    "name": "list",
                     "type": "text",
                     "isArray": true,
                     "numDimensions": 1,
@@ -38158,6 +39107,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "extractMathOperator",
                 "atom",
@@ -38306,11 +39256,6 @@
                     "name": "numValues",
                     "type": "number",
                     "isArray": false
-                },
-                {
-                    "name": "values",
-                    "type": "unknown",
-                    "isArray": false
                 }
             ],
             "top": true,
@@ -38358,6 +39303,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -38581,6 +39527,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -38986,11 +39933,6 @@
                     "name": "numValues",
                     "type": "number",
                     "isArray": false
-                },
-                {
-                    "name": "values",
-                    "type": "unknown",
-                    "isArray": false
                 }
             ],
             "top": true,
@@ -39021,6 +39963,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -39407,6 +40350,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -39451,6 +40407,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -39481,6 +40442,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -39687,35 +40649,9 @@
                     "isArray": false
                 },
                 {
-                    "name": "maths",
-                    "type": "math",
-                    "isArray": true,
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": true,
-                            "type": "math",
-                            "numDimensions": 1
-                        }
-                    ]
-                },
-                {
                     "name": "numValues",
                     "type": "number",
                     "isArray": false
-                },
-                {
-                    "name": "values",
-                    "type": "math",
-                    "isArray": true,
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": true,
-                            "type": "math",
-                            "numDimensions": 1
-                        }
-                    ]
                 }
             ],
             "top": true,
@@ -39746,6 +40682,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -39952,35 +40889,9 @@
                     "isArray": false
                 },
                 {
-                    "name": "maths",
-                    "type": "math",
-                    "isArray": true,
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": true,
-                            "type": "math",
-                            "numDimensions": 1
-                        }
-                    ]
-                },
-                {
                     "name": "numValues",
                     "type": "number",
                     "isArray": false
-                },
-                {
-                    "name": "values",
-                    "type": "math",
-                    "isArray": true,
-                    "numDimensions": 1,
-                    "indexedArrayDescription": [
-                        {
-                            "isArray": true,
-                            "type": "math",
-                            "numDimensions": 1
-                        }
-                    ]
                 }
             ],
             "top": true,
@@ -40011,6 +40922,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "extractMathOperator",
                 "electronConfiguration",
@@ -40036,7 +40948,26 @@
                 "lorem",
                 "subsetOfReals",
                 "matrix",
-                "latex"
+                "latex",
+                "clampFunction",
+                "wrapFunctionPeriodic",
+                "derivative",
+                "equilibriumPoint",
+                "equilibriumLine",
+                "atom",
+                "ion",
+                "ionicCompound",
+                "matrixInput",
+                "point",
+                "line",
+                "vector",
+                "angle",
+                "mathInput",
+                "choice",
+                "function",
+                "piecewiseFunction",
+                "endpoint",
+                "bestFitLine"
             ],
             "attributes": [
                 {
@@ -40162,11 +41093,6 @@
                 {
                     "name": "numValues",
                     "type": "number",
-                    "isArray": false
-                },
-                {
-                    "name": "values",
-                    "type": "unknown",
                     "isArray": false
                 }
             ],
@@ -40328,6 +41254,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -40664,6 +41591,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "equilibriumPoint",
                 "electronConfiguration",
@@ -41039,6 +41967,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -41416,6 +42345,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -41465,6 +42407,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -41498,6 +42445,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -44036,6 +44984,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -44476,6 +45425,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -44852,11 +45802,6 @@
                     "name": "equation",
                     "type": "math",
                     "isArray": false
-                },
-                {
-                    "name": "f",
-                    "type": "unknown",
-                    "isArray": false
                 }
             ],
             "top": true,
@@ -44896,6 +45841,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "extractMathOperator",
                 "equilibriumPoint",
@@ -45441,6 +46387,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -45615,6 +46562,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "electronConfiguration",
                 "math",
@@ -45801,6 +46749,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "equilibriumPoint",
                 "electronConfiguration",
@@ -46192,6 +47141,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "extractMathOperator",
                 "electronConfiguration",
@@ -46496,6 +47446,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -47031,6 +47982,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -47424,6 +48376,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -47748,6 +48701,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -48068,6 +49022,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -48112,6 +49079,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -48152,6 +49124,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "extractMathOperator",
                 "atom",
@@ -48435,7 +49408,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "listItems",
+                    "name": "list",
                     "type": "text",
                     "isArray": true,
                     "numDimensions": 1,
@@ -48490,6 +49463,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -48976,11 +49950,6 @@
                     ]
                 },
                 {
-                    "name": "numValues",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
                     "name": "selectedIndex",
                     "type": "number",
                     "isArray": false
@@ -49012,11 +49981,6 @@
                             "numDimensions": 1
                         }
                     ]
-                },
-                {
-                    "name": "valueRecordedAtSubmit",
-                    "type": "unknown",
-                    "isArray": false
                 }
             ],
             "top": true,
@@ -49067,6 +50031,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -49418,6 +50383,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "extractMathOperator",
                 "electronConfiguration",
@@ -49727,6 +50693,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "extractMathOperator",
                 "electronConfiguration",
@@ -50042,6 +51009,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -50522,6 +51490,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -51020,21 +51989,6 @@
                     "name": "variable",
                     "type": "_variableName",
                     "isArray": false
-                },
-                {
-                    "name": "symbolicf",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
-                    "name": "fDefinition",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
-                    "name": "f",
-                    "type": "unknown",
-                    "isArray": false
                 }
             ],
             "top": true,
@@ -51470,21 +52424,6 @@
                     "name": "variable",
                     "type": "_variableName",
                     "isArray": false
-                },
-                {
-                    "name": "symbolicf",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
-                    "name": "fDefinition",
-                    "type": "unknown",
-                    "isArray": false
-                },
-                {
-                    "name": "f",
-                    "type": "unknown",
-                    "isArray": false
                 }
             ],
             "top": true,
@@ -51515,6 +52454,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -51892,6 +52832,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -51940,6 +52893,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ],
@@ -51991,6 +52949,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -52325,6 +53284,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -52790,6 +53750,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "extractMathOperator",
                 "electronConfiguration",
@@ -53332,6 +54293,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -54306,6 +55268,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -54612,6 +55575,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -54908,6 +55872,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "extractMathOperator",
                 "atom",
@@ -55209,6 +56174,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -56221,6 +57187,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -56404,6 +57371,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -56817,6 +57785,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -57138,6 +58107,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -57463,6 +58433,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -58125,6 +59096,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -58972,6 +59944,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -59020,6 +60005,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ],
@@ -59766,6 +60756,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -60516,6 +61507,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -60574,6 +61578,11 @@
                 {
                     "name": "z",
                     "type": "math",
+                    "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
                     "isArray": false
                 }
             ],
@@ -61032,6 +62041,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -61349,6 +62359,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "extractMathOperator",
                 "atom",
@@ -61618,7 +62629,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "listItems",
+                    "name": "list",
                     "type": "text",
                     "isArray": true,
                     "numDimensions": 1,
@@ -61678,6 +62689,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "extractMathOperator",
                 "atom",
@@ -61963,7 +62975,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "listItems",
+                    "name": "list",
                     "type": "text",
                     "isArray": true,
                     "numDimensions": 1,
@@ -62034,6 +63046,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -62350,6 +63363,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -62668,6 +63682,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -63899,6 +64914,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -64337,6 +65353,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -64653,6 +65670,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -64896,6 +65914,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -65168,6 +66187,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "equilibriumPoint",
                 "electronConfiguration",
@@ -65581,6 +66601,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -65932,6 +66953,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -66243,6 +67265,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -66693,6 +67716,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -67091,6 +68115,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -67187,6 +68224,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -67237,6 +68279,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -68349,6 +69392,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -68869,6 +69913,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -69708,6 +70753,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -70006,6 +71052,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -70689,6 +71736,19 @@
                     ]
                 },
                 {
+                    "name": "list",
+                    "type": "math",
+                    "isArray": true,
+                    "numDimensions": 1,
+                    "indexedArrayDescription": [
+                        {
+                            "isArray": true,
+                            "type": "math",
+                            "numDimensions": 1
+                        }
+                    ]
+                },
+                {
                     "name": "matrixSize",
                     "type": "numberList",
                     "isArray": false
@@ -70733,6 +71793,11 @@
                     "name": "z",
                     "type": "math",
                     "isArray": false
+                },
+                {
+                    "name": "numListItems",
+                    "type": "integer",
+                    "isArray": false
                 }
             ],
             "top": true,
@@ -70763,6 +71828,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -71001,6 +72067,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "extractMathOperator",
                 "atom",
@@ -71297,7 +72364,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "listItems",
+                    "name": "list",
                     "type": "text",
                     "isArray": true,
                     "numDimensions": 1,
@@ -71363,6 +72430,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -71681,6 +72749,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",
@@ -71996,6 +73065,7 @@
                 "max",
                 "mod",
                 "gcd",
+                "lcm",
                 "extractMath",
                 "clampFunction",
                 "wrapFunctionPeriodic",


### PR DESCRIPTION
The PR adds a least common multiple `<lcm>` component that calculates the lcm for numbers and returns a symbolic expression otherwise.

Resolves #250.