### PR TITLE
Rename PageViewer to DocViewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22797,7 +22797,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.0-alpha23",
+            "version": "0.7.0-alpha24",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@chakra-ui/icons": "^2.0.19",
@@ -22838,7 +22838,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.0-alpha23",
+            "version": "0.7.0-alpha24",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -22916,7 +22916,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.0-alpha23",
+            "version": "0.7.0-alpha24",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22797,7 +22797,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.0-alpha24",
+            "version": "0.7.0-alpha25",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@chakra-ui/icons": "^2.0.19",
@@ -22838,7 +22838,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.0-alpha24",
+            "version": "0.7.0-alpha25",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -22916,7 +22916,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.0-alpha24",
+            "version": "0.7.0-alpha25",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml-iframe",
     "type": "module",
     "description": "A renderer for DoenetML contained in an iframe",
-    "version": "0.7.0-alpha24",
+    "version": "0.7.0-alpha25",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml-iframe",
     "type": "module",
     "description": "A renderer for DoenetML contained in an iframe",
-    "version": "0.7.0-alpha23",
+    "version": "0.7.0-alpha24",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml-iframe/src/iframe-viewer-index.ts
+++ b/packages/doenetml-iframe/src/iframe-viewer-index.ts
@@ -30,12 +30,6 @@ document.addEventListener("DOMContentLoaded", () => {
                     args,
                 });
             },
