### PR TITLE
remove obsolete references to `page`

### DIFF
--- a/packages/doenetml-worker/src/components/Ref.js
+++ b/packages/doenetml-worker/src/components/Ref.js
@@ -28,13 +28,6 @@ export default class Ref extends InlineComponent {
             public: true,
             forRenderer: true,
         };
-        attributes.page = {
-            createPrimitiveOfType: "integer",
-            createStateVariable: "page",
-            defaultValue: null,
-            public: true,
-            forRenderer: true,
-        };
         attributes.createButton = {
             createComponentOfType: "boolean",
             createStateVariable: "createButton",
@@ -109,10 +102,6 @@ export default class Ref extends InlineComponent {
                     dependencyType: "stateVariable",
                     variableName: "uri",
                 },
-                page: {
-                    dependencyType: "stateVariable",
-                    variableName: "page",
-                },
                 targetInactive: {
                     dependencyType: "stateVariable",
                     variableName: "targetInactive",
@@ -123,7 +112,7 @@ export default class Ref extends InlineComponent {
                 },
             }),
             definition: function ({ dependencyValues }) {
-                if (dependencyValues.uri || dependencyValues.page) {
+                if (dependencyValues.uri) {
                     if (dependencyValues.targetAttribute) {
                         let targetName = dependencyValues.targetAttribute;
                         if (targetName[0] !== "/") {
@@ -364,7 +353,6 @@ export default class Ref extends InlineComponent {
         let variantIndex = await this.stateValues.variantIndex;
         let edit = await this.stateValues.edit;
         let hash = await this.stateValues.hash;
-        let page = await this.stateValues.page;
         let uri = await this.stateValues.uri;
         let targetName = await this.stateValues.targetName;
 
@@ -376,7 +364,6 @@ export default class Ref extends InlineComponent {
             variantIndex,
             edit,
             hash,
-            page,
             uri,
             targetName,
             actionId,

--- a/packages/doenetml-worker/src/components/Video.js
+++ b/packages/doenetml-worker/src/components/Video.js
@@ -606,7 +606,7 @@ export default class Video extends BlockComponent {
             sourceInformation,
             skipRendererUpdate,
             overrideReadOnly: true,
-            doNotSave: true, // video actions don't count as changing page state
+            doNotSave: true, // video actions don't count as changing doc state
         });
     }
 

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -286,7 +286,6 @@ export function DocViewer({
 
     const postfixForWindowFunctions =
         prefixForIds
-            .replace(/^page/, "")
             .replaceAll("/", "")
             .replaceAll("\\", "")
             .replaceAll("-", "_") || "1";
@@ -611,7 +610,6 @@ export function DocViewer({
             variantIndex,
             edit,
             hash,
-            page,
             uri,
             targetName,
             actionId,
@@ -623,7 +621,6 @@ export function DocViewer({
             variantIndex?: number;
             edit?: boolean;
             hash?: string;
-            page?: number;
             uri?: string;
             targetName?: string;
             actionId?: string;
@@ -638,7 +635,6 @@ export function DocViewer({
                     variantIndex,
                     edit,
                     hash,
-                    page,
                     givenUri: uri,
                     targetName,
                     linkSettings,
@@ -1564,7 +1560,6 @@ export function getURLFromRef({
     variantIndex,
     edit,
     hash,
-    page,
     givenUri,
     targetName = "",
     linkSettings,
@@ -1576,7 +1571,6 @@ export function getURLFromRef({
     variantIndex?: number;
     edit?: boolean;
     hash?: string;
-    page?: number;
     givenUri?: string;
     targetName?: string;
     linkSettings: Record<string, any>;
@@ -1639,12 +1633,7 @@ export function getURLFromRef({
         if (hash) {
             url += hash;
         } else {
-            if (page) {
-                url += `#page${page}`;
-                if (targetName) {
-                    url += cesc(targetName);
-                }
-            } else if (targetName) {
+            if (targetName) {
                 url += "#" + cesc(targetName);
             }
         }
@@ -1661,13 +1650,9 @@ export function getURLFromRef({
     } else {
         url = search;
 
-        if (page) {
-            url += `#page${page}`;
-        } else {
-            let firstSlash = id.indexOf("\\/");
-            let prefix = id.substring(0, firstSlash);
-            url += "#" + prefix;
-        }
+        let firstSlash = id.indexOf("\\/");
+        let prefix = id.substring(0, firstSlash);
+        url += "#" + prefix;
         url += cesc(targetName);
         targetForATag = null;
         haveValidTarget = true;

--- a/packages/doenetml/src/Viewer/renderers/ref.jsx
+++ b/packages/doenetml/src/Viewer/renderers/ref.jsx
@@ -68,7 +68,6 @@ export default React.memo(function Ref(props) {
         variantIndex: SVs.variantIndex,
         edit: SVs.edit,
         hash: SVs.hash,
-        page: SVs.page,
         givenUri: SVs.uri,
         targetName: SVs.targetName,
         linkSettings,


### PR DESCRIPTION
Remove obsolete references to `page` that persisted from when DoenetML could represent multi-page documents.