### PR TITLE
improvements to label state variables and update functions

### DIFF
--- a/packages/doenetml-worker/src/components/Label.js
+++ b/packages/doenetml-worker/src/components/Label.js
@@ -10,6 +10,7 @@ import {
     returnAnchorStateVariableDefinition,
 } from "../utils/graphical";
 import { textFromChildren } from "../utils/text";
+import { latexToText, textToLatex } from "../utils/math";
 
 export default class Label extends InlineComponent {
     constructor(args) {
@@ -222,57 +223,74 @@ export default class Label extends InlineComponent {
                     variableName: "hasLatex",
                 },
             }),
-            definition: function ({ dependencyValues }) {
+            definition: function ({ dependencyValues, componentName }) {
                 if (
                     dependencyValues.inlineChildren.length === 0 &&
                     dependencyValues.valueShadow !== null
                 ) {
                     let value = dependencyValues.valueShadow;
                     let text = value;
+                    let latex = value;
                     if (dependencyValues.hasLatex) {
-                        text = text.replace(/\\\(/g, "");
-                        text = text.replace(/\\\)/g, "");
+                        latex = latex.replace(/\\\(/g, "");
+                        latex = latex.replace(/\\\)/g, "");
+
+                        text = extractTextFromLabel(text);
                     }
-                    return { setValue: { text, latex: text, value } };
+
+                    return { setValue: { text, latex, value } };
                 }
 
-                let textFromComponentConverter = function (
-                    comp,
-                    getValue = true,
-                ) {
+                let valueFromComponentConverter = function (comp) {
                     if (typeof comp !== "object") {
                         return comp.toString();
                     } else if (comp.stateValues.hidden) {
                         return "";
                     } else if (
                         typeof comp.stateValues.hasLatex === "boolean" &&
-                        typeof comp.stateValues.value === "string" &&
-                        typeof comp.stateValues.text === "string"
+                        typeof comp.stateValues.value === "string"
                     ) {
                         // if component has a boolean hasLatex state variable
-                        // and value and text are strings
-                        // then use value and text directly
-                        return getValue
-                            ? comp.stateValues.value
-                            : comp.stateValues.text;
+                        // and value is string
+                        // then use value directly
+                        // (as it is a label or similar)
+                        return comp.stateValues.value;
                     } else if (
                         typeof comp.stateValues.renderAsMath === "boolean" &&
                         typeof comp.stateValues.latex === "string" &&
                         typeof comp.stateValues.text === "string"
                     ) {
                         // if have both latex and string,
-                        // use render as math, if exists, to decide which to use
+                        // and renderAsMath exists, then we'll use renderAsMath
+                        // to decide which to use
                         if (comp.stateValues.renderAsMath) {
-                            return getValue
-                                ? "\\(" + comp.stateValues.latex + "\\)"
-                                : comp.stateValues.latex;
+                            return "\\(" + comp.stateValues.latex + "\\)";
                         } else {
                             return comp.stateValues.text;
                         }
                     } else if (typeof comp.stateValues.latex === "string") {
-                        return getValue
-                            ? "\\(" + comp.stateValues.latex + "\\)"
-                            : comp.stateValues.latex;
+                        // if no renderAsMath, then we'll use latex if it exists
+                        return "\\(" + comp.stateValues.latex + "\\)";
+                    } else if (typeof comp.stateValues.text === "string") {
+                        return comp.stateValues.text;
+                    }
+                };
+
+                let textFromComponentConverter = function (
+                    comp,
+                    preferLatex = false,
+                ) {
+                    if (typeof comp !== "object") {
+                        return comp.toString();
+                    } else if (comp.stateValues.hidden) {
+                        return "";
+                    } else if (
+                        typeof comp.stateValues.text === "string" &&
+                        !preferLatex
+                    ) {
+                        return comp.stateValues.text;
+                    } else if (typeof comp.stateValues.latex === "string") {
+                        return comp.stateValues.latex;
                     } else if (typeof comp.stateValues.text === "string") {
                         return comp.stateValues.text;
                     }
@@ -280,14 +298,18 @@ export default class Label extends InlineComponent {
 
                 let value = textFromChildren(
                     dependencyValues.inlineChildren,
-                    (x) => textFromComponentConverter(x, true),
+                    valueFromComponentConverter,
                 );
                 let text = textFromChildren(
                     dependencyValues.inlineChildren,
                     (x) => textFromComponentConverter(x, false),
                 );
+                let latex = textFromChildren(
+                    dependencyValues.inlineChildren,
+                    (x) => textFromComponentConverter(x, true),
+                );
 
-                return { setValue: { text, latex: text, value } };
+                return { setValue: { text, latex, value } };
             },
             inverseDefinition: function ({
                 desiredStateVariableValues,
@@ -300,7 +322,16 @@ export default class Label extends InlineComponent {
                 } else if (
                     typeof desiredStateVariableValues.text === "string"
                 ) {
-                    desiredValue = desiredStateVariableValues.text;
+                    if (dependencyValues.hasLatex) {
+                        // if hasLatex is set, then the only invertible form is where there is a single
+                        // latex expression.
+                        // Attempt to convert text into latex.
+                        desiredValue = textToLatex(
+                            desiredStateVariableValues.text,
+                        );
+                    } else {
+                        desiredValue = desiredStateVariableValues.text;
+                    }
                 } else if (
                     typeof desiredStateVariableValues.latex === "string"
                 ) {
@@ -324,7 +355,6 @@ export default class Label extends InlineComponent {
                     };
                 } else if (dependencyValues.inlineChildren.length === 1) {
                     let comp = dependencyValues.inlineChildren[0];
-                    let desiredValue = desiredStateVariableValues.value;
 
                     if (typeof comp !== "object") {
                         return {
@@ -517,4 +547,33 @@ export default class Label extends InlineComponent {
             });
         }
     }
+}
+
+/**
+ * Extract text from a label string consisting of regular text and latex snippets enclosed by `\(` and `\)`.
+ *
+ * For each latex string delimited by `\(` and `\)`, attempt to create a math expression from that latex.
+ */
+function extractTextFromLabel(labelValue) {
+    let unprocessedText = labelValue;
+    let text = "";
+    let match = unprocessedText.match(/\\\((.*?)\\\)/);
+    while (match) {
+        let preChars = match.index;
+
+        // add text before the latex piece found
+        text += unprocessedText.slice(0, preChars);
+
+        // attempt to convert the latex piece found
+        text += latexToText(match[1]);
+
+        // remove processed text and continue
+        unprocessedText = unprocessedText.slice(preChars + match[0].length);
+        match = unprocessedText.match(/\\\((.*?)\\\)/);
+    }
+
+    // add any leftover text after all latex pieces
+    text += unprocessedText;
+
+    return text;
 }

--- a/packages/doenetml-worker/src/components/MMeMen.js
+++ b/packages/doenetml-worker/src/components/MMeMen.js
@@ -9,7 +9,7 @@ import {
     returnAnchorAttributes,
     returnAnchorStateVariableDefinition,
 } from "../utils/graphical";
-import { latexToAst, superSubscriptsToUnicode } from "../utils/math";
+import { latexToText } from "../utils/math";
 import { createInputStringFromChildren } from "../utils/parseMath";
 
 export class M extends InlineComponent {
@@ -197,20 +197,8 @@ export class M extends InlineComponent {
                 },
             }),
             definition: function ({ dependencyValues }) {
-                let expression;
-                try {
-                    expression = me.fromAst(
-                        latexToAst.convert(dependencyValues.latex),
-                    );
-                } catch (e) {
-                    // just return latex if can't parse with math-expressions
-                    return { setValue: { text: dependencyValues.latex } };
-                }
-
                 return {
-                    setValue: {
-                        text: superSubscriptsToUnicode(expression.toString()),
-                    },
+                    setValue: { text: latexToText(dependencyValues.latex) },
                 };
             },
         };

--- a/packages/doenetml-worker/src/test/tagSpecific/label.test.ts
+++ b/packages/doenetml-worker/src/test/tagSpecific/label.test.ts
@@ -18,8 +18,8 @@ describe("Label tag tests", async () => {
             doenetML: `
 <label name="l1">Hello</label>
 <label name="l2"><text name="text">Hello</text></label>
-<label name="l3"><m name="m">\\left(x^2,\\frac{y^2}{z^2}\\right)</m></label>
-<label name="l4"><math name="math">(a^2,b^2/c^2)</math></label>
+<label name="l3"><m name="m">\\left(x_2 y_{2.1},\\frac{y^2}{z^{2.1}}\\right)</m></label>
+<label name="l4"><math name="math">(a_2 b_2.1,b^2/c^2.1)</math></label>
 <label name="l5"><number name="number1">1</number></label>
 <label name="l6"><number name="number2" renderAsMath>2</number></label>
 <label name="l7">$text and $m and $math and $number1 and $number2</label>
@@ -31,12 +31,12 @@ describe("Label tag tests", async () => {
         const stateVariables = await returnAllStateVariables(core);
         let l1 = "Hello";
         let l2 = "Hello";
-        let l3Latex = "\\left(x^2,\\frac{y^2}{z^2}\\right)";
+        let l3Latex = "\\left(x_2 y_{2.1},\\frac{y^2}{z^{2.1}}\\right)";
         let l3Value = `\\(${l3Latex}\\)`;
-        let l3Text = "( x², (y²)/(z²) )";
-        let l4Latex = "\\left( a^{2}, \\frac{b^{2}}{c^{2}} \\right)";
+        let l3Text = "( x₂ y_2.1, (y²)/(z^2.1) )";
+        let l4Latex = "\\left( a_{2} b_{2.1}, \\frac{b^{2}}{c^{2.1}} \\right)";
         let l4Value = `\\(${l4Latex}\\)`;
-        let l4Text = "( a², (b²)/(c²) )";
+        let l4Text = "( a₂ b_2.1, (b²)/(c^2.1) )";
         let l5 = "1";
         let l6Latex = "2";
         let l6Value = `\\(${l6Latex}\\)`;

--- a/packages/doenetml-worker/src/utils/math.ts
+++ b/packages/doenetml-worker/src/utils/math.ts
@@ -850,9 +850,9 @@ export function superSubscriptsToUnicode(text: string) {
         return newVal;
     }
 
-    text = text.replace(/_(\d+)/g, replaceSubscripts);
+    text = text.replace(/_(\d+)(?!\.)/g, replaceSubscripts);
     text = text.replace(/_\(([\d +-]+)\)/g, replaceSubscripts);
-    text = text.replace(/\^(\d+)/g, replaceSuperscripts);
+    text = text.replace(/\^(\d+)(?!\.)/g, replaceSuperscripts);
     text = text.replace(/\^\(([\d +-]+)\)/g, replaceSuperscripts);
 
     return text;

--- a/packages/doenetml-worker/src/utils/math.ts
+++ b/packages/doenetml-worker/src/utils/math.ts
@@ -1079,3 +1079,37 @@ export async function preprocessMathInverseDefinition({
         return { desiredValue };
     }
 }
+
+/**
+ * Attempt to create a text representation of a latex expression by creating a math expression from that latex
+ * and converting the math expression to a string.
+ * If unsuccessful, just return the original latex.
+ */
+export function latexToText(latex: string) {
+    let expression;
+    try {
+        expression = me.fromAst(latexToAst.convert(latex));
+    } catch (e) {
+        // just return latex if can't parse with math-expressions
+        return latex;
+    }
+
+    return superSubscriptsToUnicode(expression.toString());
+}
+
+/**
+ * Attempt to create a latex representation of a text expression by creating a math expression from that text
+ * and converting the math expression to a latex.
+ * If unsuccessful, just return the original text.
+ */
+export function textToLatex(text: string) {
+    let expression;
+    try {
+        expression = me.fromAst(textToAst.convert(text));
+    } catch (e) {
+        // just return text if can't parse with math-expressions
+        return text;
+    }
+
+    return expression.toLatex();
+}


### PR DESCRIPTION
This PR improves the `value`/`text`/`latex` state variables of `<label>`. In particular,  the `text` state variable no longer matches the `latex` state variable when the label contains math, but instead match the behavior of `text` state variable of other mathematical components.

In addition, the PR has bug fixes for the inverse update functions of these state variables and the  `superSubscriptsToUnicode` function.
