### PR TITLE
add showAnswerResponseMenu and answerResponseCounts attributes

### DIFF
--- a/packages/doenetml-iframe/src/iframe-editor-index.ts
+++ b/packages/doenetml-iframe/src/iframe-editor-index.ts
@@ -11,7 +11,21 @@ interface Window {
     ) => void;
 }
 
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener("DOMContentLoaded", async () => {
+    let pause100 = function () {
+        return new Promise((resolve, _reject) => {
+            setTimeout(resolve, 100);
+        });
+    };
+
+    // wait up to a second window.renderDoenetViewerToContainer to be found
+    for (let i = 0; i < 10; i++) {
+        if (typeof window.renderDoenetViewerToContainer === "function") {
+            break;
+        }
+        await pause100();
+    }
+
     if (typeof window.renderDoenetEditorToContainer !== "function") {
         return messageParentFromEditor({
             error: "Invalid DoenetML version or DoenetML package not found",

--- a/packages/doenetml-iframe/src/iframe-viewer-index.ts
+++ b/packages/doenetml-iframe/src/iframe-viewer-index.ts
@@ -11,7 +11,21 @@ interface Window {
     ) => void;
 }
 
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener("DOMContentLoaded", async () => {
+    let pause100 = function () {
+        return new Promise((resolve, _reject) => {
+            setTimeout(resolve, 100);
+        });
+    };
+
+    // wait up to a second window.renderDoenetViewerToContainer to be found
+    for (let i = 0; i < 10; i++) {
+        if (typeof window.renderDoenetViewerToContainer === "function") {
+            break;
+        }
+        await pause100();
+    }
+
     if (typeof window.renderDoenetViewerToContainer !== "function") {
         return messageParentFromViewer({
             error: "Invalid DoenetML version or DoenetML package not found",

--- a/packages/doenetml-iframe/src/iframe-viewer-index.ts
+++ b/packages/doenetml-iframe/src/iframe-viewer-index.ts
@@ -78,6 +78,8 @@ window.addEventListener("message", (e) => {
         !e.data.subject?.endsWith("response")
     ) {
         window.parent.postMessage(e.data);
+    } else if (e.data.subject === "requestAnswerResponses") {
+        window.parent.postMessage(e.data);
     }
 });
 

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -32,7 +32,7 @@ export function EditorViewer({
     prefixForIds = "",
     linkSettings,
     darkMode = "light",
-    showAnswerTitles,
+    showAnswerResponseMenu,
     width = "100%",
     height = "500px",
     backgroundColor = "doenet.mainGray",
@@ -56,7 +56,7 @@ export function EditorViewer({
     prefixForIds?: string;
     linkSettings?: { viewURL: string; editURL: string };
     darkMode?: "dark" | "light";
-    showAnswerTitles?: boolean;
+    showAnswerResponseMenu?: boolean;
     width?: string;
     height?: string;
     backgroundColor?: string;
@@ -538,7 +538,7 @@ export function EditorViewer({
                             scrollableContainer.current ?? undefined
                         }
                         darkMode={darkMode}
-                        showAnswerTitles={showAnswerTitles}
+                        showAnswerResponseMenu={showAnswerResponseMenu}
                     />
                 </Box>
             </GridItem>

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -32,7 +32,8 @@ export function EditorViewer({
     prefixForIds = "",
     linkSettings,
     darkMode = "light",
-    showAnswerResponseMenu,
+    showAnswerResponseMenu = false,
+    answerResponseCounts = {},
     width = "100%",
     height = "500px",
     backgroundColor = "doenet.mainGray",
@@ -57,6 +58,7 @@ export function EditorViewer({
     linkSettings?: { viewURL: string; editURL: string };
     darkMode?: "dark" | "light";
     showAnswerResponseMenu?: boolean;
+    answerResponseCounts?: Record<string, number>;
     width?: string;
     height?: string;
     backgroundColor?: string;
@@ -539,6 +541,7 @@ export function EditorViewer({
                         }
                         darkMode={darkMode}
                         showAnswerResponseMenu={showAnswerResponseMenu}
+                        answerResponseCounts={answerResponseCounts}
                     />
                 </Box>
             </GridItem>

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -58,7 +58,8 @@ export function DocViewer({
     linkSettings = { viewURL: "/portfolioviewer", editURL: "/publiceditor" },
     scrollableContainer,
     darkMode,
-    showAnswerResponseMenu,
+    showAnswerResponseMenu = false,
+    answerResponseCounts = {},
     initializeCounters = {},
 }: {
     doenetML: string;
@@ -88,6 +89,7 @@ export function DocViewer({
     scrollableContainer?: HTMLDivElement | Window;
     darkMode?: "dark" | "light";
     showAnswerResponseMenu?: boolean;
+    answerResponseCounts?: Record<string, number>;
     initializeCounters?: Record<string, number>;
 }) {
     const updateRendererSVsWithRecoil = useRecoilCallback(
@@ -282,6 +284,7 @@ export function DocViewer({
         scrollableContainer,
         darkMode,
         showAnswerResponseMenu,
+        answerResponseCounts,
     };
 
     const postfixForWindowFunctions =

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -58,7 +58,7 @@ export function DocViewer({
     linkSettings = { viewURL: "/portfolioviewer", editURL: "/publiceditor" },
     scrollableContainer,
     darkMode,
-    showAnswerTitles,
+    showAnswerResponseMenu,
     initializeCounters = {},
 }: {
     doenetML: string;
@@ -87,7 +87,7 @@ export function DocViewer({
     linkSettings?: { viewURL: string; editURL: string };
     scrollableContainer?: HTMLDivElement | Window;
     darkMode?: "dark" | "light";
-    showAnswerTitles?: boolean;
+    showAnswerResponseMenu?: boolean;
     initializeCounters?: Record<string, number>;
 }) {
     const updateRendererSVsWithRecoil = useRecoilCallback(
@@ -281,7 +281,7 @@ export function DocViewer({
         linkSettings,
         scrollableContainer,
         darkMode,
-        showAnswerTitles,
+        showAnswerResponseMenu,
     };
 
     const postfixForWindowFunctions =
@@ -958,6 +958,8 @@ export function DocViewer({
                         rendererClasses: newRendererClasses,
                         flags,
                         coreId: coreId.current,
+                        docId,
+                        activityId,
                         callAction,
                         navigate,
                         location,

--- a/packages/doenetml/src/Viewer/renderers/answer.jsx
+++ b/packages/doenetml/src/Viewer/renderers/answer.jsx
@@ -34,7 +34,8 @@ export default React.memo(function Answer(props) {
     let { name, id, SVs, docId, activityId, actions, children, callAction } =
         useDoenetRenderer(props);
 
-    const { showAnswerResponseMenu } = useContext(DocContext) || {};
+    const { showAnswerResponseMenu, answerResponseCounts } =
+        useContext(DocContext) || {};
 
     if (SVs.hidden) {
         return null;
@@ -75,9 +76,10 @@ export default React.memo(function Answer(props) {
     if (showAnswerResponseMenu) {
         answerResponseMenu = (
             <AnswerResponseMenu
-                answerName={name}
+                answerId={name}
                 docId={docId}
                 activityId={activityId}
+                numResponses={answerResponseCounts?.[name]}
             />
         );
     }

--- a/packages/doenetml/src/Viewer/renderers/answer.jsx
+++ b/packages/doenetml/src/Viewer/renderers/answer.jsx
@@ -9,6 +9,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import styled from "styled-components";
 import { DocContext } from "../DocViewer";
+import { AnswerResponseMenu } from "./utils/AnswerResponseMenu";
 
 // Moved most of checkWorkStyle styling into Button
 const Button = styled.button`
@@ -30,10 +31,10 @@ const Button = styled.button`
 `;
 
 export default React.memo(function Answer(props) {
-    let { name, id, SVs, actions, children, callAction } =
+    let { name, id, SVs, docId, activityId, actions, children, callAction } =
         useDoenetRenderer(props);
 
-    const { showAnswerTitles } = useContext(DocContext) || {};
+    const { showAnswerResponseMenu } = useContext(DocContext) || {};
 
     if (SVs.hidden) {
         return null;
@@ -67,6 +68,17 @@ export default React.memo(function Answer(props) {
                 inputChildNames.includes(
                     child.props.componentInstructions.componentName,
                 ),
+        );
+    }
+
+    let answerResponseMenu = null;
+    if (showAnswerResponseMenu) {
+        answerResponseMenu = (
+            <AnswerResponseMenu
+                answerName={name}
+                docId={docId}
+                activityId={activityId}
+            />
         );
     }
 
@@ -113,14 +125,8 @@ export default React.memo(function Answer(props) {
                         submitAnswer();
                     }
                 }}
-                title={showAnswerTitles ? `Answer name: ${name}` : null}
             >
                 <FontAwesomeIcon
-                    style={
-                        {
-                            /*marginRight: "4px", paddingLeft: "2px"*/
-                        }
-                    }
                     icon={faLevelDownAlt}
                     transform={{ rotate: 90 }}
                 />
@@ -218,6 +224,7 @@ export default React.memo(function Answer(props) {
                 <a name={id} />
                 {inputChildrenToRender}
                 {checkworkComponent}
+                {answerResponseMenu}
             </span>
         );
     } else {
@@ -225,6 +232,7 @@ export default React.memo(function Answer(props) {
             <span id={id} style={{ marginBottom: "4px" }}>
                 <a name={id} />
                 {inputChildrenToRender}
+                {answerResponseMenu}
             </span>
         );
     }

--- a/packages/doenetml/src/Viewer/renderers/booleanInput.jsx
+++ b/packages/doenetml/src/Viewer/renderers/booleanInput.jsx
@@ -17,7 +17,6 @@ import { MathJax } from "better-react-mathjax";
 import { BoardContext } from "./graph";
 import me from "math-expressions";
 import { getPositionFromAnchorByCoordinate } from "./utils/graph";
-import { DocContext } from "../DocViewer";
 
 // Moved most of checkWorkStyle styling into Button
 const Button = styled.button`
@@ -64,8 +63,6 @@ export default React.memo(function BooleanInput(props) {
     let anchorRel = useRef(null);
 
     const board = useContext(BoardContext);
-
-    const { showAnswerTitles } = useContext(DocContext) || {};
 
     let pointerAtDown = useRef(false);
     let pointAtDown = useRef(false);
@@ -482,7 +479,6 @@ export default React.memo(function BooleanInput(props) {
 
     //Assume we don't have a check work button
     let checkWorkButton = null;
-    let icon = props.icon;
     if (SVs.includeCheckWork && !SVs.suppressCheckwork) {
         let validationState = "unvalidated";
         if (SVs.valueHasBeenValidated) {
@@ -515,11 +511,6 @@ export default React.memo(function BooleanInput(props) {
                             });
                         }
                     }}
-                    title={
-                        showAnswerTitles
-                            ? `Answer name: ${actions.submitAnswer.componentName}`
-                            : null
-                    }
                 >
                     <FontAwesomeIcon
                         style={
@@ -664,9 +655,6 @@ export default React.memo(function BooleanInput(props) {
                 )}
             </label>
         );
-        {
-            checkWorkButton;
-        }
     }
 
     return (

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.jsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.jsx
@@ -12,7 +12,6 @@ import { rendererState } from "../useDoenetRenderer";
 import { useSetRecoilState } from "recoil";
 import styled from "styled-components";
 import "./choiceInput.css";
-import { DocContext } from "../DocViewer";
 
 // Moved most of checkWorkStyle styling into Button
 const Button = styled.button`
@@ -58,8 +57,6 @@ export default React.memo(function ChoiceInput(props) {
     const setRendererState = useSetRecoilState(rendererState(rendererName));
 
     let selectedIndicesWhenSetState = useRef(null);
-
-    const { showAnswerTitles } = useContext(DocContext) || {};
 
     if (
         !ignoreUpdate &&
@@ -203,11 +200,6 @@ export default React.memo(function ChoiceInput(props) {
                                 });
                             }
                         }}
-                        title={
-                            showAnswerTitles
-                                ? `Answer name: ${actions.submitAnswer.componentName}`
-                                : null
-                        }
                     >
                         <FontAwesomeIcon
                             style={
@@ -411,11 +403,6 @@ export default React.memo(function ChoiceInput(props) {
                                 });
                             }
                         }}
-                        title={
-                            showAnswerTitles
-                                ? `Answer name: ${actions.submitAnswer.componentName}`
-                                : null
-                        }
                     >
                         <FontAwesomeIcon
                             style={

--- a/packages/doenetml/src/Viewer/renderers/mathInput.jsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.jsx
@@ -21,7 +21,6 @@ import { MathJax } from "better-react-mathjax";
 import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import { rendererState } from "../useDoenetRenderer";
 import "./mathInput.css";
-import { DocContext } from "../DocViewer";
 
 // Moved most of checkWorkStyle styling into Button
 const Button = styled.button`
@@ -68,8 +67,6 @@ export default function MathInput(props) {
     const keyboardCausedBlur = useRef(false);
 
     const setRendererState = useSetRecoilState(rendererState(rendererName));
-
-    const { showAnswerTitles } = useContext(DocContext) || {};
 
     let rendererValue = useRef(SVs.rawRendererValue);
 
@@ -295,11 +292,6 @@ export default function MathInput(props) {
                             });
                         }
                     }}
-                    title={
-                        showAnswerTitles
-                            ? `Answer name: ${actions.submitAnswer.componentName}`
-                            : null
-                    }
                 >
                     <FontAwesomeIcon
                         icon={faLevelDownAlt}

--- a/packages/doenetml/src/Viewer/renderers/matrixInput.jsx
+++ b/packages/doenetml/src/Viewer/renderers/matrixInput.jsx
@@ -14,7 +14,6 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import styled from "styled-components";
 import "./mathInput.css";
-import { DocContext } from "../DocViewer";
 
 const Matrix = styled.div`
     position: relative;
@@ -74,8 +73,6 @@ export default React.memo(function MatrixInput(props) {
         useDoenetRenderer(props);
 
     let validationState = useRef(null);
-
-    const { showAnswerTitles } = useContext(DocContext) || {};
 
     function updateValidationState() {
         validationState.current = "unvalidated";
@@ -145,11 +142,6 @@ export default React.memo(function MatrixInput(props) {
                             });
                         }
                     }}
-                    title={
-                        showAnswerTitles
-                            ? `Answer name: ${actions.submitAnswer.componentName}`
-                            : null
-                    }
                 >
                     <FontAwesomeIcon
                         icon={faLevelDownAlt}

--- a/packages/doenetml/src/Viewer/renderers/section.jsx
+++ b/packages/doenetml/src/Viewer/renderers/section.jsx
@@ -13,7 +13,6 @@ import { faCaretDown as twirlIsOpen } from "@fortawesome/free-solid-svg-icons";
 import useDoenetRenderer from "../useDoenetRenderer";
 import VisibilitySensor from "react-visibility-sensor-v2";
 import { addCommasForCompositeRanges } from "./utils/composites";
-import { DocContext } from "../DocViewer";
 
 // Moved most of checkWorkStyle styling into Button
 const Button = styled.button`
@@ -38,8 +37,6 @@ export default React.memo(function Section(props) {
     let { name, id, SVs, children, actions, callAction } =
         useDoenetRenderer(props);
     // console.log("name: ", name, " SVs: ", SVs," Children",children);
-
-    const { showAnswerTitles } = useContext(DocContext) || {};
 
     let onChangeVisibility = (isVisible) => {
         callAction({
@@ -239,7 +236,6 @@ export default React.memo(function Section(props) {
                         submitAllAnswers();
                     }
                 }}
-                title={showAnswerTitles ? `Answer name: ${name}` : null}
             >
                 <FontAwesomeIcon
                     icon={faLevelDownAlt}

--- a/packages/doenetml/src/Viewer/renderers/textInput.jsx
+++ b/packages/doenetml/src/Viewer/renderers/textInput.jsx
@@ -16,7 +16,6 @@ import { MathJax } from "better-react-mathjax";
 import { BoardContext } from "./graph";
 import me from "math-expressions";
 import { getPositionFromAnchorByCoordinate } from "./utils/graph";
-import { DocContext } from "../DocViewer";
 
 // Moved most of checkWorkStyle styling into Button
 const Button = styled.button`
@@ -87,8 +86,6 @@ export default function TextInput(props) {
         actionName === "moveInput";
 
     const [rendererValue, setRendererValue] = useState(SVs.immediateValue);
-
-    const { showAnswerTitles } = useContext(DocContext) || {};
 
     // add ref, because event handler called from jsxgraph doesn't get new value
     let rendererValueRef = useRef(null);
@@ -639,11 +636,6 @@ export default function TextInput(props) {
                             });
                         }
                     }}
-                    title={
-                        showAnswerTitles
-                            ? `Answer name: ${actions.submitAnswer.componentName}`
-                            : null
-                    }
                 >
                     <FontAwesomeIcon
                         style={

--- a/packages/doenetml/src/Viewer/renderers/utils/AnswerResponseMenu.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/AnswerResponseMenu.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import {
+    IconButton,
+    Menu,
+    MenuButton,
+    MenuItem,
+    MenuList,
+} from "@chakra-ui/react";
+import { MdInfoOutline } from "react-icons/md";
+
+export function AnswerResponseMenu({
+    answerName,
+    activityId,
+    docId,
+}: {
+    answerName: string;
+    activityId: string;
+    docId: string;
+}) {
+    return (
+        <Menu>
+            <MenuButton
+                as={IconButton}
+                icon={<MdInfoOutline />}
+                size="xs"
+                paddingLeft="2px"
+                paddingRight="2px"
+                cursor="pointer"
+            />
+            <MenuList>
+                <MenuItem
+                    cursor="pointer"
+                    onClick={() => {
+                        window.postMessage({
+                            subject: "requestAnswerResponses",
+                            answerName,
+                            activityId,
+                            docId,
+                        });
+                    }}
+                >
+                    Show responses to {answerName}
+                </MenuItem>
+            </MenuList>
+        </Menu>
+    );
+}

--- a/packages/doenetml/src/Viewer/renderers/utils/AnswerResponseMenu.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/AnswerResponseMenu.tsx
@@ -1,45 +1,42 @@
 import React from "react";
-import {
-    IconButton,
-    Menu,
-    MenuButton,
-    MenuItem,
-    MenuList,
-} from "@chakra-ui/react";
-import { MdInfoOutline } from "react-icons/md";
+import { Button, Menu, MenuButton, MenuItem, MenuList } from "@chakra-ui/react";
 
 export function AnswerResponseMenu({
-    answerName,
+    answerId,
     activityId,
     docId,
+    numResponses = 0,
 }: {
-    answerName: string;
+    answerId: string;
     activityId: string;
     docId: string;
+    numResponses?: number;
 }) {
     return (
         <Menu>
             <MenuButton
-                as={IconButton}
-                icon={<MdInfoOutline />}
+                as={Button}
                 size="xs"
                 paddingLeft="2px"
                 paddingRight="2px"
                 cursor="pointer"
-            />
+            >
+                {numResponses}
+            </MenuButton>
             <MenuList>
                 <MenuItem
                     cursor="pointer"
                     onClick={() => {
                         window.postMessage({
                             subject: "requestAnswerResponses",
-                            answerName,
+                            answerId,
                             activityId,
                             docId,
                         });
                     }}
                 >
-                    Show responses to {answerName}
+                    Show {numResponses} response{numResponses === 1 ? "" : "s"}{" "}
+                    to {answerId}
                 </MenuItem>
             </MenuList>
         </Menu>

--- a/packages/doenetml/src/Viewer/useDoenetRenderer.tsx
+++ b/packages/doenetml/src/Viewer/useDoenetRenderer.tsx
@@ -81,6 +81,8 @@ export default function useDoenetRenderer(
             componentInstructions: childInstructions,
             rendererClasses: props.rendererClasses,
             coreId: props.coreId,
+            docId: props.docId,
+            activityId: props.activityId,
             callAction: props.callAction,
         };
 
@@ -126,6 +128,8 @@ export default function useDoenetRenderer(
         name: effectiveName,
         id: prefixForIds + cesc(effectiveName),
         SVs: stateValues,
+        docId: props.docId,
+        activityId: props.activityId,
         actions,
         children,
         sourceOfUpdate,

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -119,6 +119,7 @@ export function DoenetViewer({
     scrollableContainer,
     darkMode = "light",
     showAnswerResponseMenu = false,
+    answerResponseCounts = {},
     includeVariantSelector = false,
     initializeCounters = {},
 }: {
@@ -150,6 +151,7 @@ export function DoenetViewer({
     scrollableContainer?: HTMLDivElement | Window;
     darkMode?: "dark" | "light";
     showAnswerResponseMenu?: boolean;
+    answerResponseCounts?: Record<string, number>;
     includeVariantSelector?: boolean;
     initializeCounters?: Record<string, number>;
 }) {
@@ -268,6 +270,7 @@ export function DoenetViewer({
             scrollableContainer={scrollableContainer}
             darkMode={darkMode}
             showAnswerResponseMenu={showAnswerResponseMenu}
+            answerResponseCounts={answerResponseCounts}
             initializeCounters={initializeCounters}
         />
     );
@@ -303,6 +306,7 @@ export function DoenetEditor({
     linkSettings,
     darkMode = "light",
     showAnswerResponseMenu = false,
+    answerResponseCounts = {},
     width,
     height,
     viewerLocation,
@@ -329,6 +333,7 @@ export function DoenetEditor({
     linkSettings?: { viewURL: string; editURL: string };
     darkMode?: "dark" | "light";
     showAnswerResponseMenu?: boolean;
+    answerResponseCounts?: Record<string, number>;
     width?: string;
     height?: string;
     viewerLocation?: "left" | "right" | "top" | "bottom";
@@ -361,6 +366,7 @@ export function DoenetEditor({
             linkSettings={linkSettings}
             darkMode={darkMode}
             showAnswerResponseMenu={showAnswerResponseMenu}
+            answerResponseCounts={answerResponseCounts}
             width={width}
             height={height}
             viewerLocation={viewerLocation}

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -118,7 +118,7 @@ export function DoenetViewer({
     linkSettings,
     scrollableContainer,
     darkMode = "light",
-    showAnswerTitles = false,
+    showAnswerResponseMenu = false,
     includeVariantSelector = false,
     initializeCounters = {},
 }: {
@@ -149,7 +149,7 @@ export function DoenetViewer({
     linkSettings?: { viewURL: string; editURL: string };
     scrollableContainer?: HTMLDivElement | Window;
     darkMode?: "dark" | "light";
-    showAnswerTitles?: boolean;
+    showAnswerResponseMenu?: boolean;
     includeVariantSelector?: boolean;
     initializeCounters?: Record<string, number>;
 }) {
@@ -267,7 +267,7 @@ export function DoenetViewer({
             linkSettings={linkSettings}
             scrollableContainer={scrollableContainer}
             darkMode={darkMode}
-            showAnswerTitles={showAnswerTitles}
+            showAnswerResponseMenu={showAnswerResponseMenu}
             initializeCounters={initializeCounters}
         />
     );
@@ -302,7 +302,7 @@ export function DoenetEditor({
     navigate,
     linkSettings,
     darkMode = "light",
-    showAnswerTitles = false,
+    showAnswerResponseMenu = false,
     width,
     height,
     viewerLocation,
@@ -328,7 +328,7 @@ export function DoenetEditor({
     navigate?: any;
     linkSettings?: { viewURL: string; editURL: string };
     darkMode?: "dark" | "light";
-    showAnswerTitles?: boolean;
+    showAnswerResponseMenu?: boolean;
     width?: string;
     height?: string;
     viewerLocation?: "left" | "right" | "top" | "bottom";
@@ -360,7 +360,7 @@ export function DoenetEditor({
             prefixForIds={prefixForIds}
             linkSettings={linkSettings}
             darkMode={darkMode}
-            showAnswerTitles={showAnswerTitles}
+            showAnswerResponseMenu={showAnswerResponseMenu}
             width={width}
             height={height}
             viewerLocation={viewerLocation}


### PR DESCRIPTION
The PR adds `showAnswerResponseMenu` and ` answerResponseCounts` attributes to `<DoenetViewer>` and `<DoenetEditor>`. If `showAnswerResponseMenu`  is set to `true`, then we add a button menu after each answer, that gives an option to show responses for that answer.  The text of the button is the number of responses for that answer, as determined by `answerResponseCounts`. If the menu option is selected, then we send a message to the containing app that we are requesting the answer responses to that particular answer.