### PR TITLE
add doenetmlChangeCallback to DoenetEditor

### DIFF
--- a/packages/doenetml-iframe/src/iframe-viewer-index.ts
+++ b/packages/doenetml-iframe/src/iframe-viewer-index.ts
@@ -2,7 +2,7 @@
 // created by DoenetViewer.
 declare const viewerId: string;
 declare const doenetViewerProps: object;
-declare const haveCallbacks: string[];
+declare const haveViewerCallbacks: string[];
 interface Window {
     renderDoenetViewerToContainer: (
         container: Element,
@@ -33,7 +33,7 @@ document.addEventListener("DOMContentLoaded", () => {
         "setErrorsAndWarningsCallback",
     ];
     for (const callback of callbackNames) {
-        callbackOverrides[callback] = haveCallbacks.includes(callback)
+        callbackOverrides[callback] = haveViewerCallbacks.includes(callback)
             ? (args: unknown) => {
                   messageParentFromViewer({
                       callback,

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -350,6 +350,11 @@ export function DoenetEditor({
                         data.args,
                     );
                 }
+                case "documentStructureCallback": {
+                    return doenetEditorProps.documentStructureCallback?.(
+                        data.args,
+                    );
+                }
             }
         };
         if (ref.current) {

--- a/packages/doenetml-iframe/src/utils.ts
+++ b/packages/doenetml-iframe/src/utils.ts
@@ -27,7 +27,7 @@ export function createHtmlForDoenetViewer(
     standaloneUrl: string,
     cssUrl: string,
 ) {
-    const haveCallbacks: string[] = [];
+    const haveViewerCallbacks: string[] = [];
     const callbackNames = [
         "reportScoreAndStateCallback",
         "setIsInErrorState",
@@ -38,7 +38,7 @@ export function createHtmlForDoenetViewer(
     ];
     for (const callback of callbackNames) {
         if (callback in doenetViewerProps) {
-            haveCallbacks.push(callback);
+            haveViewerCallbacks.push(callback);
         }
     }
 
@@ -52,10 +52,10 @@ export function createHtmlForDoenetViewer(
         <script type="module">
             const viewerId = "${id}";
             const doenetViewerProps = ${JSON.stringify(doenetViewerProps)};
-            const haveCallbacks = ${JSON.stringify(haveCallbacks)};
+            const haveViewerCallbacks = ${JSON.stringify(haveViewerCallbacks)};
             
             // This source code has been compiled by vite and should be directly included.
-            // It assumes that viewerId, doenetViewerProps, and haveCallbacks are defined in the global scope.
+            // It assumes that viewerId, doenetViewerProps, and haveViewerCallbacks are defined in the global scope.
             ${viewerIframeJsSource}
         </script>
         <div id="root">
@@ -79,6 +79,18 @@ export function createHtmlForDoenetEditor(
 ) {
     const augmentedProps = { width, height: "100vh", ...doenetEditorProps };
 
+    const haveEditorCallbacks: string[] = [];
+    const callbackNames = [
+        "doenetmlChangeCallback",
+        "immediateDoenetmlChangeCallback",
+        "documentStructureCallback",
+    ];
+    for (const callback of callbackNames) {
+        if (callback in doenetEditorProps) {
+            haveEditorCallbacks.push(callback);
+        }
+    }
+
     return `
     <html style="overflow:hidden">
     <head>
@@ -89,9 +101,10 @@ export function createHtmlForDoenetEditor(
         <script type="module">
             const editorId = "${id}";
             const doenetEditorProps = ${JSON.stringify(augmentedProps)};
+            const haveEditorCallbacks = ${JSON.stringify(haveEditorCallbacks)};
             
             // This source code has been compiled by vite and should be directly included.
-            // It assumes that editorId and doenetEditorProps are defined in the global scope.
+            // It assumes that editorId, doenetEditorProps, and have EditorCallbacks are defined in the global scope.
             ${editorIframeJsSource}
         </script>
         <div id="root">

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -40,6 +40,7 @@ export function EditorViewer({
     viewerLocation = "right",
     doenetmlChangeCallback,
     immediateDoenetmlChangeCallback,
+    documentStructureCallback,
     id: specifiedId,
     readOnly = false,
     showFormatter = true,
@@ -63,6 +64,7 @@ export function EditorViewer({
     viewerLocation?: "left" | "right" | "top" | "bottom";
     doenetmlChangeCallback?: Function;
     immediateDoenetmlChangeCallback?: Function;
+    documentStructureCallback?: Function;
     id?: string;
     readOnly?: boolean;
     showFormatter?: boolean;
@@ -495,6 +497,7 @@ export function EditorViewer({
                         setErrorsAndWarningsCallback={
                             setErrorsAndWarningsCallback
                         }
+                        documentStructureCallback={documentStructureCallback}
                         location={location}
                         navigate={navigate}
                         linkSettings={linkSettings}

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -319,6 +319,7 @@ export function DoenetEditor({
     showViewer,
     doenetmlChangeCallback,
     immediateDoenetmlChangeCallback,
+    documentStructureCallback,
     id,
     readOnly = false,
     showFormatter = true,
@@ -344,6 +345,7 @@ export function DoenetEditor({
     showViewer?: boolean;
     doenetmlChangeCallback?: Function;
     immediateDoenetmlChangeCallback?: Function;
+    documentStructureCallback?: Function;
     id?: string;
     readOnly?: boolean;
     showFormatter?: boolean;
@@ -375,6 +377,7 @@ export function DoenetEditor({
             showViewer={showViewer}
             doenetmlChangeCallback={doenetmlChangeCallback}
             immediateDoenetmlChangeCallback={immediateDoenetmlChangeCallback}
+            documentStructureCallback={documentStructureCallback}
             id={id}
             readOnly={readOnly}
             showFormatter={showFormatter}


### PR DESCRIPTION
This PR adds a `doenetmlChangeCallback` to the editor, which is triggered whenever the viewer inside the editor is updated. The callback returns the variants and the base level component counts.