### PR TITLE
New callbacks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22797,7 +22797,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.0-alpha29",
+            "version": "0.7.0-alpha30",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@chakra-ui/icons": "^2.0.19",
@@ -22838,7 +22838,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.0-alpha29",
+            "version": "0.7.0-alpha30",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -22916,7 +22916,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.0-alpha29",
+            "version": "0.7.0-alpha30",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml-iframe",
     "type": "module",
     "description": "A renderer for DoenetML contained in an iframe",
-    "version": "0.7.0-alpha29",
+    "version": "0.7.0-alpha30",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml-iframe/src/iframe-viewer-index.ts
+++ b/packages/doenetml-iframe/src/iframe-viewer-index.ts
@@ -24,9 +24,9 @@ document.addEventListener("DOMContentLoaded", () => {
             externalVirtualKeyboardProvided: true,
             // Callbacks have to be explicitly overridden here so that they
             // can message the parent React component (outside the iframe).
-            updateCreditAchievedCallback: (args: unknown) => {
+            reportScoreAndStateCallback: (args: unknown) => {
                 messageParentFromViewer({
-                    callback: "updateCreditAchievedCallback",
+                    callback: "reportScoreAndStateCallback",
                     args,
                 });
             },
@@ -39,6 +39,12 @@ document.addEventListener("DOMContentLoaded", () => {
             generatedVariantCallback: (args: unknown) => {
                 messageParentFromViewer({
                     callback: "generatedVariantCallback",
+                    args,
+                });
+            },
+            documentStructureCallback: (args: unknown) => {
+                messageParentFromViewer({
+                    callback: "documentStructureCallback",
                     args,
                 });
             },
@@ -58,8 +64,8 @@ window.addEventListener("message", (e) => {
         return;
     }
     if (
-        e.data.subject.startsWith("SPLICE") &&
-        !e.data.subject.endsWith("response")
+        e.data.subject?.startsWith("SPLICE") &&
+        !e.data.subject?.endsWith("response")
     ) {
         window.parent.postMessage(e.data);
     }

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -184,6 +184,9 @@ export function DoenetViewer({
                         data.args,
                     );
                 }
+                case "initializedCallback": {
+                    return doenetViewerProps.initializedCallback?.(data.args);
+                }
                 case "setErrorsAndWarningsCallback": {
                     return doenetViewerProps.setErrorsAndWarningsCallback?.(
                         data.args,

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -166,8 +166,8 @@ export function DoenetViewer({
             }
 
             switch (data.callback) {
-                case "updateCreditAchievedCallback": {
-                    return doenetViewerProps.updateCreditAchievedCallback?.(
+                case "reportScoreAndStateCallback": {
+                    return doenetViewerProps.reportScoreAndStateCallback?.(
                         data.args,
                     );
                 }
@@ -176,6 +176,11 @@ export function DoenetViewer({
                 }
                 case "generatedVariantCallback": {
                     return doenetViewerProps.generatedVariantCallback?.(
+                        data.args,
+                    );
+                }
+                case "documentStructureCallback": {
+                    return doenetViewerProps.documentStructureCallback?.(
                         data.args,
                     );
                 }

--- a/packages/doenetml-iframe/src/utils.ts
+++ b/packages/doenetml-iframe/src/utils.ts
@@ -27,6 +27,21 @@ export function createHtmlForDoenetViewer(
     standaloneUrl: string,
     cssUrl: string,
 ) {
+    const haveCallbacks: string[] = [];
+    const callbackNames = [
+        "reportScoreAndStateCallback",
+        "setIsInErrorState",
+        "generatedVariantCallback",
+        "documentStructureCallback",
+        "initializedCallback",
+        "setErrorsAndWarningsCallback",
+    ];
+    for (const callback of callbackNames) {
+        if (callback in doenetViewerProps) {
+            haveCallbacks.push(callback);
+        }
+    }
+
     return `
     <html style="overflow:hidden">
     <head>
@@ -37,9 +52,10 @@ export function createHtmlForDoenetViewer(
         <script type="module">
             const viewerId = "${id}";
             const doenetViewerProps = ${JSON.stringify(doenetViewerProps)};
+            const haveCallbacks = ${JSON.stringify(haveCallbacks)};
             
             // This source code has been compiled by vite and should be directly included.
-            // It assumes that id and doenetViewerProps are defined in the global scope.
+            // It assumes that viewerId, doenetViewerProps, and haveCallbacks are defined in the global scope.
             ${viewerIframeJsSource}
         </script>
         <div id="root">
@@ -75,7 +91,7 @@ export function createHtmlForDoenetEditor(
             const doenetEditorProps = ${JSON.stringify(augmentedProps)};
             
             // This source code has been compiled by vite and should be directly included.
-            // It assumes that id and doenetEditorProps are defined in the global scope.
+            // It assumes that editorId and doenetEditorProps are defined in the global scope.
             ${editorIframeJsSource}
         </script>
         <div id="root">

--- a/packages/doenetml-worker/src/Core.js
+++ b/packages/doenetml-worker/src/Core.js
@@ -229,9 +229,6 @@ export default class Core {
         this.errorWarnings.errors.push(...res.errors);
         this.errorWarnings.warnings.push(...res.warnings);
 
-        this.failedToSavePageState = false;
-        this.failedToSaveCreditForItem = false;
-
         // console.log(`serialized components at the beginning`)
         // console.log(deepClone(serializedComponents));
 
@@ -12908,13 +12905,6 @@ export default class Core {
             // else override timeout to save any pending changes to database
             await this.saveChangesToDatabase(true);
         }
-
-        postMessage({
-            messageType: "saveImmediatelyResult",
-            success: !(
-                this.failedToSavePageState || this.failedToSaveCreditForItem
-            ),
-        });
     }
 
     async saveState(overrideThrottle = false, onSubmission = false) {
@@ -13013,7 +13003,7 @@ export default class Core {
         }
 
         postMessage({
-            messageType: "saveCreditForItem",
+            messageType: "reportScoreAndState",
             state: { ...this.pageStateToBeSavedToDatabase },
             score: await this.document.stateValues.creditAchieved,
         });
@@ -13145,10 +13135,6 @@ export default class Core {
         }
 
         await this.saveImmediately();
-
-        if (this.failedToSavePageState || this.failedToSaveCreditForItem) {
-            throw Error("Terminating core failed due to failure to save data.");
-        }
     }
 
     recordAnswerToAutoSubmit(componentName) {

--- a/packages/doenetml-worker/src/CoreWorker.js
+++ b/packages/doenetml-worker/src/CoreWorker.js
@@ -191,13 +191,21 @@ async function initializeWorker({
         coreBaseArgs.componentInfoObjects,
     );
 
+    // count the number of occurrences of each component type from the document's immediate children
+    const baseLevelComponentCounts =
+        coreBaseArgs.serializedDocument.children.reduce((a, c) => {
+            if (typeof c === "object") {
+                a[c.componentType] = (a[c.componentType] ?? 0) + 1;
+            }
+            return a;
+        }, {});
+
     postMessage({
-        messageType: "allPossibleVariants",
+        messageType: "documentStructure",
         args: {
             success: true,
             allPossibleVariants,
-            attemptNumber,
-            requestedVariantIndex,
+            baseLevelComponentCounts,
         },
     });
 }

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.7.0-alpha29",
+    "version": "0.7.0-alpha30",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -47,7 +47,8 @@ export function DocViewer({
     flags,
     requestedVariantIndex,
     setErrorsAndWarningsCallback,
-    updateCreditAchievedCallback,
+    reportScoreAndStateCallback,
+    documentStructureCallback,
     setIsInErrorState,
     prefixForIds = "",
     location = {},
@@ -73,7 +74,8 @@ export function DocViewer({
     flags: DoenetMLFlags;
     requestedVariantIndex: number;
     setErrorsAndWarningsCallback?: Function;
-    updateCreditAchievedCallback?: Function;
+    reportScoreAndStateCallback?: Function;
+    documentStructureCallback?: Function;
     setIsInErrorState?: Function;
     prefixForIds?: string;
     location?: any;
@@ -380,8 +382,6 @@ export function DocViewer({
                         setIsInErrorState?.(false);
                     }
                 }
-            } else if (e.data.messageType === "updateCreditAchieved") {
-                updateCreditAchievedCallback?.(e.data.args);
             } else if (e.data.messageType === "savedState") {
                 // saveStateCallback?.();
             } else if (e.data.messageType === "sendAlert") {
@@ -413,10 +413,15 @@ export function DocViewer({
                 navigate(location.search + e.data.args.hash, {
                     replace: true,
                 });
-            } else if (e.data.messageType === "saveCreditForItem") {
+            } else if (e.data.messageType === "reportScoreAndState") {
                 window.postMessage({
                     ...e.data,
                     subject: "SPLICE.reportScoreAndState",
+                    activityId,
+                    docId,
+                });
+                reportScoreAndStateCallback?.({
+                    ...e.data,
                     activityId,
                     docId,
                 });
@@ -434,10 +439,9 @@ export function DocViewer({
                     activityId,
                     docId,
                 });
-            } else if (e.data.messageType === "allPossibleVariants") {
-                window.postMessage({
+            } else if (e.data.messageType === "documentStructure") {
+                documentStructureCallback?.({
                     ...e.data,
-                    subject: "SPLICE.allPossibleVariants",
                     activityId,
                     docId,
                 });

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -101,10 +101,12 @@ export function DoenetViewer({
     attemptNumber = 1,
     render = true,
     requestedVariantIndex,
+    initialState,
     reportScoreAndStateCallback,
     setIsInErrorState,
     generatedVariantCallback: specifiedGeneratedVariantCallback,
     documentStructureCallback,
+    initializedCallback,
     setErrorsAndWarningsCallback,
     forceDisable = false,
     forceShowCorrectness = false,
@@ -130,10 +132,12 @@ export function DoenetViewer({
     attemptNumber?: number;
     render?: boolean;
     requestedVariantIndex?: number;
+    initialState?: Record<string, any> | null;
     reportScoreAndStateCallback?: Function;
     setIsInErrorState?: Function;
     generatedVariantCallback?: Function;
     documentStructureCallback?: Function;
+    initializedCallback?: Function;
     setErrorsAndWarningsCallback?: Function;
     forceDisable?: boolean;
     forceShowCorrectness?: boolean;
@@ -256,10 +260,12 @@ export function DoenetViewer({
             render={render}
             hidden={hidden}
             requestedVariantIndex={variantIndex.current}
+            initialState={initialState}
             reportScoreAndStateCallback={reportScoreAndStateCallback}
             setIsInErrorState={setIsInErrorState}
             generatedVariantCallback={generatedVariantCallback}
             documentStructureCallback={documentStructureCallback}
+            initializedCallback={initializedCallback}
             setErrorsAndWarningsCallback={setErrorsAndWarningsCallback}
             forceDisable={forceDisable}
             forceShowCorrectness={forceShowCorrectness}

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -101,9 +101,10 @@ export function DoenetViewer({
     attemptNumber = 1,
     render = true,
     requestedVariantIndex,
-    updateCreditAchievedCallback,
+    reportScoreAndStateCallback,
     setIsInErrorState,
     generatedVariantCallback: specifiedGeneratedVariantCallback,
+    documentStructureCallback,
     setErrorsAndWarningsCallback,
     forceDisable = false,
     forceShowCorrectness = false,
@@ -129,9 +130,10 @@ export function DoenetViewer({
     attemptNumber?: number;
     render?: boolean;
     requestedVariantIndex?: number;
-    updateCreditAchievedCallback?: Function;
+    reportScoreAndStateCallback?: Function;
     setIsInErrorState?: Function;
     generatedVariantCallback?: Function;
+    documentStructureCallback?: Function;
     setErrorsAndWarningsCallback?: Function;
     forceDisable?: boolean;
     forceShowCorrectness?: boolean;
@@ -254,9 +256,10 @@ export function DoenetViewer({
             render={render}
             hidden={hidden}
             requestedVariantIndex={variantIndex.current}
-            updateCreditAchievedCallback={updateCreditAchievedCallback}
+            reportScoreAndStateCallback={reportScoreAndStateCallback}
             setIsInErrorState={setIsInErrorState}
             generatedVariantCallback={generatedVariantCallback}
+            documentStructureCallback={documentStructureCallback}
             setErrorsAndWarningsCallback={setErrorsAndWarningsCallback}
             forceDisable={forceDisable}
             forceShowCorrectness={forceShowCorrectness}

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.7.0-alpha29",
+    "version": "0.7.0-alpha30",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/test-cypress/cypress/e2e/DocViewer/docViewerAttributes.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/docViewerAttributes.cy.js
@@ -6,15 +6,18 @@ describe("PageViewer Attribute Tests", function () {
         cy.visit("/");
     });
 
-    it("get variants without rendering or starting core", () => {
+    it("get variants, component counts without rendering or starting core", () => {
         let allPossibleVariants = null;
+        let baseLevelComponentCounts = null;
 
         function variantsListener(e) {
             if (e.origin !== window.location.origin) {
                 return;
             }
-            if (e.data.subject === "SPLICE.allPossibleVariants") {
+
+            if (e.data.messageType === "documentStructure") {
                 allPossibleVariants = e.data.args.allPossibleVariants;
+                baseLevelComponentCounts = e.data.args.baseLevelComponentCounts;
             }
         }
 
@@ -51,6 +54,10 @@ describe("PageViewer Attribute Tests", function () {
 
         cy.window().then(async (win) => {
             win.removeEventListener("message", variantsListener);
+            expect(baseLevelComponentCounts).eqls({
+                text: 1,
+                selectFromSequence: 1,
+            });
         });
 
         cy.get(cesc2("#/t")).should("not.exist");

--- a/packages/test-cypress/src/CypressTest.tsx
+++ b/packages/test-cypress/src/CypressTest.tsx
@@ -498,6 +498,9 @@ export function CypressTest() {
                 }}
                 attemptNumber={attemptNumber}
                 requestedVariantIndex={requestedVariantIndex.current}
+                documentStructureCallback={(args: unknown) => {
+                    window.postMessage(args);
+                }}
                 activityId="activityIdFromCypress"
                 render={render}
                 location={location}


### PR DESCRIPTION
This PR adds new callbacks `reportScoreAndState`,  `documentStructure`, and `initialized` callbacks, and removes the `updateCreditAchieved` callback. It also adds the ability to pass in initial state via the `initialState` prop.

The `reportScoreAndState` callback and `initialState` prop will prevent the corresponding SPLICE messages if they are present.