### PR TITLE
Rename scored items to scored components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22800,7 +22800,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.0-alpha31",
+            "version": "0.7.0-alpha32",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@chakra-ui/icons": "^2.0.19",
@@ -22841,7 +22841,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.0-alpha31",
+            "version": "0.7.0-alpha32",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -22919,7 +22919,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.0-alpha31",
+            "version": "0.7.0-alpha32",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml-iframe",
     "type": "module",
     "description": "A renderer for DoenetML contained in an iframe",
-    "version": "0.7.0-alpha31",
+    "version": "0.7.0-alpha32",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml-worker/src/Core.js
+++ b/packages/doenetml-worker/src/Core.js
@@ -11160,12 +11160,12 @@ export default class Core {
                 if (!event.context) {
                     event.context = {};
                 }
-                event.context.component = componentsSubmitted[0];
+                event.context.componentNumber = componentsSubmitted[0];
                 event.context.componentCreditAchieved =
                     componentCreditAchieved[componentsSubmitted[0] - 1];
 
-                // Just in case the code gets changed to that more than component can be submitted at once
-                // record credit achieved for any additional items
+                // Just in case the code gets changed so that more than one component can be submitted at once,
+                // record credit achieved for any additional components.
                 if (componentsSubmitted.length > 1) {
                     event.context.additionalComponentCreditAchieved = {};
                     for (let componentNumber of componentsSubmitted) {

--- a/packages/doenetml-worker/src/Core.js
+++ b/packages/doenetml-worker/src/Core.js
@@ -383,9 +383,9 @@ export default class Core {
 
         this.updateInfo.componentsToUpdateRenderers.clear();
 
-        // evaluate itemCreditAchieved so that will be fresh
+        // evaluate unitCreditAchieved so that will be fresh
         // and can detect changes when it is marked stale
-        await this.document.stateValues.itemCreditAchieved;
+        await this.document.stateValues.unitCreditAchieved;
 
         // console.log(serializedComponents)
         // console.timeEnd('start up time');
@@ -396,8 +396,8 @@ export default class Core {
             await this.document.stateValues.generatedVariantInfo,
             serializedComponentsReplacer,
         );
-        this.canonicalItemVariantStrings = (
-            await this.document.stateValues.itemVariantInfo
+        this.canonicalDocVariantStrings = (
+            await this.document.stateValues.docVariantInfo
         ).map((x) => JSON.stringify(x, serializedComponentsReplacer));
 
         // Note: coreInfo is fixed even though this.rendererTypesInDocument could change
@@ -11047,7 +11047,7 @@ export default class Core {
         let newStateVariableValues = {};
         let newStateVariableValuesProcessed = [];
         let workspace = {};
-        let recordItemSubmissions = [];
+        let recordUnitSubmissions = [];
 
         for (let instruction of updateInstructions) {
             if (instruction.componentName) {
@@ -11111,7 +11111,7 @@ export default class Core {
                 newStateVariableValuesProcessed.push(newStateVariableValues);
                 newStateVariableValues = {};
             } else if (instruction.updateType === "recordItemSubmission") {
-                recordItemSubmissions.push(instruction);
+                recordUnitSubmissions.push(instruction);
             } else if (
                 instruction.updateType === "setComponentNeedingUpdateValue"
             ) {
@@ -11143,32 +11143,32 @@ export default class Core {
 
         await this.processStateVariableTriggers();
 
-        if (!skipRendererUpdate || recordItemSubmissions.length > 0) {
+        if (!skipRendererUpdate || recordUnitSubmissions.length > 0) {
             await this.updateAllChangedRenderers(sourceInformation, actionId);
         }
 
-        if (recordItemSubmissions.length > 0) {
-            let itemsSubmitted = [
-                ...new Set(recordItemSubmissions.map((x) => x.itemNumber)),
+        if (recordUnitSubmissions.length > 0) {
+            let unitsSubmitted = [
+                ...new Set(recordUnitSubmissions.map((x) => x.unitNumber)),
             ];
-            let itemCreditAchieved =
-                await this.document.stateValues.itemCreditAchieved;
+            let unitCreditAchieved =
+                await this.document.stateValues.unitCreditAchieved;
 
             if (event) {
                 if (!event.context) {
                     event.context = {};
                 }
-                event.context.item = itemsSubmitted[0];
-                event.context.itemCreditAchieved =
-                    itemCreditAchieved[itemsSubmitted[0] - 1];
+                event.context.unit = unitsSubmitted[0];
+                event.context.unitCreditAchieved =
+                    unitCreditAchieved[unitsSubmitted[0] - 1];
 
-                // Just in case the code gets changed to that more than item can be submitted at once
+                // Just in case the code gets changed to that more than unit can be submitted at once
                 // record credit achieved for any additional items
-                if (itemsSubmitted.length > 1) {
-                    event.context.additionalItemCreditAchieved = {};
-                    for (let itemNumber of itemsSubmitted) {
-                        event.context.additionalItemCreditAchieved[itemNumber] =
-                            itemCreditAchieved[itemNumber - 1];
+                if (unitsSubmitted.length > 1) {
+                    event.context.additionalUnitCreditAchieved = {};
+                    for (let unitNumber of unitsSubmitted) {
+                        event.context.additionalUnitCreditAchieved[unitNumber] =
+                            unitCreditAchieved[unitNumber - 1];
                     }
                 }
                 event.context.docCreditAchieved =
@@ -11256,7 +11256,7 @@ export default class Core {
         }
 
         let alreadySaved = false;
-        if (recordItemSubmissions.length > 0) {
+        if (recordUnitSubmissions.length > 0) {
             this.saveState(true, true);
             alreadySaved = true;
         }
@@ -11269,9 +11269,9 @@ export default class Core {
             }, 1000);
         }
 
-        // evaluate itemCreditAchieved so that will be fresh
+        // evaluate unitCreditAchieved so that will be fresh
         // and can detect changes when it is marked stale
-        await this.document.stateValues.itemCreditAchieved;
+        await this.document.stateValues.unitCreditAchieved;
 
         if (event) {
             this.requestRecordEvent(event);
@@ -13020,7 +13020,7 @@ export default class Core {
         };
     }
 
-    get scoredItemWeights() {
+    get scoredUnitWeights() {
         return (async () =>
             (await this.document.stateValues.scoredDescendants).map(
                 (x) => x.stateValues.weight,

--- a/packages/doenetml-worker/src/components/Answer.js
+++ b/packages/doenetml-worker/src/components/Answer.js
@@ -2051,20 +2051,20 @@ export default class Answer extends InlineComponent {
             },
         };
 
-        stateVariableDefinitions.inItemNumber = {
+        stateVariableDefinitions.inUnitNumber = {
             returnDependencies: () => ({
                 documentAncestor: {
                     dependencyType: "ancestor",
                     componentType: "document",
-                    variableNames: ["itemNumberByAnswerName"],
+                    variableNames: ["unitNumberByAnswerName"],
                 },
             }),
             definition({ dependencyValues, componentName }) {
                 return {
                     setValue: {
-                        inItemNumber:
+                        inUnitNumber:
                             dependencyValues.documentAncestor.stateValues
-                                .itemNumberByAnswerName[componentName],
+                                .unitNumberByAnswerName[componentName],
                     },
                 };
             },
@@ -2211,7 +2211,7 @@ export default class Answer extends InlineComponent {
 
         instructions.push({
             updateType: "recordItemSubmission",
-            itemNumber: await this.stateValues.inItemNumber,
+            unitNumber: await this.stateValues.inUnitNumber,
             submittedComponent: this.componentName,
             response: currentResponses,
             responseText,

--- a/packages/doenetml-worker/src/components/Answer.js
+++ b/packages/doenetml-worker/src/components/Answer.js
@@ -2051,20 +2051,20 @@ export default class Answer extends InlineComponent {
             },
         };
 
-        stateVariableDefinitions.inUnitNumber = {
+        stateVariableDefinitions.inComponentNumber = {
             returnDependencies: () => ({
                 documentAncestor: {
                     dependencyType: "ancestor",
                     componentType: "document",
-                    variableNames: ["unitNumberByAnswerName"],
+                    variableNames: ["componentNumberByAnswerName"],
                 },
             }),
             definition({ dependencyValues, componentName }) {
                 return {
                     setValue: {
-                        inUnitNumber:
+                        inComponentNumber:
                             dependencyValues.documentAncestor.stateValues
-                                .unitNumberByAnswerName[componentName],
+                                .componentNumberByAnswerName[componentName],
                     },
                 };
             },
@@ -2211,7 +2211,7 @@ export default class Answer extends InlineComponent {
 
         instructions.push({
             updateType: "recordItemSubmission",
-            unitNumber: await this.stateValues.inUnitNumber,
+            componentNumber: await this.stateValues.inComponentNumber,
             submittedComponent: this.componentName,
             response: currentResponses,
             responseText,

--- a/packages/doenetml-worker/src/components/Document.js
+++ b/packages/doenetml-worker/src/components/Document.js
@@ -326,7 +326,7 @@ export default class Document extends BaseComponent {
             },
         };
 
-        stateVariableDefinitions.itemCreditAchieved = {
+        stateVariableDefinitions.unitCreditAchieved = {
             isArray: true,
             returnArraySizeDependencies: () => ({
                 numScoredDescendants: {
@@ -356,18 +356,18 @@ export default class Document extends BaseComponent {
                 return { dependenciesByKey };
             },
             arrayDefinitionByKey({ dependencyValuesByKey, arrayKeys }) {
-                let itemCreditAchieved = {};
+                let unitCreditAchieved = {};
 
                 for (let arrayKey of arrayKeys) {
-                    itemCreditAchieved[arrayKey] =
+                    unitCreditAchieved[arrayKey] =
                         dependencyValuesByKey[arrayKey].creditAchieved;
                 }
 
-                return { setValue: { itemCreditAchieved } };
+                return { setValue: { unitCreditAchieved } };
             },
         };
 
-        stateVariableDefinitions.itemNumberByAnswerName = {
+        stateVariableDefinitions.unitNumberByAnswerName = {
             stateVariablesDeterminingDependencies: ["scoredDescendants"],
             returnDependencies({ stateValues }) {
                 let dependencies = {
@@ -389,18 +389,18 @@ export default class Document extends BaseComponent {
                 return dependencies;
             },
             definition({ dependencyValues, componentInfoObjects }) {
-                let itemNumberByAnswerName = {};
+                let unitNumberByAnswerName = {};
 
                 for (let [
                     ind,
                     component,
                 ] of dependencyValues.scoredDescendants.entries()) {
-                    let itemNumber = ind + 1;
+                    let unitNumber = ind + 1;
                     for (let answerDescendant of dependencyValues[
                         `descendantsOf${ind}`
                     ]) {
-                        itemNumberByAnswerName[answerDescendant.componentName] =
-                            itemNumber;
+                        unitNumberByAnswerName[answerDescendant.componentName] =
+                            unitNumber;
                     }
                     if (
                         componentInfoObjects.isInheritedComponentType({
@@ -408,16 +408,16 @@ export default class Document extends BaseComponent {
                             baseComponentType: "answer",
                         })
                     ) {
-                        itemNumberByAnswerName[component.componentName] =
-                            itemNumber;
+                        unitNumberByAnswerName[component.componentName] =
+                            unitNumber;
                     }
                 }
 
-                return { setValue: { itemNumberByAnswerName } };
+                return { setValue: { unitNumberByAnswerName } };
             },
         };
 
-        stateVariableDefinitions.itemVariantInfo = {
+        stateVariableDefinitions.docVariantInfo = {
             isArray: true,
             returnArraySizeDependencies: () => ({
                 numScoredDescendants: {
@@ -448,14 +448,14 @@ export default class Document extends BaseComponent {
                 return { dependenciesByKey };
             },
             arrayDefinitionByKey({ dependencyValuesByKey, arrayKeys }) {
-                let itemVariantInfo = {};
+                let docVariantInfo = {};
 
                 for (let arrayKey of arrayKeys) {
-                    itemVariantInfo[arrayKey] =
+                    docVariantInfo[arrayKey] =
                         dependencyValuesByKey[arrayKey].generatedVariantInfo;
                 }
 
-                return { setValue: { itemVariantInfo } };
+                return { setValue: { docVariantInfo } };
             },
         };
 
@@ -558,9 +558,9 @@ export default class Document extends BaseComponent {
                     dependencyType: "stateVariable",
                     variableName: "scoredDescendants",
                 },
-                itemCreditAchieved: {
+                unitCreditAchieved: {
                     dependencyType: "stateVariable",
-                    variableName: "itemCreditAchieved",
+                    variableName: "unitCreditAchieved",
                 },
             }),
             definition({ dependencyValues }) {
@@ -573,7 +573,7 @@ export default class Document extends BaseComponent {
                 ] of dependencyValues.scoredDescendants.entries()) {
                     let weight = component.stateValues.weight;
                     creditSum +=
-                        dependencyValues.itemCreditAchieved[ind] * weight;
+                        dependencyValues.unitCreditAchieved[ind] * weight;
                     totalWeight += weight;
                 }
                 let creditAchieved;

--- a/packages/doenetml-worker/src/components/Document.js
+++ b/packages/doenetml-worker/src/components/Document.js
@@ -326,7 +326,7 @@ export default class Document extends BaseComponent {
             },
         };
 
-        stateVariableDefinitions.unitCreditAchieved = {
+        stateVariableDefinitions.componentCreditAchieved = {
             isArray: true,
             returnArraySizeDependencies: () => ({
                 numScoredDescendants: {
@@ -356,18 +356,18 @@ export default class Document extends BaseComponent {
                 return { dependenciesByKey };
             },
             arrayDefinitionByKey({ dependencyValuesByKey, arrayKeys }) {
-                let unitCreditAchieved = {};
+                let componentCreditAchieved = {};
 
                 for (let arrayKey of arrayKeys) {
-                    unitCreditAchieved[arrayKey] =
+                    componentCreditAchieved[arrayKey] =
                         dependencyValuesByKey[arrayKey].creditAchieved;
                 }
 
-                return { setValue: { unitCreditAchieved } };
+                return { setValue: { componentCreditAchieved } };
             },
         };
 
-        stateVariableDefinitions.unitNumberByAnswerName = {
+        stateVariableDefinitions.componentNumberByAnswerName = {
             stateVariablesDeterminingDependencies: ["scoredDescendants"],
             returnDependencies({ stateValues }) {
                 let dependencies = {
@@ -389,18 +389,19 @@ export default class Document extends BaseComponent {
                 return dependencies;
             },
             definition({ dependencyValues, componentInfoObjects }) {
-                let unitNumberByAnswerName = {};
+                let componentNumberByAnswerName = {};
 
                 for (let [
                     ind,
                     component,
                 ] of dependencyValues.scoredDescendants.entries()) {
-                    let unitNumber = ind + 1;
+                    let componentNumber = ind + 1;
                     for (let answerDescendant of dependencyValues[
                         `descendantsOf${ind}`
                     ]) {
-                        unitNumberByAnswerName[answerDescendant.componentName] =
-                            unitNumber;
+                        componentNumberByAnswerName[
+                            answerDescendant.componentName
+                        ] = componentNumber;
                     }
                     if (
                         componentInfoObjects.isInheritedComponentType({
@@ -408,12 +409,12 @@ export default class Document extends BaseComponent {
                             baseComponentType: "answer",
                         })
                     ) {
-                        unitNumberByAnswerName[component.componentName] =
-                            unitNumber;
+                        componentNumberByAnswerName[component.componentName] =
+                            componentNumber;
                     }
                 }
 
-                return { setValue: { unitNumberByAnswerName } };
+                return { setValue: { componentNumberByAnswerName } };
             },
         };
 
@@ -558,9 +559,9 @@ export default class Document extends BaseComponent {
                     dependencyType: "stateVariable",
                     variableName: "scoredDescendants",
                 },
-                unitCreditAchieved: {
+                componentCreditAchieved: {
                     dependencyType: "stateVariable",
-                    variableName: "unitCreditAchieved",
+                    variableName: "componentCreditAchieved",
                 },
             }),
             definition({ dependencyValues }) {
@@ -573,7 +574,7 @@ export default class Document extends BaseComponent {
                 ] of dependencyValues.scoredDescendants.entries()) {
                     let weight = component.stateValues.weight;
                     creditSum +=
-                        dependencyValues.unitCreditAchieved[ind] * weight;
+                        dependencyValues.componentCreditAchieved[ind] * weight;
                     totalWeight += weight;
                 }
                 let creditAchieved;

--- a/packages/doenetml-worker/src/components/Ref.js
+++ b/packages/doenetml-worker/src/components/Ref.js
@@ -28,13 +28,6 @@ export default class Ref extends InlineComponent {
             public: true,
             forRenderer: true,
         };
-        attributes.page = {
-            createPrimitiveOfType: "integer",
-            createStateVariable: "page",
-            defaultValue: null,
-            public: true,
-            forRenderer: true,
-        };
         attributes.createButton = {
             createComponentOfType: "boolean",
             createStateVariable: "createButton",
@@ -109,10 +102,6 @@ export default class Ref extends InlineComponent {
                     dependencyType: "stateVariable",
                     variableName: "uri",
                 },
-                page: {
-                    dependencyType: "stateVariable",
-                    variableName: "page",
-                },
                 targetInactive: {
                     dependencyType: "stateVariable",
                     variableName: "targetInactive",
@@ -123,7 +112,7 @@ export default class Ref extends InlineComponent {
                 },
             }),
             definition: function ({ dependencyValues }) {
-                if (dependencyValues.uri || dependencyValues.page) {
+                if (dependencyValues.uri) {
                     if (dependencyValues.targetAttribute) {
                         let targetName = dependencyValues.targetAttribute;
                         if (targetName[0] !== "/") {
@@ -364,7 +353,6 @@ export default class Ref extends InlineComponent {
         let variantIndex = await this.stateValues.variantIndex;
         let edit = await this.stateValues.edit;
         let hash = await this.stateValues.hash;
-        let page = await this.stateValues.page;
         let uri = await this.stateValues.uri;
         let targetName = await this.stateValues.targetName;
 
@@ -376,7 +364,6 @@ export default class Ref extends InlineComponent {
             variantIndex,
             edit,
             hash,
-            page,
             uri,
             targetName,
             actionId,

--- a/packages/doenetml-worker/src/components/Video.js
+++ b/packages/doenetml-worker/src/components/Video.js
@@ -606,7 +606,7 @@ export default class Video extends BlockComponent {
             sourceInformation,
             skipRendererUpdate,
             overrideReadOnly: true,
-            doNotSave: true, // video actions don't count as changing page state
+            doNotSave: true, // video actions don't count as changing doc state
         });
     }
 

--- a/packages/doenetml-worker/src/test/tagSpecific/document.test.ts
+++ b/packages/doenetml-worker/src/test/tagSpecific/document.test.ts
@@ -80,7 +80,7 @@ describe("Document tag tests", async () => {
         expect(stateVariables["/docCa"].stateValues.value).eq(1);
     });
 
-    it(`unit credit achieved, don't skip weight 0`, async () => {
+    it(`component credit achieved, don't skip weight 0`, async () => {
         let core = await createTestCore({
             doenetML: `
   $_document1.creditAchieved{assignNames="docCa"}

--- a/packages/doenetml-worker/src/test/tagSpecific/document.test.ts
+++ b/packages/doenetml-worker/src/test/tagSpecific/document.test.ts
@@ -80,7 +80,7 @@ describe("Document tag tests", async () => {
         expect(stateVariables["/docCa"].stateValues.value).eq(1);
     });
 
-    it(`item credit achieved, don't skip weight 0`, async () => {
+    it(`unit credit achieved, don't skip weight 0`, async () => {
         let core = await createTestCore({
             doenetML: `
   $_document1.creditAchieved{assignNames="docCa"}
@@ -102,7 +102,7 @@ describe("Document tag tests", async () => {
         let stateVariables = await returnAllStateVariables(core);
         expect(stateVariables["/docCa"].stateValues.value).eq(0);
         expect(
-            stateVariables["/_document1"].stateValues.itemCreditAchieved,
+            stateVariables["/_document1"].stateValues.unitCreditAchieved,
         ).eqls([0, 0, 0, 0, 0]);
 
         let mathInputXName =
@@ -127,7 +127,7 @@ describe("Document tag tests", async () => {
         expect(stateVariables["/x"].stateValues.creditAchieved).eq(1);
         expect(stateVariables["/docCa"].stateValues.value).eq(1 / 3);
         expect(
-            stateVariables["/_document1"].stateValues.itemCreditAchieved,
+            stateVariables["/_document1"].stateValues.unitCreditAchieved,
         ).eqls([1, 0, 0, 0, 0]);
 
         await updateMathInputValue({
@@ -141,7 +141,7 @@ describe("Document tag tests", async () => {
         expect(stateVariables["/a"].stateValues.creditAchieved).eq(1);
         expect(stateVariables["/docCa"].stateValues.value).eq(1 / 3);
         expect(
-            stateVariables["/_document1"].stateValues.itemCreditAchieved,
+            stateVariables["/_document1"].stateValues.unitCreditAchieved,
         ).eqls([1, 1, 0, 0, 0]);
 
         await updateMathInputValue({
@@ -155,7 +155,7 @@ describe("Document tag tests", async () => {
         expect(stateVariables["/y"].stateValues.creditAchieved).eq(1);
         expect(stateVariables["/docCa"].stateValues.value).eq(2 / 3);
         expect(
-            stateVariables["/_document1"].stateValues.itemCreditAchieved,
+            stateVariables["/_document1"].stateValues.unitCreditAchieved,
         ).eqls([1, 1, 1, 0, 0]);
 
         await updateMathInputValue({
@@ -169,7 +169,7 @@ describe("Document tag tests", async () => {
         expect(stateVariables["/b"].stateValues.creditAchieved).eq(1);
         expect(stateVariables["/docCa"].stateValues.value).eq(2 / 3);
         expect(
-            stateVariables["/_document1"].stateValues.itemCreditAchieved,
+            stateVariables["/_document1"].stateValues.unitCreditAchieved,
         ).eqls([1, 1, 1, 1, 0]);
 
         await updateMathInputValue({
@@ -183,7 +183,7 @@ describe("Document tag tests", async () => {
         expect(stateVariables["/z"].stateValues.creditAchieved).eq(1);
         expect(stateVariables["/docCa"].stateValues.value).eq(1);
         expect(
-            stateVariables["/_document1"].stateValues.itemCreditAchieved,
+            stateVariables["/_document1"].stateValues.unitCreditAchieved,
         ).eqls([1, 1, 1, 1, 1]);
     });
 

--- a/packages/doenetml-worker/src/test/tagSpecific/document.test.ts
+++ b/packages/doenetml-worker/src/test/tagSpecific/document.test.ts
@@ -102,7 +102,7 @@ describe("Document tag tests", async () => {
         let stateVariables = await returnAllStateVariables(core);
         expect(stateVariables["/docCa"].stateValues.value).eq(0);
         expect(
-            stateVariables["/_document1"].stateValues.unitCreditAchieved,
+            stateVariables["/_document1"].stateValues.componentCreditAchieved,
         ).eqls([0, 0, 0, 0, 0]);
 
         let mathInputXName =
@@ -127,7 +127,7 @@ describe("Document tag tests", async () => {
         expect(stateVariables["/x"].stateValues.creditAchieved).eq(1);
         expect(stateVariables["/docCa"].stateValues.value).eq(1 / 3);
         expect(
-            stateVariables["/_document1"].stateValues.unitCreditAchieved,
+            stateVariables["/_document1"].stateValues.componentCreditAchieved,
         ).eqls([1, 0, 0, 0, 0]);
 
         await updateMathInputValue({
@@ -141,7 +141,7 @@ describe("Document tag tests", async () => {
         expect(stateVariables["/a"].stateValues.creditAchieved).eq(1);
         expect(stateVariables["/docCa"].stateValues.value).eq(1 / 3);
         expect(
-            stateVariables["/_document1"].stateValues.unitCreditAchieved,
+            stateVariables["/_document1"].stateValues.componentCreditAchieved,
         ).eqls([1, 1, 0, 0, 0]);
 
         await updateMathInputValue({
@@ -155,7 +155,7 @@ describe("Document tag tests", async () => {
         expect(stateVariables["/y"].stateValues.creditAchieved).eq(1);
         expect(stateVariables["/docCa"].stateValues.value).eq(2 / 3);
         expect(
-            stateVariables["/_document1"].stateValues.unitCreditAchieved,
+            stateVariables["/_document1"].stateValues.componentCreditAchieved,
         ).eqls([1, 1, 1, 0, 0]);
 
         await updateMathInputValue({
@@ -169,7 +169,7 @@ describe("Document tag tests", async () => {
         expect(stateVariables["/b"].stateValues.creditAchieved).eq(1);
         expect(stateVariables["/docCa"].stateValues.value).eq(2 / 3);
         expect(
-            stateVariables["/_document1"].stateValues.unitCreditAchieved,
+            stateVariables["/_document1"].stateValues.componentCreditAchieved,
         ).eqls([1, 1, 1, 1, 0]);
 
         await updateMathInputValue({
@@ -183,7 +183,7 @@ describe("Document tag tests", async () => {
         expect(stateVariables["/z"].stateValues.creditAchieved).eq(1);
         expect(stateVariables["/docCa"].stateValues.value).eq(1);
         expect(
-            stateVariables["/_document1"].stateValues.unitCreditAchieved,
+            stateVariables["/_document1"].stateValues.componentCreditAchieved,
         ).eqls([1, 1, 1, 1, 1]);
     });
 

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.7.0-alpha31",
+    "version": "0.7.0-alpha32",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -286,7 +286,6 @@ export function DocViewer({
 
     const postfixForWindowFunctions =
         prefixForIds
-            .replace(/^page/, "")
             .replaceAll("/", "")
             .replaceAll("\\", "")
             .replaceAll("-", "_") || "1";
@@ -611,7 +610,6 @@ export function DocViewer({
             variantIndex,
             edit,
             hash,
-            page,
             uri,
             targetName,
             actionId,
@@ -623,7 +621,6 @@ export function DocViewer({
             variantIndex?: number;
             edit?: boolean;
             hash?: string;
-            page?: number;
             uri?: string;
             targetName?: string;
             actionId?: string;
@@ -638,7 +635,6 @@ export function DocViewer({
                     variantIndex,
                     edit,
                     hash,
-                    page,
                     givenUri: uri,
                     targetName,
                     linkSettings,
@@ -1564,7 +1560,6 @@ export function getURLFromRef({
     variantIndex,
     edit,
     hash,
-    page,
     givenUri,
     targetName = "",
     linkSettings,
@@ -1576,7 +1571,6 @@ export function getURLFromRef({
     variantIndex?: number;
     edit?: boolean;
     hash?: string;
-    page?: number;
     givenUri?: string;
     targetName?: string;
     linkSettings: Record<string, any>;
@@ -1639,12 +1633,7 @@ export function getURLFromRef({
         if (hash) {
             url += hash;
         } else {
-            if (page) {
-                url += `#page${page}`;
-                if (targetName) {
-                    url += cesc(targetName);
-                }
-            } else if (targetName) {
+            if (targetName) {
                 url += "#" + cesc(targetName);
             }
         }
@@ -1661,13 +1650,9 @@ export function getURLFromRef({
     } else {
         url = search;
 
-        if (page) {
-            url += `#page${page}`;
-        } else {
-            let firstSlash = id.indexOf("\\/");
-            let prefix = id.substring(0, firstSlash);
-            url += "#" + prefix;
-        }
+        let firstSlash = id.indexOf("\\/");
+        let prefix = id.substring(0, firstSlash);
+        url += "#" + prefix;
         url += cesc(targetName);
         targetForATag = null;
         haveValidTarget = true;

--- a/packages/doenetml/src/Viewer/renderers/ref.jsx
+++ b/packages/doenetml/src/Viewer/renderers/ref.jsx
@@ -68,7 +68,6 @@ export default React.memo(function Ref(props) {
         variantIndex: SVs.variantIndex,
         edit: SVs.edit,
         hash: SVs.hash,
-        page: SVs.page,
         givenUri: SVs.uri,
         targetName: SVs.targetName,
         linkSettings,

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.7.0-alpha31",
+    "version": "0.7.0-alpha32",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/test-cypress/cypress/e2e/tagSpecific/codeeditor.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/codeeditor.cy.js
@@ -1306,6 +1306,9 @@ describe("Code Editor Tag Tests", function () {
             "text",
             "<p>Hello!</p>",
         );
+
+        cy.wait(500);
+
         cy.get(`[data-test="Viewer Update Button"]`).click();
 
         cy.get(cesc2("#/_p1")).should("have.text", "<p>Hello!</p>");
@@ -1400,6 +1403,9 @@ describe("Code Editor Tag Tests", function () {
         );
 
         cy.get(cesc("#\\/editor") + " .cm-content").type("{end}{enter}");
+
+        cy.wait(500);
+
         cy.get(`[data-test="Viewer Update Button"]`).click();
 
         cy.get(cesc2("#/_p1")).should("have.text", "<p>Hello!</p>\n");
@@ -1470,6 +1476,8 @@ describe("Code Editor Tag Tests", function () {
             "<p>Apple</p>",
         );
         cy.get(cesc("#\\/editor1") + " .cm-content").type("{end}{enter}");
+
+        cy.wait(500);
 
         cy.get(
             cesc2("#/editor1-viewer-controls") +

--- a/packages/test-cypress/cypress/e2e/tagSpecific/copy.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/copy.cy.js
@@ -1091,17 +1091,17 @@ describe("Copy Tag Tests", function () {
             "Two variants from copied document",
         ); // to wait for page to load
 
-        cy.get(cesc("#\\/thedoc")).should("contain.text", "first");
-
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
 
             expect(
                 stateVariables["/thedoc"].sharedParameters.allPossibleVariants,
             ).eqls(["first", "last"]);
-            expect(stateVariables["/thedoc"].sharedParameters.variantName).eq(
-                "first",
-            );
+
+            const variantOne =
+                stateVariables["/thedoc"].sharedParameters.variantName;
+            const variantTwo = variantOne === "first" ? "last" : "first";
+
             expect(
                 stateVariables["/_document1"].sharedParameters
                     .allPossibleVariants,
@@ -1109,36 +1109,39 @@ describe("Copy Tag Tests", function () {
             expect(
                 stateVariables["/_document1"].sharedParameters.variantName,
             ).eq("a");
-        });
 
-        cy.window().then(async (win) => {
-            win.postMessage(
-                {
-                    doenetML,
-                    requestedVariantIndex: 2,
-                },
-                "*",
-            );
-        });
+            cy.get(cesc("#\\/thedoc")).should("contain.text", variantOne);
 
-        cy.get(cesc("#\\/thedoc")).should("contain.text", "last");
+            cy.window().then(async (win) => {
+                win.postMessage(
+                    {
+                        doenetML,
+                        requestedVariantIndex: 2,
+                    },
+                    "*",
+                );
+            });
 
-        cy.window().then(async (win) => {
-            let stateVariables = await win.returnAllStateVariables1();
+            cy.get(cesc("#\\/thedoc")).should("contain.text", variantTwo);
 
-            expect(
-                stateVariables["/thedoc"].sharedParameters.allPossibleVariants,
-            ).eqls(["first", "last"]);
-            expect(stateVariables["/thedoc"].sharedParameters.variantName).eq(
-                "last",
-            );
-            expect(
-                stateVariables["/_document1"].sharedParameters
-                    .allPossibleVariants,
-            ).eqls(["a", "b"]);
-            expect(
-                stateVariables["/_document1"].sharedParameters.variantName,
-            ).eq("b");
+            cy.window().then(async (win) => {
+                let stateVariables = await win.returnAllStateVariables1();
+
+                expect(
+                    stateVariables["/thedoc"].sharedParameters
+                        .allPossibleVariants,
+                ).eqls(["first", "last"]);
+                expect(
+                    stateVariables["/thedoc"].sharedParameters.variantName,
+                ).eq(variantTwo);
+                expect(
+                    stateVariables["/_document1"].sharedParameters
+                        .allPossibleVariants,
+                ).eqls(["a", "b"]);
+                expect(
+                    stateVariables["/_document1"].sharedParameters.variantName,
+                ).eq("b");
+            });
         });
     });
 

--- a/packages/test-cypress/cypress/e2e/tagSpecific/paginator.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/paginator.cy.js
@@ -1170,12 +1170,16 @@ describe("Paginator Tag Tests", function () {
         cy.get(cesc2("#/ca")).should("have.text", "0");
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
+
+            let correctSound =
+                stateVariables["/problem1/sound"].stateValues.value;
+
             choices =
                 stateVariables["/problem1/_choiceinput1"].stateValues
                     .choiceTexts;
-            let mouseInd = choices.indexOf("squeak") + 1;
+            let correctInd = choices.indexOf(correctSound) + 1;
             cy.get(
-                cesc2(`#/problem1/_choiceinput1_choice${mouseInd}_input`),
+                cesc2(`#/problem1/_choiceinput1_choice${correctInd}_input`),
             ).click();
         });
 
@@ -1335,13 +1339,21 @@ describe("Paginator Tag Tests", function () {
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
+
+                let correctSound =
+                    stateVariables["/problem1/sound"].stateValues.value;
+                let incorrectSound =
+                    correctSound === "woof" ? "squeak" : "woof";
+
                 let choiceTexts =
                     stateVariables["/problem1/_choiceinput1"].stateValues
                         .choiceTexts;
                 expect(choiceTexts).eqls(choices);
-                let dogInd = choices.indexOf("woof") + 1;
+                let incorrectInd = choices.indexOf(incorrectSound) + 1;
                 cy.get(
-                    cesc2(`#/problem1/_choiceinput1_choice${dogInd}_input`),
+                    cesc2(
+                        `#/problem1/_choiceinput1_choice${incorrectInd}_input`,
+                    ),
                 ).click();
             });
 
@@ -1353,13 +1365,16 @@ describe("Paginator Tag Tests", function () {
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
+                let correctSound =
+                    stateVariables["/problem1/sound"].stateValues.value;
+
                 let choiceTexts =
                     stateVariables["/problem1/_choiceinput1"].stateValues
                         .choiceTexts;
                 expect(choiceTexts).eqls(choices);
-                let mouseInd = choices.indexOf("squeak") + 1;
+                let correctInd = choices.indexOf(correctSound) + 1;
                 cy.get(
-                    cesc2(`#/problem1/_choiceinput1_choice${mouseInd}_input`),
+                    cesc2(`#/problem1/_choiceinput1_choice${correctInd}_input`),
                 ).click();
             });
 
@@ -1418,13 +1433,17 @@ describe("Paginator Tag Tests", function () {
         cy.get(cesc2("#/ca")).should("have.text", "0");
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
+
+            let correctSound =
+                stateVariables["/problem1/sound"].stateValues.value;
+
             let choices = [
                 ...stateVariables["/problem1/_choiceinput1"].stateValues
                     .choiceTexts,
             ];
-            let mouseInd = choices.indexOf("squeak") + 1;
+            let correctInd = choices.indexOf(correctSound) + 1;
             cy.get(
-                cesc2(`#/problem1/_choiceinput1_choice${mouseInd}_input`),
+                cesc2(`#/problem1/_choiceinput1_choice${correctInd}_input`),
             ).click();
         });
 

--- a/packages/test-cypress/cypress/e2e/tagSpecific/problem.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/problem.cy.js
@@ -1439,80 +1439,101 @@ describe("Problem Tag Tests", function () {
 
         cy.get(cesc("#\\/_text1")).should("have.text", "a"); //wait for page to load
 
-        cy.get(cesc2("#/ca")).should("have.text", "0");
-
-        cy.get(cesc2("#/problem1/input1_input")).type("banana{enter}");
-        cy.get(cesc2("#/problem1/input1_incorrect")).should("be.visible");
-        cy.get(cesc2("#/ca")).should("have.text", "0");
-
-        cy.get(cesc2("#/problem1/input2_submit")).should("be.visible");
-
-        cy.wait(2000); // wait to make sure debounce save happened
-
-        cy.reload();
-
         cy.window().then(async (win) => {
-            win.postMessage(
-                {
-                    doenetML,
-                },
-                "*",
+            let stateVariables = await win.returnAllStateVariables1();
+
+            let selectedFruitName =
+                stateVariables["/problem1/fruit/name"].stateValues.value;
+            let otherFruitName =
+                selectedFruitName === "apple" ? "banana" : "apple";
+            let selectedFruitColor =
+                stateVariables["/problem1/fruit/color"].stateValues.value;
+            let otherFruitColor =
+                selectedFruitColor === "red" ? "yellow" : "red";
+
+            cy.get(cesc2("#/ca")).should("have.text", "0");
+
+            cy.get(cesc2("#/problem1/input1_input")).type(
+                `${otherFruitName}{enter}`,
             );
+            cy.get(cesc2("#/problem1/input1_incorrect")).should("be.visible");
+            cy.get(cesc2("#/ca")).should("have.text", "0");
+
+            cy.get(cesc2("#/problem1/input2_submit")).should("be.visible");
+
+            cy.wait(2000); // wait to make sure debounce save happened
+
+            cy.reload();
+
+            cy.window().then(async (win) => {
+                win.postMessage(
+                    {
+                        doenetML,
+                    },
+                    "*",
+                );
+            });
+            cy.get(cesc("#\\/_text1")).should("have.text", "a"); //wait for page to load
+
+            cy.get(cesc2("#/problem1/input1_incorrect")).should("be.visible");
+            cy.get(cesc2("#/problem1/input2_submit")).should("be.visible");
+            cy.get(cesc2("#/ca")).should("have.text", "0");
+
+            cy.get(cesc2("#/problem1/input1_input"))
+                .clear()
+                .type(selectedFruitName);
+            cy.get(cesc2("#/problem1/input1_submit")).click();
+            cy.get(cesc2("#/problem1/input1_correct")).should("be.visible");
+            cy.get(cesc2("#/ca")).should("have.text", "0.5");
+
+            cy.get(cesc2("#/problem1/input2_input"))
+                .clear()
+                .type(`${otherFruitColor}{enter}`);
+            cy.get(cesc2("#/problem1/input2_incorrect")).should("be.visible");
+            cy.get(cesc2("#/ca")).should("have.text", "0.5");
+
+            cy.wait(2000); // wait to make sure debounce save happened
+
+            cy.reload();
+
+            cy.window().then(async (win) => {
+                win.postMessage(
+                    {
+                        doenetML,
+                    },
+                    "*",
+                );
+            });
+            cy.get(cesc("#\\/_text1")).should("have.text", "a"); //wait for page to load
+
+            cy.get(cesc2("#/problem1/input1_correct")).should("be.visible");
+            cy.get(cesc2("#/problem1/input2_incorrect")).should("be.visible");
+            cy.get(cesc2("#/ca")).should("have.text", "0.5");
+
+            cy.get(cesc2("#/problem1/input2_input"))
+                .clear()
+                .type(selectedFruitColor);
+            cy.get(cesc2("#/problem1/input2_submit")).click();
+            cy.get(cesc2("#/problem1/input2_correct")).should("be.visible");
+            cy.get(cesc2("#/ca")).should("have.text", "1");
+
+            cy.wait(2000); // wait to make sure debounce save happened
+
+            cy.reload();
+
+            cy.window().then(async (win) => {
+                win.postMessage(
+                    {
+                        doenetML,
+                    },
+                    "*",
+                );
+            });
+            cy.get(cesc("#\\/_text1")).should("have.text", "a"); //wait for page to load
+
+            cy.get(cesc2("#/problem1/input1_correct")).should("be.visible");
+            cy.get(cesc2("#/problem1/input2_correct")).should("be.visible");
+            cy.get(cesc2("#/ca")).should("have.text", "1");
         });
-        cy.get(cesc("#\\/_text1")).should("have.text", "a"); //wait for page to load
-
-        cy.get(cesc2("#/problem1/input1_incorrect")).should("be.visible");
-        cy.get(cesc2("#/problem1/input2_submit")).should("be.visible");
-        cy.get(cesc2("#/ca")).should("have.text", "0");
-
-        cy.get(cesc2("#/problem1/input1_input")).clear().type("apple");
-        cy.get(cesc2("#/problem1/input1_submit")).click();
-        cy.get(cesc2("#/problem1/input1_correct")).should("be.visible");
-        cy.get(cesc2("#/ca")).should("have.text", "0.5");
-
-        cy.get(cesc2("#/problem1/input2_input")).clear().type("yellow{enter}");
-        cy.get(cesc2("#/problem1/input2_incorrect")).should("be.visible");
-        cy.get(cesc2("#/ca")).should("have.text", "0.5");
-
-        cy.wait(2000); // wait to make sure debounce save happened
-
-        cy.reload();
-
-        cy.window().then(async (win) => {
-            win.postMessage(
-                {
-                    doenetML,
-                },
-                "*",
-            );
-        });
-        cy.get(cesc("#\\/_text1")).should("have.text", "a"); //wait for page to load
-
-        cy.get(cesc2("#/problem1/input1_correct")).should("be.visible");
-        cy.get(cesc2("#/problem1/input2_incorrect")).should("be.visible");
-        cy.get(cesc2("#/ca")).should("have.text", "0.5");
-
-        cy.get(cesc2("#/problem1/input2_input")).clear().type("red");
-        cy.get(cesc2("#/problem1/input2_submit")).click();
-        cy.get(cesc2("#/problem1/input2_correct")).should("be.visible");
-        cy.get(cesc2("#/ca")).should("have.text", "1");
-
-        cy.wait(2000); // wait to make sure debounce save happened
-
-        cy.reload();
-
-        cy.window().then(async (win) => {
-            win.postMessage(
-                {
-                    doenetML,
-                },
-                "*",
-            );
-        });
-        cy.get(cesc("#\\/_text1")).should("have.text", "a"); //wait for page to load
-
-        cy.get(cesc2("#/problem1/input1_correct")).should("be.visible");
-        cy.get(cesc2("#/problem1/input2_correct")).should("be.visible");
-        cy.get(cesc2("#/ca")).should("have.text", "1");
     });
 });


### PR DESCRIPTION
DoenetML had this concept of "scored items", which were sectioning components with `aggregateScores` set and any answer blanks not in such a sectioning component. This PR changes their name to "scored components", as the better reflects the concept and facilitates the use of the term "item" to refer the DoenetML document itself when it is part of a problem set.