### PR TITLE
bugfix: answer with select in award

### DIFF
--- a/packages/doenetml-worker/src/test/tagSpecific/answer.test.ts
+++ b/packages/doenetml-worker/src/test/tagSpecific/answer.test.ts
@@ -5790,4 +5790,30 @@ What is the derivative of <function name="f">x^2</function>?
             ],
         });
     });
+
+    it("bugfix: answer with select in award", async () => {
+        const doenetML = `
+    <select name="c">30</select>
+
+    <mathInput name="userAns" />
+
+    <answer name="ans">
+        <award name="correct">
+        <when>$userAns = $c</when> </award>
+    </answer>
+  `;
+
+        let core = await createTestCore({ doenetML });
+
+        await updateMathInputValue({
+            latex: "30",
+            name: "/userAns",
+            core,
+        });
+
+        await submitAnswer({ name: "/ans", core });
+
+        let stateVariables = await returnAllStateVariables(core);
+        expect(stateVariables["/ans"].stateValues.creditAchieved).eq(1);
+    });
 });

--- a/packages/doenetml-worker/src/utils/expandDoenetML.js
+++ b/packages/doenetml-worker/src/utils/expandDoenetML.js
@@ -1679,7 +1679,9 @@ export function componentFromAttribute({
         };
     } else {
         if (!value.childrenForComponent) {
-            value.childrenForComponent = [value.rawString];
+            if (value.rawString !== undefined) {
+                value.childrenForComponent = [value.rawString];
+            }
         }
         return { attribute: value, errors, warnings };
     }


### PR DESCRIPTION
Fix a bug where having referencing a `<select>` directly into an `<award>` caused a crash.