-            updateAttemptNumber: (args: unknown) => {
-                messageParentFromViewer({
-                    callback: "updateAttemptNumber",
-                    args,
-                });
-            },
             setIsInErrorState: (args: unknown) => {
                 messageParentFromViewer({
                     callback: "setIsInErrorState",

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -169,9 +169,6 @@ export function DoenetViewer({
                         data.args,
                     );
                 }
-                case "updateAttemptNumber": {
-                    return doenetViewerProps.updateAttemptNumber?.(data.args);
-                }
                 case "setIsInErrorState": {
                     return doenetViewerProps.setIsInErrorState?.(data.args);
                 }

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -19,6 +19,7 @@ const latestDoenetmlVersion: string = version;
 
 export { mathjaxConfig } from "@doenet/utils";
 export type { ErrorDescription, WarningDescription };
+export { parseAndCompile } from "@doenet/parser";
 
 import { ExternalVirtualKeyboard } from "@doenet/virtual-keyboard";
 import "@doenet/virtual-keyboard/style.css";

--- a/packages/doenetml-iframe/src/test-main.tsx
+++ b/packages/doenetml-iframe/src/test-main.tsx
@@ -43,6 +43,8 @@ function App() {
                 }
                 standaloneUrl={STANDALONE_BLOB_URL}
                 cssUrl={STANDALONE_CSS_BLOB_URL}
+                activityId={"a"}
+                docId={"1"}
             />
 
             <h4>DoenetML {STANDALONE_VERSION} (locally-built copy):</h4>
@@ -57,6 +59,8 @@ function App() {
                 }
                 standaloneUrl={STANDALONE_BLOB_URL}
                 cssUrl={STANDALONE_CSS_BLOB_URL}
+                activityId={"a"}
+                docId={"2"}
             />
         </React.Fragment>
     );

--- a/packages/doenetml-worker/src/Core.js
+++ b/packages/doenetml-worker/src/Core.js
@@ -54,25 +54,21 @@ export default class Core {
         preliminaryWarnings,
         activityId,
         cid,
-        pageNumber,
+        docId,
         attemptNumber = 1,
-        itemNumber = 1,
-        serverSaveId,
         requestedVariant,
         requestedVariantIndex,
         theme,
         prerender = false,
         stateVariableChanges: stateVariableChangesString,
         coreId,
-        updateDataOnContentChange,
     }) {
         // console.time('core');
 
         this.coreId = coreId;
         this.activityId = activityId;
-        this.pageNumber = pageNumber;
+        this.docId = docId;
         this.attemptNumber = attemptNumber;
-        this.itemNumber = itemNumber;
         this.doenetML = doenetML;
         this.allDoenetMLs = allDoenetMLs;
         this.serializedDocument = serializedDocument;
@@ -83,9 +79,6 @@ export default class Core {
             errors: [...preliminaryErrors],
             warnings: [...preliminaryWarnings],
         };
-
-        this.serverSaveId = serverSaveId;
-        this.updateDataOnContentChange = updateDataOnContentChange;
 
         this.numerics = new Numerics();
         // this.flags = new Proxy(flags, readOnlyProxyHandler); //components shouldn't modify flags
@@ -11355,7 +11348,7 @@ export default class Core {
         const payload = {
             activityId: this.activityId,
             pageCid: this.cid,
-            pageNumber: this.pageNumber,
+            docId: this.docId,
             attemptNumber: this.attemptNumber,
             pageVariantIndex: this.requestedVariant.index,
             verb: event.verb,
@@ -12928,8 +12921,6 @@ export default class Core {
             return;
         }
 
-        let saveId = nanoid();
-
         let coreStateString = JSON.stringify(
             this.cumulativeStateVariableChanges,
             serializedComponentsReplacer,
@@ -12941,13 +12932,12 @@ export default class Core {
 
         if (this.flags.allowLocalState) {
             await idb_set(
-                `${this.activityId}|${this.pageNumber}|${this.attemptNumber}|${this.cid}`,
+                `${this.activityId}|${this.docId}|${this.attemptNumber}|${this.cid}`,
                 {
                     data_format_version,
                     coreState: coreStateString,
                     rendererState: rendererStateString,
                     coreInfo: this.coreInfoString,
-                    saveId,
                 },
             );
         }
@@ -12966,12 +12956,9 @@ export default class Core {
             coreInfo: this.coreInfoString,
             coreState: coreStateString,
             rendererState: rendererStateString,
-            pageNumber: this.pageNumber,
+            docId: this.docId,
             attemptNumber: this.attemptNumber,
             activityId: this.activityId,
-            saveId,
-            serverSaveId: this.serverSaveId,
-            updateDataOnContentChange: this.updateDataOnContentChange,
             onSubmission,
         };
 
@@ -13022,8 +13009,6 @@ export default class Core {
             }
         }
 
-        this.pageStateToBeSavedToDatabase.serverSaveId = this.serverSaveId;
-
         postMessage({
             messageType: "saveCreditForItem",
             state: { ...this.pageStateToBeSavedToDatabase },
@@ -13047,8 +13032,7 @@ export default class Core {
         postMessage({
             messageType: "recordSolutionView",
             activityId: this.activityId,
-            itemNumber: this.itemNumber,
-            pageNumber: this.pageNumber,
+            docId: this.docId,
             attemptNumber: this.attemptNumber,
         });
 

--- a/packages/doenetml-worker/src/CoreWorker.js
+++ b/packages/doenetml-worker/src/CoreWorker.js
@@ -121,20 +121,18 @@ globalThis.onmessage = function (e) {
 
 async function initializeWorker({
     doenetML,
-    preliminarySerializedComponents,
     flags,
+    activityId,
+    docId,
+    attemptNumber,
+    requestedVariantIndex,
 }) {
-    // Note: preliminarySerializeComponents is optional.
-    // If it is undefined, expandDoenetMLsToFullSerializedComponents will parse doenetML
-    // to create the serialized components
-
     let componentInfoObjects = createComponentInfoObjects(flags);
 
     let expandResult;
     try {
         expandResult = await expandDoenetMLsToFullSerializedComponents({
             doenetMLs: [doenetML],
-            preliminarySerializedComponents: [preliminarySerializedComponents],
             componentInfoObjects,
             flags,
         });
@@ -143,18 +141,33 @@ async function initializeWorker({
         initializeResult = { success: false, errMsg: e.message };
         postMessage({
             messageType: "initializeResult",
-            args: initializeResult,
+            args: {
+                ...initializeResult,
+                activityId,
+                docId,
+                attemptNumber,
+                requestedVariantIndex,
+            },
         });
         postMessage({
             messageType: "allPossibleVariants",
-            args: { success: false },
+            args: {
+                success: false,
+                activityId,
+                docId,
+                attemptNumber,
+                requestedVariantIndex,
+            },
         });
     }
 
     coreBaseArgs = {
         doenetML,
-        preliminarySerializedComponents,
         flags,
+        activityId,
+        docId,
+        attemptNumber,
+        requestedVariantIndex,
         serializedDocument: addDocumentIfItsMissing(
             expandResult.fullSerializedComponents[0],
         )[0],
@@ -168,7 +181,13 @@ async function initializeWorker({
 
     postMessage({
         messageType: "initializeResult",
-        args: initializeResult,
+        args: {
+            ...initializeResult,
+            activityId,
+            docId,
+            attemptNumber,
+            requestedVariantIndex,
+        },
     });
 
     let allPossibleVariants = await returnAllPossibleVariants(
@@ -178,7 +197,14 @@ async function initializeWorker({
 
     postMessage({
         messageType: "allPossibleVariants",
-        args: { success: true, allPossibleVariants },
+        args: {
+            success: true,
+            allPossibleVariants,
+            activityId,
+            docId,
+            attemptNumber,
+            requestedVariantIndex,
+        },
     });
 }
 

--- a/packages/doenetml-worker/src/test/utils/test-core.ts
+++ b/packages/doenetml-worker/src/test/utils/test-core.ts
@@ -67,14 +67,12 @@ export async function createTestCore({
         componentInfoObjects,
         activityId: "",
         cid: "",
-        pageNumber: 1,
-        serverSaveId: "",
+        docId: "1",
         activityVariantIndex: 1,
         requestedVariant: null,
         requestedVariantIndex: requestedVariantIndex,
         stateVariableChanges: "",
         coreId: "",
-        updateDataOnContentChange: null,
         theme,
     };
 

--- a/packages/doenetml-worker/src/utils/expandDoenetML.js
+++ b/packages/doenetml-worker/src/utils/expandDoenetML.js
@@ -9,7 +9,6 @@ import {
 
 export async function expandDoenetMLsToFullSerializedComponents({
     doenetMLs,
-    preliminarySerializedComponents = [],
     componentInfoObjects,
     nPreviousDoenetMLs = 0,
 }) {
@@ -22,20 +21,9 @@ export async function expandDoenetMLsToFullSerializedComponents({
     for (let [ind, doenetML] of doenetMLs.entries()) {
         let errorsForDoenetML = [];
         let warningsForDoenetML = [];
-        let result;
-
-        // if we happened to send in the parsed preliminary serialized components,
-        // then we don't need to parse the DoenetML again
-        let serializedComponents;
-        if (preliminarySerializedComponents[ind]) {
-            serializedComponents = JSON.parse(
-                JSON.stringify(preliminarySerializedComponents[ind]),
-            );
-        } else {
-            result = parseAndCompile(doenetML);
-            serializedComponents = result.components;
-            errorsForDoenetML.push(...result.errors);
-        }
+        let result = parseAndCompile(doenetML);
+        let serializedComponents = result.components;
+        errorsForDoenetML.push(...result.errors);
 
         serializedComponents = cleanIfHaveJustDocument(serializedComponents);
 

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.7.0-alpha24",
+    "version": "0.7.0-alpha25",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.7.0-alpha23",
+    "version": "0.7.0-alpha24",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -18,7 +18,7 @@ import { WarningTwoIcon } from "@chakra-ui/icons";
 // @ts-ignore
 import VariantSelect from "./VariantSelect";
 import { CodeMirror } from "@doenet/codemirror";
-import { PageViewer } from "../Viewer/PageViewer";
+import { DocViewer } from "../Viewer/DocViewer";
 import ErrorWarningPopovers from "./ErrorWarningPopovers";
 import type { WarningDescription, ErrorDescription } from "@doenet/utils";
 import { nanoid } from "nanoid";
@@ -473,7 +473,7 @@ export function EditorViewer({
                     ref={scrollableContainer}
                 >
                     {/* @ts-ignore */}
-                    <PageViewer
+                    <DocViewer
                         doenetML={viewerDoenetML}
                         flags={{
                             showCorrectness: true,

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -362,7 +362,8 @@ export function DocViewer({
                 setStage("coreCreated");
                 window.postMessage({
                     subject: "SPLICE.initialized",
-                    arg: { activityId, docId },
+                    activityId,
+                    docId,
                 });
                 // coreCreatedCallback?.();
             } else if (e.data.messageType === "initializeRenderers") {

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -36,7 +36,7 @@ export function DocViewer({
     userId,
     activityId = "a",
     docId = "1",
-    rendered = true,
+    render = true,
     hidden = false,
     attemptNumber = 1,
     forceDisable = false,
@@ -61,7 +61,7 @@ export function DocViewer({
     userId?: string;
     activityId?: string;
     docId?: string;
-    rendered?: boolean;
+    render?: boolean;
     hidden?: boolean;
     attemptNumber?: number;
     forceDisable?: boolean;
@@ -75,18 +75,12 @@ export function DocViewer({
     updateCreditAchievedCallback?: Function;
     setIsInErrorState?: Function;
     prefixForIds?: string;
-    render?: boolean;
-    isCurrent?: boolean;
-    hideWhenNotCurrent?: boolean;
-    addVirtualKeyboard?: boolean;
-    externalVirtualKeyboardProvided?: boolean;
     location?: any;
     navigate?: any;
     linkSettings?: { viewURL: string; editURL: string };
     scrollableContainer?: HTMLDivElement | Window;
     darkMode?: "dark" | "light";
     showAnswerTitles?: boolean;
-    includeVariantSelector?: boolean;
 }) {
     const updateRendererSVsWithRecoil = useRecoilCallback(
         ({ snapshot, set }) =>
@@ -559,7 +553,7 @@ export function DocViewer({
     }, [location, hash, coreCreated.current, coreWorker]);
 
     useEffect(() => {
-        if (hash && documentRenderer && rendered) {
+        if (hash && documentRenderer && render) {
             let anchor = hash.slice(1);
             if (
                 (!previousLocationKeys.current.includes(location.key) ||
@@ -571,7 +565,7 @@ export function DocViewer({
             }
             previousLocationKeys.current.push(location.key);
         }
-    }, [location, hash, documentRenderer, rendered]);
+    }, [location, hash, documentRenderer, render]);
 
     useEffect(() => {
         callAction({
@@ -1099,7 +1093,7 @@ export function DocViewer({
 
         //Guard against the possibility that parameters changed while waiting
         if (coreIdWhenCalled === coreId.current) {
-            if (rendered) {
+            if (render) {
                 startCore(initialPass);
             } else {
                 setStage("readyToCreateCore");
@@ -1334,7 +1328,7 @@ export function DocViewer({
 
     // if we are just starting and the document isn't being rendered,
     // don't do anything more
-    if (initialPass && !rendered) {
+    if (initialPass && !render) {
         return null;
     }
 
@@ -1409,9 +1403,9 @@ export function DocViewer({
         return null;
     }
 
-    if (stage === "readyToCreateCore" && rendered) {
+    if (stage === "readyToCreateCore" && render) {
         startCore();
-    } else if (stage === "waitingOnCore" && !rendered && !coreCreated.current) {
+    } else if (stage === "waitingOnCore" && !render && !coreCreated.current) {
         // we've moved off this doc, but core is still being created
         // so reinitialize core
         reinitializeCoreAndTerminateAnimations();
@@ -1419,7 +1413,7 @@ export function DocViewer({
         setStage("readyToCreateCore");
     }
 
-    if (hidden || !rendered) {
+    if (hidden || !render) {
         return null;
     }
 

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -360,6 +360,10 @@ export function DocViewer({
                     });
                 }
                 setStage("coreCreated");
+                window.postMessage({
+                    subject: "SPLICE.initialized",
+                    arg: { activityId, docId },
+                });
                 // coreCreatedCallback?.();
             } else if (e.data.messageType === "initializeRenderers") {
                 if (

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -1,5 +1,8 @@
 import React, {
     createContext,
+    ErrorInfo,
+    ReactElement,
+    ReactNode,
     useCallback,
     useEffect,
     useRef,
@@ -18,26 +21,23 @@ import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons";
 import { rendererState } from "./useDoenetRenderer";
 import { atom, atomFamily, useRecoilCallback, useRecoilValue } from "recoil";
 import { get as idb_get } from "idb-keyval";
-import { createCoreWorker, initializeCoreWorker } from "../utils/pageUtils";
+import { createCoreWorker, initializeCoreWorker } from "../utils/docUtils";
+import { DoenetMLFlags } from "../doenetml";
 
 const rendererUpdatesToIgnore = atomFamily({
     key: "rendererUpdatesToIgnore",
     default: {},
 });
 
-const sendAlert = (msg, type) => console.log(msg);
+export const DocContext = createContext({});
 
-export const PageContext = createContext();
-
-export function PageViewer({
-    userId,
-    activityId,
+export function DocViewer({
     doenetML,
-    pageNumber = "1",
-    render: pageIsActive = true,
-    isCurrent: pageIsCurrent = true,
-    hideWhenNotCurrent = false,
-    itemNumber = 1,
+    userId,
+    activityId = "a",
+    docId = "1",
+    rendered = true,
+    hidden = false,
     attemptNumber = 1,
     forceDisable = false,
     forceShowCorrectness = false,
@@ -49,8 +49,6 @@ export function PageViewer({
     setErrorsAndWarningsCallback,
     updateCreditAchievedCallback,
     setIsInErrorState,
-    updateAttemptNumber,
-    updateDataOnContentChange,
     prefixForIds = "",
     location = {},
     navigate,
@@ -58,6 +56,37 @@ export function PageViewer({
     scrollableContainer,
     darkMode,
     showAnswerTitles,
+}: {
+    doenetML: string;
+    userId?: string;
+    activityId?: string;
+    docId?: string;
+    rendered?: boolean;
+    hidden?: boolean;
+    attemptNumber?: number;
+    forceDisable?: boolean;
+    forceShowCorrectness?: boolean;
+    forceShowSolution?: boolean;
+    forceUnsuppressCheckwork?: boolean;
+    generatedVariantCallback?: Function;
+    flags: DoenetMLFlags;
+    requestedVariantIndex: number;
+    setErrorsAndWarningsCallback?: Function;
+    updateCreditAchievedCallback?: Function;
+    setIsInErrorState?: Function;
+    prefixForIds?: string;
+    render?: boolean;
+    isCurrent?: boolean;
+    hideWhenNotCurrent?: boolean;
+    addVirtualKeyboard?: boolean;
+    externalVirtualKeyboardProvided?: boolean;
+    location?: any;
+    navigate?: any;
+    linkSettings?: { viewURL: string; editURL: string };
+    scrollableContainer?: HTMLDivElement | Window;
+    darkMode?: "dark" | "light";
+    showAnswerTitles?: boolean;
+    includeVariantSelector?: boolean;
 }) {
     const updateRendererSVsWithRecoil = useRecoilCallback(
         ({ snapshot, set }) =>
@@ -69,6 +98,14 @@ export function PageViewer({
                 sourceOfUpdate,
                 baseStateVariable,
                 actionId,
+            }: {
+                coreId: string;
+                componentName: string;
+                stateValues: Record<string, any>;
+                childrenInstructions?: Record<string, any>[];
+                sourceOfUpdate?: Record<string, any>;
+                baseStateVariable?: string;
+                actionId?: string;
             }) => {
                 let ignoreUpdate = false;
 
@@ -80,7 +117,7 @@ export function PageViewer({
                     ).contents;
 
                     if (Object.keys(updatesToIgnore).length > 0) {
-                        let valueFromRenderer = updatesToIgnore[actionId];
+                        let valueFromRenderer = updatesToIgnore[actionId || ""];
                         let valueFromCore = stateValues[baseStateVariable];
                         if (
                             valueFromRenderer === valueFromCore ||
@@ -96,9 +133,11 @@ export function PageViewer({
                             ignoreUpdate = true;
                             set(
                                 rendererUpdatesToIgnore(rendererName),
-                                (was) => {
+                                (was: Record<string, any>) => {
                                     let newUpdatesToIgnore = { ...was };
-                                    delete newUpdatesToIgnore[actionId];
+                                    if (actionId) {
+                                        delete newUpdatesToIgnore[actionId];
+                                    }
                                     return newUpdatesToIgnore;
                                 },
                             );
@@ -111,21 +150,25 @@ export function PageViewer({
                     }
                 }
 
-                let newRendererState = {
-                    stateValues,
-                    childrenInstructions,
-                    sourceOfUpdate,
-                    ignoreUpdate,
-                    prefixForIds,
-                };
+                let childrenInstructions2: Record<string, any>[];
 
                 if (childrenInstructions === undefined) {
                     let previousRendererState = snapshot.getLoadable(
                         rendererState(rendererName),
                     ).contents;
-                    newRendererState.childrenInstructions =
+                    childrenInstructions2 =
                         previousRendererState.childrenInstructions;
+                } else {
+                    childrenInstructions2 = childrenInstructions;
                 }
+
+                let newRendererState = {
+                    stateValues,
+                    childrenInstructions: childrenInstructions2,
+                    sourceOfUpdate,
+                    ignoreUpdate,
+                    prefixForIds,
+                };
 
                 set(rendererState(rendererName), newRendererState);
             },
@@ -138,55 +181,96 @@ export function PageViewer({
                 // add to updates to ignore so don't apply change again
                 // if it comes back from core without any changes
                 // (possibly after a delay)
-                set(rendererUpdatesToIgnore(rendererName), (was) => {
-                    let newUpdatesToIgnore = { ...was };
-                    newUpdatesToIgnore[actionId] = baseVariableValue;
-                    return newUpdatesToIgnore;
-                });
+                set(
+                    rendererUpdatesToIgnore(rendererName),
+                    (was: Record<string, any>) => {
+                        let newUpdatesToIgnore = { ...was };
+                        newUpdatesToIgnore[actionId] = baseVariableValue;
+                        return newUpdatesToIgnore;
+                    },
+                );
             },
     );
 
-    const [errMsg, setErrMsg] = useState(null);
+    const [errMsg, setErrMsg] = useState<string | null>(null);
 
-    const cid = useRef(null);
-    const lastDoenetML = useRef(null);
-    const lastPageNumber = useRef(null);
-    const lastAttemptNumber = useRef(null);
-    const lastRequestedVariantIndex = useRef(null);
+    const cid = useRef<string | null>(null);
+    const lastDoenetML = useRef<string | null>(null);
+    const lastActivityId = useRef<string | null>(null);
+    const lastDocId = useRef<string | null>(null);
+    const lastAttemptNumber = useRef<number | null>(null);
+    const lastRequestedVariantIndex = useRef<number | null>(null);
+    const initialPass = useRef(true);
 
     const [stage, setStage] = useState("initial");
 
-    const [documentRenderer, setDocumentRenderer] = useState(null);
+    const [documentRenderer, setDocumentRenderer] =
+        useState<ReactElement | null>(null);
 
-    const initialCoreData = useRef({});
+    const initialCoreData = useRef<{
+        coreState: Record<string, any>;
+        requestedVariant: Record<string, any>;
+    } | null>(null);
 
-    const rendererClasses = useRef({});
-    const coreInfo = useRef(null);
+    const rendererClasses = useRef<Record<string, any>>({});
+    const coreInfo = useRef<Record<string, any> | null>(null);
     const coreCreated = useRef(false);
     const coreCreationInProgress = useRef(false);
-    const coreId = useRef(null);
-    const errorWarnings = useRef(null);
+    const coreId = useRef<string>("");
+    const errorWarnings = useRef<{
+        errors: any[];
+        warnings: any[];
+    }>({ errors: [], warnings: [] });
 
-    const resolveAllStateVariables = useRef(null);
-    const resolveErrorWarnings = useRef(null);
-    const actionsBeforeCoreCreated = useRef([]);
+    const resolveAllStateVariables = useRef<((value: unknown) => void) | null>(
+        null,
+    );
+    const resolveErrorWarnings = useRef<((value: unknown) => void) | null>(
+        null,
+    );
+    const actionsBeforeCoreCreated = useRef<
+        {
+            actionName: string;
+            componentName?: string;
+            args: Record<string, any>;
+        }[]
+    >([]);
 
     const preventMoreAnimations = useRef(false);
-    const animationInfo = useRef({});
+    const animationInfo = useRef<
+        Record<string, { animationFrameID?: number; timeoutId?: number }>
+    >({});
 
-    const resolveActionPromises = useRef({});
-    const actionTentativelySkipped = useRef(null);
+    const resolveActionPromises = useRef<Record<string, (value: any) => void>>(
+        {},
+    );
+    const actionTentativelySkipped = useRef<{
+        action: { actionName: string; componentName?: string };
+        args: Record<string, any>;
+        baseVariableValue?: any;
+        componentName?: string;
+        rendererType?: string;
+        promiseResolve?: (value: any) => void;
+    } | null>(null);
 
-    const saveStatePromises = useRef({});
+    const saveStatePromises = useRef<
+        Record<
+            string,
+            {
+                resolve: (value: Record<string, any>) => void;
+                reject: (value: unknown) => void;
+            }
+        >
+    >({});
 
-    const previousLocationKeys = useRef([]);
+    const previousLocationKeys = useRef<any[]>([]);
 
     const errorInitializingRenderers = useRef(false);
     const errorInsideRenderers = useRef(false);
 
     const [ignoreRendererError, setIgnoreRendererError] = useState(false);
 
-    const [coreWorkerInfo, setCoreWorkerInfo] = useState(null);
+    const [coreWorker, setCoreWorker] = useState<Worker | null>(null);
 
     let hash = location.hash;
 
@@ -208,20 +292,25 @@ export function PageViewer({
 
     useEffect(() => {
         async function initialize() {
-            let coreWorker = createCoreWorker();
-
-            let theInfo = {
-                coreWorker,
-                doenetML,
-                flags,
-            };
-
-            setCoreWorkerInfo(theInfo);
+            let newCoreWorker = createCoreWorker();
+            setCoreWorker(newCoreWorker);
 
             try {
-                await initializeCoreWorker(theInfo);
-            } catch (e) {
-                setErrMsg(`Error initializing activity: ${e.message}`);
+                await initializeCoreWorker({
+                    coreWorker: newCoreWorker,
+                    doenetML,
+                    flags,
+                    activityId,
+                    docId,
+                    attemptNumber,
+                    requestedVariantIndex,
+                });
+            } catch (e: any) {
+                let message = "";
+                if ("message" in e) {
+                    message = e.message;
+                }
+                setErrMsg(`Error initializing activity: ${message}`);
             }
         }
 
@@ -229,10 +318,10 @@ export function PageViewer({
     }, []);
 
     useEffect(() => {
-        if (!coreWorkerInfo) {
+        if (!coreWorker) {
             return;
         }
-        coreWorkerInfo.coreWorker.onmessage = function (e) {
+        coreWorker.onmessage = function (e) {
             // console.log("message from core", e.data);
             if (e.data.messageType === "updateRenderers") {
                 if (
@@ -240,12 +329,12 @@ export function PageViewer({
                     coreInfo.current &&
                     !errorInitializingRenderers.current &&
                     !errorInsideRenderers.current &&
-                    !(hideWhenNotCurrent && !pageIsCurrent)
+                    !hidden
                 ) {
                     // we don't initialize renderer state values if already have a coreInfo
                     // and no errors were encountered
                     // as we must have already gotten the renderer information before core was created.
-                    // Exception if page is not current and we hide the page when it is not current,
+                    // Exception if doc is hidden,
                     // then we still update the renderers.
                     // This exception is important because, in this case,
                     // the renderers have not yet been rendered, so any errors would not yet have revealed
@@ -266,7 +355,7 @@ export function PageViewer({
                 coreCreationInProgress.current = false;
                 preventMoreAnimations.current = false;
                 for (let actionArgs of actionsBeforeCoreCreated.current) {
-                    coreWorkerInfo.coreWorker.postMessage({
+                    coreWorker.postMessage({
                         messageType: "requestAction",
                         args: actionArgs,
                     });
@@ -296,18 +385,18 @@ export function PageViewer({
                 // saveStateCallback?.();
             } else if (e.data.messageType === "sendAlert") {
                 console.log(`Sending alert message: ${e.data.args.message}`);
-                sendAlert(e.data.args.message, e.data.args.alertType);
+                // sendAlert(e.data.args.message, e.data.args.alertType);
             } else if (e.data.messageType === "resolveAction") {
                 resolveAction(e.data.args);
             } else if (e.data.messageType === "returnAllStateVariables") {
                 console.log(e.data.args);
-                resolveAllStateVariables.current(e.data.args);
+                resolveAllStateVariables.current?.(e.data.args);
             } else if (e.data.messageType === "returnErrorWarnings") {
-                let errorWarnings = e.data.args;
-                console.log(errorWarnings);
-                resolveErrorWarnings.current(errorWarnings);
+                let returnedErrorWarnings = e.data.args;
+                console.log(returnedErrorWarnings);
+                resolveErrorWarnings.current?.(returnedErrorWarnings);
             } else if (e.data.messageType === "componentRangePieces") {
-                window["componentRangePieces" + pageNumber] =
+                (window as any)["componentRangePieces" + docId] =
                     e.data.args.componentRangePieces;
             } else if (e.data.messageType === "inErrorState") {
                 setIsInErrorState?.(true);
@@ -315,8 +404,6 @@ export function PageViewer({
             } else if (e.data.messageType === "setErrorWarnings") {
                 errorWarnings.current = e.data.errorWarnings;
                 setErrorsAndWarningsCallback?.(errorWarnings.current);
-            } else if (e.data.messageType === "resetPage") {
-                resetPage(e.data.args);
             } else if (e.data.messageType === "copyToClipboard") {
                 copyToClipboard(e.data.args);
             } else if (e.data.messageType === "navigateToTarget") {
@@ -346,14 +433,14 @@ export function PageViewer({
                     subject: "SPLICE.allPossibleVariants",
                 });
             } else if (e.data.messageType === "terminated") {
-                reinitializeCoreAndTerminateAnimations(coreWorkerInfo);
+                reinitializeCoreAndTerminateAnimations();
             }
         };
-    }, [coreWorkerInfo?.coreWorker, location]);
+    }, [coreWorker, location]);
 
     useEffect(() => {
         return () => {
-            coreWorkerInfo?.coreWorker.postMessage({
+            coreWorker?.postMessage({
                 messageType: "terminate",
             });
         };
@@ -381,24 +468,25 @@ export function PageViewer({
     });
 
     useEffect(() => {
-        if (!coreWorkerInfo) {
+        if (!coreWorker) {
             return;
         }
-        if (pageNumber !== null) {
-            window["returnAllStateVariables" + postfixForWindowFunctions] =
-                function () {
-                    coreWorkerInfo.coreWorker.postMessage({
-                        messageType: "returnAllStateVariables",
-                    });
+        if (docId !== null) {
+            (window as any)[
+                "returnAllStateVariables" + postfixForWindowFunctions
+            ] = function () {
+                coreWorker.postMessage({
+                    messageType: "returnAllStateVariables",
+                });
 
-                    return new Promise((resolve, reject) => {
-                        resolveAllStateVariables.current = resolve;
-                    });
-                };
+                return new Promise((resolve, reject) => {
+                    resolveAllStateVariables.current = resolve;
+                });
+            };
 
-            window["returnErrorWarnings" + postfixForWindowFunctions] =
+            (window as any)["returnErrorWarnings" + postfixForWindowFunctions] =
                 function () {
-                    coreWorkerInfo.coreWorker.postMessage({
+                    coreWorker.postMessage({
                         messageType: "returnErrorWarnings",
                     });
 
@@ -407,18 +495,23 @@ export function PageViewer({
                     });
                 };
 
-            window["callAction" + postfixForWindowFunctions] = async function ({
-                actionName,
-                componentName,
-                args,
-            }) {
-                return await callAction({
-                    action: { actionName, componentName },
+            (window as any)["callAction" + postfixForWindowFunctions] =
+                async function ({
+                    actionName,
+                    componentName,
                     args,
-                });
-            };
+                }: {
+                    actionName: string;
+                    componentName: string;
+                    args: Record<string, any>;
+                }) {
+                    return await callAction({
+                        action: { actionName, componentName },
+                        args,
+                    });
+                };
         }
-    }, [pageNumber, coreWorkerInfo]);
+    }, [docId, coreWorker]);
 
     useEffect(() => {
         return () => {
@@ -431,24 +524,24 @@ export function PageViewer({
     }, []);
 
     useEffect(() => {
-        if (!coreWorkerInfo) {
+        if (!coreWorker) {
             return;
         }
         document.addEventListener("visibilitychange", () => {
-            coreWorkerInfo.coreWorker.postMessage({
+            coreWorker.postMessage({
                 messageType: "visibilityChange",
                 args: {
                     visible: document.visibilityState === "visible",
                 },
             });
         });
-    }, [coreWorkerInfo]);
+    }, [coreWorker]);
 
     useEffect(() => {
-        if (hash && coreCreated.current && coreWorkerInfo?.coreWorker) {
+        if (hash && coreCreated.current && coreWorker) {
             let anchor = hash.slice(1);
             if (anchor.substring(0, prefixForIds.length) === prefixForIds) {
-                coreWorkerInfo.coreWorker.postMessage({
+                coreWorker.postMessage({
                     messageType: "navigatingToComponent",
                     args: {
                         componentName: anchor
@@ -459,16 +552,10 @@ export function PageViewer({
                 });
             }
         }
-    }, [
-        location,
-        hash,
-        coreCreated.current,
-        coreWorkerInfo,
-        coreWorkerInfo?.coreWorker,
-    ]);
+    }, [location, hash, coreCreated.current, coreWorker]);
 
     useEffect(() => {
-        if (hash && documentRenderer && pageIsActive) {
+        if (hash && documentRenderer && rendered) {
             let anchor = hash.slice(1);
             if (
                 (!previousLocationKeys.current.includes(location.key) ||
@@ -480,7 +567,7 @@ export function PageViewer({
             }
             previousLocationKeys.current.push(location.key);
         }
-    }, [location, hash, documentRenderer, pageIsActive]);
+    }, [location, hash, documentRenderer, rendered]);
 
     useEffect(() => {
         callAction({
@@ -489,6 +576,7 @@ export function PageViewer({
         });
     }, [darkMode]);
 
+    // TODO: fix this function as it uses conventions that are no longer valid
     const navigateToTarget = useCallback(
         async ({
             cid,
@@ -502,6 +590,18 @@ export function PageViewer({
             actionId,
             componentName,
             effectiveName,
+        }: {
+            cid?: string;
+            activityId?: string;
+            variantIndex?: number;
+            edit?: boolean;
+            hash?: string;
+            page?: number;
+            uri?: string;
+            targetName?: string;
+            actionId?: string;
+            componentName?: string;
+            effectiveName: string;
         }) => {
             let id = prefixForIds + cesc(effectiveName);
             let { targetForATag, url, haveValidTarget, externalUri } =
@@ -540,10 +640,11 @@ export function PageViewer({
         [location],
     );
 
-    async function reinitializeCoreAndTerminateAnimations(newCoreWorkerInfo) {
+    async function reinitializeCoreAndTerminateAnimations() {
         preventMoreAnimations.current = true;
-        coreWorkerInfo.coreWorker.terminate();
-        coreWorkerInfo.coreWorker = createCoreWorker();
+        coreWorker?.terminate();
+        const newCoreWorker = createCoreWorker();
+        setCoreWorker(newCoreWorker);
 
         coreCreated.current = false;
         coreCreationInProgress.current = false;
@@ -553,7 +654,17 @@ export function PageViewer({
         animationInfo.current = {};
         actionsBeforeCoreCreated.current = [];
 
-        await initializeCoreWorker(newCoreWorkerInfo);
+        await initializeCoreWorker({
+            coreWorker: newCoreWorker,
+            doenetML,
+            flags,
+            activityId,
+            docId,
+            attemptNumber,
+            requestedVariantIndex,
+        });
+
+        return newCoreWorker;
     }
 
     async function callAction({
@@ -563,13 +674,21 @@ export function PageViewer({
         componentName,
         rendererType,
         promiseResolve,
+    }: {
+        action: { actionName: string; componentName?: string };
+        args: Record<string, any>;
+        baseVariableValue?: any;
+        componentName?: string;
+        rendererType?: string;
+        promiseResolve?: (value: any) => void;
     }) {
         // Note: the reason we check both the renderer class and .type
         // is that if the renderer was memoized, then the renderer class itself is on .type,
         // Otherwise, the renderer class is the value of the rendererClasses entry.
         let ignoreActionsWithoutCore =
-            rendererClasses.current[rendererType]?.ignoreActionsWithoutCore ||
-            rendererClasses.current[rendererType]?.type
+            rendererClasses.current[rendererType ?? ""]
+                ?.ignoreActionsWithoutCore ||
+            rendererClasses.current[rendererType ?? ""]?.type
                 ?.ignoreActionsWithoutCore;
         if (
             !coreCreated.current &&
@@ -581,7 +700,7 @@ export function PageViewer({
             // and either the action must be ignored without core or core isn't actually
             // in the process of being created (relevant case is that core has been terminated).
             // Also, don't ignore if the doNotIgnore argument has been set
-            // (used for actions called directly from PageViewer for initialization)
+            // (used for actions called directly from DocViewer for initialization)
 
             if (promiseResolve) {
                 // if were given promiseResolve, then action was called from resolveAction
@@ -599,7 +718,7 @@ export function PageViewer({
         if (actionTentativelySkipped.current) {
             // we are for sure skipping the actionTentativelySkipped,
             // so resolve its promise as false
-            actionTentativelySkipped.current.promiseResolve(false);
+            actionTentativelySkipped.current.promiseResolve?.(false);
             actionTentativelySkipped.current = null;
         }
 
@@ -669,7 +788,7 @@ export function PageViewer({
 
         if (coreCreated.current) {
             // Note: it is possible that core has been terminated, so we need the question mark
-            coreWorkerInfo.coreWorker?.postMessage({
+            coreWorker?.postMessage({
                 messageType: "requestAction",
                 args: actionArgs,
             });
@@ -700,6 +819,12 @@ export function PageViewer({
         forceShowCorrectness,
         forceShowSolution,
         forceUnsuppressCheckwork,
+    }: {
+        rendererState: Record<string, Record<string, any>>;
+        forceDisable: boolean;
+        forceShowCorrectness: boolean;
+        forceShowSolution: boolean;
+        forceUnsuppressCheckwork: boolean;
     }) {
         for (let componentName in rendererState) {
             let stateValues = rendererState[componentName].stateValues;
@@ -736,7 +861,7 @@ export function PageViewer({
         }
     }
 
-    function initializeRenderers(args) {
+    function initializeRenderers(args: Record<string, any>) {
         if (args.rendererState) {
             delete args.rendererState.__componentNeedingUpdateValue;
             if (
@@ -766,15 +891,18 @@ export function PageViewer({
 
         coreInfo.current = args.coreInfo;
 
+        if (!coreInfo.current) {
+            return;
+        }
+
         generatedVariantCallback?.({
-            pageVariant: {
-                variantInfo: JSON.parse(
-                    coreInfo.current.generatedVariantString,
-                    serializedComponentsReviver,
-                ),
-                allPossibleVariants: coreInfo.current.allPossibleVariants,
-                itemNumber,
-            },
+            variantInfo: JSON.parse(
+                coreInfo.current.generatedVariantString,
+                serializedComponentsReviver,
+            ),
+            allPossibleVariants: coreInfo.current.allPossibleVariants,
+            activityId,
+            docId,
         });
 
         let renderPromises = [];
@@ -814,7 +942,7 @@ export function PageViewer({
                     }),
                 );
 
-                renderersInitializedCallback?.();
+                // renderersInitializedCallback?.();
             })
             .catch((e) => {
                 errorInitializingRenderers.current = true;
@@ -822,7 +950,13 @@ export function PageViewer({
     }
 
     //offscreen then postpone that one
-    function updateRenderers({ updateInstructions, actionId }) {
+    function updateRenderers({
+        updateInstructions,
+        actionId,
+    }: {
+        updateInstructions: Record<string, any>[];
+        actionId?: string;
+    }) {
         for (let instruction of updateInstructions) {
             if (instruction.instructionType === "updateRendererStates") {
                 for (let {
@@ -854,7 +988,7 @@ export function PageViewer({
         resolveAction({ actionId });
     }
 
-    function resolveAction({ actionId }) {
+    function resolveAction({ actionId }: { actionId?: string }) {
         if (actionId) {
             resolveActionPromises.current[actionId]?.(true);
             delete resolveActionPromises.current[actionId];
@@ -870,36 +1004,6 @@ export function PageViewer({
         }
     }
 
-    function resetPage({ changedOnDevice, newCid, newAttemptNumber }) {
-        // console.log('resetPage', changedOnDevice, newCid, newAttemptNumber);
-
-        if (newAttemptNumber !== attemptNumber) {
-            sendAlert(
-                `Reverted activity as attempt number changed on other device`,
-                "info",
-            );
-            if (updateAttemptNumber) {
-                updateAttemptNumber(newAttemptNumber);
-            } else {
-                // what do we do in this case?
-                setIsInErrorState?.(true);
-                setErrMsg(
-                    "how to reset attempt number when not given updateAttemptNumber function?",
-                );
-            }
-        } else {
-            // TODO: are there cases where will get an infinite loop here?
-            // TODO: since we removed the pageContentChanged feature, it's not clear what to do here.
-            // We should either make this work correctly or remove any calls to resetPage.
-            // sendAlert(
-            //     `Reverted page to state saved on device ${changedOnDevice}`,
-            //     "info",
-            // );
-            // coreId.current = nanoid();
-            // setPageContentChanged(true);
-        }
-    }
-
     async function loadStateAndInitialize() {
         const coreIdWhenCalled = coreId.current;
         let loadedState = false;
@@ -911,7 +1015,7 @@ export function PageViewer({
 
             try {
                 localInfo = await idb_get(
-                    `${activityId}|${pageNumber}|${attemptNumber}|${cid.current}`,
+                    `${activityId}|${docId}|${attemptNumber}|${cid.current}`,
                 );
                 if (localInfo.data_format_version !== data_format_version) {
                     // the data saved does not match the current version, so we ignore it
@@ -953,7 +1057,6 @@ export function PageViewer({
 
                 initialCoreData.current = {
                     coreState,
-                    serverSaveId: localInfo.saveId,
                     requestedVariant: JSON.parse(
                         coreInfo.generatedVariantString,
                         serializedComponentsReviver,
@@ -969,17 +1072,22 @@ export function PageViewer({
                 try {
                     let resp = await getStateViaSplice({
                         cid: cid.current,
-                        pageNumber,
-                        attemptNumber,
                         activityId,
+                        docId,
+                        attemptNumber,
                         userId,
                     });
                     if (resp.loadedState) {
-                        processLoadedPageState(JSON.parse(resp.state));
+                        processLoadedDocState(JSON.parse(resp.state));
                     }
-                } catch (e) {
+                } catch (e: any) {
                     setIsInErrorState?.(true);
-                    setErrMsg(`Error loading page state: ${e.message}`);
+
+                    let message = "";
+                    if ("message" in e) {
+                        message = e.message;
+                    }
+                    setErrMsg(`Error loading doc state: ${message}`);
                     return;
                 }
             }
@@ -987,7 +1095,7 @@ export function PageViewer({
 
         //Guard against the possibility that parameters changed while waiting
         if (coreIdWhenCalled === coreId.current) {
-            if (pageIsActive) {
+            if (rendered) {
                 startCore();
             } else {
                 setStage("readyToCreateCore");
@@ -997,31 +1105,40 @@ export function PageViewer({
 
     function getStateViaSplice({
         cid,
-        pageNumber,
-        attemptNumber,
         activityId,
+        docId,
+        attemptNumber,
         userId,
+    }: {
+        cid: string;
+        activityId: string;
+        docId: string;
+        attemptNumber: number;
+        userId?: string;
     }) {
         let messageId = nanoid();
-        let savePromiseResolve, savePromiseReject;
+        let savePromiseResolve: (value: Record<string, any>) => void,
+            savePromiseReject: (value: unknown) => void;
 
-        let savePromise = new Promise((resolve, reject) => {
-            savePromiseResolve = resolve;
-            savePromiseReject = reject;
-            window.postMessage({
-                subject: "SPLICE.getState",
-                messageId,
-                cid,
-                pageNumber,
-                attemptNumber,
-                activityId,
-                userId,
-            });
-        });
+        let savePromise = new Promise<Record<string, any>>(
+            (resolve, reject) => {
+                savePromiseResolve = resolve;
+                savePromiseReject = reject;
+                window.postMessage({
+                    subject: "SPLICE.getState",
+                    messageId,
+                    cid,
+                    activityId,
+                    docId,
+                    attemptNumber,
+                    userId,
+                });
+            },
+        );
 
         saveStatePromises.current[messageId] = {
-            resolve: savePromiseResolve,
-            reject: savePromiseReject,
+            resolve: savePromiseResolve!,
+            reject: savePromiseReject!,
         };
 
         const MESSAGE_TIMEOUT = 15000;
@@ -1031,13 +1148,13 @@ export function PageViewer({
                 return;
             }
             delete saveStatePromises.current[messageId];
-            savePromiseReject({ message: "Time out loading page state" });
+            savePromiseReject({ message: "Time out loading doc state" });
         }, MESSAGE_TIMEOUT);
 
         return savePromise;
     }
 
-    function processLoadedPageState(data) {
+    function processLoadedDocState(data: Record<string, any>) {
         let coreInfo = JSON.parse(data.coreInfo, serializedComponentsReviver);
 
         let rendererState = JSON.parse(
@@ -1062,7 +1179,6 @@ export function PageViewer({
 
         initialCoreData.current = {
             coreState: JSON.parse(data.coreState, serializedComponentsReviver),
-            serverSaveId: data.saveId,
             requestedVariant: JSON.parse(
                 coreInfo.generatedVariantString,
                 serializedComponentsReviver,
@@ -1071,40 +1187,37 @@ export function PageViewer({
     }
 
     async function startCore() {
-        let theInfo = {
-            coreWorker: coreWorkerInfo.coreWorker,
-            doenetML,
-            flags,
-        };
-        setCoreWorkerInfo(theInfo);
-
         //Kill the current core if it exists
-        if (coreCreated.current) {
-            await reinitializeCoreAndTerminateAnimations(theInfo);
-        } else {
-            // otherwise, just initialize to give it the current DoenetML
-            await initializeCoreWorker(theInfo);
+
+        let thisCoreWorker = coreWorker;
+
+        if (coreCreated.current || !thisCoreWorker) {
+            thisCoreWorker = await reinitializeCoreAndTerminateAnimations();
+        } else if (!initialPass.current) {
+            // otherwise, if not initial pass, then re-initialize to give it the current DoenetML
+            await initializeCoreWorker({
+                coreWorker: thisCoreWorker,
+                doenetML,
+                flags,
+                activityId,
+                docId,
+                attemptNumber,
+                requestedVariantIndex,
+            });
         }
 
         resolveActionPromises.current = {};
 
-        // console.log(`send message to create core ${pageNumber}`)
-        coreWorkerInfo.coreWorker.postMessage({
+        // console.log(`send message to create core ${docId}`)
+        thisCoreWorker.postMessage({
             messageType: "createCore",
             args: {
                 coreId: coreId.current,
                 userId,
                 cid: cid.current,
-                activityId,
                 theme: darkMode,
-                requestedVariantIndex,
-                pageNumber,
-                attemptNumber,
-                itemNumber,
-                updateDataOnContentChange,
-                serverSaveId: initialCoreData.current.serverSaveId,
-                requestedVariant: initialCoreData.current.requestedVariant,
-                stateVariableChanges: initialCoreData.current.coreState
+                requestedVariant: initialCoreData.current?.requestedVariant,
+                stateVariableChanges: initialCoreData.current?.coreState
                     ? JSON.stringify(
                           initialCoreData.current.coreState,
                           serializedComponentsReplacer,
@@ -1117,7 +1230,17 @@ export function PageViewer({
         coreCreationInProgress.current = true;
     }
 
-    function requestAnimationFrame({ action, actionArgs, delay, animationId }) {
+    function requestAnimationFrame({
+        action,
+        actionArgs,
+        delay,
+        animationId,
+    }: {
+        action: { actionName: string; componentName?: string };
+        actionArgs: Record<string, any>;
+        delay?: number;
+        animationId: string;
+    }) {
         if (!preventMoreAnimations.current) {
             // create new animationId
 
@@ -1141,7 +1264,15 @@ export function PageViewer({
         }
     }
 
-    function _requestAnimationFrame({ action, actionArgs, animationId }) {
+    function _requestAnimationFrame({
+        action,
+        actionArgs,
+        animationId,
+    }: {
+        action: { actionName: string; componentName?: string };
+        actionArgs: Record<string, any>;
+        animationId: string;
+    }) {
         let animationFrameID = window.requestAnimationFrame(() =>
             callAction({
                 action,
@@ -1154,7 +1285,7 @@ export function PageViewer({
         animationInfoObj.animationFrameID = animationFrameID;
     }
 
-    async function cancelAnimationFrame(animationId) {
+    async function cancelAnimationFrame(animationId: string) {
         let animationInfoObj = animationInfo.current[animationId];
         let timeoutId = animationInfoObj?.timeoutId;
         if (timeoutId !== undefined) {
@@ -1167,7 +1298,13 @@ export function PageViewer({
         delete animationInfo.current[animationId];
     }
 
-    async function copyToClipboard({ text, actionId }) {
+    async function copyToClipboard({
+        text,
+        actionId,
+    }: {
+        text: string;
+        actionId?: string;
+    }) {
         await navigator.clipboard.writeText(text);
 
         resolveAction({ actionId });
@@ -1181,7 +1318,7 @@ export function PageViewer({
         }
     }
 
-    if (!coreWorkerInfo) {
+    if (!coreWorker) {
         return null;
     }
 
@@ -1189,13 +1326,19 @@ export function PageViewer({
     // set state to props and record that that need a new core
 
     let changedState = false;
+    initialPass.current = lastDoenetML.current === null;
     if (lastDoenetML.current !== doenetML) {
         lastDoenetML.current = doenetML;
         changedState = true;
     }
 
-    if (lastPageNumber.current !== pageNumber) {
-        lastPageNumber.current = pageNumber;
+    if (lastDocId.current !== docId) {
+        lastDocId.current = docId;
+        changedState = true;
+    }
+
+    if (lastActivityId.current !== activityId) {
+        lastActivityId.current = activityId;
         changedState = true;
     }
 
@@ -1219,7 +1362,7 @@ export function PageViewer({
         }
 
         coreId.current = nanoid();
-        initialCoreData.current = {};
+        initialCoreData.current = null;
         coreInfo.current = null;
         setDocumentRenderer(null);
         coreCreated.current = false;
@@ -1255,29 +1398,26 @@ export function PageViewer({
         return null;
     }
 
-    if (stage === "readyToCreateCore" && pageIsActive) {
+    if (stage === "readyToCreateCore" && rendered) {
         startCore();
-    } else if (
-        stage === "waitingOnCore" &&
-        !pageIsActive &&
-        !coreCreated.current
-    ) {
-        // we've moved off this page, but core is still being created
+    } else if (stage === "waitingOnCore" && !rendered && !coreCreated.current) {
+        // we've moved off this doc, but core is still being created
         // so reinitialize core
-        reinitializeCoreAndTerminateAnimations(coreWorkerInfo);
+        reinitializeCoreAndTerminateAnimations();
 
         setStage("readyToCreateCore");
     }
 
-    if ((hideWhenNotCurrent && !pageIsCurrent) || !pageIsActive) {
+    if (hidden || !rendered) {
         return null;
     }
 
     let noCoreWarning = null;
-    let pageStyle = {
+    let viewerStyle = {
         maxWidth: "850px",
         paddingLeft: "20px",
         paddingRight: "20px",
+        backgroundColor: "inherit",
     };
     if (!coreCreated.current) {
         if (!documentRenderer) {
@@ -1287,14 +1427,14 @@ export function PageViewer({
                 </div>
             );
         }
-        pageStyle.backgroundColor = "#F0F0F0";
+        viewerStyle.backgroundColor = "#F0F0F0";
     }
 
     let errorOverview = null;
     if (documentRenderer && errorWarnings.current?.errors.length > 0) {
         let errorStyle = {
             backgroundColor: "#ff9999",
-            textAlign: "center",
+            textAlign: "center" as const,
             borderWidth: 3,
             borderStyle: "solid",
         };
@@ -1314,18 +1454,21 @@ export function PageViewer({
             coreCreated={coreCreated.current}
         >
             {noCoreWarning}
-            <div style={pageStyle} className="doenet-viewer">
+            <div style={viewerStyle} className="doenet-viewer">
                 {errorOverview}
-                <PageContext.Provider value={contextForRenderers}>
+                <DocContext.Provider value={contextForRenderers}>
                     {documentRenderer}
-                </PageContext.Provider>
+                </DocContext.Provider>
             </div>
         </ErrorBoundary>
     );
 }
 
-export async function renderersloadComponent(promises, rendererClassNames) {
-    var rendererClasses = {};
+export async function renderersloadComponent(
+    promises: Promise<any>[],
+    rendererClassNames: string[],
+) {
+    var rendererClasses: Record<string, any> = {};
     for (let [index, promise] of promises.entries()) {
         try {
             let module = await promise;
@@ -1338,18 +1481,28 @@ export async function renderersloadComponent(promises, rendererClassNames) {
     return rendererClasses;
 }
 
-class ErrorBoundary extends React.Component {
-    constructor(props) {
+type ErrorProps = {
+    setIsInErrorState: Function | undefined;
+    errorHandler: Function | undefined;
+    ignoreError: boolean;
+    coreCreated: boolean;
+    children?: ReactNode;
+};
+
+type ErrorState = { hasError: boolean };
+
+class ErrorBoundary extends React.Component<ErrorProps, ErrorState> {
+    constructor(props: ErrorProps) {
         super(props);
         this.state = { hasError: false };
     }
 
-    static getDerivedStateFromError(error) {
+    static getDerivedStateFromError(_: Error): ErrorState {
         return { hasError: true };
     }
-    componentDidCatch(error, errorInfo) {
+    componentDidCatch(error: Error, errorInfo: ErrorInfo) {
         this.props.setIsInErrorState?.(true);
-        this.props.errorHandler();
+        this.props.errorHandler?.();
     }
     render() {
         if (this.state.hasError && !this.props.ignoreError) {
@@ -1363,6 +1516,7 @@ class ErrorBoundary extends React.Component {
     }
 }
 
+// TODO: fix this function as it assume conventions that are no longer valid
 export function getURLFromRef({
     cid,
     activityId,
@@ -1375,6 +1529,18 @@ export function getURLFromRef({
     linkSettings,
     search = "",
     id = "",
+}: {
+    cid?: string;
+    activityId?: string;
+    variantIndex?: number;
+    edit?: boolean;
+    hash?: string;
+    page?: number;
+    givenUri?: string;
+    targetName?: string;
+    linkSettings: Record<string, any>;
+    search?: string;
+    id?: string;
 }) {
     // possible linkSettings
     // - viewURL
@@ -1382,7 +1548,7 @@ export function getURLFromRef({
     // - useQueryParameters
 
     let url = "";
-    let targetForATag = "_blank";
+    let targetForATag: string | null = "_blank";
     let haveValidTarget = false;
     let externalUri = false;
 

--- a/packages/doenetml/src/Viewer/renderers/answer.jsx
+++ b/packages/doenetml/src/Viewer/renderers/answer.jsx
@@ -8,7 +8,7 @@ import {
     faCloud,
 } from "@fortawesome/free-solid-svg-icons";
 import styled from "styled-components";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 // Moved most of checkWorkStyle styling into Button
 const Button = styled.button`
@@ -33,7 +33,7 @@ export default React.memo(function Answer(props) {
     let { name, id, SVs, actions, children, callAction } =
         useDoenetRenderer(props);
 
-    const { showAnswerTitles } = useContext(PageContext) || {};
+    const { showAnswerTitles } = useContext(DocContext) || {};
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/booleanInput.jsx
+++ b/packages/doenetml/src/Viewer/renderers/booleanInput.jsx
@@ -17,7 +17,7 @@ import { MathJax } from "better-react-mathjax";
 import { BoardContext } from "./graph";
 import me from "math-expressions";
 import { getPositionFromAnchorByCoordinate } from "./utils/graph";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 // Moved most of checkWorkStyle styling into Button
 const Button = styled.button`
@@ -65,7 +65,7 @@ export default React.memo(function BooleanInput(props) {
 
     const board = useContext(BoardContext);
 
-    const { showAnswerTitles } = useContext(PageContext) || {};
+    const { showAnswerTitles } = useContext(DocContext) || {};
 
     let pointerAtDown = useRef(false);
     let pointAtDown = useRef(false);

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.jsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.jsx
@@ -12,7 +12,7 @@ import { rendererState } from "../useDoenetRenderer";
 import { useSetRecoilState } from "recoil";
 import styled from "styled-components";
 import "./choiceInput.css";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 // Moved most of checkWorkStyle styling into Button
 const Button = styled.button`
@@ -59,7 +59,7 @@ export default React.memo(function ChoiceInput(props) {
 
     let selectedIndicesWhenSetState = useRef(null);
 
-    const { showAnswerTitles } = useContext(PageContext) || {};
+    const { showAnswerTitles } = useContext(DocContext) || {};
 
     if (
         !ignoreUpdate &&

--- a/packages/doenetml/src/Viewer/renderers/circle.jsx
+++ b/packages/doenetml/src/Viewer/renderers/circle.jsx
@@ -13,7 +13,7 @@ import {
     normalizePointSize,
     normalizePointStyle,
 } from "./utils/graph";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 export default React.memo(function Circle(props) {
     let { name, id, SVs, actions, callAction } = useDoenetRenderer(props);
@@ -52,7 +52,7 @@ export default React.memo(function Circle(props) {
     fixed.current = SVs.fixed;
     fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
 
-    const { darkMode } = useContext(PageContext) || {};
+    const { darkMode } = useContext(DocContext) || {};
 
     useEffect(() => {
         //On unmount

--- a/packages/doenetml/src/Viewer/renderers/contentBrowser.jsx
+++ b/packages/doenetml/src/Viewer/renderers/contentBrowser.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect } from "react";
 import useDoenetRenderer from "../useDoenetRenderer";
 import VisibilitySensor from "react-visibility-sensor-v2";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 import { cesc } from "@doenet/utils";
 import { addCommasForCompositeRanges } from "./utils/composites";
 
@@ -9,7 +9,7 @@ export default React.memo(function ContentBrowser(props) {
     let { name, id, SVs, children, actions, callAction } =
         useDoenetRenderer(props);
 
-    let { location = {} } = useContext(PageContext) || {};
+    let { location = {} } = useContext(DocContext) || {};
 
     let search = location.search || "";
     let hash = location.hash || "";

--- a/packages/doenetml/src/Viewer/renderers/curve.jsx
+++ b/packages/doenetml/src/Viewer/renderers/curve.jsx
@@ -7,7 +7,7 @@ import {
     LINE_LAYER_OFFSET,
     VERTEX_LAYER_OFFSET,
 } from "./graph";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 export default React.memo(function Curve(props) {
     let { name, id, SVs, actions, sourceOfUpdate, callAction } =
@@ -58,7 +58,7 @@ export default React.memo(function Curve(props) {
     let lastControlPointPositionsFromCore = useRef(null);
     lastControlPointPositionsFromCore.current = SVs.numericalControlPoints;
 
-    const { darkMode } = useContext(PageContext) || {};
+    const { darkMode } = useContext(DocContext) || {};
 
     useEffect(() => {
         //On unmount

--- a/packages/doenetml/src/Viewer/renderers/label.jsx
+++ b/packages/doenetml/src/Viewer/renderers/label.jsx
@@ -5,7 +5,7 @@ import { MathJax } from "better-react-mathjax";
 import me from "math-expressions";
 import { textRendererStyle } from "@doenet/utils";
 import { getPositionFromAnchorByCoordinate } from "./utils/graph";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 export default React.memo(function Label(props) {
     let { name, id, SVs, children, actions, callAction } =
@@ -37,7 +37,7 @@ export default React.memo(function Label(props) {
     fixed.current = SVs.fixed;
     fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
 
-    const { darkMode } = useContext(PageContext) || {};
+    const { darkMode } = useContext(DocContext) || {};
 
     useEffect(() => {
         //On unmount

--- a/packages/doenetml/src/Viewer/renderers/line.jsx
+++ b/packages/doenetml/src/Viewer/renderers/line.jsx
@@ -4,7 +4,7 @@ import { BoardContext, LINE_LAYER_OFFSET } from "./graph";
 import me from "math-expressions";
 import { MathJax } from "better-react-mathjax";
 import { textRendererStyle } from "@doenet/utils";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 export default React.memo(function Line(props) {
     let { name, id, SVs, actions, callAction } = useDoenetRenderer(props);
@@ -34,7 +34,7 @@ export default React.memo(function Line(props) {
     fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
     switchable.current = SVs.switchable && !SVs.fixed;
 
-    const { darkMode } = useContext(PageContext) || {};
+    const { darkMode } = useContext(DocContext) || {};
 
     useEffect(() => {
         //On unmount

--- a/packages/doenetml/src/Viewer/renderers/lineSegment.jsx
+++ b/packages/doenetml/src/Viewer/renderers/lineSegment.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useRef } from "react";
 import useDoenetRenderer from "../useDoenetRenderer";
 import { BoardContext, LINE_LAYER_OFFSET, VERTEX_LAYER_OFFSET } from "./graph";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 export default React.memo(function LineSegment(props) {
     let { name, id, SVs, actions, sourceOfUpdate, callAction } =
@@ -36,7 +36,7 @@ export default React.memo(function LineSegment(props) {
     endpointsFixed.current =
         !SVs.endpointsDraggable || SVs.fixed || SVs.fixLocation;
 
-    const { darkMode } = useContext(PageContext) || {};
+    const { darkMode } = useContext(DocContext) || {};
 
     useEffect(() => {
         //On unmount

--- a/packages/doenetml/src/Viewer/renderers/math.jsx
+++ b/packages/doenetml/src/Viewer/renderers/math.jsx
@@ -6,7 +6,7 @@ import me from "math-expressions";
 import { textRendererStyle } from "@doenet/utils";
 import { getPositionFromAnchorByCoordinate } from "./utils/graph";
 import { cesc } from "@doenet/utils";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 export default React.memo(function MathComponent(props) {
     let { name, id, SVs, actions, sourceOfUpdate, callAction } =
@@ -38,7 +38,7 @@ export default React.memo(function MathComponent(props) {
     fixed.current = SVs.fixed;
     fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
 
-    const { darkMode } = useContext(PageContext) || {};
+    const { darkMode } = useContext(DocContext) || {};
 
     useEffect(() => {
         //On unmount

--- a/packages/doenetml/src/Viewer/renderers/mathInput.jsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.jsx
@@ -21,7 +21,7 @@ import { MathJax } from "better-react-mathjax";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { rendererState } from "../useDoenetRenderer";
 import "./mathInput.css";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 // Moved most of checkWorkStyle styling into Button
 const Button = styled.button`
@@ -69,7 +69,7 @@ export default function MathInput(props) {
 
     const setRendererState = useSetRecoilState(rendererState(rendererName));
 
-    const { showAnswerTitles } = useContext(PageContext) || {};
+    const { showAnswerTitles } = useContext(DocContext) || {};
 
     let rendererValue = useRef(SVs.rawRendererValue);
 

--- a/packages/doenetml/src/Viewer/renderers/matrixInput.jsx
+++ b/packages/doenetml/src/Viewer/renderers/matrixInput.jsx
@@ -14,7 +14,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import styled from "styled-components";
 import "./mathInput.css";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 const Matrix = styled.div`
     position: relative;
@@ -75,7 +75,7 @@ export default React.memo(function MatrixInput(props) {
 
     let validationState = useRef(null);
 
-    const { showAnswerTitles } = useContext(PageContext) || {};
+    const { showAnswerTitles } = useContext(DocContext) || {};
 
     function updateValidationState() {
         validationState.current = "unvalidated";

--- a/packages/doenetml/src/Viewer/renderers/number.jsx
+++ b/packages/doenetml/src/Viewer/renderers/number.jsx
@@ -6,7 +6,7 @@ import useDoenetRenderer from "../useDoenetRenderer";
 import me from "math-expressions";
 import { textRendererStyle } from "@doenet/utils";
 import { getPositionFromAnchorByCoordinate } from "./utils/graph";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 export default React.memo(function NumberComponent(props) {
     let { name, id, SVs, actions, sourceOfUpdate, callAction } =
@@ -38,7 +38,7 @@ export default React.memo(function NumberComponent(props) {
     fixed.current = SVs.fixed;
     fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
 
-    const { darkMode } = useContext(PageContext) || {};
+    const { darkMode } = useContext(DocContext) || {};
 
     useEffect(() => {
         //On unmount

--- a/packages/doenetml/src/Viewer/renderers/point.jsx
+++ b/packages/doenetml/src/Viewer/renderers/point.jsx
@@ -10,7 +10,7 @@ import {
     normalizePointSize,
     normalizePointStyle,
 } from "./utils/graph";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 export default React.memo(function Point(props) {
     let { name, id, SVs, actions, sourceOfUpdate, callAction } =
@@ -51,7 +51,7 @@ export default React.memo(function Point(props) {
     fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
     switchable.current = SVs.switchable && !SVs.fixed;
 
-    const { darkMode } = useContext(PageContext) || {};
+    const { darkMode } = useContext(DocContext) || {};
 
     const useOpenSymbol =
         SVs.open || ["cross", "plus"].includes(SVs.selectedStyle.markerStyle); // Cross and plus should always be treated as "open" to remain visible on graph

--- a/packages/doenetml/src/Viewer/renderers/polygon.jsx
+++ b/packages/doenetml/src/Viewer/renderers/polygon.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useRef } from "react";
 import useDoenetRenderer from "../useDoenetRenderer";
 import { BoardContext, LINE_LAYER_OFFSET, VERTEX_LAYER_OFFSET } from "./graph";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 export default React.memo(function Polygon(props) {
     let { name, id, SVs, actions, sourceOfUpdate, callAction } =
@@ -36,7 +36,7 @@ export default React.memo(function Polygon(props) {
         !SVs.verticesDraggable || SVs.fixed || SVs.fixLocation;
     vertexIndicesDraggable.current = SVs.vertexIndicesDraggable;
 
-    const { darkMode } = useContext(PageContext) || {};
+    const { darkMode } = useContext(DocContext) || {};
 
     useEffect(() => {
         //On unmount

--- a/packages/doenetml/src/Viewer/renderers/polyline.jsx
+++ b/packages/doenetml/src/Viewer/renderers/polyline.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useRef } from "react";
 import useDoenetRenderer from "../useDoenetRenderer";
 import { BoardContext, LINE_LAYER_OFFSET, VERTEX_LAYER_OFFSET } from "./graph";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 export default React.memo(function Polyline(props) {
     let { name, id, SVs, actions, sourceOfUpdate, callAction } =
@@ -37,7 +37,7 @@ export default React.memo(function Polyline(props) {
         !SVs.verticesDraggable || SVs.fixed || SVs.fixLocation;
     vertexIndicesDraggable.current = SVs.vertexIndicesDraggable;
 
-    const { darkMode } = useContext(PageContext) || {};
+    const { darkMode } = useContext(DocContext) || {};
 
     useEffect(() => {
         //On unmount

--- a/packages/doenetml/src/Viewer/renderers/ray.jsx
+++ b/packages/doenetml/src/Viewer/renderers/ray.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState, useRef } from "react";
 import useDoenetRenderer from "../useDoenetRenderer";
 import { BoardContext, LINE_LAYER_OFFSET } from "./graph";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 export default React.memo(function Ray(props) {
     let { name, id, SVs, actions, sourceOfUpdate, callAction } =
@@ -32,7 +32,7 @@ export default React.memo(function Ray(props) {
     fixed.current = SVs.fixed;
     fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
 
-    const { darkMode } = useContext(PageContext) || {};
+    const { darkMode } = useContext(DocContext) || {};
 
     useEffect(() => {
         //On unmount

--- a/packages/doenetml/src/Viewer/renderers/ref.jsx
+++ b/packages/doenetml/src/Viewer/renderers/ref.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import { PageContext, getURLFromRef } from "../PageViewer";
+import { DocContext, getURLFromRef } from "../DocViewer";
 import useDoenetRenderer from "../useDoenetRenderer";
 import styled from "styled-components";
 
@@ -49,7 +49,7 @@ export default React.memo(function Ref(props) {
         navigate,
         linkSettings,
         scrollableContainer,
-    } = useContext(PageContext) || {};
+    } = useContext(DocContext) || {};
 
     let search = location.search || "";
 

--- a/packages/doenetml/src/Viewer/renderers/regionBetweenCurveXAxis.jsx
+++ b/packages/doenetml/src/Viewer/renderers/regionBetweenCurveXAxis.jsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useState, useRef } from "react";
 import useDoenetRenderer from "../useDoenetRenderer";
 import { BoardContext, LINE_LAYER_OFFSET } from "./graph";
 import { createFunctionFromDefinition } from "@doenet/utils";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 export default React.memo(function RegionBetweenCurveXAxis(props) {
     let { name, id, SVs } = useDoenetRenderer(props);
@@ -14,7 +14,7 @@ export default React.memo(function RegionBetweenCurveXAxis(props) {
     let curveJXG = useRef(null);
     let integralJXG = useRef(null);
 
-    const { darkMode } = useContext(PageContext) || {};
+    const { darkMode } = useContext(DocContext) || {};
 
     useEffect(() => {
         //On unmount

--- a/packages/doenetml/src/Viewer/renderers/regionBetweenCurves.jsx
+++ b/packages/doenetml/src/Viewer/renderers/regionBetweenCurves.jsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useState, useRef } from "react";
 import useDoenetRenderer from "../useDoenetRenderer";
 import { BoardContext, LINE_LAYER_OFFSET } from "./graph";
 import { createFunctionFromDefinition } from "@doenet/utils";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 export default React.memo(function RegionBetweenCurves(props) {
     let { name, id, SVs } = useDoenetRenderer(props);
@@ -17,7 +17,7 @@ export default React.memo(function RegionBetweenCurves(props) {
     let left = useRef(null);
     let right = useRef(null);
 
-    const { darkMode } = useContext(PageContext) || {};
+    const { darkMode } = useContext(DocContext) || {};
 
     useEffect(() => {
         //On unmount

--- a/packages/doenetml/src/Viewer/renderers/section.jsx
+++ b/packages/doenetml/src/Viewer/renderers/section.jsx
@@ -13,7 +13,7 @@ import { faCaretDown as twirlIsOpen } from "@fortawesome/free-solid-svg-icons";
 import useDoenetRenderer from "../useDoenetRenderer";
 import VisibilitySensor from "react-visibility-sensor-v2";
 import { addCommasForCompositeRanges } from "./utils/composites";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 // Moved most of checkWorkStyle styling into Button
 const Button = styled.button`
@@ -39,7 +39,7 @@ export default React.memo(function Section(props) {
         useDoenetRenderer(props);
     // console.log("name: ", name, " SVs: ", SVs," Children",children);
 
-    const { showAnswerTitles } = useContext(PageContext) || {};
+    const { showAnswerTitles } = useContext(DocContext) || {};
 
     let onChangeVisibility = (isVisible) => {
         callAction({

--- a/packages/doenetml/src/Viewer/renderers/text.jsx
+++ b/packages/doenetml/src/Viewer/renderers/text.jsx
@@ -4,7 +4,7 @@ import useDoenetRenderer from "../useDoenetRenderer";
 import me from "math-expressions";
 import { textRendererStyle } from "@doenet/utils";
 import { getPositionFromAnchorByCoordinate } from "./utils/graph";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 export default React.memo(function Text(props) {
     let { name, id, SVs, actions, sourceOfUpdate, callAction } =
@@ -36,7 +36,7 @@ export default React.memo(function Text(props) {
     fixed.current = SVs.fixed;
     fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
 
-    const { darkMode } = useContext(PageContext) || {};
+    const { darkMode } = useContext(DocContext) || {};
 
     useEffect(() => {
         //On unmount

--- a/packages/doenetml/src/Viewer/renderers/textInput.jsx
+++ b/packages/doenetml/src/Viewer/renderers/textInput.jsx
@@ -16,7 +16,7 @@ import { MathJax } from "better-react-mathjax";
 import { BoardContext } from "./graph";
 import me from "math-expressions";
 import { getPositionFromAnchorByCoordinate } from "./utils/graph";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 // Moved most of checkWorkStyle styling into Button
 const Button = styled.button`
@@ -88,7 +88,7 @@ export default function TextInput(props) {
 
     const [rendererValue, setRendererValue] = useState(SVs.immediateValue);
 
-    const { showAnswerTitles } = useContext(PageContext) || {};
+    const { showAnswerTitles } = useContext(DocContext) || {};
 
     // add ref, because event handler called from jsxgraph doesn't get new value
     let rendererValueRef = useRef(null);

--- a/packages/doenetml/src/Viewer/renderers/vector.jsx
+++ b/packages/doenetml/src/Viewer/renderers/vector.jsx
@@ -3,7 +3,7 @@ import useDoenetRenderer from "../useDoenetRenderer";
 import { BoardContext, LINE_LAYER_OFFSET, VERTEX_LAYER_OFFSET } from "./graph";
 import { MathJax } from "better-react-mathjax";
 import { textRendererStyle } from "@doenet/utils";
-import { PageContext } from "../PageViewer";
+import { DocContext } from "../DocViewer";
 
 export default React.memo(function Vector(props) {
     let { name, id, SVs, actions, sourceOfUpdate, callAction } =
@@ -41,7 +41,7 @@ export default React.memo(function Vector(props) {
     tailDraggable.current = SVs.tailDraggable && !SVs.fixed && !SVs.fixLocation;
     headDraggable.current = SVs.headDraggable && !SVs.fixed && !SVs.fixLocation;
 
-    const { darkMode } = useContext(PageContext) || {};
+    const { darkMode } = useContext(DocContext) || {};
 
     useEffect(() => {
         //On unmount

--- a/packages/doenetml/src/Viewer/useDoenetRenderer.tsx
+++ b/packages/doenetml/src/Viewer/useDoenetRenderer.tsx
@@ -1,10 +1,19 @@
 import React, { useEffect, useState } from "react";
 import { atomFamily, useRecoilValue, useSetRecoilState } from "recoil";
 // import { serializedComponentsReviver } from '@doenet/utils';
-import { renderersloadComponent } from "./PageViewer";
+import { renderersloadComponent } from "./DocViewer";
 import { cesc } from "@doenet/utils";
 
-export const rendererState = atomFamily({
+export const rendererState = atomFamily<
+    {
+        stateValues: Record<string, any>;
+        sourceOfUpdate?: Record<string, any>;
+        ignoreUpdate: boolean;
+        childrenInstructions: Record<string, any>[];
+        prefixForIds: string;
+    },
+    string
+>({
     key: "rendererState",
     default: {
         stateValues: {},
@@ -18,7 +27,7 @@ export const rendererState = atomFamily({
 
 // TODO: potentially remove initializeChildrenOnConstruction
 export default function useDoenetRenderer(
-    props,
+    props: Record<string, any>,
     initializeChildrenOnConstruction = true,
 ) {
     let actions = props.componentInstructions.actions;
@@ -59,7 +68,10 @@ export default function useDoenetRenderer(
         }
     }, [renderersToLoad, props.rendererClasses]);
 
-    function createChildFromInstructions(childInstructions, loadMoreRenderers) {
+    function createChildFromInstructions(
+        childInstructions: Record<string, any> | string,
+        loadMoreRenderers: boolean,
+    ) {
         if (typeof childInstructions === "string") {
             return childInstructions;
         }
@@ -78,7 +90,7 @@ export default function useDoenetRenderer(
         if (!rendererClass) {
             //If we don't have the component then attempt to load it
             if (loadMoreRenderers) {
-                setRenderersToLoad((old) => {
+                setRenderersToLoad((old: Promise<any>[]) => {
                     let rendererPromises = { ...old };
                     if (!(childInstructions.rendererType in rendererPromises)) {
                         rendererPromises[childInstructions.rendererType] =
@@ -98,7 +110,7 @@ export default function useDoenetRenderer(
     }
 
     let rendererType = props.componentInstructions.rendererType;
-    const callAction = (argObj) => {
+    const callAction = (argObj: Record<string, any>) => {
         if (!argObj.componentName) {
             argObj = { ...argObj };
             argObj.componentName = componentName;

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -2,7 +2,7 @@ import "./DoenetML.css";
 // @ts-ignore
 import { prng_alea } from "esm-seedrandom";
 import React, { useCallback, useRef, useState } from "react";
-import { PageViewer } from "./Viewer/PageViewer";
+import { DocViewer } from "./Viewer/DocViewer";
 import { RecoilRoot } from "recoil";
 import { MathJaxContext } from "better-react-mathjax";
 import { mathjaxConfig } from "@doenet/utils";
@@ -95,17 +95,15 @@ const theme = extendTheme({
 export function DoenetViewer({
     doenetML,
     flags: specifiedFlags = {},
-    activityId,
+    activityId = "a",
+    docId = "1",
     prefixForIds = "",
     userId,
     attemptNumber = 1,
-    itemNumber = 1,
-    render = true,
-    isCurrent = true,
-    hideWhenNotCurrent = false,
+    rendered = true,
+    hidden = false,
     requestedVariantIndex,
     updateCreditAchievedCallback,
-    updateAttemptNumber,
     setIsInErrorState,
     generatedVariantCallback: specifiedGeneratedVariantCallback,
     setErrorsAndWarningsCallback,
@@ -117,7 +115,6 @@ export function DoenetViewer({
     externalVirtualKeyboardProvided = false,
     location,
     navigate,
-    updateDataOnContentChange = false,
     linkSettings,
     scrollableContainer,
     darkMode = "light",
@@ -127,16 +124,14 @@ export function DoenetViewer({
     doenetML: string;
     flags?: DoenetMLFlagsSubset;
     activityId?: string;
+    docId?: string;
     prefixForIds?: string;
     userId?: string;
     attemptNumber?: number;
-    itemNumber?: number;
-    render?: boolean;
-    isCurrent?: boolean;
-    hideWhenNotCurrent?: boolean;
+    rendered?: boolean;
+    hidden?: boolean;
     requestedVariantIndex?: number;
     updateCreditAchievedCallback?: Function;
-    updateAttemptNumber?: Function;
     setIsInErrorState?: Function;
     generatedVariantCallback?: Function;
     setErrorsAndWarningsCallback?: Function;
@@ -148,7 +143,6 @@ export function DoenetViewer({
     externalVirtualKeyboardProvided?: boolean;
     location?: any;
     navigate?: any;
-    updateDataOnContentChange?: boolean;
     linkSettings?: { viewURL: string; editURL: string };
     scrollableContainer?: HTMLDivElement | Window;
     darkMode?: "dark" | "light";
@@ -240,22 +234,18 @@ export function DoenetViewer({
     ) : null;
 
     const viewer = (
-        <PageViewer
+        <DocViewer
             doenetML={doenetML}
-            updateDataOnContentChange={updateDataOnContentChange}
             flags={flags}
             activityId={activityId}
+            docId={docId}
             prefixForIds={prefixForIds}
             userId={userId}
             attemptNumber={attemptNumber}
-            pageNumber={itemNumber.toString()}
-            itemNumber={itemNumber}
-            render={render}
-            isCurrent={isCurrent}
-            hideWhenNotCurrent={hideWhenNotCurrent}
+            rendered={rendered}
+            hidden={hidden}
             requestedVariantIndex={variantIndex.current}
             updateCreditAchievedCallback={updateCreditAchievedCallback}
-            updateAttemptNumber={updateAttemptNumber}
             setIsInErrorState={setIsInErrorState}
             generatedVariantCallback={generatedVariantCallback}
             setErrorsAndWarningsCallback={setErrorsAndWarningsCallback}
@@ -292,7 +282,7 @@ export function DoenetViewer({
 
 export function DoenetEditor({
     doenetML,
-    activityId,
+    activityId = "a",
     prefixForIds = "",
     addVirtualKeyboard = true,
     externalVirtualKeyboardProvided = false,

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -216,7 +216,7 @@ export function DoenetViewer({
         // regenerate only if one of the props in propSet has changed
         if (thisPropSet.some((v, i) => v !== lastPropSet.current[i])) {
             if (requestedVariantIndex === undefined) {
-                let rng = new rngClass(new Date());
+                let rng = new rngClass();
                 requestedVariantIndex = Math.floor(rng() * 1000000) + 1;
             }
             variantIndex.current = Math.round(requestedVariantIndex);

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -100,7 +100,7 @@ export function DoenetViewer({
     prefixForIds = "",
     userId,
     attemptNumber = 1,
-    rendered = true,
+    render = true,
     hidden = false,
     requestedVariantIndex,
     updateCreditAchievedCallback,
@@ -128,7 +128,7 @@ export function DoenetViewer({
     prefixForIds?: string;
     userId?: string;
     attemptNumber?: number;
-    rendered?: boolean;
+    render?: boolean;
     hidden?: boolean;
     requestedVariantIndex?: number;
     updateCreditAchievedCallback?: Function;
@@ -242,7 +242,7 @@ export function DoenetViewer({
             prefixForIds={prefixForIds}
             userId={userId}
             attemptNumber={attemptNumber}
-            rendered={rendered}
+            render={render}
             hidden={hidden}
             requestedVariantIndex={variantIndex.current}
             updateCreditAchievedCallback={updateCreditAchievedCallback}

--- a/packages/doenetml/src/utils/docUtils.ts
+++ b/packages/doenetml/src/utils/docUtils.ts
@@ -1,3 +1,4 @@
+import { DoenetMLFlags } from "../doenetml";
 import { doenetGlobalConfig } from "../global-config";
 
 export function createCoreWorker() {
@@ -6,21 +7,37 @@ export function createCoreWorker() {
     });
 }
 
-export function initializeCoreWorker({ coreWorker, doenetML, flags }) {
+export function initializeCoreWorker({
+    coreWorker,
+    doenetML,
+    flags,
+    activityId,
+    docId,
+    attemptNumber,
+    requestedVariantIndex,
+}: {
+    coreWorker: Worker;
+    doenetML: string;
+    flags: DoenetMLFlags;
+    activityId: string;
+    docId: string;
+    attemptNumber: number;
+    requestedVariantIndex: number;
+}) {
     // Initializes core worker with the given arguments.
     // Returns a promise.
     // If the worker is successfully initialized, the promise is resolved
     // If an error was encountered while initializing, the promise is rejected
 
-    let resolveInitializePromise;
-    let rejectInitializePromise;
+    let resolveInitializePromise: (value?: unknown) => void;
+    let rejectInitializePromise: (reason?: any) => void;
 
     let initializePromise = new Promise((resolve, reject) => {
         resolveInitializePromise = resolve;
         rejectInitializePromise = reject;
     });
 
-    let initializeListener = function (e) {
+    let initializeListener = function (e: MessageEvent<any>) {
         if (e.data.messageType === "initializeResult") {
             coreWorker.removeEventListener("message", initializeListener);
 
@@ -41,6 +58,10 @@ export function initializeCoreWorker({ coreWorker, doenetML, flags }) {
         args: {
             doenetML,
             flags,
+            activityId,
+            docId,
+            attemptNumber,
+            requestedVariantIndex,
         },
     });
 

--- a/packages/doenetml/tsconfig.json
+++ b/packages/doenetml/tsconfig.json
@@ -2,7 +2,8 @@
     "extends": "../../tsconfig.build.json",
     "compilerOptions": {
         "outDir": "./dist/",
-        "rootDir": "./src"
+        "rootDir": "./src",
+        "lib": ["ES2021.String", "WebWorker", "DOM"]
     },
     "include": ["./**/*.ts", "./**/*.tsx", "./**/*.js", "./**/*.jsx"],
     "exclude": [

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.7.0-alpha23",
+    "version": "0.7.0-alpha24",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.7.0-alpha24",
+    "version": "0.7.0-alpha25",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/test-cypress/cypress/e2e/DocViewer/docViewerAttributes.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/docViewerAttributes.cy.js
@@ -20,7 +20,7 @@ describe("PageViewer Attribute Tests", function () {
         });
 
         cy.get("#testRunner_toggleControls").click();
-        cy.get("#testRunner_render").click();
+        cy.get("#testRunner_rendered").click();
         cy.wait(100);
         cy.get("#testRunner_toggleControls").click();
 

--- a/packages/test-cypress/cypress/e2e/DocViewer/docViewerAttributes.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/docViewerAttributes.cy.js
@@ -20,7 +20,7 @@ describe("PageViewer Attribute Tests", function () {
         });
 
         cy.get("#testRunner_toggleControls").click();
-        cy.get("#testRunner_rendered").click();
+        cy.get("#testRunner_render").click();
         cy.wait(100);
         cy.get("#testRunner_toggleControls").click();
 

--- a/packages/test-cypress/src/CypressTest.tsx
+++ b/packages/test-cypress/src/CypressTest.tsx
@@ -18,7 +18,7 @@ export function CypressTest() {
         allowSaveSubmissions: boolean;
         allowSaveEvents: boolean;
         autoSubmit: boolean;
-        render: boolean;
+        rendered: boolean;
         darkMode: "light" | "dark";
         showEditor: boolean;
         viewerLocation: "left" | "right" | "bottom" | "top";
@@ -36,7 +36,7 @@ export function CypressTest() {
         allowSaveSubmissions: false,
         allowSaveEvents: false,
         autoSubmit: false,
-        render: true,
+        rendered: true,
         darkMode: "light",
         showEditor: false,
         viewerLocation: "right",
@@ -89,7 +89,7 @@ export function CypressTest() {
         testSettings.allowSaveEvents,
     );
     const [autoSubmit, setAutoSubmit] = useState(testSettings.autoSubmit);
-    const [render, setRender] = useState(testSettings.render);
+    const [rendered, setRendered] = useState(testSettings.rendered);
 
     const [showEditor, setShowEditor] = useState(testSettings.showEditor);
     const [viewerLocation, setViewerLocation] = useState(
@@ -411,20 +411,20 @@ export function CypressTest() {
                     <label>
                         {" "}
                         <input
-                            id="testRunner_render"
+                            id="testRunner_rendered"
                             type="checkbox"
-                            checked={render}
+                            checked={rendered}
                             onChange={() => {
-                                testSettings.render = !testSettings.render;
+                                testSettings.rendered = !testSettings.rendered;
                                 localStorage.setItem(
                                     "test settings",
                                     JSON.stringify(testSettings),
                                 );
-                                setRender((was: boolean) => !was);
+                                setRendered((was: boolean) => !was);
                                 setUpdateNumber((was: number) => was + 1);
                             }}
                         />
-                        Render
+                        Rendered
                     </label>
                 </div>
                 <hr />
@@ -510,7 +510,6 @@ export function CypressTest() {
                 key={"activityViewer" + updateNumber}
                 doenetML={doenetMLstring}
                 // cid={"185fd09b6939d867d4faee82393d4a879a2051196b476acdca26140864bc967a"}
-                updateDataOnContentChange={true}
                 flags={{
                     showCorrectness,
                     readOnly,
@@ -527,7 +526,7 @@ export function CypressTest() {
                 attemptNumber={attemptNumber}
                 requestedVariantIndex={requestedVariantIndex.current}
                 activityId="activityIdFromCypress"
-                render={render}
+                rendered={rendered}
                 location={location}
                 navigate={navigate}
                 linkSettings={{

--- a/packages/test-cypress/src/CypressTest.tsx
+++ b/packages/test-cypress/src/CypressTest.tsx
@@ -18,7 +18,7 @@ export function CypressTest() {
         allowSaveSubmissions: boolean;
         allowSaveEvents: boolean;
         autoSubmit: boolean;
-        rendered: boolean;
+        render: boolean;
         darkMode: "light" | "dark";
         showEditor: boolean;
         viewerLocation: "left" | "right" | "bottom" | "top";
@@ -36,7 +36,7 @@ export function CypressTest() {
         allowSaveSubmissions: false,
         allowSaveEvents: false,
         autoSubmit: false,
-        rendered: true,
+        render: true,
         darkMode: "light",
         showEditor: false,
         viewerLocation: "right",
@@ -89,7 +89,7 @@ export function CypressTest() {
         testSettings.allowSaveEvents,
     );
     const [autoSubmit, setAutoSubmit] = useState(testSettings.autoSubmit);
-    const [rendered, setRendered] = useState(testSettings.rendered);
+    const [render, setRender] = useState(testSettings.render);
 
     const [showEditor, setShowEditor] = useState(testSettings.showEditor);
     const [viewerLocation, setViewerLocation] = useState(
@@ -411,20 +411,20 @@ export function CypressTest() {
                     <label>
                         {" "}
                         <input
-                            id="testRunner_rendered"
+                            id="testRunner_render"
                             type="checkbox"
-                            checked={rendered}
+                            checked={render}
                             onChange={() => {
-                                testSettings.rendered = !testSettings.rendered;
+                                testSettings.render = !testSettings.render;
                                 localStorage.setItem(
                                     "test settings",
                                     JSON.stringify(testSettings),
                                 );
-                                setRendered((was: boolean) => !was);
+                                setRender((was: boolean) => !was);
                                 setUpdateNumber((was: number) => was + 1);
                             }}
                         />
-                        Rendered
+                        Render
                     </label>
                 </div>
                 <hr />
@@ -526,7 +526,7 @@ export function CypressTest() {
                 attemptNumber={attemptNumber}
                 requestedVariantIndex={requestedVariantIndex.current}
                 activityId="activityIdFromCypress"
-                rendered={rendered}
+                render={render}
                 location={location}
                 navigate={navigate}
                 linkSettings={{

--- a/packages/test-viewer/src/test/testViewer.tsx
+++ b/packages/test-viewer/src/test/testViewer.tsx
@@ -12,7 +12,7 @@ export default function TestViewer() {
         readOnly: boolean;
         showFeedback: boolean;
         showHints: boolean;
-        render: boolean;
+        rendered: boolean;
         showEditor: boolean;
         viewerLocation: "left" | "right" | "bottom" | "top";
     } = {
@@ -21,7 +21,7 @@ export default function TestViewer() {
         readOnly: false,
         showFeedback: true,
         showHints: true,
-        render: true,
+        rendered: true,
         showEditor: false,
         viewerLocation: "right",
     };
@@ -36,7 +36,7 @@ export default function TestViewer() {
         readOnly,
         showFeedback,
         showHints,
-        render,
+        rendered,
         showEditor,
         viewerLocation,
     } = testSettings;
@@ -140,17 +140,17 @@ export default function TestViewer() {
                         {" "}
                         <input
                             type="checkbox"
-                            checked={render}
+                            checked={rendered}
                             onChange={() => {
                                 setTestSettings((was) => {
                                     let newObj = { ...was };
-                                    newObj.render = !was.render;
+                                    newObj.rendered = !was.rendered;
                                     return newObj;
                                 });
                                 setUpdateNumber((was) => was + 1);
                             }}
                         />
-                        Render
+                        Rendered
                     </label>
                 </div>
                 <div>
@@ -225,7 +225,7 @@ export default function TestViewer() {
                 autoSubmit: false,
             }}
             activityId=""
-            render={render}
+            rendered={rendered}
             addVirtualKeyboard={true}
         />
     );

--- a/packages/test-viewer/src/test/testViewer.tsx
+++ b/packages/test-viewer/src/test/testViewer.tsx
@@ -12,7 +12,7 @@ export default function TestViewer() {
         readOnly: boolean;
         showFeedback: boolean;
         showHints: boolean;
-        rendered: boolean;
+        render: boolean;
         showEditor: boolean;
         viewerLocation: "left" | "right" | "bottom" | "top";
     } = {
@@ -21,7 +21,7 @@ export default function TestViewer() {
         readOnly: false,
         showFeedback: true,
         showHints: true,
-        rendered: true,
+        render: true,
         showEditor: false,
         viewerLocation: "right",
     };
@@ -36,7 +36,7 @@ export default function TestViewer() {
         readOnly,
         showFeedback,
         showHints,
-        rendered,
+        render,
         showEditor,
         viewerLocation,
     } = testSettings;
@@ -140,17 +140,17 @@ export default function TestViewer() {
                         {" "}
                         <input
                             type="checkbox"
-                            checked={rendered}
+                            checked={render}
                             onChange={() => {
                                 setTestSettings((was) => {
                                     let newObj = { ...was };
-                                    newObj.rendered = !was.rendered;
+                                    newObj.render = !was.render;
                                     return newObj;
                                 });
                                 setUpdateNumber((was) => was + 1);
                             }}
                         />
-                        Rendered
+                        Render
                     </label>
                 </div>
                 <div>
@@ -225,7 +225,7 @@ export default function TestViewer() {
                 autoSubmit: false,
             }}
             activityId=""
-            rendered={rendered}
+            render={render}
             addVirtualKeyboard={true}
         />
     );


### PR DESCRIPTION
This PR renames `<PageViewer>` to `<DocViewer>` and does some clean-up.  In particular, it minimizes the amount of work performed when `render=false`, other than what is needed to return all possible variants.