### PR TITLE
improve equality checks involving tuples, vectors, intervals, and arrays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "./packages/*"
             ],
             "dependencies": {
-                "math-expressions": "^2.0.0-alpha71",
+                "math-expressions": "^2.0.0-alpha73",
                 "react-router-dom": "^6.26.2"
             },
             "devDependencies": {
@@ -13748,9 +13748,9 @@
             }
         },
         "node_modules/math-expressions": {
-            "version": "2.0.0-alpha71",
-            "resolved": "https://registry.npmjs.org/math-expressions/-/math-expressions-2.0.0-alpha71.tgz",
-            "integrity": "sha512-NMTjBbuzchbEBId1VDP0VzB3qNiqu+sJHS34MyH5ONQtJFzxqXzKH7nqsvemdsTpnlFWMjFzHEPEa524E9oo2A==",
+            "version": "2.0.0-alpha73",
+            "resolved": "https://registry.npmjs.org/math-expressions/-/math-expressions-2.0.0-alpha73.tgz",
+            "integrity": "sha512-Ic0vNYU9/fh+beBFNGhm3ZaYUKLWq2zxPyEwmqaJ9MYEwh8nDlB0gIMf6WnYoQdIWQ/op4pENpe6j9iN6O3rMw==",
             "license": "(GPL-3.0 OR Apache-2.0)",
             "dependencies": {
                 "@babel/cli": "^7.25.7",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
         }
     },
     "dependencies": {
-        "math-expressions": "^2.0.0-alpha71",
+        "math-expressions": "^2.0.0-alpha73",
         "react-router-dom": "^6.26.2"
     }
 }

--- a/packages/doenetml-worker/src/test/math/mathExpressionsEquality.test.ts
+++ b/packages/doenetml-worker/src/test/math/mathExpressionsEquality.test.ts
@@ -947,6 +947,22 @@ describe("Math expressions equality tests", async () => {
                 symbolicSimplifyEqual: false,
                 symbolicSimplifyExpandEqual: false,
             },
+            {
+                expr1: "<math createIntervals>(1,2) union (3,4)</math>",
+                expr2: "<math>(1,2) union (3,4)</math>",
+                equal: true,
+                symbolicEqual: true,
+                symbolicSimplifyEqual: true,
+                symbolicSimplifyExpandEqual: true,
+            },
+            {
+                expr1: "<math createIntervals>(1,2) union [3,4]</math>",
+                expr2: "<math>(1,2) union [3,4]</math>",
+                equal: true,
+                symbolicEqual: true,
+                symbolicSimplifyEqual: true,
+                symbolicSimplifyExpandEqual: true,
+            },
         ];
 
         let doenetML = "";

