### PR TITLE
Prevent initial rendering of DoenetML when it is hidden

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22797,7 +22797,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.0-alpha25",
+            "version": "0.7.0-alpha26",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@chakra-ui/icons": "^2.0.19",
@@ -22838,7 +22838,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.0-alpha25",
+            "version": "0.7.0-alpha26",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -22916,7 +22916,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.0-alpha25",
+            "version": "0.7.0-alpha26",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml-iframe",
     "type": "module",
     "description": "A renderer for DoenetML contained in an iframe",
-    "version": "0.7.0-alpha25",
+    "version": "0.7.0-alpha26",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.7.0-alpha25",
+    "version": "0.7.0-alpha26",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/src/utils/isVisible.ts
+++ b/packages/doenetml/src/utils/isVisible.ts
@@ -1,0 +1,52 @@
+import { RefObject, useEffect, useState } from "react";
+
+/**
+ * Returns `true` if the any portion of the element referenced by `ref`
+ * is visible in the browser's viewport
+ *
+ * From: https://dev.to/jmalvarez/check-if-an-element-is-visible-with-react-hooks-27h8
+ */
+export function useIsVisible(ref: RefObject<HTMLElement>) {
+    const [isIntersecting, setIntersecting] = useState(false);
+
+    useEffect(() => {
+        const observer = new IntersectionObserver(([entry]) =>
+            setIntersecting(entry.isIntersecting),
+        );
+
+        if (ref.current) {
+            observer.observe(ref.current);
+        }
+        return () => {
+            observer.disconnect();
+        };
+    }, [ref]);
+
+    return isIntersecting;
+}
+
+/**
+ * Returns true if the element referenced by `ref` is anywhere on the page
+ * (more precisely, within 1000000px of the browser's viewport).
+ *
+ * Used to approximately detect if the element is not hidden.
+ */
+export function useIsOnPage(ref: RefObject<HTMLElement>) {
+    const [isIntersecting, setIntersecting] = useState(false);
+
+    useEffect(() => {
+        const observer = new IntersectionObserver(
+            ([entry]) => setIntersecting(entry.isIntersecting),
+            { rootMargin: "1000000px" },
+        );
+
+        if (ref.current) {
+            observer.observe(ref.current);
+        }
+        return () => {
+            observer.disconnect();
+        };
+    }, [ref]);
+
+    return isIntersecting;
+}

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.7.0-alpha25",
+    "version": "0.7.0-alpha26",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,


### PR DESCRIPTION
This PR changes the initialization of `<DocViewer>` so that it starts off with `hidden=true` and switches to `hidden=false` only when its `<div>` is "visible" somewhere on the current browser page. (It does not have to be in the current browser viewport.) Since the renderers are not initialized until `hidden=false`, this approach allows core to complete its slow initialization even while inside a hidden `<div>` but for jsxgraph to hold off its initialization until the `<div>` is no longer hidden. Since, for some reason, initializing jsxgraph inside a hidden `<div>` can cause garbled output, this algorithm represents a tradeoff that allows core to complete its initialization ahead of time for a hidden document while still producing readable graphs.