### PR TITLE
request solution view callback when solutionDisplayMode is "buttonRequirePermission"

### DIFF
--- a/.github/workflows/gh-pages-docs.yml
+++ b/.github/workflows/gh-pages-docs.yml
@@ -42,7 +42,9 @@ jobs:
             - name: Build Docs
               run: |
                   export NODE_OPTIONS="--max_old_space_size=4096"
-                  cd packages/docs-nextra
+                  cd packages/doenetml
+                  npm run build
+                  cd ../docs-nextra
                   npm run build
             - name: Setup Pages
               uses: actions/configure-pages@v5

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -148,8 +148,11 @@ export function DoenetViewer({
                 return;
             }
 
-            // forward response from SPLICE getState to iframe
-            if (event.data.subject === "SPLICE.getState.response") {
+            // forward response from SPLICE getState or requestSolutionView to iframe
+            if (
+                event.data.subject === "SPLICE.getState.response" ||
+                event.data.subject === "SPLICE.requestSolutionView.response"
+            ) {
                 ref.current?.contentWindow?.postMessage(event.data);
                 return;
             }

--- a/packages/doenetml-worker-javascript/src/Core.js
+++ b/packages/doenetml-worker-javascript/src/Core.js
@@ -69,6 +69,7 @@ export default class Core {
         cancelAnimationFrame,
         copyToClipboard,
         sendEvent,
+        requestSolutionView,
     }) {
         // console.time('core');
 
@@ -85,6 +86,7 @@ export default class Core {
         this.cancelAnimationFrame = cancelAnimationFrame;
         this.copyToClipboard = copyToClipboard;
         this.sendEvent = sendEvent;
+        this.requestSolutionViewCallback = requestSolutionView;
 
         this.cid = cid;
 
@@ -134,7 +136,7 @@ export default class Core {
             requestRecordEvent: this.requestRecordEvent.bind(this),
             requestAnimationFrame: this.requestAnimationFrame.bind(this),
             cancelAnimationFrame: this.cancelAnimationFrame.bind(this),
-            recordSolutionView: this.recordSolutionView.bind(this),
+            requestSolutionView: this.requestSolutionView.bind(this),
             requestComponentDoenetML: this.requestComponentDoenetML.bind(this),
             copyToClipboard: this.copyToClipboard.bind(this),
             navigateToTarget: this.navigateToTarget.bind(this),
@@ -12934,29 +12936,12 @@ export default class Core {
         return;
     }
 
-    async recordSolutionView() {
-        // TODO: check if student was actually allowed to view solution.
-
-        // if not allowed to save state, then allow view but don't record it
-        if (!this.flags.allowSaveState) {
-            return {
-                allowView: true,
-                message: "",
-                scoredComponent: this.documentName,
-            };
-        }
-
-        postMessage({
-            messageType: "recordSolutionView",
-            activityId: this.activityId,
-            docId: this.docId,
-            attemptNumber: this.attemptNumber,
-        });
+    async requestSolutionView(componentName) {
+        const requestResult =
+            await this.requestSolutionViewCallback(componentName);
 
         return {
-            allowView: true,
-            message: "",
-            scoredComponent: this.documentName,
+            allowView: requestResult.allowView,
         };
     }
 

--- a/packages/doenetml-worker-javascript/src/Core.js
+++ b/packages/doenetml-worker-javascript/src/Core.js
@@ -12936,6 +12936,13 @@ export default class Core {
         return;
     }
 
+    /**
+     * Poll `requestSolutionViewCallback` to determine whether or not
+     * the user is allowed to view the solution.
+     *
+     * Note: this will occur only if the `solutionDisplayMode` flag is set to
+     * "buttonRequirePermission".
+     */
     async requestSolutionView(componentName) {
         const requestResult =
             await this.requestSolutionViewCallback(componentName);

--- a/packages/doenetml-worker-javascript/src/CoreWorker.ts
+++ b/packages/doenetml-worker-javascript/src/CoreWorker.ts
@@ -355,15 +355,13 @@ export class PublicDoenetMLCore {
     }
     /**
      * Submit any answers that are waiting to auto-submitted and save all state
-     * so that the worker can be terminate without losing data.
-     * Then close the worker.
+     * so that the worker can be terminated without losing data.
      */
     async terminate() {
         if (this.core) {
             await this.core.terminate();
             this.core = null;
         }
-        close();
     }
 
     // Turn on or off recording of the visibility of document components,

--- a/packages/doenetml-worker-javascript/src/CoreWorker.ts
+++ b/packages/doenetml-worker-javascript/src/CoreWorker.ts
@@ -27,6 +27,9 @@ export type CopyToClipboard = (args: {
     actionId?: string;
 }) => void;
 export type SendEvent = (data: any) => void;
+export type RequestSolutionView = (componentName: string) => Promise<{
+    allowView: boolean;
+}>;
 
 /**
  * A wrapper around `Core` that contains the arguments for constructing
@@ -167,6 +170,7 @@ export class PublicDoenetMLCore {
         cancelAnimationFrame: CancelAnimationFrame,
         copyToClipboard: CopyToClipboard,
         sendEvent: SendEvent,
+        requestSolutionView: RequestSolutionView,
     ) {
         let coreArgs = {
             ...this.coreBaseArgs!,
@@ -177,6 +181,7 @@ export class PublicDoenetMLCore {
             cancelAnimationFrame,
             copyToClipboard,
             sendEvent,
+            requestSolutionView,
         };
 
         if (this.initializeResult?.success) {

--- a/packages/doenetml-worker-javascript/src/components/Document.js
+++ b/packages/doenetml-worker-javascript/src/components/Document.js
@@ -250,28 +250,6 @@ export default class Document extends BaseComponent {
             definition: () => ({ setValue: { level: 0 } }),
         };
 
-        stateVariableDefinitions.viewedSolution = {
-            defaultValue: false,
-            hasEssential: true,
-            returnDependencies: () => ({}),
-            definition: () => ({
-                useEssentialOrDefaultValue: {
-                    viewedSolution: true,
-                },
-            }),
-            inverseDefinition({ desiredStateVariableValues }) {
-                return {
-                    success: true,
-                    instructions: [
-                        {
-                            setEssentialValue: "viewedSolution",
-                            value: desiredStateVariableValues.viewedSolution,
-                        },
-                    ],
-                };
-            },
-        };
-
         stateVariableDefinitions.scoredDescendants = {
             returnDependencies: () => ({
                 scoredDescendants: {

--- a/packages/doenetml-worker-javascript/src/components/Solution.js
+++ b/packages/doenetml-worker-javascript/src/components/Solution.js
@@ -263,6 +263,10 @@ export class Solution extends BlockComponent {
 
         let allowView = true;
 
+        // If we require permission to view the solution,
+        // then we must request the solution view before opening.
+        // If a response with `allowView` equal to `false`
+        // is not received, the solution will stay closed.
         if (displayMode === "buttonRequirePermission") {
             const requestResult = await this.coreFunctions.requestSolutionView(
                 this.componentName,

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -517,28 +517,6 @@ export class SectioningComponent extends BlockComponent {
             },
         };
 
-        stateVariableDefinitions.viewedSolution = {
-            defaultValue: false,
-            hasEssential: true,
-            returnDependencies: () => ({}),
-            definition: () => ({
-                useEssentialOrDefaultValue: {
-                    viewedSolution: true,
-                },
-            }),
-            inverseDefinition({ desiredStateVariableValues }) {
-                return {
-                    success: true,
-                    instructions: [
-                        {
-                            setEssentialValue: "viewedSolution",
-                            value: desiredStateVariableValues.viewedSolution,
-                        },
-                    ],
-                };
-            },
-        };
-
         stateVariableDefinitions.scoredDescendants = {
             returnDependencies: () => ({
                 scoredDescendants: {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/solution.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/solution.test.ts
@@ -97,4 +97,111 @@ describe("Solution tag tests", async () => {
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables["/solOpen"].stateValues.value).eq(false);
     });
+
+    it("solution display mode = displayed", async () => {
+        let core = await createTestCore({
+            doenetML: `
+  <solution name="sol">
+    <p name="p">The solution</p>
+  </solution>
+  <boolean name="solOpen" copySource="sol.open" />
+  `,
+            flags: { solutionDisplayMode: "displayed" },
+        });
+
+        // Solution starts out open
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables["/solOpen"].stateValues.value).eq(true);
+        expect(stateVariables["/p"].stateValues.text).eq("The solution");
+
+        // The solution cannot be closed
+        await closeSolution({ name: "/sol", core });
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables["/solOpen"].stateValues.value).eq(true);
+    });
+
+    it("solution display mode = none", async () => {
+        let core = await createTestCore({
+            doenetML: `
+  <solution name="sol">
+    <p name="p">The solution</p>
+  </solution>
+  <boolean name="solOpen" copySource="sol.open" />
+  `,
+            flags: { solutionDisplayMode: "none" },
+        });
+
+        // Solution is hidden
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables["/solOpen"].stateValues.value).eq(false);
+        expect(stateVariables["/sol"].stateValues.hidden).eq(true);
+        expect(stateVariables["/p"]).be.undefined;
+
+        // The solution cannot be opened
+        await revealSolution({ name: "/sol", core });
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables["/solOpen"].stateValues.value).eq(false);
+        expect(stateVariables["/sol"].stateValues.hidden).eq(true);
+        expect(stateVariables["/p"]).be.undefined;
+    });
+
+    it("request solution view, solution display mode = buttonRequirePermission", async () => {
+        // an empty solution was creating an infinite loop
+        // as the zero replacements were always treated as uninitialized
+        let numRequests = 0;
+
+        const doenetML = `
+  <solution name="sol">
+    <p name="p">The solution</p>
+  </solution>
+  <boolean name="solOpen" copySource="sol.open" />
+  `;
+
+        // first, we allow solution views
+        let core = await createTestCore({
+            doenetML,
+            flags: { solutionDisplayMode: "buttonRequirePermission" },
+            requestSolutionView: async () => {
+                numRequests++;
+                return { allowView: true };
+            },
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables["/solOpen"].stateValues.value).eq(false);
+        expect(stateVariables["/p"]).be.undefined;
+        expect(numRequests).eq(0);
+
+        await revealSolution({ name: "/sol", core });
+        expect(numRequests).eq(1);
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables["/solOpen"].stateValues.value).eq(true);
+        expect(stateVariables["/p"].stateValues.text).eq("The solution");
+
+        await closeSolution({ name: "/sol", core });
+        expect(numRequests).eq(1);
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables["/solOpen"].stateValues.value).eq(false);
+
+        // second, we do not allow solution views
+        core = await createTestCore({
+            doenetML,
+            flags: { solutionDisplayMode: "buttonRequirePermission" },
+            requestSolutionView: async () => {
+                numRequests++;
+                return { allowView: false };
+            },
+        });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables["/solOpen"].stateValues.value).eq(false);
+        expect(stateVariables["/p"]).be.undefined;
+        expect(numRequests).eq(1);
+
+        await revealSolution({ name: "/sol", core });
+        expect(numRequests).eq(2);
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables["/solOpen"].stateValues.value).eq(false);
+        expect(stateVariables["/p"]).be.undefined;
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/utils/test-core.ts
+++ b/packages/doenetml-worker-javascript/src/test/utils/test-core.ts
@@ -3,7 +3,11 @@ import { PublicDoenetMLCore } from "../../CoreWorker";
 type DoenetMLFlags = {
     showCorrectness: boolean;
     readOnly: boolean;
-    solutionDisplayMode: string;
+    solutionDisplayMode:
+        | "button"
+        | "buttonRequirePermission"
+        | "displayed"
+        | "none";
     showFeedback: boolean;
     showHints: boolean;
     allowLoadState: boolean;
@@ -34,12 +38,16 @@ export async function createTestCore({
     flags: specifiedFlags = {},
     theme,
     initializeCounters = {},
+    requestSolutionView = async () => ({ allowView: true }),
 }: {
     doenetML: string;
     requestedVariantIndex?: number;
     flags?: DoenetMLFlagsSubset;
     theme?: "dark" | "light";
     initializeCounters?: Record<string, number>;
+    requestSolutionView?: (componentName: string) => Promise<{
+        allowView: boolean;
+    }>;
 }) {
     const flags: DoenetMLFlags = { ...defaultFlags, ...specifiedFlags };
 
@@ -67,6 +75,8 @@ export async function createTestCore({
         () => null,
         () => null,
         () => null,
+        () => null,
+        requestSolutionView,
     );
 
     if (!dastResult.success) {

--- a/packages/doenetml-worker/lib-js-wasm-binding/src/CoreWorker.ts
+++ b/packages/doenetml-worker/lib-js-wasm-binding/src/CoreWorker.ts
@@ -355,6 +355,8 @@ export class CoreWorker {
         } else {
             resolve();
         }
+
+        close(); // Terminate the worker itself
     }
 
     async returnAllStateVariables(consoleLogComponents = false) {

--- a/packages/doenetml-worker/lib-js-wasm-binding/src/CoreWorker.ts
+++ b/packages/doenetml-worker/lib-js-wasm-binding/src/CoreWorker.ts
@@ -356,7 +356,8 @@ export class CoreWorker {
             resolve();
         }
 
-        close(); // Terminate the worker itself
+        // Terminate the worker itself
+        close();
     }
 
     async returnAllStateVariables(consoleLogComponents = false) {

--- a/packages/doenetml-worker/lib-js-wasm-binding/src/CoreWorker.ts
+++ b/packages/doenetml-worker/lib-js-wasm-binding/src/CoreWorker.ts
@@ -20,6 +20,7 @@ import {
     PublicDoenetMLCore as PublicDoenetMLCoreJavascript,
     ReportScoreAndStateCallback,
     RequestAnimationFrame,
+    RequestSolutionView,
     SendEvent,
     UpdateRenderersCallback,
 } from "@doenet/doenetml-worker-javascript";
@@ -212,6 +213,7 @@ export class CoreWorker {
         cancelAnimationFrame: CancelAnimationFrame,
         copyToClipboard: CopyToClipboard,
         sendEvent: SendEvent,
+        requestSolutionView: RequestSolutionView,
     ) {
         const isProcessingPromise = this.isProcessingPromise;
         let { promise, resolve } = promiseWithResolver();
@@ -234,6 +236,7 @@ export class CoreWorker {
                 cancelAnimationFrame,
                 copyToClipboard,
                 sendEvent,
+                requestSolutionView,
             );
         } catch (err) {
             console.error(err);

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -262,7 +262,9 @@ export function DocViewer({
         promiseResolve?: (value: any) => void;
     } | null>(null);
 
-    const saveStatePromises = useRef<
+    // Promises representing outstanding requests to get the state of the document.
+    // Keyed by the messageId of the SPLICE message requesting the state.
+    const getStatePromises = useRef<
         Record<
             string,
             {
@@ -271,6 +273,9 @@ export function DocViewer({
             }
         >
     >({});
+
+    // Promises representing outstanding requests to view the solution.
+    // Keyed by the messageId of the SPLICE message requesting the solution view.
     const requestSolutionViewPromises = useRef<
         Record<
             string,
@@ -322,11 +327,11 @@ export function DocViewer({
                 return;
             }
             if (e.data.subject === "SPLICE.getState.response") {
-                let promiseInfo = saveStatePromises.current[e.data.messageId];
+                let promiseInfo = getStatePromises.current[e.data.messageId];
                 if (!promiseInfo) {
                     return;
                 }
-                delete saveStatePromises.current[e.data.messageId];
+                delete getStatePromises.current[e.data.messageId];
 
                 if (e.data.success) {
                     promiseInfo.resolve(e.data);
@@ -1015,13 +1020,13 @@ export function DocViewer({
         userId?: string;
     }) {
         let messageId = nanoid();
-        let savePromiseResolve: (value: Record<string, any>) => void,
-            savePromiseReject: (value: unknown) => void;
+        let getStatePromiseResolve: (value: Record<string, any>) => void,
+            getStatePromiseReject: (value: unknown) => void;
 
-        let savePromise = new Promise<Record<string, any>>(
+        let getStatePromise = new Promise<Record<string, any>>(
             (resolve, reject) => {
-                savePromiseResolve = resolve;
-                savePromiseReject = reject;
+                getStatePromiseResolve = resolve;
+                getStatePromiseReject = reject;
                 window.postMessage({
                     subject: "SPLICE.getState",
                     messageId,
@@ -1034,22 +1039,22 @@ export function DocViewer({
             },
         );
 
-        saveStatePromises.current[messageId] = {
-            resolve: savePromiseResolve!,
-            reject: savePromiseReject!,
+        getStatePromises.current[messageId] = {
+            resolve: getStatePromiseResolve!,
+            reject: getStatePromiseReject!,
         };
 
         const MESSAGE_TIMEOUT = 15000;
 
         setTimeout(() => {
-            if (!saveStatePromises.current[messageId]) {
+            if (!getStatePromises.current[messageId]) {
                 return;
             }
-            delete saveStatePromises.current[messageId];
-            savePromiseReject({ message: "Time out loading doc state" });
+            delete getStatePromises.current[messageId];
+            getStatePromiseReject({ message: "Time out loading doc state" });
         }, MESSAGE_TIMEOUT);
 
-        return savePromise;
+        return getStatePromise;
     }
 
     function processLoadedDocState(data: Record<string, any>) {
@@ -1258,6 +1263,17 @@ export function DocViewer({
         });
     }
 
+    /**
+     * Request permission to view the solution of `componentName`
+     * using SPLICE messaging.
+     *
+     * Sends a "SPLICE.requestSolutionView". The returned promise will
+     * resolve when a matching "SPLICE.requestSolutionView.response"
+     * is received.
+     *
+     * Return a promise that will resolve to an object with key:
+     * allowView: whether or not the solution can be viewed
+     */
     function requestSolutionView(componentName: string) {
         let messageId = nanoid();
         let requestSolutionPromiseResolve: (value: {

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -18,7 +18,11 @@ export const version: string = DOENETML_VERSION;
 export type DoenetMLFlags = {
     showCorrectness: boolean;
     readOnly: boolean;
-    solutionDisplayMode: string;
+    solutionDisplayMode:
+        | "button"
+        | "buttonRequirePermission"
+        | "displayed"
+        | "none";
     showFeedback: boolean;
     showHints: boolean;
     allowLoadState: boolean;


### PR DESCRIPTION
This PR introduces a new `solutionDisplayMode`: "buttonRequirePermission". In this mode, a solution starts off collapsed, identical to "button" mode. However, when a user attempts to open a solution, a "SPLICE.requestSolutionView" message is sent. In order for the solution to open, a matching "SPLICE.requestSolutionView.response" must be received with `{allowView: true}`. Otherwise, the solution remains closed, and the user cannot view the solution.

This mode allows applications to verify and record the fact that a student viewed a solution before the solution will be revealed. A loss of a connection with the server will disallow solution views rather than allowing the solution to be viewed without detecting the fact.