--- a/packages/doenetml-worker/src/test/tagSpecific/math.test.ts
+++ b/packages/doenetml-worker/src/test/tagSpecific/math.test.ts
@@ -4142,19 +4142,19 @@ describe("Math tag tests", async () => {
             "(a,b)+(e,f)",
         );
         expect(cleanLatex(stateVariables["/t2isumSimp"].stateValues.latex)).eq(
-            "(e,f)+(a,b)",
+            "(a,b)+(e,f)",
         );
         expect(cleanLatex(stateVariables["/v2isum"].stateValues.latex)).eq(
             "(c,d)+(e,f)",
         );
         expect(cleanLatex(stateVariables["/v2isumSimp"].stateValues.latex)).eq(
-            "(e,f)+(c,d)",
+            "(c,d)+(e,f)",
         );
         expect(cleanLatex(stateVariables["/a2isum"].stateValues.latex)).eq(
             "\\langlep,q\\rangle+(e,f)",
         );
         expect(cleanLatex(stateVariables["/a2isumSimp"].stateValues.latex)).eq(
-            "\\langlep,q\\rangle+(e,f)",
+            "(e,f)+\\langlep,q\\rangle",
         );
         expect(cleanLatex(stateVariables["/st2mul"].stateValues.latex)).eq(
             "m(a,b)",
@@ -4517,25 +4517,25 @@ describe("Math tag tests", async () => {
         );
         expect(
             cleanLatex(stateVariables["/m21t2sumSimp"].stateValues.latex),
-        ).eq("\\begin{bmatrix}e\\\\f\\end{bmatrix}+(i,j)");
+        ).eq("(i,j)+\\begin{bmatrix}e\\\\f\\end{bmatrix}");
         expect(cleanLatex(stateVariables["/m21v2sum"].stateValues.latex)).eq(
             "\\begin{bmatrix}e\\\\f\\end{bmatrix}+(k,l)",
         );
         expect(
             cleanLatex(stateVariables["/m21v2sumSimp"].stateValues.latex),
-        ).eq("\\begin{bmatrix}e\\\\f\\end{bmatrix}+(k,l)");
+        ).eq("(k,l)+\\begin{bmatrix}e\\\\f\\end{bmatrix}");
         expect(cleanLatex(stateVariables["/m12t2sum"].stateValues.latex)).eq(
             "\\begin{bmatrix}g&h\\end{bmatrix}+(i,j)",
         );
         expect(
             cleanLatex(stateVariables["/m12t2sumSimp"].stateValues.latex),
-        ).eq("\\begin{bmatrix}g&h\\end{bmatrix}+(i,j)");
+        ).eq("(i,j)+\\begin{bmatrix}g&h\\end{bmatrix}");
         expect(cleanLatex(stateVariables["/m12v2sum"].stateValues.latex)).eq(
             "\\begin{bmatrix}g&h\\end{bmatrix}+(k,l)",
         );
         expect(
             cleanLatex(stateVariables["/m12v2sumSimp"].stateValues.latex),
-        ).eq("\\begin{bmatrix}g&h\\end{bmatrix}+(k,l)");
+        ).eq("(k,l)+\\begin{bmatrix}g&h\\end{bmatrix}");
         expect(cleanLatex(stateVariables["/m22m21sum"].stateValues.latex)).eq(
             "\\begin{bmatrix}a&b\\\\c&d\\end{bmatrix}+\\begin{bmatrix}e\\\\f\\end{bmatrix}",
         );

--- a/packages/doenetml-worker/src/utils/checkEquality.js
+++ b/packages/doenetml-worker/src/utils/checkEquality.js
@@ -358,7 +358,8 @@ export default function checkEquality({
                 return { fraction_equal: 0 };
             } else if (vectorOperators.includes(object2_operator)) {
                 // since we can convert tuple to vector
-                // change object2 to array of selements
+                // change object2 to array of elements
+                // (we also allow vectors and altVectors to be equal to each other. Is that OK?)
                 object2 = object2.tree.slice(1);
             } else {
                 // since can convert singleton to a vector of length 1
@@ -378,7 +379,7 @@ export default function checkEquality({
                 return { fraction_equal: 0 };
             } else if (object1_operator === "tuple") {
                 // since can convert tuple to vector
-                // change object2 to array of elements
+                // change object1 to array of elements
                 object1 = object1.tree.slice(1);
             } else {
                 // since can convert singleton to a vector of length 1
@@ -412,16 +413,16 @@ export default function checkEquality({
                     return { fraction_equal: 0 };
                 }
             } else if (object2_operator === "array") {
-                let operands = object2.tree.slice(1);
+                let operands2 = object2.tree.slice(1);
                 if (
-                    operands.length === 2 &&
+                    operands2.length === 2 &&
                     leftClosed === true &&
                     rightClosed === true
                 ) {
                     // since can convert array to closed interval
                     // and object1 is closed interval
                     // make object2 be array of endpoints
-                    object2 = operands;
+                    object2 = operands2;
                 } else {
                     return { fraction_equal: 0 };
                 }


### PR DESCRIPTION
This PR upgrades math-expressions to a version has improved equality checks for tuples and related. The following changes where made:
- tuples, vectors, altVectors, and open intervals are considered identical even deep inside a mathematical expression
- arrays and closed intervals are considered identical even deep inside a mathematical expression
- tuples, vectors, altVectors, and open intervals  are treated as identical when sorting
- arrays and closed intervals are considered identical when sorting.

In addition, the complex numerical answer validation will always be available if `symbolicEquality` is not specified, even if the expression contains operators such as logical or set operators.

Fixes #168