### PR TITLE
Fix bug to handle non-standard case of isResponse in composites

### DIFF
--- a/packages/doenetml-worker/src/components/Answer.js
+++ b/packages/doenetml-worker/src/components/Answer.js
@@ -258,13 +258,24 @@ export default class Answer extends InlineComponent {
 
             function checkForResponseDescendant(components) {
                 for (let component of components) {
+                    if (component?.attributes) {
+                        for (const attr in component.attributes) {
+                            // Need a case-insensitive test because composites such as Copy
+                            // don't have have an isResponse attribute, but accept any attribute,
+                            // which means those attribute names have not been normalized
+                            if (attr.toLowerCase() === "isresponse") {
+                                if (
+                                    component.attributes[attr].primitive !==
+                                    false
+                                ) {
+                                    // idea: catch either isResponse = true or isResponse.primitive=true
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+
                     if (
-                        component?.attributes?.isResponse &&
-                        component.attributes.isResponse.primitive !== false
-                    ) {
-                        // idea: catch either isResponse = true or isResponse.primitive=true
-                        return true;
-                    } else if (
                         component.children &&
                         checkForResponseDescendant(component.children)
                     ) {

--- a/packages/doenetml-worker/src/test/tagSpecific/answer.test.ts
+++ b/packages/doenetml-worker/src/test/tagSpecific/answer.test.ts
@@ -2884,7 +2884,7 @@ Enter any letter:
         });
     });
 
-    it("answer based on point", async () => {
+    it("answer based on point, nonstandard case for isResponse", async () => {
         const doenetML = `
         <p>Criterion: <mathInput name="mi" prefill="1" /></p>
         <p>Move point so that its x-coordinate is larger than $mi.value.</p>
@@ -2895,7 +2895,7 @@ Enter any letter:
 
         <answer name="a"> 
           <award><when>
-            $mi < $P.x{isResponse}
+            $mi < $P.x{isresPoNse}
           </when></award>
         </answer>
 


### PR DESCRIPTION
This PR fixes a bug where specifying isResponse on a composite with non-standard case lead to a duplicate prop error