### PR TITLE
optionally postpone rendering of collapsible sections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22797,7 +22797,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha31",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@chakra-ui/icons": "^2.0.19",
@@ -22838,7 +22838,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha31",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -22916,7 +22916,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.0-alpha30",
+            "version": "0.7.0-alpha31",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml-iframe",
     "type": "module",
     "description": "A renderer for DoenetML contained in an iframe",
-    "version": "0.7.0-alpha30",
+    "version": "0.7.0-alpha31",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml-worker/src/ComponentTypes.js
+++ b/packages/doenetml-worker/src/ComponentTypes.js
@@ -148,7 +148,7 @@ import Endpoint from "./components/Endpoint";
 import Sort from "./components/Sort";
 import Shuffle from "./components/Shuffle";
 import SolveEquations from "./components/SolveEquations";
-import SolutionContainer from "./components/SolutionContainer";
+import PostponeRenderContainer from "./components/PostponeRenderContainer";
 import SubsetOfRealsInput from "./components/SubsetOfRealsInput";
 import SubsetOfReals from "./components/SubsetOfReals";
 import Split from "./components/Split";
@@ -344,7 +344,7 @@ const componentTypeArray = [
     Sort,
     Shuffle,
     SolveEquations,
-    SolutionContainer,
+    PostponeRenderContainer,
     SubsetOfRealsInput,
     SubsetOfReals,
     Split,

--- a/packages/doenetml-worker/src/components/PostponeRenderContainer.js
+++ b/packages/doenetml-worker/src/components/PostponeRenderContainer.js
@@ -1,9 +1,7 @@
 import Template from "./Template";
 
-export default class SolutionContainer extends Template {
-    static componentType = "_solutionContainer";
-
-    static stateVariableToEvaluateAfterReplacements = "open";
+export default class PostponeRenderContainer extends Template {
+    static componentType = "_postponeRenderContainer";
 
     static createAttributesObject() {
         let attributes = super.createAttributesObject();
@@ -16,14 +14,14 @@ export default class SolutionContainer extends Template {
 
         stateVariableDefinitions.rendered = {
             returnDependencies: () => ({
-                parentOpen: {
+                parentRendered: {
                     dependencyType: "parentStateVariable",
-                    variableName: "open",
+                    variableName: "rendered",
                 },
             }),
             markStale: () => ({ updateReplacements: true }),
             definition({ dependencyValues }) {
-                let rendered = Boolean(dependencyValues.parentOpen);
+                let rendered = Boolean(dependencyValues.parentRendered);
                 return { setValue: { rendered } };
             },
         };

--- a/packages/doenetml-worker/src/components/Sectioning.js
+++ b/packages/doenetml-worker/src/components/Sectioning.js
@@ -70,6 +70,10 @@ export class Aside extends SectioningComponentNumberWithSiblings {
     static createAttributesObject() {
         let attributes = super.createAttributesObject();
 
+        attributes.postponeRendering = {
+            createPrimitiveOfType: "boolean",
+        };
+
         attributes.collapsible = {
             createComponentOfType: "boolean",
             createStateVariable: "collapsible",
@@ -101,6 +105,23 @@ export class Aside extends SectioningComponentNumberWithSiblings {
         stateVariableDefinitions.open.definition = ({ dependencyValues }) => ({
             useEssentialOrDefaultValue: {
                 open: {
+                    defaultValue: dependencyValues.startOpen,
+                },
+            },
+        });
+
+        stateVariableDefinitions.rendered.returnDependencies = () => ({
+            startOpen: {
+                dependencyType: "stateVariable",
+                variableName: "startOpen",
+            },
+        });
+
+        stateVariableDefinitions.rendered.definition = ({
+            dependencyValues,
+        }) => ({
+            useEssentialOrDefaultValue: {
+                rendered: {
                     defaultValue: dependencyValues.startOpen,
                 },
             },
@@ -212,6 +233,10 @@ export class Proof extends UnnumberedSectioningComponent {
     static createAttributesObject() {
         let attributes = super.createAttributesObject();
 
+        attributes.postponeRendering = {
+            createPrimitiveOfType: "boolean",
+        };
+
         attributes.collapsible = {
             createComponentOfType: "boolean",
             createStateVariable: "collapsible",
@@ -243,6 +268,23 @@ export class Proof extends UnnumberedSectioningComponent {
         stateVariableDefinitions.open.definition = ({ dependencyValues }) => ({
             useEssentialOrDefaultValue: {
                 open: {
+                    defaultValue: dependencyValues.startOpen,
+                },
+            },
+        });
+
+        stateVariableDefinitions.rendered.returnDependencies = () => ({
+            startOpen: {
+                dependencyType: "stateVariable",
+                variableName: "startOpen",
+            },
+        });
+
+        stateVariableDefinitions.rendered.definition = ({
+            dependencyValues,
+        }) => ({
+            useEssentialOrDefaultValue: {
+                rendered: {
                     defaultValue: dependencyValues.startOpen,
                 },
             },

--- a/packages/doenetml-worker/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker/src/components/abstract/SectioningComponent.js
@@ -128,6 +128,50 @@ export class SectioningComponent extends BlockComponent {
         return attributes;
     }
 
+    static returnSugarInstructions() {
+        let sugarInstructions = super.returnSugarInstructions();
+
+        let wrapWithContainer = function ({
+            matchedChildren,
+            componentAttributes,
+        }) {
+            if (componentAttributes.postponeRendering) {
+                const titleChildren = [];
+                const postponedChildren = [];
+
+                for (const child of matchedChildren) {
+                    if (
+                        typeof child === "object" &&
+                        child.componentType === "title"
+                    ) {
+                        titleChildren.push(child);
+                    } else {
+                        postponedChildren.push(child);
+                    }
+                }
+
+                return {
+                    success: true,
+                    newChildren: [
+                        ...titleChildren,
+                        {
+                            componentType: "_postponeRenderContainer",
+                            children: postponedChildren,
+                        },
+                    ],
+                };
+            } else {
+                return { success: false };
+            }
+        };
+
+        sugarInstructions.push({
+            replacementFunction: wrapWithContainer,
+        });
+
+        return sugarInstructions;
+    }
+
     static returnChildGroups() {
         return [
             {
@@ -861,6 +905,31 @@ export class SectioningComponent extends BlockComponent {
             },
         };
 
+        stateVariableDefinitions.rendered = {
+            forRenderer: true,
+            defaultValue: true,
+            hasEssential: true,
+            returnDependencies: () => ({}),
+            definition() {
+                return {
+                    useEssentialOrDefaultValue: {
+                        rendered: true,
+                    },
+                };
+            },
+            inverseDefinition({ desiredStateVariableValues }) {
+                return {
+                    success: true,
+                    instructions: [
+                        {
+                            setEssentialValue: "rendered",
+                            value: desiredStateVariableValues.rendered,
+                        },
+                    ],
+                };
+            },
+        };
+
         stateVariableDefinitions.createSubmitAllButton = {
             forRenderer: true,
             additionalStateVariablesDefined: [
@@ -985,7 +1054,7 @@ export class SectioningComponent extends BlockComponent {
         sourceInformation = {},
         skipRendererUpdate = false,
     }) {
-        return await this.coreFunctions.performUpdate({
+        await this.coreFunctions.performUpdate({
             updateInstructions: [
                 {
                     updateType: "updateValue",
@@ -1005,6 +1074,21 @@ export class SectioningComponent extends BlockComponent {
                     componentType: this.componentType,
                 },
             },
+        });
+
+        return this.coreFunctions.performUpdate({
+            updateInstructions: [
+                {
+                    updateType: "updateValue",
+                    componentName: this.componentName,
+                    stateVariable: "rendered",
+                    value: true,
+                },
+            ],
+            actionId,
+            sourceInformation,
+            skipRendererUpdate,
+            overrideReadOnly: true,
         });
     }
 

--- a/packages/doenetml-worker/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker/src/components/abstract/SectioningComponent.js
@@ -1064,7 +1064,6 @@ export class SectioningComponent extends BlockComponent {
                 },
             ],
             overrideReadOnly: true,
-            actionId,
             sourceInformation,
             skipRendererUpdate,
             event: {

--- a/packages/doenetml-worker/src/test/tagSpecific/sectioning.test.ts
+++ b/packages/doenetml-worker/src/test/tagSpecific/sectioning.test.ts
@@ -930,6 +930,114 @@ describe("Sectioning tag tests", async () => {
         expect(stateVariables["/aside1"].stateValues.open).eq(false);
     });
 
+    it("aside content with postponeRendering isn't created before opening", async () => {
+        let core = await createTestCore({
+            doenetML: `
+      <aside name="aside" postponeRendering>
+        <title>My aside</title>
+        <p name="asideText">This is the text of the aside.</p>
+      </aside>
+      `,
+        });
+        let stateVariables = await returnAllStateVariables(core);
+        expect(stateVariables["/aside"].stateValues.title).eq("My aside"); // title is created before opening
+        expect(stateVariables["/asideText"]).be.undefined;
+
+        await core.requestAction({
+            actionName: "revealSection",
+            componentName: "/aside",
+            args: {},
+            event: null,
+        });
+        stateVariables = await returnAllStateVariables(core);
+        expect(stateVariables["/aside"].stateValues.title).eq("My aside");
+        expect(stateVariables["/asideText"].stateValues.text).eq(
+            "This is the text of the aside.",
+        );
+    });
+
+    it("aside content without postponeRendering is created before opening", async () => {
+        let core = await createTestCore({
+            doenetML: `
+      <aside name="aside">
+        <title>My aside</title>
+        <p name="asideText">This is the text of the aside.</p>
+      </aside>
+      `,
+        });
+        let stateVariables = await returnAllStateVariables(core);
+        expect(stateVariables["/aside"].stateValues.title).eq("My aside");
+        expect(stateVariables["/asideText"].stateValues.text).eq(
+            "This is the text of the aside.",
+        );
+
+        await core.requestAction({
+            actionName: "revealSection",
+            componentName: "/aside",
+            args: {},
+            event: null,
+        });
+        stateVariables = await returnAllStateVariables(core);
+        expect(stateVariables["/aside"].stateValues.title).eq("My aside");
+        expect(stateVariables["/asideText"].stateValues.text).eq(
+            "This is the text of the aside.",
+        );
+    });
+
+    it("proof content with postponeRendering isn't created before opening", async () => {
+        let core = await createTestCore({
+            doenetML: `
+      <proof name="proof" postponeRendering>
+        <title>My proof</title>
+        <p name="proofText">This is the text of the proof.</p>
+      </proof>
+      `,
+        });
+        let stateVariables = await returnAllStateVariables(core);
+        expect(stateVariables["/proof"].stateValues.title).eq("My proof"); // title is created before opening
+        expect(stateVariables["/proofText"]).be.undefined;
+
+        await core.requestAction({
+            actionName: "revealSection",
+            componentName: "/proof",
+            args: {},
+            event: null,
+        });
+        stateVariables = await returnAllStateVariables(core);
+        expect(stateVariables["/proof"].stateValues.title).eq("My proof");
+        expect(stateVariables["/proofText"].stateValues.text).eq(
+            "This is the text of the proof.",
+        );
+    });
+
+    it("proof content without postponeRendering is created before opening", async () => {
+        let core = await createTestCore({
+            doenetML: `
+      <proof name="proof">
+        <title>My proof</title>
+        <p name="proofText">This is the text of the proof.</p>
+      </proof>
+      `,
+        });
+        let stateVariables = await returnAllStateVariables(core);
+        expect(stateVariables["/proof"].stateValues.title).eq("My proof");
+        expect(stateVariables["/proofText"].stateValues.text).eq(
+            "This is the text of the proof.",
+        );
+
+        await core.requestAction({
+            actionName: "revealSection",
+            componentName: "/proof",
+            args: {},
+            event: null,
+        });
+        stateVariables = await returnAllStateVariables(core);
+        expect(stateVariables["/proof"].stateValues.title).eq("My proof");
+        expect(stateVariables["/proofText"].stateValues.text).eq(
+            "This is the text of the proof.",
+        );
+    });
+
     it("Exercise with statement, hint, givenanswer, and solution", async () => {
         let core = await createTestCore({
             doenetML: `

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.7.0-alpha30",
+    "version": "0.7.0-alpha31",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/src/Viewer/renderers/section.jsx
+++ b/packages/doenetml/src/Viewer/renderers/section.jsx
@@ -351,7 +351,7 @@ export default React.memo(function Section(props) {
         if (SVs.open) {
             innerContent = (
                 <div style={{ display: "block", padding: "6px" }}>
-                    {children}
+                    {SVs.rendered ? children : <p>Initializing...</p>}
                     {checkworkComponent}
                 </div>
             );

--- a/packages/doenetml/src/Viewer/renderers/solution.jsx
+++ b/packages/doenetml/src/Viewer/renderers/solution.jsx
@@ -68,7 +68,7 @@ export default React.memo(function Solution(props) {
 
         icon = <FontAwesomeIcon icon={puzzle} />;
         openCloseText = "close";
-        childrenToRender = children;
+        childrenToRender = SVs.rendered ? children : <p>Initializing...</p>;
         infoBlockStyle = {
             display: "block",
             margin: "0px 4px 12px 4px",

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.7.0-alpha30",
+    "version": "0.7.0-alpha31",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/test-cypress/cypress/e2e/tagSpecific/sectioning.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/sectioning.cy.js
@@ -267,6 +267,36 @@ describe("Sectioning Tag Tests", function () {
         cy.get(cesc("#\\/title32")).should("have.text", "Aside 5");
     });
 
+    it("Aside with postpone rendering opens before initializing", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+
+<aside name="aside" postponeRendering>
+  <title>An aside</title>
+  <p>The aside</p>
+  <samplePrimeNumbers minValue="1" maxValue="10000000" />
+</aside>
+
+`,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc2("#/aside")).should("contain.text", "An aside");
+        cy.get(cesc2("#/aside")).should("not.contain.text", "The aside");
+
+        cy.get(cesc2("#/aside")).click();
+        cy.get(cesc2("#/aside")).should("contain.text", "Initializing");
+        cy.get(cesc2("#/aside")).should("not.contain.text", "The aside");
+
+        cy.log("Eventually aside finishes rendering");
+        cy.get(cesc2("#/aside")).should("contain.text", "The aside");
+        cy.get(cesc2("#/aside")).should("not.contain.text", "Initializing");
+    });
+
     it("Exercise with statement, hint, givenanswer, and solution", () => {
         cy.window().then(async (win) => {
             win.postMessage(

--- a/packages/test-cypress/cypress/e2e/tagSpecific/sectioning.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/sectioning.cy.js
@@ -297,6 +297,36 @@ describe("Sectioning Tag Tests", function () {
         cy.get(cesc2("#/aside")).should("not.contain.text", "Initializing");
     });
 
+    it("Proof with postpone rendering opens before initializing", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+
+<proof name="proof" postponeRendering>
+<title>An proof</title>
+<p>The proof</p>
+<samplePrimeNumbers minValue="1" maxValue="10000000" />
+</proof>
+
+`,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc2("#/proof")).should("contain.text", "An proof");
+        cy.get(cesc2("#/proof")).should("not.contain.text", "The proof");
+
+        cy.get(cesc2("#/proof")).click();
+        cy.get(cesc2("#/proof")).should("contain.text", "Initializing");
+        cy.get(cesc2("#/proof")).should("not.contain.text", "The proof");
+
+        cy.log("Eventually proof finishes rendering");
+        cy.get(cesc2("#/proof")).should("contain.text", "The proof");
+        cy.get(cesc2("#/proof")).should("not.contain.text", "Initializing");
+    });
+
     it("Exercise with statement, hint, givenanswer, and solution", () => {
         cy.window().then(async (win) => {
             win.postMessage(


### PR DESCRIPTION
This PR adds a `postponeRendering` attribute to `<aside>` and `<proof>`. Assuming they don't start open, the contents (other than title) are not created until after they are opened. This feature can be used to speed up the initial render of the document if the postponed sections contain content that is slow to create.

For these sections, and for solution which already postponed rendering, immediately open the box when they are clicked open to give visual feedback that they were opened. Then, do the (possibly slow) work of creating the components and rendering them.