### PR TITLE
add activityId and docId to all SPLICE calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22797,7 +22797,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.0-alpha28",
+            "version": "0.7.0-alpha29",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@chakra-ui/icons": "^2.0.19",
@@ -22838,7 +22838,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.0-alpha28",
+            "version": "0.7.0-alpha29",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -22916,7 +22916,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.0-alpha28",
+            "version": "0.7.0-alpha29",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22797,7 +22797,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.0-alpha27",
+            "version": "0.7.0-alpha28",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@chakra-ui/icons": "^2.0.19",
@@ -22838,7 +22838,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.0-alpha27",
+            "version": "0.7.0-alpha28",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -22916,7 +22916,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.0-alpha27",
+            "version": "0.7.0-alpha28",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml-iframe",
     "type": "module",
     "description": "A renderer for DoenetML contained in an iframe",
-    "version": "0.7.0-alpha28",
+    "version": "0.7.0-alpha29",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml-iframe",
     "type": "module",
     "description": "A renderer for DoenetML contained in an iframe",
-    "version": "0.7.0-alpha27",
+    "version": "0.7.0-alpha28",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml-worker/src/CoreWorker.js
+++ b/packages/doenetml-worker/src/CoreWorker.js
@@ -144,8 +144,6 @@ async function initializeWorker({
             messageType: "initializeResult",
             args: {
                 ...initializeResult,
-                activityId,
-                docId,
                 attemptNumber,
                 requestedVariantIndex,
             },
@@ -154,8 +152,6 @@ async function initializeWorker({
             messageType: "allPossibleVariants",
             args: {
                 success: false,
-                activityId,
-                docId,
                 attemptNumber,
                 requestedVariantIndex,
             },
@@ -185,8 +181,6 @@ async function initializeWorker({
         messageType: "initializeResult",
         args: {
             ...initializeResult,
-            activityId,
-            docId,
             attemptNumber,
             requestedVariantIndex,
         },
@@ -202,8 +196,6 @@ async function initializeWorker({
         args: {
             success: true,
             allPossibleVariants,
-            activityId,
-            docId,
             attemptNumber,
             requestedVariantIndex,
         },

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.7.0-alpha27",
+    "version": "0.7.0-alpha28",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.7.0-alpha28",
+    "version": "0.7.0-alpha29",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -1091,7 +1091,7 @@ export function DocViewer({
                         userId,
                     });
                     if (resp.loadedState) {
-                        processLoadedDocState(JSON.parse(resp.state));
+                        processLoadedDocState(resp.state);
                     }
                 } catch (e: any) {
                     setIsInErrorState?.(true);

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -417,21 +417,29 @@ export function DocViewer({
                 window.postMessage({
                     ...e.data,
                     subject: "SPLICE.reportScoreAndState",
+                    activityId,
+                    docId,
                 });
             } else if (e.data.messageType === "recordSolutionView") {
                 window.postMessage({
                     ...e.data,
                     subject: "SPLICE.recordSolutionView",
+                    activityId,
+                    docId,
                 });
             } else if (e.data.messageType === "sendEvent") {
                 window.postMessage({
                     ...e.data,
                     subject: "SPLICE.sendEvent",
+                    activityId,
+                    docId,
                 });
             } else if (e.data.messageType === "allPossibleVariants") {
                 window.postMessage({
                     ...e.data,
                     subject: "SPLICE.allPossibleVariants",
+                    activityId,
+                    docId,
                 });
             } else if (e.data.messageType === "terminated") {
                 reinitializeCoreAndTerminateAnimations();

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -456,8 +456,11 @@ export function DocViewer({
     }, []);
 
     useEffect(() => {
-        window.addEventListener("message", (e) => {
-            if (e.origin !== window.location.origin) {
+        const listener = function (e: MessageEvent) {
+            if (
+                e.origin !== window.location.origin &&
+                e.origin !== window.parent.location.origin
+            ) {
                 return;
             }
             if (typeof e.data !== "object") {
@@ -476,8 +479,14 @@ export function DocViewer({
                     promiseInfo.reject(e.data);
                 }
             }
-        });
-    });
+        };
+
+        window.addEventListener("message", listener);
+
+        return () => {
+            window.removeEventListener("message", listener);
+        };
+    }, []);
 
     useEffect(() => {
         if (!coreWorker) {

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.7.0-alpha28",
+    "version": "0.7.0-alpha29",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.7.0-alpha27",
+    "version": "0.7.0-alpha28",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,


### PR DESCRIPTION
This PR adds activityId and docId to all SPLICE calls, changes the assumption to have parsed state received via SPLICE, and allows messages where either the window or parent locations matches the origin.