### PR TITLE
remove leading slash from answerId in answer response menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22800,7 +22800,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.0-alpha32",
+            "version": "0.7.0-alpha33",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@chakra-ui/icons": "^2.0.19",
@@ -22841,7 +22841,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.0-alpha32",
+            "version": "0.7.0-alpha33",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -22919,7 +22919,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.0-alpha32",
+            "version": "0.7.0-alpha33",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml-iframe",
     "type": "module",
     "description": "A renderer for DoenetML contained in an iframe",
-    "version": "0.7.0-alpha32",
+    "version": "0.7.0-alpha33",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.7.0-alpha32",
+    "version": "0.7.0-alpha33",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/src/Viewer/renderers/utils/AnswerResponseMenu.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/AnswerResponseMenu.tsx
@@ -12,6 +12,7 @@ export function AnswerResponseMenu({
     docId: string;
     numResponses?: number;
 }) {
+    const modifiedId = answerId[0] === "/" ? answerId.substring(1) : answerId;
     return (
         <Menu>
             <MenuButton
@@ -36,7 +37,7 @@ export function AnswerResponseMenu({
                     }}
                 >
                     Show {numResponses} response{numResponses === 1 ? "" : "s"}{" "}
-                    to {answerId}
+                    to {modifiedId}
                 </MenuItem>
             </MenuList>
         </Menu>

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.7.0-alpha32",
+    "version": "0.7.0-alpha33",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,


### PR DESCRIPTION
This PR removes the slash in front of answer ids when displaying the answer response menu, just to make the answer id easier to read.