### PR TITLE
add initializeCounters to the state that is saved and loaded

### DIFF
--- a/packages/doenetml-worker/src/Core.js
+++ b/packages/doenetml-worker/src/Core.js
@@ -110,6 +110,7 @@ export default class Core {
                 }
             }
         }
+        this.receivedStateVariableChanges = Boolean(stateVariableChangesString);
 
         this.coreFunctions = {
             requestUpdate: this.requestUpdate.bind(this),
@@ -420,6 +421,10 @@ export default class Core {
         this.messageViewerReady();
 
         this.resolveInitialized();
+
+        if (!this.receivedStateVariableChanges) {
+            this.saveState();
+        }
     }
 
     async onDocumentFirstVisible() {
@@ -12952,6 +12957,7 @@ export default class Core {
             coreInfo: this.coreInfoString,
             coreState: coreStateString,
             rendererState: rendererStateString,
+            initializeCounters: this.initializeCounters,
             docId: this.docId,
             attemptNumber: this.attemptNumber,
             activityId: this.activityId,

--- a/packages/doenetml-worker/src/CoreWorker.js
+++ b/packages/doenetml-worker/src/CoreWorker.js
@@ -126,7 +126,6 @@ async function initializeWorker({
     docId,
     attemptNumber,
     requestedVariantIndex,
-    initializeCounters,
 }) {
     let componentInfoObjects = createComponentInfoObjects(flags);
 
@@ -165,7 +164,6 @@ async function initializeWorker({
         docId,
         attemptNumber,
         requestedVariantIndex,
-        initializeCounters,
         serializedDocument: addDocumentIfItsMissing(
             expandResult.fullSerializedComponents[0],
         )[0],

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -60,7 +60,7 @@ export function DocViewer({
     darkMode,
     showAnswerResponseMenu = false,
     answerResponseCounts = {},
-    initializeCounters = {},
+    initializeCounters: prescribedInitializeCounters = {},
 }: {
     doenetML: string;
     userId?: string;
@@ -215,6 +215,13 @@ export function DocViewer({
         requestedVariant: Record<string, any>;
     } | null>(null);
 
+    const initializeCounters = useRef<Record<string, number>>(
+        prescribedInitializeCounters,
+    );
+    useEffect(() => {
+        initializeCounters.current = prescribedInitializeCounters;
+    }, [prescribedInitializeCounters]);
+
     const rendererClasses = useRef<Record<string, any>>({});
     const coreInfo = useRef<Record<string, any> | null>(null);
     const coreCreated = useRef(false);
@@ -307,7 +314,6 @@ export function DocViewer({
                     docId,
                     attemptNumber,
                     requestedVariantIndex,
-                    initializeCounters,
                 });
             } catch (e: any) {
                 let message = "";
@@ -688,7 +694,6 @@ export function DocViewer({
             docId,
             attemptNumber,
             requestedVariantIndex,
-            initializeCounters,
         });
 
         return newCoreWorker;
@@ -1111,7 +1116,9 @@ export function DocViewer({
                             userId,
                         });
                         if (resp.loadedState) {
-                            processLoadedDocState(resp.state);
+                            if (resp.state) {
+                                processLoadedDocState(resp.state);
+                            }
                         }
                     }
                 } catch (e: any) {
@@ -1218,6 +1225,7 @@ export function DocViewer({
                 serializedComponentsReviver,
             ),
         };
+        initializeCounters.current = data.initializeCounters;
     }
 
     async function startCore(initialPass = false) {
@@ -1236,7 +1244,6 @@ export function DocViewer({
                 docId,
                 attemptNumber,
                 requestedVariantIndex,
-                initializeCounters,
             });
         }
 
@@ -1257,6 +1264,7 @@ export function DocViewer({
                           serializedComponentsReplacer,
                       )
                     : undefined,
+                initializeCounters: initializeCounters.current,
             },
         });
 

--- a/packages/doenetml/src/utils/docUtils.ts
+++ b/packages/doenetml/src/utils/docUtils.ts
@@ -15,7 +15,6 @@ export function initializeCoreWorker({
     docId,
     attemptNumber,
     requestedVariantIndex,
-    initializeCounters,
 }: {
     coreWorker: Worker;
     doenetML: string;
@@ -24,7 +23,6 @@ export function initializeCoreWorker({
     docId: string;
     attemptNumber: number;
     requestedVariantIndex: number;
-    initializeCounters: Record<string, number>;
 }) {
     // Initializes core worker with the given arguments.
     // Returns a promise.
@@ -64,7 +62,6 @@ export function initializeCoreWorker({
             docId,
             attemptNumber,
             requestedVariantIndex,
-            initializeCounters,
         },
     });
 


### PR DESCRIPTION
This PR adds the `initializeCounters` object to the state that is loaded/saved. In this way, counters will have the same values regardless of the `initializeCounters` object passed in when a document with saved state is loaded.