### PR TITLE
add the ability to initialize section (and similar) counters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22797,7 +22797,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.0-alpha26",
+            "version": "0.7.0-alpha27",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@chakra-ui/icons": "^2.0.19",
@@ -22838,7 +22838,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.0-alpha26",
+            "version": "0.7.0-alpha27",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -22916,7 +22916,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.0-alpha26",
+            "version": "0.7.0-alpha27",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml-iframe",
     "type": "module",
     "description": "A renderer for DoenetML contained in an iframe",
-    "version": "0.7.0-alpha26",
+    "version": "0.7.0-alpha27",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml-worker/src/Core.js
+++ b/packages/doenetml-worker/src/Core.js
@@ -58,6 +58,7 @@ export default class Core {
         attemptNumber = 1,
         requestedVariant,
         requestedVariantIndex,
+        initializeCounters = {},
         theme,
         prerender = false,
         stateVariableChanges: stateVariableChangesString,
@@ -89,6 +90,8 @@ export default class Core {
         this.getStateVariableValue = this.getStateVariableValue.bind(this);
 
         this.componentInfoObjects = componentInfoObjects;
+
+        this.initializeCounters = initializeCounters;
 
         const stateVariableChanges = stateVariableChangesString
             ? JSON.parse(

--- a/packages/doenetml-worker/src/CoreWorker.js
+++ b/packages/doenetml-worker/src/CoreWorker.js
@@ -126,6 +126,7 @@ async function initializeWorker({
     docId,
     attemptNumber,
     requestedVariantIndex,
+    initializeCounters,
 }) {
     let componentInfoObjects = createComponentInfoObjects(flags);
 
@@ -168,6 +169,7 @@ async function initializeWorker({
         docId,
         attemptNumber,
         requestedVariantIndex,
+        initializeCounters,
         serializedDocument: addDocumentIfItsMissing(
             expandResult.fullSerializedComponents[0],
         )[0],

--- a/packages/doenetml-worker/src/Dependencies.js
+++ b/packages/doenetml-worker/src/Dependencies.js
@@ -7903,6 +7903,37 @@ class CountAmongSiblingsDependency extends Dependency {
                 .map((x) => x.componentName)
                 .indexOf(this.upstreamComponentName) + 1;
 
+        // if `initializeCounters` was passed into core with a key that matches the component type
+        // then increment `value` so that the first instance would yield that initial counter.
+        if (this.parentName === this.dependencyHandler.core.documentName) {
+            let initializeCounters =
+                this.dependencyHandler.core.initializeCounters;
+
+            if (this.includeInheritedComponentTypes) {
+                // if we are including inherited component types,
+                // then just use the first counter found and skip any additional counters
+                // (where the order encountered is arbitrary)
+                for (let cType in initializeCounters) {
+                    if (
+                        this.dependencyHandler.componentInfoObjects.isInheritedComponentType(
+                            {
+                                inheritedComponentType: cType,
+                                baseComponentType: childComponentType,
+                            },
+                        )
+                    ) {
+                        value += initializeCounters[cType] - 1;
+                        break;
+                    }
+                }
+            } else {
+                let initialCounter = initializeCounters[childComponentType];
+                if (initialCounter) {
+                    value += initialCounter - 1;
+                }
+            }
+        }
+
         // don't need changes, as it is changed directly from core
         // and then upstream variables are marked as changed
         return { value, changes: {} };

--- a/packages/doenetml-worker/src/test/tagSpecific/sectioning.test.ts
+++ b/packages/doenetml-worker/src/test/tagSpecific/sectioning.test.ts
@@ -595,11 +595,13 @@ describe("Sectioning tag tests", async () => {
         autoNumber = false,
         autoName = false,
         noParent = false,
+        initialCounter,
     }: {
         customTitles?: boolean;
         autoNumber?: boolean;
         autoName?: boolean;
         noParent?: boolean;
+        initialCounter?: number;
     }) {
         const includeAutoNumber = autoNumber ? "includeAutoNumber " : "";
         const includeAutoName = autoName ? "includeAutoName " : "";
@@ -607,22 +609,26 @@ describe("Sectioning tag tests", async () => {
             ? 'includeParentNumber="false" '
             : "";
 
+        const offset = initialCounter ? initialCounter - 1 : 0;
+        const s1 = (1 + offset).toString();
+        const s2 = (2 + offset).toString();
+
         let byIndex: Record<
             string,
             { title: string; number: string; level: number }
         > = {
-            1: { title: "A", number: "1", level: 1 },
-            2: { title: "B", number: "2", level: 1 },
-            21: { title: "BA", number: "2.1", level: 2 },
-            211: { title: "BAA", number: "2.1.1", level: 3 },
-            2111: { title: "BAAA", number: "2.1.1.1", level: 4 },
-            2112: { title: "BAAB", number: "2.1.1.2", level: 4 },
-            22: { title: "BB", number: "2.2", level: 2 },
-            221: { title: "BBA", number: "2.2.1", level: 3 },
-            222: { title: "BBB", number: "2.2.2", level: 3 },
-            223: { title: "BBC", number: "2.2.3", level: 3 },
-            2231: { title: "BBCA", number: "2.2.3.1", level: 4 },
-            23: { title: "BC", number: "2.3", level: 2 },
+            1: { title: "A", number: `${s1}`, level: 1 },
+            2: { title: "B", number: `${s2}`, level: 1 },
+            21: { title: "BA", number: `${s2}.1`, level: 2 },
+            211: { title: "BAA", number: `${s2}.1.1`, level: 3 },
+            2111: { title: "BAAA", number: `${s2}.1.1.1`, level: 4 },
+            2112: { title: "BAAB", number: `${s2}.1.1.2`, level: 4 },
+            22: { title: "BB", number: `${s2}.2`, level: 2 },
+            221: { title: "BBA", number: `${s2}.2.1`, level: 3 },
+            222: { title: "BBB", number: `${s2}.2.2`, level: 3 },
+            223: { title: "BBC", number: `${s2}.2.3`, level: 3 },
+            2231: { title: "BBCA", number: `${s2}.2.3.1`, level: 4 },
+            23: { title: "BC", number: `${s2}.3`, level: 2 },
         };
 
         if (noParent) {
@@ -717,6 +723,9 @@ describe("Sectioning tag tests", async () => {
 
         let core = await createTestCore({
             doenetML,
+            initializeCounters: initialCounter
+                ? { section: initialCounter }
+                : {},
         });
 
         const stateVariables = await returnAllStateVariables(core);
@@ -785,6 +794,10 @@ describe("Sectioning tag tests", async () => {
             autoNumber: true,
             noParent: true,
         });
+    });
+
+    it("Auto naming of section titles, initialCounter", async () => {
+        await test_auto_naming({ initialCounter: 3 });
     });
 
     it("Example, problems, exercise do not include parent number", async () => {

--- a/packages/doenetml-worker/src/test/utils/test-core.ts
+++ b/packages/doenetml-worker/src/test/utils/test-core.ts
@@ -40,11 +40,13 @@ export async function createTestCore({
     requestedVariantIndex = 1,
     flags: specifiedFlags = {},
     theme,
+    initializeCounters = {},
 }: {
     doenetML: string;
     requestedVariantIndex?: number;
     flags?: DoenetMLFlagsSubset;
     theme?: "dark" | "light";
+    initializeCounters?: Record<string, number>;
 }) {
     let componentInfoObjects = createComponentInfoObjects();
 
@@ -70,7 +72,8 @@ export async function createTestCore({
         docId: "1",
         activityVariantIndex: 1,
         requestedVariant: null,
-        requestedVariantIndex: requestedVariantIndex,
+        requestedVariantIndex,
+        initializeCounters,
         stateVariableChanges: "",
         coreId: "",
         theme,

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.7.0-alpha26",
+    "version": "0.7.0-alpha27",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -56,6 +56,7 @@ export function DocViewer({
     scrollableContainer,
     darkMode,
     showAnswerTitles,
+    initializeCounters = {},
 }: {
     doenetML: string;
     userId?: string;
@@ -81,6 +82,7 @@ export function DocViewer({
     scrollableContainer?: HTMLDivElement | Window;
     darkMode?: "dark" | "light";
     showAnswerTitles?: boolean;
+    initializeCounters?: Record<string, number>;
 }) {
     const updateRendererSVsWithRecoil = useRecoilCallback(
         ({ snapshot, set }) =>
@@ -297,6 +299,7 @@ export function DocViewer({
                     docId,
                     attemptNumber,
                     requestedVariantIndex,
+                    initializeCounters,
                 });
             } catch (e: any) {
                 let message = "";
@@ -660,6 +663,7 @@ export function DocViewer({
             docId,
             attemptNumber,
             requestedVariantIndex,
+            initializeCounters,
         });
 
         return newCoreWorker;
@@ -1200,6 +1204,7 @@ export function DocViewer({
                 docId,
                 attemptNumber,
                 requestedVariantIndex,
+                initializeCounters,
             });
         }
 

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -120,6 +120,7 @@ export function DoenetViewer({
     darkMode = "light",
     showAnswerTitles = false,
     includeVariantSelector = false,
+    initializeCounters = {},
 }: {
     doenetML: string;
     flags?: DoenetMLFlagsSubset;
@@ -147,6 +148,7 @@ export function DoenetViewer({
     darkMode?: "dark" | "light";
     showAnswerTitles?: boolean;
     includeVariantSelector?: boolean;
+    initializeCounters?: Record<string, number>;
 }) {
     const [variants, setVariants] = useState({
         index: 1,
@@ -272,6 +274,7 @@ export function DoenetViewer({
             scrollableContainer={scrollableContainer}
             darkMode={darkMode}
             showAnswerTitles={showAnswerTitles}
+            initializeCounters={initializeCounters}
         />
     );
 

--- a/packages/doenetml/src/utils/docUtils.ts
+++ b/packages/doenetml/src/utils/docUtils.ts
@@ -15,6 +15,7 @@ export function initializeCoreWorker({
     docId,
     attemptNumber,
     requestedVariantIndex,
+    initializeCounters,
 }: {
     coreWorker: Worker;
     doenetML: string;
@@ -23,6 +24,7 @@ export function initializeCoreWorker({
     docId: string;
     attemptNumber: number;
     requestedVariantIndex: number;
+    initializeCounters: Record<string, number>;
 }) {
     // Initializes core worker with the given arguments.
     // Returns a promise.
@@ -62,6 +64,7 @@ export function initializeCoreWorker({
             docId,
             attemptNumber,
             requestedVariantIndex,
+            initializeCounters,
         },
     });
 

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.7.0-alpha26",
+    "version": "0.7.0-alpha27",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,


### PR DESCRIPTION
This PR adds a `initializeCounters` attribute to `<DoenetViewer>` that allows one to alter the initial value of auto-numbered sectioning components.