### PR TITLE
fix css so choiceinputs are not cramped on google sites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21542,7 +21542,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.0-alpha37",
+            "version": "0.7.0-alpha39",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@chakra-ui/icons": "^2.2.4",
@@ -21582,7 +21582,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.0-alpha37",
+            "version": "0.7.0-alpha39",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -21797,7 +21797,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.0-alpha37",
+            "version": "0.7.0-alpha39",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml-iframe",
     "type": "module",
     "description": "A renderer for DoenetML contained in an iframe",
-    "version": "0.7.0-alpha37",
+    "version": "0.7.0-alpha39",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.7.0-alpha37",
+    "version": "0.7.0-alpha39",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -463,13 +463,16 @@ export function EditorViewer({
         );
     }
 
+    const controlHeight =
+        !readOnly || variants.numVariants > 1 ? "32px" : "0px";
+
     const viewerPanel = (
         <Grid
             width="100%"
             height="100%"
             templateAreas={`"controls"
                             "viewer"`}
-            gridTemplateRows={`32px 1fr`}
+            gridTemplateRows={`${controlHeight} 1fr`}
             gridTemplateColumns={`1fr`}
             overflowY="hidden"
         >
@@ -482,58 +485,61 @@ export function EditorViewer({
                 id={id + "-viewer-controls"}
             >
                 <HStack w="100%" h="32px" bg={backgroundColor}>
-                    <Box>
-                        <Tooltip
-                            hasArrow
-                            label={
-                                platform == "Mac"
-                                    ? "Updates Viewer cmd+s"
-                                    : "Updates Viewer ctrl+s"
-                            }
-                        >
-                            <Button
-                                size="sm"
-                                variant="outline"
-                                data-test="Viewer Update Button"
-                                bg="doenet.canvas"
-                                leftIcon={<RxUpdate />}
-                                rightIcon={
-                                    codeChanged ? (
-                                        <WarningTwoIcon
-                                            color="doenet.mainBlue"
-                                            fontSize="18px"
-                                        />
-                                    ) : undefined
+                    {!readOnly && (
+                        <Box>
+                            <Tooltip
+                                hasArrow
+                                label={
+                                    platform == "Mac"
+                                        ? "Updates Viewer cmd+s"
+                                        : "Updates Viewer ctrl+s"
                                 }
-                                isDisabled={!codeChanged}
-                                onClick={() => {
-                                    setViewerDoenetML(
-                                        editorDoenetMLRef.current,
-                                    );
-                                    window.clearTimeout(
-                                        updateValueTimer.current ?? undefined,
-                                    );
-                                    if (
-                                        lastReportedDoenetML.current !==
-                                        editorDoenetMLRef.current
-                                    ) {
-                                        lastReportedDoenetML.current =
-                                            editorDoenetMLRef.current;
-                                        if (!showViewer) {
-                                            doenetmlChangeCallback?.(
-                                                editorDoenetMLRef.current,
-                                            );
-                                        }
-                                    }
-                                    setCodeChanged(false);
-                                    updateValueTimer.current = null;
-                                    setResponses([]);
-                                }}
                             >
-                                Update
-                            </Button>
-                        </Tooltip>
-                    </Box>
+                                <Button
+                                    size="sm"
+                                    variant="outline"
+                                    data-test="Viewer Update Button"
+                                    bg="doenet.canvas"
+                                    leftIcon={<RxUpdate />}
+                                    rightIcon={
+                                        codeChanged ? (
+                                            <WarningTwoIcon
+                                                color="doenet.mainBlue"
+                                                fontSize="18px"
+                                            />
+                                        ) : undefined
+                                    }
+                                    isDisabled={!codeChanged}
+                                    onClick={() => {
+                                        setViewerDoenetML(
+                                            editorDoenetMLRef.current,
+                                        );
+                                        window.clearTimeout(
+                                            updateValueTimer.current ??
+                                                undefined,
+                                        );
+                                        if (
+                                            lastReportedDoenetML.current !==
+                                            editorDoenetMLRef.current
+                                        ) {
+                                            lastReportedDoenetML.current =
+                                                editorDoenetMLRef.current;
+                                            if (!showViewer) {
+                                                doenetmlChangeCallback?.(
+                                                    editorDoenetMLRef.current,
+                                                );
+                                            }
+                                        }
+                                        setCodeChanged(false);
+                                        updateValueTimer.current = null;
+                                        setResponses([]);
+                                    }}
+                                >
+                                    Update
+                                </Button>
+                            </Tooltip>
+                        </Box>
+                    )}
                     {variants.numVariants > 1 && (
                         <Box bg={backgroundColor} h="32px" width="100%">
                             <VariantSelect

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.css
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.css
@@ -6,6 +6,7 @@
     position: relative;
     padding-left: 24px;
     margin-bottom: 4px;
+    min-height: 24px;
     cursor: pointer;
     -webkit-user-select: none;
     -moz-user-select: none;
@@ -108,6 +109,7 @@
     position: relative;
     padding-left: 24px;
     margin-bottom: 4px;
+    min-height: 24px;
     cursor: pointer;
     -webkit-user-select: none;
     -moz-user-select: none;

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.7.0-alpha37",
+    "version": "0.7.0-alpha39",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,


### PR DESCRIPTION
This PR adds a `min-height` to choice input containers so that they don't overlap when the DoenetML is embedded in a google site.

It also includes some formatting tweaks for the editor.