### PR TITLE
Supress a few warnings to make for cleaner build logs

### DIFF
--- a/packages/doenetml-iframe/vite.config.ts
+++ b/packages/doenetml-iframe/vite.config.ts
@@ -3,6 +3,7 @@ import dts from "vite-plugin-dts";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import { createPackageJsonTransformer } from "../../scripts/transform-package-json";
 import { version } from "./package.json";
+import { suppressLogPlugin } from "../../scripts/vite-plugins";
 
 // These are the dependencies that will not be bundled into the library.
 const EXTERNAL_DEPS = ["react", "react-dom"];
@@ -25,6 +26,7 @@ export default defineConfig({
                 { src: "README.md", dest: "./" },
             ],
         }),
+        suppressLogPlugin(),
     ],
     build: {
         minify: false,

--- a/packages/doenetml-prototype/vite.config.ts
+++ b/packages/doenetml-prototype/vite.config.ts
@@ -6,6 +6,7 @@ import * as path from "node:path";
 import { visualizer } from "rollup-plugin-visualizer";
 import { version } from "./package.json";
 import { createRequire } from "module";
+import { suppressLogPlugin } from "../../scripts/vite-plugins";
 const require = createRequire(import.meta.url);
 
 // These are the dependencies that will not be bundled into the library.
@@ -38,6 +39,7 @@ export default defineConfig({
         }),
         dts({ rollupTypes: true }),
         visualizer() as PluginOption,
+        suppressLogPlugin(),
     ],
     server: {
         port: 8012,

--- a/packages/doenetml-worker-rust/vite.config.ts
+++ b/packages/doenetml-worker-rust/vite.config.ts
@@ -1,11 +1,12 @@
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
+import { suppressLogPlugin } from "../../scripts/vite-plugins";
 
 // https://vitejs.dev/config/
 export default defineConfig({
     // Note: for some reason {rollupTypes: true} causes an extra `.d` to be added to the types file name.
     // So, it becomes `index.d.d.ts` instead of `index.d.ts`. So avoid rolling up the types until this can be resolved.
-    plugins: [dts()],
+    plugins: [dts(), suppressLogPlugin()],
     base: "./",
     build: {
         minify: false,

--- a/packages/doenetml-worker/vite.config.ts
+++ b/packages/doenetml-worker/vite.config.ts
@@ -1,10 +1,12 @@
 /// <reference types="vitest/config" />
 import nodePolyfills from "rollup-plugin-polyfill-node";
 import { defineConfig } from "vite";
+import { suppressLogPlugin } from "../../scripts/vite-plugins";
 
 // https://vitejs.dev/config/
 export default defineConfig({
     base: "./",
+    plugins: [suppressLogPlugin()],
     build: {
         minify: true,
         sourcemap: true,

--- a/packages/doenetml/vite.config.ts
+++ b/packages/doenetml/vite.config.ts
@@ -7,6 +7,7 @@ const require = createRequire(import.meta.url);
 import dts from "vite-plugin-dts";
 import { createPackageJsonTransformer } from "../../scripts/transform-package-json";
 import { version } from "./package.json";
+import { suppressLogPlugin } from "../../scripts/vite-plugins";
 
 // These are the dependencies that will not be bundled into the library.
 const EXTERNAL_DEPS = ["react", "react-dom", "styled-components"];
@@ -39,6 +40,7 @@ export default defineConfig({
                 },
             ],
         }),
+        suppressLogPlugin(),
     ],
     define: {
         DOENETML_VERSION: JSON.stringify(version),

--- a/packages/standalone/vite.config.ts
+++ b/packages/standalone/vite.config.ts
@@ -3,6 +3,7 @@ import dts from "vite-plugin-dts";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import { createPackageJsonTransformer } from "../../scripts/transform-package-json";
 import { version } from "./package.json";
+import { suppressLogPlugin } from "../../scripts/vite-plugins";
 
 // These are the dependencies that will not be bundled into the library.
 const EXTERNAL_DEPS = [];
@@ -21,6 +22,7 @@ export default defineConfig({
                 },
             ],
         }),
+        suppressLogPlugin(),
     ],
     build: {
         minify: true,

--- a/packages/static-assets/vite.config.ts
+++ b/packages/static-assets/vite.config.ts
@@ -5,6 +5,7 @@ import { viteStaticCopy } from "vite-plugin-static-copy";
 import dsv from "@rollup/plugin-dsv";
 import * as compressJson from "compress-json";
 import * as path from "node:path";
+import { suppressLogPlugin } from "../../scripts/vite-plugins";
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
 // https://vitejs.dev/config/
@@ -26,6 +27,7 @@ export default defineConfig({
             ],
         }),
         compressJsonPlugin(),
+        suppressLogPlugin(),
     ],
     build: {
         minify: false,

--- a/packages/test-viewer/vite.config.ts
+++ b/packages/test-viewer/vite.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vite";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import path from "node:path";
 import { createRequire } from "module";
+import { suppressLogPlugin } from "../../scripts/vite-plugins";
 const require = createRequire(import.meta.url);
 
 // https://vitejs.dev/config/
@@ -23,6 +24,7 @@ export default defineConfig({
                 },
             ],
         }),
+        suppressLogPlugin(),
     ],
     server: {
         port: 8012,

--- a/scripts/vite-plugins.ts
+++ b/scripts/vite-plugins.ts
@@ -1,0 +1,23 @@
+import { PluginOption } from "vite";
+
+/**
+ * Vite plugin to suppress warnings about using eval and some other log messages that clutter the logs.
+ */
+export function suppressLogPlugin(): PluginOption {
+    return {
+        name: "suppress-log",
+        onLog(level, message) {
+            if (message.code === "EVAL") {
+                // Don't warn about using eval. We know it's bad and the messages just clutter the logs
+                return false;
+            }
+            if (
+                /import.meta.url/.test(message.message) &&
+                /@vite-ignore/.test(message.message)
+            ) {
+                // There is an ignorable warning about import.meta.url that is not relevant to us
+                return false;
+            }
+        },
+    };
+}


### PR DESCRIPTION
Don't show warnings about using `eval`.

I tried to suppress the output of the big long Base64 URL in the build logs, but couldn't figure out how...