### PR TITLE
add more location checks to message listener

### DIFF
--- a/packages/doenetml-iframe/src/iframe-viewer-index.ts
+++ b/packages/doenetml-iframe/src/iframe-viewer-index.ts
@@ -54,6 +54,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
 // forward all SPLICE messages that aren't a response to parent
 window.addEventListener("message", (e) => {
+    if (e.origin !== window.parent.location.origin) {
+        return;
+    }
     if (
         e.data.subject.startsWith("SPLICE") &&
         !e.data.subject.endsWith("response")

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -145,15 +145,16 @@ export function DoenetViewer({
 
     React.useEffect(() => {
         const listener = (event: MessageEvent<IframeMessage>) => {
+            if (event.origin !== window.location.origin) {
+                return;
+            }
+
             // forward response from SPLICE getState to iframe
             if (event.data.subject === "SPLICE.getState.response") {
                 ref.current?.contentWindow?.postMessage(event.data);
                 return;
             }
-            if (
-                event.origin !== window.location.origin ||
-                event.data?.origin !== id
-            ) {
+            if (event.data?.origin !== id) {
                 return;
             }
 

--- a/packages/doenetml-worker/src/Core.js
+++ b/packages/doenetml-worker/src/Core.js
@@ -13023,8 +13023,8 @@ export default class Core {
     async recordSolutionView() {
         // TODO: check if student was actually allowed to view solution.
 
-        // if not allowed to save submissions, then allow view but don't record it
-        if (!this.flags.allowSaveSubmissions) {
+        // if not allowed to save state, then allow view but don't record it
+        if (!this.flags.allowSaveState) {
             return {
                 allowView: true,
                 message: "",

--- a/packages/doenetml-worker/src/test/utils/test-core.ts
+++ b/packages/doenetml-worker/src/test/utils/test-core.ts
@@ -14,7 +14,6 @@ type DoenetMLFlags = {
     allowLoadState: boolean;
     allowSaveState: boolean;
     allowLocalState: boolean;
-    allowSaveSubmissions: boolean;
     allowSaveEvents: boolean;
     autoSubmit: boolean;
 };
@@ -30,7 +29,6 @@ const defaultFlags: DoenetMLFlags = {
     allowLoadState: false,
     allowSaveState: false,
     allowLocalState: false,
-    allowSaveSubmissions: false,
     allowSaveEvents: false,
     autoSubmit: false,
 };

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -484,7 +484,6 @@ export function EditorViewer({
                             allowLoadState: false,
                             allowSaveState: false,
                             allowLocalState: false,
-                            allowSaveSubmissions: false,
                             allowSaveEvents: false,
                             readOnly: false,
                         }}

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -449,6 +449,9 @@ export function DocViewer({
 
     useEffect(() => {
         window.addEventListener("message", (e) => {
+            if (e.origin !== window.location.origin) {
+                return;
+            }
             if (typeof e.data !== "object") {
                 return;
             }

--- a/packages/doenetml/src/Viewer/renderers/codeViewer.jsx
+++ b/packages/doenetml/src/Viewer/renderers/codeViewer.jsx
@@ -141,7 +141,6 @@ export default React.memo(function CodeViewer(props) {
                         allowLoadState: false,
                         allowSaveState: false,
                         allowLocalState: false,
-                        allowSaveSubmissions: false,
                         allowSaveEvents: false,
                     }}
                     activityId={id}

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -25,7 +25,6 @@ export type DoenetMLFlags = {
     allowLoadState: boolean;
     allowSaveState: boolean;
     allowLocalState: boolean;
-    allowSaveSubmissions: boolean;
     allowSaveEvents: boolean;
     autoSubmit: boolean;
 };
@@ -41,7 +40,6 @@ export const defaultFlags: DoenetMLFlags = {
     allowLoadState: false,
     allowSaveState: false,
     allowLocalState: false,
-    allowSaveSubmissions: false,
     allowSaveEvents: false,
     autoSubmit: false,
 };
@@ -183,10 +181,6 @@ export function DoenetViewer({
         // and disable even looking up state from local storage (as we want to get the state from the database)
         flags.allowLocalState = false;
         flags.allowSaveState = false;
-    } else if (flags.allowSaveState) {
-        // allowSaveState implies allowLoadState
-        // Rationale: saving state will result in loading a new state if another device changed it
-        flags.allowLoadState = true;
     }
 
     const generatedVariantCallback = useCallback(

--- a/packages/test-cypress/cypress/e2e/DocViewer/docViewerAttributes.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/docViewerAttributes.cy.js
@@ -10,6 +10,9 @@ describe("PageViewer Attribute Tests", function () {
         let allPossibleVariants = null;
 
         function variantsListener(e) {
+            if (e.origin !== window.location.origin) {
+                return;
+            }
             if (e.data.subject === "SPLICE.allPossibleVariants") {
                 allPossibleVariants = e.data.args.allPossibleVariants;
             }

--- a/packages/test-cypress/src/CypressTest.tsx
+++ b/packages/test-cypress/src/CypressTest.tsx
@@ -15,7 +15,6 @@ export function CypressTest() {
         allowLoadState: boolean;
         allowSaveState: boolean;
         allowLocalState: boolean;
-        allowSaveSubmissions: boolean;
         allowSaveEvents: boolean;
         autoSubmit: boolean;
         render: boolean;
@@ -33,7 +32,6 @@ export function CypressTest() {
         allowLoadState: false,
         allowSaveState: false,
         allowLocalState: false,
-        allowSaveSubmissions: false,
         allowSaveEvents: false,
         autoSubmit: false,
         render: true,
@@ -81,9 +79,6 @@ export function CypressTest() {
     );
     const [allowLocalState, setAllowLocalState] = useState(
         testSettings.allowLocalState,
-    );
-    const [allowSaveSubmissions, setAllowSaveSubmissions] = useState(
-        testSettings.allowSaveSubmissions,
     );
     const [allowSaveEvents, setAllowSaveEvents] = useState(
         testSettings.allowSaveEvents,
@@ -347,27 +342,6 @@ export function CypressTest() {
                     <label>
                         {" "}
                         <input
-                            id="testRunner_allowSaveSubmissions"
-                            type="checkbox"
-                            checked={allowSaveSubmissions}
-                            onChange={() => {
-                                testSettings.allowSaveSubmissions =
-                                    !testSettings.allowSaveSubmissions;
-                                localStorage.setItem(
-                                    "test settings",
-                                    JSON.stringify(testSettings),
-                                );
-                                setAllowSaveSubmissions((was: boolean) => !was);
-                                setUpdateNumber((was: number) => was + 1);
-                            }}
-                        />
-                        Allow Save Submissions
-                    </label>
-                </div>
-                <div>
-                    <label>
-                        {" "}
-                        <input
                             id="testRunner_allowSaveEvents"
                             type="checkbox"
                             checked={allowSaveEvents}
@@ -519,7 +493,6 @@ export function CypressTest() {
                     allowLoadState,
                     allowSaveState,
                     allowLocalState,
-                    allowSaveSubmissions,
                     allowSaveEvents,
                     autoSubmit,
                 }}

--- a/packages/test-viewer/src/main.jsx
+++ b/packages/test-viewer/src/main.jsx
@@ -7,6 +7,10 @@ import "@doenet/doenetml/style.css";
 const root = createRoot(document.getElementById("root"));
 
 window.addEventListener("message", (event) => {
+    if (event.origin !== window.location.origin) {
+        return;
+    }
+
     if (event.data.subject == "SPLICE.reportScoreAndState") {
         console.log(event.data.score);
         console.log(event.data.state);

--- a/packages/test-viewer/src/test/testViewer.tsx
+++ b/packages/test-viewer/src/test/testViewer.tsx
@@ -220,7 +220,6 @@ export default function TestViewer() {
                 allowLoadState: false,
                 allowSaveState: false,
                 allowLocalState: false,
-                allowSaveSubmissions: true,
                 allowSaveEvents: false,
                 autoSubmit: false,
             }}


### PR DESCRIPTION
This PR adds a few more checks to message event listeners to filter out events that come from the same origin.

It also removes the `allowSaveSubmissions` flag which is obsolete given that we now only support SPLICE messages for saving state, and SPLICE combines saving submissions and state.