### PR TITLE
rename componentName to componentIdx

### DIFF
--- a/packages/doenetml-worker-javascript/src/Core.js
+++ b/packages/doenetml-worker-javascript/src/Core.js
@@ -225,7 +225,7 @@ export default class Core {
         this.componentIndexArray =
             extractComponentNamesAndIndices(serializedComponents);
 
-        this.documentName = serializedComponents[0].componentName;
+        this.documentName = serializedComponents[0].componentIdx;
 
         if (!serializedComponents[0].state) {
             serializedComponents[0].state = {};
@@ -246,7 +246,7 @@ export default class Core {
 
         this.saveStateToDBTimerId = null;
 
-        // rendererState the current state of each renderer, keyed by componentName
+        // rendererState the current state of each renderer, keyed by componentIdx
         this.rendererState = {
             __componentNeedingUpdateValue: null,
         };
@@ -407,10 +407,10 @@ export default class Core {
 
         // warning if there are any children that are unmatched
         if (Object.keys(this.unmatchedChildren).length > 0) {
-            for (let componentName in this.unmatchedChildren) {
-                let parent = this._components[componentName];
+            for (let componentIdx in this.unmatchedChildren) {
+                let parent = this._components[componentIdx];
                 this.errorWarnings.warnings.push({
-                    message: this.unmatchedChildren[componentName].message,
+                    message: this.unmatchedChildren[componentIdx].message,
                     level: 1,
                     doenetMLrange: parent.doenetMLrange,
                 });
@@ -430,7 +430,7 @@ export default class Core {
         this.requestRecordEvent({
             verb: "experienced",
             object: {
-                componentName: this.document.componentName,
+                componentIdx: this.document.componentIdx,
                 componentType: "document",
             },
         });
@@ -498,7 +498,7 @@ export default class Core {
 
     async addComponents({
         serializedComponents,
-        parentName,
+        parentIdx,
         indexOfDefiningChildren,
         initialAdd = false,
         assignNamesOffset,
@@ -512,10 +512,10 @@ export default class Core {
         let createNameContext = "";
 
         if (!initialAdd) {
-            parent = this._components[parentName];
+            parent = this._components[parentIdx];
             if (!parent) {
                 this.errorWarnings.warnings.push({
-                    message: `Cannot add children to parent ${parentName} as ${parentName} does not exist`,
+                    message: `Cannot add children to parent ${parentIdx} as ${parentIdx} does not exist`,
                     level: 1,
                 });
                 this.newErrorWarning = true;
@@ -524,7 +524,7 @@ export default class Core {
 
             ancestors = [
                 {
-                    componentName: parentName,
+                    componentIdx: parentIdx,
                     componentClass: parent.constructor,
                 },
                 ...parent.ancestors,
@@ -557,7 +557,7 @@ export default class Core {
 
         let deletedComponents = {};
         let addedComponents = {};
-        newComponents.forEach((x) => (addedComponents[x.componentName] = x));
+        newComponents.forEach((x) => (addedComponents[x.componentIdx] = x));
 
         if (initialAdd) {
             if (newComponents.length !== 1) {
@@ -577,10 +577,10 @@ export default class Core {
                     this.updateInfo.stateVariablesToEvaluate;
                 this.updateInfo.stateVariablesToEvaluate = [];
                 for (let {
-                    componentName,
+                    componentIdx,
                     stateVariable,
                 } of stateVariablesToEvaluate) {
-                    let comp = this._components[componentName];
+                    let comp = this._components[componentIdx];
                     if (comp && comp.state[stateVariable]) {
                         await this.getStateVariableValue({
                             component: comp,
@@ -670,10 +670,10 @@ export default class Core {
                     this.updateInfo.stateVariablesToEvaluate;
                 this.updateInfo.stateVariablesToEvaluate = [];
                 for (let {
-                    componentName,
+                    componentIdx,
                     stateVariable,
                 } of stateVariablesToEvaluate) {
-                    let comp = this._components[componentName];
+                    let comp = this._components[componentIdx];
                     if (comp && comp.state[stateVariable]) {
                         await this.getStateVariableValue({
                             component: comp,
@@ -732,13 +732,13 @@ export default class Core {
         this.componentsWithChangedChildrenToRender = new Set([]);
 
         //TODO: Figure out what we need from here
-        for (let componentName of componentsWithChangedChildrenToRenderInProgress) {
-            if (componentName in this.componentsToRender) {
+        for (let componentIdx of componentsWithChangedChildrenToRenderInProgress) {
+            if (componentIdx in this.componentsToRender) {
                 // check to see if current children who render are
                 // different from last time rendered
 
                 let currentChildIdentifiers = [];
-                let unproxiedComponent = this._components[componentName];
+                let unproxiedComponent = this._components[componentIdx];
                 let indicesToRender = [];
 
                 if (
@@ -766,7 +766,7 @@ export default class Core {
                         if (indicesToRender.includes(ind)) {
                             if (child.rendererType) {
                                 currentChildIdentifiers.push(
-                                    `nameType:${child.componentName};${child.componentType}`,
+                                    `nameType:${child.componentIdx};${child.componentType}`,
                                 );
                                 renderedInd++;
                             } else if (typeof child === "string") {
@@ -785,13 +785,13 @@ export default class Core {
                 }
 
                 let previousChildRenderers =
-                    this.componentsToRender[componentName].children;
+                    this.componentsToRender[componentIdx].children;
 
                 let previousChildIdentifiers = [];
                 for (let [ind, child] of previousChildRenderers.entries()) {
-                    if (child.componentName) {
+                    if (child.componentIdx) {
                         previousChildIdentifiers.push(
-                            `nameType:${child.componentName};${child.componentType}`,
+                            `nameType:${child.componentIdx};${child.componentType}`,
                         );
                     } else if (typeof child === "string") {
                         previousChildIdentifiers.push(`string${ind}:${child}`);
@@ -811,10 +811,10 @@ export default class Core {
                 ) {
                     // delete old renderers
                     for (let child of previousChildRenderers) {
-                        if (child.componentName) {
+                        if (child.componentIdx) {
                             let deletedNames =
                                 this.deleteFromComponentsToRender({
-                                    componentName: child.componentName,
+                                    componentIdx: child.componentIdx,
                                     recurseToChildren: true,
                                     componentsWithChangedChildrenToRenderInProgress,
                                 });
@@ -851,28 +851,28 @@ export default class Core {
                         }
                     }
 
-                    this.componentsToRender[componentName].children =
+                    this.componentsToRender[componentIdx].children =
                         childrenToRender;
 
-                    newChildrenInstructions[componentName] = childrenToRender;
+                    newChildrenInstructions[componentIdx] = childrenToRender;
 
                     componentsWithChangedChildrenToRenderInProgress.delete(
-                        componentName,
+                        componentIdx,
                     );
 
-                    if (!componentNamesToUpdate.includes(componentName)) {
-                        componentNamesToUpdate.push(componentName);
+                    if (!componentNamesToUpdate.includes(componentIdx)) {
+                        componentNamesToUpdate.push(componentIdx);
                     }
                 }
             }
         }
 
-        for (let componentName of componentNamesToUpdate) {
+        for (let componentIdx of componentNamesToUpdate) {
             if (
-                componentName in this.componentsToRender
-                // && !deletedRenderers.includes(componentName)  TODO: what if recreate with same name?
+                componentIdx in this.componentsToRender
+                // && !deletedRenderers.includes(componentIdx)  TODO: what if recreate with same name?
             ) {
-                let component = this._components[componentName];
+                let component = this._components[componentIdx];
                 if (component) {
                     let stateValuesForRenderer = {};
                     for (let stateVariable in component.state) {
@@ -893,25 +893,25 @@ export default class Core {
                     }
 
                     let newRendererState = {
-                        componentName,
+                        componentIdx,
                         stateValues: stateValuesForRenderer,
                         rendererType: component.rendererType, // TODO: need this to ignore baseVariables change: is this right place?
                     };
 
                     // this.renderState is used to save the renderer state to the database
-                    if (!this.rendererState[componentName]) {
-                        this.rendererState[componentName] = {};
+                    if (!this.rendererState[componentIdx]) {
+                        this.rendererState[componentIdx] = {};
                     }
 
-                    this.rendererState[componentName].stateValues =
+                    this.rendererState[componentIdx].stateValues =
                         stateValuesForRenderer;
 
                     // only add childrenInstructions if they changed
-                    if (newChildrenInstructions[componentName]) {
+                    if (newChildrenInstructions[componentIdx]) {
                         newRendererState.childrenInstructions =
-                            newChildrenInstructions[componentName];
-                        this.rendererState[componentName].childrenInstructions =
-                            newChildrenInstructions[componentName];
+                            newChildrenInstructions[componentIdx];
+                        this.rendererState[componentIdx].childrenInstructions =
+                            newChildrenInstructions[componentIdx];
                     }
 
                     rendererStatesToUpdate.push(newRendererState);
@@ -974,7 +974,7 @@ export default class Core {
             stateValuesForRendererAlwaysUpdate = stateValuesForRenderer;
         }
 
-        let componentName = component.componentName;
+        let componentIdx = component.componentIdx;
 
         let childrenToRender = [];
         if (component.constructor.renderChildren) {
@@ -1005,30 +1005,30 @@ export default class Core {
         }
 
         rendererStatesToUpdate.push({
-            componentName,
+            componentIdx,
             stateValues: stateValuesForRenderer,
             childrenInstructions: childrenToRender,
         });
         if (Object.keys(stateValuesForRendererAlwaysUpdate).length > 0) {
             rendererStatesToForceUpdate.push({
-                componentName,
+                componentIdx,
                 stateValues: stateValuesForRendererAlwaysUpdate,
             });
         }
 
         // this.renderState is used to save the renderer state to the database
-        this.rendererState[componentName] = {
+        this.rendererState[componentIdx] = {
             stateValues: stateValuesForRenderer,
             childrenInstructions: childrenToRender,
         };
 
-        componentsWithChangedChildrenToRenderInProgress.delete(componentName);
+        componentsWithChangedChildrenToRenderInProgress.delete(componentIdx);
 
         let requestActions = {};
         for (let actionName in component.actions) {
             requestActions[actionName] = {
                 actionName,
-                componentName: component.componentName,
+                componentIdx: component.componentIdx,
             };
         }
 
@@ -1037,20 +1037,20 @@ export default class Core {
             if (action) {
                 requestActions[actionName] = {
                     actionName,
-                    componentName: action.componentName,
+                    componentIdx: action.componentIdx,
                 };
             }
         }
 
         let rendererInstructions = {
-            componentName: componentName,
+            componentIdx: componentIdx,
             effectiveName: component.componentOrAdaptedName,
             componentType: component.componentType,
             rendererType: component.rendererType,
             actions: requestActions,
         };
 
-        this.componentsToRender[componentName] = {
+        this.componentsToRender[componentIdx] = {
             children: childrenToRender,
         };
 
@@ -1062,17 +1062,17 @@ export default class Core {
     }
 
     deleteFromComponentsToRender({
-        componentName,
+        componentIdx,
         recurseToChildren = true,
         componentsWithChangedChildrenToRenderInProgress,
     }) {
-        let deletedComponentNames = [componentName];
+        let deletedComponentNames = [componentIdx];
         if (recurseToChildren) {
-            let componentInstruction = this.componentsToRender[componentName];
+            let componentInstruction = this.componentsToRender[componentIdx];
             if (componentInstruction) {
                 for (let child of componentInstruction.children) {
                     let additionalDeleted = this.deleteFromComponentsToRender({
-                        componentName: child.componentName,
+                        componentIdx: child.componentIdx,
                         recurseToChildren,
                         componentsWithChangedChildrenToRenderInProgress,
                     });
@@ -1080,8 +1080,8 @@ export default class Core {
                 }
             }
         }
-        delete this.componentsToRender[componentName];
-        componentsWithChangedChildrenToRenderInProgress.delete(componentName);
+        delete this.componentsToRender[componentIdx];
+        componentsWithChangedChildrenToRenderInProgress.delete(componentIdx);
 
         return deletedComponentNames;
     }
@@ -1093,13 +1093,13 @@ export default class Core {
 
         let triggeredAction = false;
 
-        for (let componentName in this.stateVariableChangeTriggers) {
-            let component = this._components[componentName];
+        for (let componentIdx in this.stateVariableChangeTriggers) {
+            let component = this._components[componentIdx];
             for (let stateVariable in this.stateVariableChangeTriggers[
-                componentName
+                componentIdx
             ]) {
                 let triggerInstructions =
-                    this.stateVariableChangeTriggers[componentName][
+                    this.stateVariableChangeTriggers[componentIdx][
                         stateVariable
                     ];
 
@@ -1111,7 +1111,7 @@ export default class Core {
                     let action = component.actions[triggerInstructions.action];
                     if (action) {
                         await this.performAction({
-                            componentName,
+                            componentIdx,
                             actionName: triggerInstructions.action,
                             args: {
                                 stateValues: { [stateVariable]: value },
@@ -1143,18 +1143,18 @@ export default class Core {
         while (expandedAnother) {
             expandedAnother = false;
 
-            for (let parentName of parentsWithCompositesNotReady) {
-                let parent = this._components[parentName];
+            for (let parentIdx of parentsWithCompositesNotReady) {
+                let parent = this._components[parentIdx];
                 let foundReady = false;
-                for (let compositeName of parent.unexpandedCompositesNotReady) {
-                    let composite = this._components[compositeName];
+                for (let compositeIdx of parent.unexpandedCompositesNotReady) {
+                    let composite = this._components[compositeIdx];
                     if (composite.state.readyToExpandWhenResolved.isResolved) {
                         foundReady = true;
                         break;
                     } else {
                         let resolveResult = await this.dependencies.resolveItem(
                             {
-                                componentName: composite.componentName,
+                                componentIdx: composite.componentIdx,
                                 type: "stateVariable",
                                 stateVariable: "readyToExpandWhenResolved",
                                 force,
@@ -1170,7 +1170,7 @@ export default class Core {
                 }
 
                 if (foundReady) {
-                    let parent = this._components[parentName];
+                    let parent = this._components[parentIdx];
                     await this.deriveChildResultsFromDefiningChildren({
                         parent,
                         expandComposites: true,
@@ -1188,7 +1188,7 @@ export default class Core {
         component,
         forceExpandComposites = false,
     ) {
-        // console.log(`expand composites of descendants of ${component.componentName}, forceExpandComposites = ${forceExpandComposites}`)
+        // console.log(`expand composites of descendants of ${component.componentIdx}, forceExpandComposites = ${forceExpandComposites}`)
 
         // attempt to expand the composites of all descendants
         // include attributes with children
@@ -1202,14 +1202,14 @@ export default class Core {
                 forceExpandComposites,
             });
             if (component.unexpandedCompositesNotReady.length > 0) {
-                parentsWithCompositesNotReady.push(component.componentName);
+                parentsWithCompositesNotReady.push(component.componentIdx);
             } else {
-                // console.log(`resolving blockers from changed active children of ${component.componentName}`)
+                // console.log(`resolving blockers from changed active children of ${component.componentIdx}`)
                 await this.dependencies.resolveBlockersFromChangedActiveChildren(
                     component,
                     forceExpandComposites,
                 );
-                // console.log(`done resolving blockers from changed active children of ${component.componentName}`)
+                // console.log(`done resolving blockers from changed active children of ${component.componentIdx}`)
             }
         }
 
@@ -1227,8 +1227,8 @@ export default class Core {
             }
         }
 
-        for (let childName in component.allChildren) {
-            let child = component.allChildren[childName].component;
+        for (let childIdx in component.allChildren) {
+            let child = component.allChildren[childIdx].component;
             if (typeof child !== "object") {
                 continue;
             }
@@ -1242,17 +1242,17 @@ export default class Core {
                 ...additionalParentsWithNotReady,
             );
         }
-        // console.log(`done expanding composites of descendants of ${component.componentName}`)
+        // console.log(`done expanding composites of descendants of ${component.componentIdx}`)
 
         return parentsWithCompositesNotReady;
     }
 
     async componentAndRenderedDescendants(component) {
-        if (!component?.componentName) {
+        if (!component?.componentIdx) {
             return [];
         }
 
-        let componentNames = [component.componentName];
+        let componentNames = [component.componentIdx];
         if (component.constructor.renderChildren) {
             if (!component.matchedCompositeChildren) {
                 await this.deriveChildResultsFromDefiningChildren({
@@ -1278,12 +1278,12 @@ export default class Core {
         let namespaceForUnamed = "/";
 
         if (ancestors.length > 0) {
-            let parentName = ancestors[0].componentName;
-            let parent = this.components[parentName];
+            let parentIdx = ancestors[0].componentIdx;
+            let parent = this.components[parentIdx];
             if (parent.attributes.newNamespace?.primitive) {
-                namespaceForUnamed = parent.componentName + "/";
+                namespaceForUnamed = parent.componentIdx + "/";
             } else {
-                namespaceForUnamed = getNamespaceFromName(parent.componentName);
+                namespaceForUnamed = getNamespaceFromName(parent.componentIdx);
             }
         }
 
@@ -1317,7 +1317,7 @@ export default class Core {
             componentInd,
             serializedComponent,
         ] of serializedComponents.entries()) {
-            // console.timeLog('core','<-Top serializedComponents ',serializedComponent.componentName);
+            // console.timeLog('core','<-Top serializedComponents ',serializedComponent.componentIdx);
 
             if (typeof serializedComponent !== "object") {
                 newComponents.push(serializedComponent);
@@ -1328,7 +1328,7 @@ export default class Core {
             // add to array
             if (serializedComponent.createdComponent === true) {
                 let newComponent =
-                    this._components[serializedComponent.componentName];
+                    this._components[serializedComponent.componentIdx];
                 newComponents.push(newComponent);
 
                 // set ancestors, in case component has been moved
@@ -1369,14 +1369,14 @@ export default class Core {
                 serializedComponent.doenetAttributes = {};
             }
 
-            // if have a componentName, use that for componentName
+            // if have a componentIdx, use that for componentIdx
             // otherwise generate automatic name
-            let componentName = serializedComponent.componentName;
-            if (componentName === undefined) {
+            let componentIdx = serializedComponent.componentIdx;
+            if (componentIdx === undefined) {
                 // Note: assuming that document always has a name
                 // so we never get here without an ancestor
-                let parentName = ancestors[0].componentName;
-                let longNameId = parentName + "|" + createNameContext + "|";
+                let parentIdx = ancestors[0].componentIdx;
+                let longNameId = parentIdx + "|" + createNameContext + "|";
 
                 if (serializedComponent.uniqueIdentifier) {
                     longNameId += serializedComponent.uniqueIdentifier;
@@ -1384,18 +1384,18 @@ export default class Core {
                     longNameId += componentInd;
                 }
 
-                componentName = createUniqueName(
+                componentIdx = createUniqueName(
                     serializedComponent.componentType.toLowerCase(),
                     longNameId,
                 );
 
                 // add namespace
-                componentName = namespaceForUnamed + componentName;
+                componentIdx = namespaceForUnamed + componentIdx;
             }
 
             let createResult = await this.createChildrenThenComponent({
                 serializedComponent,
-                componentName,
+                componentIdx,
                 ancestors,
                 componentClass,
                 shadow,
@@ -1411,7 +1411,7 @@ export default class Core {
                 lastErrorMessage = createResult.lastErrorMessage;
             }
 
-            // console.timeLog('core','<-Bottom serializedComponents ',serializedComponent.componentName);
+            // console.timeLog('core','<-Bottom serializedComponents ',serializedComponent.componentIdx);
         }
 
         let results = {
@@ -1424,7 +1424,7 @@ export default class Core {
 
     async createChildrenThenComponent({
         serializedComponent,
-        componentName,
+        componentIdx,
         ancestors,
         componentClass,
         shadow = false,
@@ -1439,12 +1439,12 @@ export default class Core {
         // as children may have randomly generated names which will also collide
         // if this component's name collides,
         // and we want the mesage to be based on a name that will appear in the DoenetML document.
-        if (componentName in this._components) {
-            let lastSlash = componentName.lastIndexOf("/");
-            let originalName = componentName.slice(lastSlash + 1);
+        if (componentIdx in this._components) {
+            let lastSlash = componentIdx.lastIndexOf("/");
+            let originalName = componentIdx.slice(lastSlash + 1);
 
-            let parentName = ancestors[0].componentName;
-            let longNameId = parentName + "|";
+            let parentIdx = ancestors[0].componentIdx;
+            let longNameId = parentIdx + "|";
 
             if (serializedComponent.uniqueIdentifier) {
                 longNameId += serializedComponent.uniqueIdentifier;
@@ -1452,15 +1452,15 @@ export default class Core {
                 longNameId += componentInd;
             }
 
-            componentName = createUniqueName(
+            componentIdx = createUniqueName(
                 serializedComponent.componentType.toLowerCase(),
                 longNameId,
             );
 
             // add namespace
-            componentName = namespaceForUnamed + componentName;
+            componentIdx = namespaceForUnamed + componentIdx;
 
-            // if already was an error, don't change anything other than the componentName for the error
+            // if already was an error, don't change anything other than the componentIdx for the error
             // as we don't want to add another error and the original error message was correct.
             if (componentClass.componentType !== "_error") {
                 let doenetMLrange = serializedComponent.doenetMLrange;
@@ -1471,7 +1471,7 @@ export default class Core {
                         for (let dep of depArray) {
                             if (dep.dependencyType === "referenceShadow") {
                                 let fromComposite =
-                                    this.components[dep.compositeName];
+                                    this.components[dep.compositeIdx];
                                 doenetMLrange = fromComposite.doenetMLrange;
                             }
                         }
@@ -1502,7 +1502,7 @@ export default class Core {
         let childrenToRemainSerialized = [];
 
         let ancestorsForChildren = [
-            { componentName, componentClass },
+            { componentIdx, componentClass },
             ...ancestors,
         ];
 
@@ -1567,7 +1567,7 @@ export default class Core {
                 componentClass.preprocessSerializedChildren({
                     serializedChildren,
                     attributes: serializedComponent.attributes,
-                    componentName,
+                    componentIdx,
                 });
             }
 
@@ -1718,7 +1718,7 @@ export default class Core {
 
         if (serializedComponent.downstreamDependencies) {
             for (let name in serializedComponent.downstreamDependencies) {
-                if (name === componentName) {
+                if (name === componentIdx) {
                     throw Error(
                         this.dependencies.getCircularDependencyMessage([
                             serializedComponent,
@@ -1742,16 +1742,16 @@ export default class Core {
             await this.createStateVariableDefinitions({
                 componentClass,
                 prescribedDependencies,
-                componentName,
+                componentIdx,
             });
 
         // in case component with same name was deleted before, delete from deleteComponents and deletedStateVariable
-        delete this.updateInfo.deletedComponents[componentName];
-        delete this.updateInfo.deletedStateVariables[componentName];
+        delete this.updateInfo.deletedComponents[componentIdx];
+        delete this.updateInfo.deletedStateVariables[componentIdx];
 
         // create component itself
         let newComponent = new componentClass({
-            componentName,
+            componentIdx,
             ancestors,
             definingChildren,
             stateVariableDefinitions,
@@ -1785,7 +1785,7 @@ export default class Core {
             for (let dep of depArray) {
                 if (dep.dependencyType === "referenceShadow") {
                     let shadowInfo = {
-                        componentName: name,
+                        componentIdx: name,
                     };
                     Object.assign(shadowInfo, dep);
                     delete shadowInfo.dependencyType;
@@ -1803,19 +1803,19 @@ export default class Core {
                     shadowedComponent.shadowedBy.push(newComponent);
 
                     let mediatingShadowComposite =
-                        this._components[shadowInfo.compositeName];
+                        this._components[shadowInfo.compositeIdx];
                     if (!mediatingShadowComposite.mediatesShadows) {
                         mediatingShadowComposite.mediatesShadows = [];
                     }
                     mediatingShadowComposite.mediatesShadows.push({
-                        shadowing: newComponent.componentName,
+                        shadowing: newComponent.componentIdx,
                         shadowed: name,
                         propVariable: dep.propVariable,
                     });
 
                     if (dep.isPrimaryShadow) {
                         shadowedComponent.primaryShadow =
-                            newComponent.componentName;
+                            newComponent.componentIdx;
 
                         if (
                             this.dependencies.updateTriggers
@@ -1849,23 +1849,23 @@ export default class Core {
 
         let variablesChanged =
             await this.dependencies.checkForDependenciesOnNewComponent(
-                componentName,
+                componentIdx,
             );
 
         for (let varDescription of variablesChanged) {
             await this.markStateVariableAndUpstreamDependentsStale({
-                component: this._components[varDescription.componentName],
+                component: this._components[varDescription.componentIdx],
                 varName: varDescription.varName,
             });
         }
 
-        await this.checkForStateVariablesUpdatesForNewComponent(componentName);
+        await this.checkForStateVariablesUpdatesForNewComponent(componentIdx);
 
         await this.dependencies.resolveStateVariablesIfReady({
             component: newComponent,
         });
 
-        this.recordStateVariablesMustEvaluate(componentName);
+        this.recordStateVariablesMustEvaluate(componentIdx);
 
         await this.checkForActionChaining({ component: newComponent });
 
@@ -1879,15 +1879,15 @@ export default class Core {
         return results;
     }
 
-    async checkForStateVariablesUpdatesForNewComponent(componentName) {
+    async checkForStateVariablesUpdatesForNewComponent(componentIdx) {
         if (
-            componentName in
+            componentIdx in
             this.updateInfo.stateVariableUpdatesForMissingComponents
         ) {
             let result = await this.processNewStateVariableValues({
-                [componentName]:
+                [componentIdx]:
                     this.updateInfo.stateVariableUpdatesForMissingComponents[
-                        componentName
+                        componentIdx
                     ],
             });
 
@@ -1898,16 +1898,16 @@ export default class Core {
             // hence we set justUpdatedForNewComponent which will
             // Hence, we run the definition of all variables with the extra flag
             // justUpdatedForNewComponent = true
-            let comp = this._components[componentName];
+            let comp = this._components[componentIdx];
             if (
                 comp.constructor.processWhenJustUpdatedForNewComponent ||
                 result.foundIgnore
             ) {
                 for (let vName in this.updateInfo
-                    .stateVariableUpdatesForMissingComponents[componentName]) {
+                    .stateVariableUpdatesForMissingComponents[componentIdx]) {
                     if (comp.state[vName]) {
                         this.updateInfo.stateVariablesToEvaluate.push({
-                            componentName,
+                            componentIdx,
                             stateVariable: vName,
                         });
                         comp.state[vName].justUpdatedForNewComponent = true;
@@ -1921,7 +1921,7 @@ export default class Core {
                             // of expressionWithCodes
                             comp.reprocessAfterEvaluate =
                                 this.updateInfo.stateVariableUpdatesForMissingComponents[
-                                    componentName
+                                    componentIdx
                                 ];
                         }
                     }
@@ -1929,18 +1929,18 @@ export default class Core {
             }
 
             delete this.updateInfo.stateVariableUpdatesForMissingComponents[
-                componentName
+                componentIdx
             ];
         }
     }
 
-    recordStateVariablesMustEvaluate(componentName) {
-        let comp = this._components[componentName];
+    recordStateVariablesMustEvaluate(componentIdx) {
+        let comp = this._components[componentIdx];
 
         for (let vName in comp.state) {
             if (comp.state[vName].mustEvaluate) {
                 this.updateInfo.stateVariablesToEvaluate.push({
-                    componentName,
+                    componentIdx,
                     stateVariable: vName,
                 });
             }
@@ -1952,16 +1952,16 @@ export default class Core {
         expandComposites = true,
         forceExpandComposites = false,
     }) {
-        // console.log(`derive child results for ${parent.componentName}, ${expandComposites}, ${forceExpandComposites}`)
+        // console.log(`derive child results for ${parent.componentIdx}, ${expandComposites}, ${forceExpandComposites}`)
 
         if (!this.derivingChildResults) {
             this.derivingChildResults = [];
         }
-        if (this.derivingChildResults.includes(parent.componentName)) {
-            // console.log(`not deriving child results of ${parent.componentName} while in the middle of deriving them already`)
+        if (this.derivingChildResults.includes(parent.componentIdx)) {
+            // console.log(`not deriving child results of ${parent.componentIdx} while in the middle of deriving them already`)
             return { success: false, skipping: true };
         }
-        this.derivingChildResults.push(parent.componentName);
+        this.derivingChildResults.push(parent.componentIdx);
 
         // create allChildren and activeChildren from defining children
         // apply child logic and substitute adapters to modify activeChildren
@@ -1987,7 +1987,7 @@ export default class Core {
 
         if (parent.activeChildren) {
             previousActiveChildren = parent.activeChildren.map((child) =>
-                child.componentName ? child.componentName : child,
+                child.componentIdx ? child.componentIdx : child,
             );
         }
 
@@ -2007,20 +2007,20 @@ export default class Core {
 
         for (let ind = 0; ind < parent.activeChildren.length; ind++) {
             let child = parent.activeChildren[ind];
-            let childName;
+            let childIdx;
             if (typeof child !== "object") {
                 continue;
             }
 
-            childName = child.componentName;
+            childIdx = child.componentIdx;
 
-            parent.allChildren[childName] = {
+            parent.allChildren[childIdx] = {
                 activeChildrenIndex: ind,
                 definingChildrenIndex: ind,
                 component: child,
             };
 
-            parent.allChildrenOrdered.push(childName);
+            parent.allChildrenOrdered.push(childIdx);
         }
 
         // if any of activeChildren are expanded compositeComponents
@@ -2030,7 +2030,7 @@ export default class Core {
         let childGroupResults = await this.matchChildrenToChildGroups(parent);
 
         if (childGroupResults.success) {
-            delete this.unmatchedChildren[parent.componentName];
+            delete this.unmatchedChildren[parent.componentIdx];
             parent.childrenMatchedWithPlaceholders = true;
             parent.matchedCompositeChildrenWithPlaceholders = true;
         } else {
@@ -2059,11 +2059,11 @@ export default class Core {
             if (parent.doenetAttributes.isAttributeChildFor) {
                 let attributeForComponentType =
                     parent.ancestors[0].componentClass.componentType;
-                this.unmatchedChildren[parent.componentName] = {
+                this.unmatchedChildren[parent.componentIdx] = {
                     message: `Invalid format for attribute ${parent.doenetAttributes.isAttributeChildFor} of <${attributeForComponentType}>.`,
                 };
             } else {
-                this.unmatchedChildren[parent.componentName] = {
+                this.unmatchedChildren[parent.componentIdx] = {
                     message: `Invalid children for <${
                         parent.componentType
                     }>: Found invalid children: ${unmatchedChildrenTypes.join(
@@ -2077,7 +2077,7 @@ export default class Core {
             parent,
         });
 
-        let ind = this.derivingChildResults.indexOf(parent.componentName);
+        let ind = this.derivingChildResults.indexOf(parent.componentIdx);
 
         this.derivingChildResults.splice(ind, 1);
 
@@ -2086,13 +2086,13 @@ export default class Core {
                 previousActiveChildren &&
                 previousActiveChildren.length == parent.activeChildren.length &&
                 parent.activeChildren.every((child, ind) =>
-                    child.componentName
-                        ? child.componentName === previousActiveChildren[ind]
+                    child.componentIdx
+                        ? child.componentIdx === previousActiveChildren[ind]
                         : child === previousActiveChildren[ind],
                 );
             if (!childrenUnchanged) {
                 this.componentsWithChangedChildrenToRender.add(
-                    parent.componentName,
+                    parent.componentIdx,
                 );
             }
         }
@@ -2110,7 +2110,7 @@ export default class Core {
         // then replace the composite with its replacements,
         // expanding it if not already expanded
 
-        // console.log(`expanding defining children of of ${parent.componentName}`)
+        // console.log(`expanding defining children of of ${parent.componentIdx}`)
 
         let unexpandedCompositesReady = [];
         let unexpandedCompositesNotReady = [];
@@ -2134,14 +2134,14 @@ export default class Core {
 
                 // expand composite if it isn't already
                 if (!child.isExpanded) {
-                    // console.log(`child ${child.componentName} is not expanded`)
+                    // console.log(`child ${child.componentIdx} is not expanded`)
                     // console.log(child.state.readyToExpandWhenResolved.isResolved)
 
                     if (!child.state.readyToExpandWhenResolved.isResolved) {
                         if (expandComposites) {
                             let resolveResult =
                                 await this.dependencies.resolveItem({
-                                    componentName: child.componentName,
+                                    componentIdx: child.componentIdx,
                                     type: "stateVariable",
                                     stateVariable: "readyToExpandWhenResolved",
                                     expandComposites, //: forceExpandComposites,
@@ -2150,26 +2150,26 @@ export default class Core {
 
                             if (!resolveResult.success) {
                                 unexpandedCompositesNotReady.push(
-                                    child.componentName,
+                                    child.componentIdx,
                                 );
                                 this.updateInfo.compositesToExpand.add(
-                                    child.componentName,
+                                    child.componentIdx,
                                 );
                                 continue;
                             }
                         } else {
                             unexpandedCompositesNotReady.push(
-                                child.componentName,
+                                child.componentIdx,
                             );
                             this.updateInfo.compositesToExpand.add(
-                                child.componentName,
+                                child.componentIdx,
                             );
                             continue;
                         }
                     } else if (!expandComposites) {
-                        unexpandedCompositesReady.push(child.componentName);
+                        unexpandedCompositesReady.push(child.componentIdx);
                         this.updateInfo.compositesToExpand.add(
-                            child.componentName,
+                            child.componentIdx,
                         );
                         continue;
                     }
@@ -2195,7 +2195,7 @@ export default class Core {
             }
         }
 
-        // console.log(`done expanding defining children of of ${parent.componentName}`)
+        // console.log(`done expanding defining children of of ${parent.componentIdx}`)
 
         return { unexpandedCompositesReady, unexpandedCompositesNotReady };
     }
@@ -2358,7 +2358,7 @@ export default class Core {
                 if (component.compositeReplacementActiveRange) {
                     for (let compositeInfo of component.compositeReplacementActiveRange) {
                         let composite =
-                            this._components[compositeInfo.compositeName];
+                            this._components[compositeInfo.compositeIdx];
                         if (await composite.stateValues.hidden) {
                             if (
                                 compositeInfo.firstInd <= ind &&
@@ -2385,7 +2385,7 @@ export default class Core {
         let originalChild = parent.activeChildren[childInd];
 
         let newSerializedChild;
-        if (originalChild.componentName) {
+        if (originalChild.componentIdx) {
             newSerializedChild = originalChild.getAdapter(adapterIndUsed);
         } else {
             // child isn't a component, just an object with a componentType
@@ -2407,17 +2407,17 @@ export default class Core {
             adapter === undefined ||
             adapter.componentType !== newSerializedChild.componentType
         ) {
-            if (originalChild.componentName) {
+            if (originalChild.componentIdx) {
                 let namespaceForUnamed;
                 if (parent.attributes.newNamespace?.primitive) {
-                    namespaceForUnamed = parent.componentName + "/";
+                    namespaceForUnamed = parent.componentIdx + "/";
                 } else {
                     namespaceForUnamed = getNamespaceFromName(
-                        parent.componentName,
+                        parent.componentIdx,
                     );
                 }
 
-                newSerializedChild.adaptedFrom = originalChild.componentName;
+                newSerializedChild.adaptedFrom = originalChild.componentIdx;
                 assignDoenetMLRange(
                     [newSerializedChild],
                     originalChild.doenetMLrange,
@@ -2426,7 +2426,7 @@ export default class Core {
                     serializedComponents: [newSerializedChild],
                     shadow: true,
                     ancestors: originalChild.ancestors,
-                    createNameContext: originalChild.componentName + "|adapter",
+                    createNameContext: originalChild.componentIdx + "|adapter",
                     namespaceForUnamed,
                 });
 
@@ -2448,11 +2448,11 @@ export default class Core {
 
         // Update allChildren to show that originalChild is no longer active
         // and that adapter is now an active child
-        if (originalChild.componentName) {
+        if (originalChild.componentIdx) {
             // ignore placeholder active children
-            delete parent.allChildren[originalChild.componentName]
+            delete parent.allChildren[originalChild.componentIdx]
                 .activeChildrenIndex;
-            parent.allChildren[adapter.componentName] = {
+            parent.allChildren[adapter.componentIdx] = {
                 activeChildrenIndex: childInd,
                 component: adapter,
             };
@@ -2460,14 +2460,14 @@ export default class Core {
 
         // find index of originalChild in allChildrenOrdered
         // and place adapter immediately afterward
-        if (originalChild.componentName) {
+        if (originalChild.componentIdx) {
             let originalInd = parent.allChildrenOrdered.indexOf(
-                originalChild.componentName,
+                originalChild.componentIdx,
             );
             parent.allChildrenOrdered.splice(
                 originalInd + 1,
                 0,
-                adapter.componentName,
+                adapter.componentIdx,
             );
         } else {
             // adapter of placeholder
@@ -2485,25 +2485,25 @@ export default class Core {
     async expandCompositeComponent(component) {
         if (!("readyToExpandWhenResolved" in component.state)) {
             throw Error(
-                `Could not find state variable readyToExpandWhenResolved of composite ${component.componentName}`,
+                `Could not find state variable readyToExpandWhenResolved of composite ${component.componentIdx}`,
             );
         }
 
         if (!component.state.readyToExpandWhenResolved.isResolved) {
-            this.updateInfo.compositesToExpand.add(component.componentName);
+            this.updateInfo.compositesToExpand.add(component.componentIdx);
             return { success: false };
         }
 
-        this.updateInfo.compositesToExpand.delete(component.componentName);
+        this.updateInfo.compositesToExpand.delete(component.componentIdx);
 
-        // console.log(`expanding composite ${component.componentName}`);
+        // console.log(`expanding composite ${component.componentIdx}`);
 
-        this.updateInfo.compositesBeingExpanded.push(component.componentName);
+        this.updateInfo.compositesBeingExpanded.push(component.componentIdx);
 
         if (component.parent) {
             if (component.parent.unexpandedCompositesReady) {
                 let ind = component.parent.unexpandedCompositesReady.indexOf(
-                    component.componentName,
+                    component.componentIdx,
                 );
                 if (ind !== -1) {
                     component.parent.unexpandedCompositesReady.splice(ind, 1);
@@ -2511,7 +2511,7 @@ export default class Core {
             }
             if (component.parent.unexpandedCompositesNotReady) {
                 let ind = component.parent.unexpandedCompositesNotReady.indexOf(
-                    component.componentName,
+                    component.componentIdx,
                 );
                 if (ind !== -1) {
                     component.parent.unexpandedCompositesNotReady.splice(
@@ -2551,7 +2551,7 @@ export default class Core {
         // publicCaseInsensitiveAliasSubstitutions: a function that can be used to find a case insensitive match
         //   to a public state variable, substituting aliases if necessary
         let result = await component.constructor.createSerializedReplacements({
-            component: this.components[component.componentName], // to create proxy
+            component: this.components[component.componentIdx], // to create proxy
             components: this.components,
             workspace: component.replacementsWorkspace,
             componentInfoObjects: this.componentInfoObjects,
@@ -2562,7 +2562,7 @@ export default class Core {
         });
 
         let doenetMLrange =
-            this.components[component.componentName].doenetMLrange;
+            this.components[component.componentIdx].doenetMLrange;
         let overwriteDoenetMLRange = component.componentType === "copy";
 
         this.gatherErrorsAndAssignDoenetMLRange({
@@ -2573,15 +2573,15 @@ export default class Core {
             overwriteDoenetMLRange,
         });
 
-        // console.log(`expand result for ${component.componentName}`);
+        // console.log(`expand result for ${component.componentIdx}`);
         // console.log(JSON.parse(JSON.stringify(result)));
 
         if (component.constructor.stateVariableToEvaluateAfterReplacements) {
-            // console.log(`evaluating ${component.constructor.stateVariableToEvaluateAfterReplacements} of ${component.componentName}`)
+            // console.log(`evaluating ${component.constructor.stateVariableToEvaluateAfterReplacements} of ${component.componentIdx}`)
             await component.stateValues[
                 component.constructor.stateVariableToEvaluateAfterReplacements
             ];
-            // console.log(`done evaluating ${component.constructor.stateVariableToEvaluateAfterReplacements} of ${composite.componentName}`)
+            // console.log(`done evaluating ${component.constructor.stateVariableToEvaluateAfterReplacements} of ${composite.componentIdx}`)
         }
 
         if (result.replacements) {
@@ -2601,22 +2601,22 @@ export default class Core {
             });
         } else {
             throw Error(
-                `Invalid createSerializedReplacements of ${component.componentName}`,
+                `Invalid createSerializedReplacements of ${component.componentIdx}`,
             );
         }
 
         // record that are finished expanding the composite
         let targetInd = this.updateInfo.compositesBeingExpanded.indexOf(
-            component.componentName,
+            component.componentIdx,
         );
         if (targetInd === -1) {
             throw Error(
-                `Something is wrong as we lost track that we were expanding ${component.componentName}`,
+                `Something is wrong as we lost track that we were expanding ${component.componentIdx}`,
             );
         }
         this.updateInfo.compositesBeingExpanded.splice(targetInd, 1);
 
-        return { success: true, compositesExpanded: [component.componentName] };
+        return { success: true, compositesExpanded: [component.componentIdx] };
     }
 
     gatherErrorsAndAssignDoenetMLRange({
@@ -2641,40 +2641,40 @@ export default class Core {
     }
 
     async expandShadowingComposite(component) {
-        // console.log(`expand shadowing composite, ${component.componentName}`);
+        // console.log(`expand shadowing composite, ${component.componentIdx}`);
 
         if (
             this.updateInfo.compositesBeingExpanded.includes(
-                component.shadows.componentName,
+                component.shadows.componentIdx,
             )
         ) {
             // found a circular dependency,
             // as we are in the middle of expanding a composite
             // that we are now trying to shadow
             let compositeInvolved =
-                this._components[component.shadows.componentName];
+                this._components[component.shadows.componentIdx];
             // find non-shadow for error message, as that would be a component from document
             while (compositeInvolved.shadows) {
                 compositeInvolved =
-                    this._components[compositeInvolved.shadows.componentName];
+                    this._components[compositeInvolved.shadows.componentIdx];
             }
             throw Error(
-                `Circular dependency involving ${compositeInvolved.componentName}.`,
+                `Circular dependency involving ${compositeInvolved.componentIdx}.`,
             );
         }
 
         let shadowedComposite =
-            this._components[component.shadows.componentName];
+            this._components[component.shadows.componentIdx];
         let compositesExpanded = [];
 
-        // console.log(`shadowedComposite: ${shadowedComposite.componentName}`)
+        // console.log(`shadowedComposite: ${shadowedComposite.componentIdx}`)
         // console.log(shadowedComposite.isExpanded);
         if (!shadowedComposite.isExpanded) {
             let result = await this.expandCompositeComponent(shadowedComposite);
 
             if (!result.success) {
                 throw Error(
-                    `expand result of ${component.componentName} was not a success even though ready to expand.`,
+                    `expand result of ${component.componentIdx} was not a success even though ready to expand.`,
                 );
             }
             compositesExpanded.push(...result.compositesExpanded);
@@ -2699,7 +2699,7 @@ export default class Core {
             }
         }
 
-        // console.log(`serialized replacements of ${shadowedComposite.componentName}`)
+        // console.log(`serialized replacements of ${shadowedComposite.componentIdx}`)
         // console.log(JSON.parse(JSON.stringify(serializedReplacements)))
 
         // Have three composites involved:
@@ -2710,12 +2710,12 @@ export default class Core {
         let uniqueIdentifiersUsed =
             (component.replacementsWorkspace.uniqueIdentifiersUsed = []);
 
-        let nameOfCompositeMediatingTheShadow = component.shadows.compositeName;
+        let nameOfCompositeMediatingTheShadow = component.shadows.compositeIdx;
         let compositeMediatingTheShadow =
             this.components[nameOfCompositeMediatingTheShadow];
         serializedReplacements = postProcessCopy({
             serializedComponents: serializedReplacements,
-            componentName: nameOfCompositeMediatingTheShadow,
+            componentIdx: nameOfCompositeMediatingTheShadow,
             uniqueIdentifiersUsed,
         });
 
@@ -2782,9 +2782,9 @@ export default class Core {
         // console.log(
         //   `name of composite mediating shadow: ${nameOfCompositeMediatingTheShadow}`,
         // );
-        // console.log(`name of composite shadowing: ${component.componentName}`);
+        // console.log(`name of composite shadowing: ${component.componentIdx}`);
         // console.log(
-        //   `name of shadowed composite: ${shadowedComposite.componentName}`,
+        //   `name of shadowed composite: ${shadowedComposite.componentIdx}`,
         // );
 
         // If shadowed composite mediates the shadow of compositeMediatingTheShadow,
@@ -2863,13 +2863,12 @@ export default class Core {
                 assignNames = assignNames.map((x) => [x]);
             }
 
-            let parentName = component.componentName;
+            let parentIdx = component.componentIdx;
             let parentCreatesNewNamespace = newNamespace;
             if (component.doenetAttributes.parentNameForAssignNames) {
-                parentName =
-                    component.doenetAttributes.parentNameForAssignNames;
+                parentIdx = component.doenetAttributes.parentNameForAssignNames;
                 parentCreatesNewNamespace =
-                    this._components[parentName].attributes.newNamespace
+                    this._components[parentIdx].attributes.newNamespace
                         ?.primitive;
             }
 
@@ -2882,7 +2881,7 @@ export default class Core {
             // and processAssignNames will set parentNameForAssignNames to be compositesParentNameForAssignNames
             let compositesParentNameForAssignNames;
             if (await component.stateValues.addLevelToAssignNames) {
-                compositesParentNameForAssignNames = parentName;
+                compositesParentNameForAssignNames = parentIdx;
             }
 
             let processResult = processAssignNames({
@@ -2891,8 +2890,8 @@ export default class Core {
                     component.doenetAttributes
                         .assignNamesForCompositeReplacement,
                 serializedComponents: serializedReplacements,
-                parentName,
-                parentNameForUniqueNames: component.componentName,
+                parentIdx,
+                parentNameForUniqueNames: component.componentIdx,
                 parentCreatesNewNamespace,
                 componentInfoObjects: this.componentInfoObjects,
                 originalNamesAreConsistent,
@@ -2911,7 +2910,7 @@ export default class Core {
             serializedReplacements = processResult.serializedComponents;
 
             if (
-                target?.componentName === shadowedComposite.componentName &&
+                target?.componentIdx === shadowedComposite.componentIdx &&
                 compositeMediatingTheShadow.doenetAttributes.fromCopyTarget
             ) {
                 let newReplacements = deepClone(
@@ -2931,8 +2930,8 @@ export default class Core {
                 let processResult = processAssignNames({
                     assignNames,
                     serializedComponents: newReplacements,
-                    parentName,
-                    parentNameForUniqueNames: component.componentName,
+                    parentIdx,
+                    parentNameForUniqueNames: component.componentIdx,
                     parentCreatesNewNamespace:
                         compositeMediatingTheShadow.attributes
                             .assignNewNamespaces?.primitive,
@@ -2962,7 +2961,7 @@ export default class Core {
             let processResult = processAssignNames({
                 // assignNames: component.doenetAttributes.assignNames,
                 serializedComponents: serializedReplacements,
-                parentName: component.componentName,
+                parentIdx: component.componentIdx,
                 parentCreatesNewNamespace: newNamespace,
                 componentInfoObjects: this.componentInfoObjects,
                 originalNamesAreConsistent,
@@ -3010,7 +3009,7 @@ export default class Core {
         }
 
         // console.log(
-        //   `serialized replacements for ${component.componentName} who is shadowing ${shadowedComposite.componentName}`,
+        //   `serialized replacements for ${component.componentIdx} who is shadowing ${shadowedComposite.componentIdx}`,
         // );
         // console.log(deepClone(serializedReplacements));
 
@@ -3026,16 +3025,16 @@ export default class Core {
 
         // record that are finished expanding the composite
         let targetInd = this.updateInfo.compositesBeingExpanded.indexOf(
-            component.componentName,
+            component.componentIdx,
         );
         if (targetInd === -1) {
             throw Error(
-                `Something is wrong as we lost track that we were expanding ${component.componentName}`,
+                `Something is wrong as we lost track that we were expanding ${component.componentIdx}`,
             );
         }
         this.updateInfo.compositesBeingExpanded.splice(targetInd, 1);
 
-        compositesExpanded.push(component.componentName);
+        compositesExpanded.push(component.componentIdx);
 
         return { success: true, compositesExpanded };
     }
@@ -3059,7 +3058,7 @@ export default class Core {
         // but we don't protect against that.
 
         let compositeMediatingTheShadow =
-            this.components[shadowingComposite.shadows.compositeName];
+            this.components[shadowingComposite.shadows.compositeIdx];
 
         let newNamespace =
             shadowingComposite.attributes.newNamespace?.primitive;
@@ -3071,9 +3070,11 @@ export default class Core {
 
         // check if the component that created the namespace for the shadowing composite
         // is a replacement of the composite mediating the shadow
-        let lastSlash = shadowingComposite.componentName.lastIndexOf("/");
-        let nameForNamespaceOfShadowing =
-            shadowingComposite.componentName.slice(0, lastSlash);
+        let lastSlash = shadowingComposite.componentIdx.lastIndexOf("/");
+        let nameForNamespaceOfShadowing = shadowingComposite.componentIdx.slice(
+            0,
+            lastSlash,
+        );
         let componentCreatingNamespace =
             this._components[nameForNamespaceOfShadowing];
 
@@ -3084,8 +3085,8 @@ export default class Core {
             let replacementOf = comp.replacementOf;
             if (replacementOf) {
                 if (
-                    replacementOf.componentName ===
-                    compositeMediatingTheShadow.componentName
+                    replacementOf.componentIdx ===
+                    compositeMediatingTheShadow.componentIdx
                 ) {
                     return true;
                 }
@@ -3094,7 +3095,7 @@ export default class Core {
                 }
             }
             if (
-                checkIfReplacementOfMediating(this._components[comp.parentName])
+                checkIfReplacementOfMediating(this._components[comp.parentIdx])
             ) {
                 return true;
             }
@@ -3112,7 +3113,7 @@ export default class Core {
             mediatingNewNamespace ||
             assignNewNamespaces;
 
-        // console.log(`for shadowing composite: ${shadowingComposite.componentName}`);
+        // console.log(`for shadowing composite: ${shadowingComposite.componentIdx}`);
         // console.log({
         //   newNamespace,
         //   namespaceFromReplacementOfMediating,
@@ -3128,9 +3129,9 @@ export default class Core {
 
         let namespaceForUnamed;
         if (component.attributes.newNamespace?.primitive) {
-            namespaceForUnamed = component.componentName + "/";
+            namespaceForUnamed = component.componentIdx + "/";
         } else {
-            namespaceForUnamed = getNamespaceFromName(component.componentName);
+            namespaceForUnamed = getNamespaceFromName(component.componentIdx);
         }
 
         try {
@@ -3138,7 +3139,7 @@ export default class Core {
                 serializedComponents: serializedReplacements,
                 ancestors: component.ancestors,
                 shadow: true,
-                createNameContext: component.componentName + "|replacements",
+                createNameContext: component.componentIdx + "|replacements",
                 namespaceForUnamed,
                 componentsReplacementOf: component,
             });
@@ -3163,7 +3164,7 @@ export default class Core {
         // then replace the composite with its replacements,
         // expanding it if not already expanded
 
-        // console.log(`replace composite children of ${parent.componentName}`)
+        // console.log(`replace composite children of ${parent.componentIdx}`)
 
         delete parent.placeholderActiveChildrenIndices;
         delete parent.placeholderActiveChildrenIndicesByComposite;
@@ -3228,7 +3229,7 @@ export default class Core {
                     for (let i = 0; i < numComponents; i++) {
                         replacements.push({
                             componentType,
-                            fromComposite: child.componentName,
+                            fromComposite: child.componentIdx,
                             placeholderInd: nPlaceholdersAdded,
                         });
                         nPlaceholdersAdded++;
@@ -3250,7 +3251,7 @@ export default class Core {
                         parent.placeholderActiveChildrenIndicesByComposite = {};
                     }
                     parent.placeholderActiveChildrenIndicesByComposite[
-                        child.componentName
+                        child.componentIdx
                     ] = placeholdInds;
                 } else {
                     // don't use any replacements that are marked as being withheld
@@ -3335,7 +3336,7 @@ export default class Core {
                 // - in child dependencies, where they will be translated for matched children
                 //   and used in some components to determine if those children can be formed into a list
                 parent.compositeReplacementActiveRange.push({
-                    compositeName: child.componentName,
+                    compositeIdx: child.componentIdx,
                     target: await child.stateValues.target,
                     firstInd: childInd,
                     lastInd: childInd + replacements.length - 1,
@@ -3346,13 +3347,13 @@ export default class Core {
                 parent.activeChildren.splice(childInd, 1, ...replacements);
 
                 // Update allChildren object with info on composite and its replacemnts
-                let allChildrenObj = parent.allChildren[child.componentName];
+                let allChildrenObj = parent.allChildren[child.componentIdx];
                 delete allChildrenObj.activeChildrenIndex;
                 for (let ind2 = 0; ind2 < replacements.length; ind2++) {
                     let replacement = replacements[ind2];
-                    if (replacement.componentName) {
+                    if (replacement.componentIdx) {
                         // ignore placeholder, string, and primitive number active children
-                        parent.allChildren[replacement.componentName] = {
+                        parent.allChildren[replacement.componentIdx] = {
                             activeChildrenIndex: childInd + ind2,
                             component: replacement,
                         };
@@ -3362,7 +3363,7 @@ export default class Core {
                 // find index of child in allChildrenOrdered
                 // and place replacements immediately afterward
                 let ind2 = parent.allChildrenOrdered.indexOf(
-                    child.componentName,
+                    child.componentIdx,
                 );
                 parent.allChildrenOrdered.splice(
                     ind2 + 1,
@@ -3370,9 +3371,7 @@ export default class Core {
                     ...replacements
                         .filter((x) => typeof x === "object")
                         .map((x) =>
-                            x.componentName
-                                ? x.componentName
-                                : x.placeholderInd,
+                            x.componentIdx ? x.componentIdx : x.placeholderInd,
                         ),
                 );
 
@@ -3386,9 +3385,9 @@ export default class Core {
                         ind2++
                     ) {
                         let child2 = parent.activeChildren[ind2];
-                        if (child2.componentName) {
+                        if (child2.componentIdx) {
                             parent.allChildren[
-                                child2.componentName
+                                child2.componentIdx
                             ].activeChildrenIndex += nShift;
                         }
                     }
@@ -3424,7 +3423,7 @@ export default class Core {
         let definingChildIndToAddError;
         while (!ancestorToDisplayErrors.constructor.canDisplayChildErrors) {
             let nextAncestor =
-                this._components[ancestorToDisplayErrors.parentName];
+                this._components[ancestorToDisplayErrors.parentIdx];
 
             definingChildIndToAddError = nextAncestor.definingChildren.indexOf(
                 ancestorToDisplayErrors,
@@ -3471,7 +3470,7 @@ export default class Core {
         // if updates to replacements were postponed
         // add them back to the queue
         if (!(await composite.stateValues.isInactiveCompositeReplacement)) {
-            let cName = composite.componentName;
+            let cName = composite.componentIdx;
             if (
                 this.updateInfo.inactiveCompositesToUpdateReplacements.has(
                     cName,
@@ -3503,9 +3502,9 @@ export default class Core {
                 component,
                 varName: "isInactiveCompositeReplacement",
             });
-            for (let childName in component.allChildren) {
+            for (let childIdx in component.allChildren) {
                 await this.changeInactiveComponentAndDescendants(
-                    this._components[childName],
+                    this._components[childIdx],
                     inactive,
                 );
             }
@@ -3514,7 +3513,7 @@ export default class Core {
                 let attrComp = component.attributes[attrName].component;
                 if (attrComp) {
                     await this.changeInactiveComponentAndDescendants(
-                        this._components[attrComp.componentName],
+                        this._components[attrComp.componentIdx],
                         inactive,
                     );
                 }
@@ -3551,7 +3550,7 @@ export default class Core {
     async createStateVariableDefinitions({
         componentClass,
         prescribedDependencies,
-        componentName,
+        componentIdx,
     }) {
         let redefineDependencies;
 
@@ -3560,15 +3559,15 @@ export default class Core {
                 let depArray = prescribedDependencies[name];
                 for (let dep of depArray) {
                     if (dep.dependencyType === "referenceShadow") {
-                        if (name === componentName) {
+                        if (name === componentIdx) {
                             throw Error(
-                                `Circular dependency involving ${componentName}.`,
+                                `Circular dependency involving ${componentIdx}.`,
                             );
                         }
                         redefineDependencies = {
                             linkSource: "referenceShadow",
                             targetName: name,
-                            compositeName: dep.compositeName,
+                            compositeIdx: dep.compositeIdx,
                             propVariable: dep.propVariable,
                             fromImplicitProp: dep.fromImplicitProp,
                             arrayStateVariable: dep.arrayStateVariable,
@@ -3968,7 +3967,7 @@ export default class Core {
         // attributes depend on adapterTarget (if attribute exists in adapterTarget)
         let adapterTargetComponent =
             this._components[
-                redefineDependencies.adapterTargetIdentity.componentName
+                redefineDependencies.adapterTargetIdentity.componentIdx
             ];
 
         let attributes = componentClass.createAttributesObject();
@@ -4025,9 +4024,9 @@ export default class Core {
                 stateVarDef.returnDependencies = () => ({
                     adapterTargetVariable: {
                         dependencyType: "stateVariable",
-                        componentName:
+                        componentIdx:
                             redefineDependencies.adapterTargetIdentity
-                                .componentName,
+                                .componentIdx,
                         variableName: varName,
                     },
                 });
@@ -4122,8 +4121,8 @@ export default class Core {
         stateDef.returnDependencies = () => ({
             adapterTargetVariable: {
                 dependencyType: "stateVariable",
-                componentName:
-                    redefineDependencies.adapterTargetIdentity.componentName,
+                componentIdx:
+                    redefineDependencies.adapterTargetIdentity.componentIdx,
                 variableName: redefineDependencies.adapterVariable,
             },
         });
@@ -4555,7 +4554,7 @@ export default class Core {
                 stateDef.returnDependencies = () => ({
                     targetVariable: {
                         dependencyType: "stateVariable",
-                        componentName: targetComponent.componentName,
+                        componentIdx: targetComponent.componentIdx,
                         variableName: redefineDependencies.propVariable,
                     },
                 });
@@ -4739,7 +4738,7 @@ export default class Core {
                 let dependencies = originalReturnDependencies(args);
                 dependencies.targetReadyToExpandWhenResolved = {
                     dependencyType: "stateVariable",
-                    componentName: targetComponent.componentName,
+                    componentIdx: targetComponent.componentIdx,
                     variableName: "readyToExpandWhenResolved",
                 };
                 return dependencies;
@@ -4848,7 +4847,7 @@ export default class Core {
                         dependenciesByKey[key] = {
                             targetVariable: {
                                 dependencyType: "stateVariable",
-                                componentName: targetComponent.componentName,
+                                componentIdx: targetComponent.componentIdx,
                                 variableName:
                                     overrideVarNameWith ||
                                     this.arrayVarNameFromArrayKey(key),
@@ -4861,7 +4860,7 @@ export default class Core {
                     if (copyComponentType) {
                         globalDependencies.targetVariableComponentType = {
                             dependencyType: "stateVariableComponentType",
-                            componentName: targetComponent.componentName,
+                            componentIdx: targetComponent.componentIdx,
                             variableName: varName,
                         };
                     }
@@ -4869,7 +4868,7 @@ export default class Core {
                     if (stateDef.inverseShadowToSetEntireArray) {
                         globalDependencies.targetArray = {
                             dependencyType: "stateVariable",
-                            componentName: targetComponent.componentName,
+                            componentIdx: targetComponent.componentIdx,
                             variableName: varName,
                         };
                     }
@@ -4985,13 +4984,13 @@ export default class Core {
 
                     dependencies.targetVariable = {
                         dependencyType: "stateVariable",
-                        componentName: targetComponent.componentName,
+                        componentIdx: targetComponent.componentIdx,
                         variableName: varNameInTarget,
                     };
                     if (copyComponentType) {
                         dependencies.targetVariableComponentType = {
                             dependencyType: "stateVariableComponentType",
-                            componentName: targetComponent.componentName,
+                            componentIdx: targetComponent.componentIdx,
                             variableName: varNameInTarget,
                         };
                     }
@@ -5154,10 +5153,10 @@ export default class Core {
 
         if (stateVarObj.triggerActionOnChange) {
             let componentTriggers =
-                this.stateVariableChangeTriggers[component.componentName];
+                this.stateVariableChangeTriggers[component.componentIdx];
             if (!componentTriggers) {
                 componentTriggers = this.stateVariableChangeTriggers[
-                    component.componentName
+                    component.componentIdx
                 ] = {};
             }
             componentTriggers[stateVariable] = {
@@ -5185,7 +5184,7 @@ export default class Core {
 
                 let originObj =
                     this.originsOfActionsChangedToActions[
-                        component.componentName
+                        component.componentIdx
                     ];
 
                 let previousIds;
@@ -5214,7 +5213,7 @@ export default class Core {
                             }
 
                             componentActionsChained.push({
-                                componentName: component.componentName,
+                                componentIdx: component.componentIdx,
                                 actionName: chainInfo.triggeredAction,
                                 stateVariableDefiningChain: varName,
                                 args: {},
@@ -5237,8 +5236,8 @@ export default class Core {
 
                         for (let chainedInfo of componentActionsChained) {
                             if (
-                                chainedInfo.componentName !==
-                                    component.componentName ||
+                                chainedInfo.componentIdx !==
+                                    component.componentIdx ||
                                 chainedInfo.stateVariableDefiningChain !==
                                     varName
                             ) {
@@ -5254,7 +5253,7 @@ export default class Core {
                 if (newTargets.length > 0) {
                     if (!originObj) {
                         originObj = this.originsOfActionsChangedToActions[
-                            component.componentName
+                            component.componentIdx
                         ] = {};
                     }
                     originObj[varName] = newTargets;
@@ -5263,7 +5262,7 @@ export default class Core {
 
                     if (Object.keys(originObj).length === 0) {
                         delete this.originsOfActionsChangedToActions[
-                            component.componentName
+                            component.componentIdx
                         ];
                     }
                 }
@@ -5932,7 +5931,7 @@ export default class Core {
             }
 
             stateVarObj.adjustArrayToNewArraySize = async function () {
-                // console.log(`adjust array ${stateVariable} of ${component.componentName} to new array size: ${stateVarObj.arraySize[0]}`);
+                // console.log(`adjust array ${stateVariable} of ${component.componentIdx} to new array size: ${stateVarObj.arraySize[0]}`);
                 let arraySize = await stateVarObj.arraySize;
                 stateVarObj.arrayValues.length = arraySize[0];
             };
@@ -6008,7 +6007,7 @@ export default class Core {
 
         // create returnDependencies function from returnArrayDependenciesByKey
         stateVarObj.returnDependencies = async function (args) {
-            // console.log(`return dependencies for array ${stateVariable} of ${component.componentName}`)
+            // console.log(`return dependencies for array ${stateVariable} of ${component.componentIdx}`)
             // console.log(JSON.parse(JSON.stringify(args)));
 
             args.arraySize = await stateVarObj.arraySize;
@@ -6133,7 +6132,7 @@ export default class Core {
                 variableName: stateVarObj.arraySizeStateVariable,
             };
 
-            // console.log(`resulting dependencies for ${stateVariable} of ${component.componentName}`)
+            // console.log(`resulting dependencies for ${stateVariable} of ${component.componentIdx}`)
             // console.log(dependencies)
             return dependencies;
         };
@@ -6143,7 +6142,7 @@ export default class Core {
             arrayKeys,
             arraySize,
         }) {
-            // console.log(`getCurrentFreshness for array ${stateVariable} of ${component.componentName}`)
+            // console.log(`getCurrentFreshness for array ${stateVariable} of ${component.componentIdx}`)
             // console.log(arrayKeys, arraySize);
             // console.log(JSON.parse(JSON.stringify(freshnessInfo)))
 
@@ -6177,7 +6176,7 @@ export default class Core {
             arrayKeys,
             arraySize,
         }) {
-            // console.log(`markStale for array ${stateVariable} of ${component.componentName}`)
+            // console.log(`markStale for array ${stateVariable} of ${component.componentIdx}`)
             // console.log(changes, arrayKeys, arraySize);
             // console.log(JSON.parse(JSON.stringify(freshnessInfo)))
 
@@ -6272,7 +6271,7 @@ export default class Core {
             freshnessInfo,
             arraySize,
         }) {
-            // console.log(`freshenOnNoChanges for ${stateVariable} of ${component.componentName}`)
+            // console.log(`freshenOnNoChanges for ${stateVariable} of ${component.componentIdx}`)
             let freshByKey = freshnessInfo.freshByKey;
 
             if (arrayKeys === undefined) {
@@ -6336,7 +6335,7 @@ export default class Core {
         }
 
         stateVarObj.definition = function (args) {
-            // console.log(`definition in array ${stateVariable} of ${component.componentName}`)
+            // console.log(`definition in array ${stateVariable} of ${component.componentIdx}`)
             // console.log(JSON.parse(JSON.stringify(args)));
             // console.log(args.arrayKeys)
             // console.log(args.dependencyValues)
@@ -6443,7 +6442,7 @@ export default class Core {
                     args.freshnessInfo.freshArraySize = true;
                 }
 
-                // console.log(`result of array definition of ${stateVariable} of ${component.componentName}`)
+                // console.log(`result of array definition of ${stateVariable} of ${component.componentIdx}`)
                 // console.log(JSON.parse(JSON.stringify(result)))
                 // console.log(JSON.parse(JSON.stringify(args.freshnessInfo)))
                 return result;
@@ -6756,7 +6755,7 @@ export default class Core {
                 );
             } else {
                 this.errorWarnings.warnings.push({
-                    message: `Cannot get propIndex from ${varName} of ${component.componentName} as it is not an array or array entry state variable`,
+                    message: `Cannot get propIndex from ${varName} of ${component.componentIdx} as it is not an array or array entry state variable`,
                     level: 1,
                     doenetMLrange: component.doenetMLrange,
                 });
@@ -6767,7 +6766,7 @@ export default class Core {
                 newVarNames.push(newName);
             } else {
                 this.errorWarnings.warnings.push({
-                    message: `Cannot get propIndex from ${varName} of ${component.componentName}`,
+                    message: `Cannot get propIndex from ${varName} of ${component.componentIdx}`,
                     level: 1,
                     doenetMLrange: component.doenetMLrange,
                 });
@@ -6797,18 +6796,18 @@ export default class Core {
                     includeNonStandard: recurseNonStandardComposites,
                 })
             ) {
-                compositesFound.push(replacement.componentName);
+                compositesFound.push(replacement.componentIdx);
 
                 if (!replacement.isExpanded) {
                     if (
                         replacement.state.readyToExpandWhenResolved.isResolved
                     ) {
                         unexpandedCompositesReady.push(
-                            replacement.componentName,
+                            replacement.componentIdx,
                         );
                     } else {
                         unexpandedCompositesNotReady.push(
-                            replacement.componentName,
+                            replacement.componentIdx,
                         );
                     }
                 }
@@ -6856,12 +6855,12 @@ export default class Core {
     }
 
     async getStateVariableValue({ component, stateVariable }) {
-        // console.log(`getting value of state variable ${stateVariable} of ${component.componentName}`)
+        // console.log(`getting value of state variable ${stateVariable} of ${component.componentIdx}`)
 
         let stateVarObj = component.state[stateVariable];
         if (!stateVarObj) {
             throw Error(
-                `Can't get value of ${stateVariable} of ${component.componentName} as it doesn't exist.`,
+                `Can't get value of ${stateVariable} of ${component.componentIdx} as it doesn't exist.`,
             );
         }
 
@@ -6874,7 +6873,7 @@ export default class Core {
             // the strings don't show any changes and we'll use the essential value
             // of expressionWithCodes
             let reprocessAfterEvaluate = component.reprocessAfterEvaluate;
-            delete this._components[component.componentName]
+            delete this._components[component.componentIdx]
                 .reprocessAfterEvaluate;
 
             for (let vName in reprocessAfterEvaluate) {
@@ -6887,7 +6886,7 @@ export default class Core {
             }
 
             await this.processNewStateVariableValues({
-                [component.componentName]: reprocessAfterEvaluate,
+                [component.componentIdx]: reprocessAfterEvaluate,
             });
         }
 
@@ -6904,7 +6903,7 @@ export default class Core {
         for (let varName of allStateVariablesAffected) {
             if (!component.state[varName].isResolved) {
                 let result = await this.dependencies.resolveItem({
-                    componentName: component.componentName,
+                    componentIdx: component.componentIdx,
                     type: "stateVariable",
                     stateVariable: varName,
                     force: true,
@@ -6912,13 +6911,13 @@ export default class Core {
 
                 if (!result.success) {
                     throw Error(
-                        `Can't get value of ${stateVariable} of ${component.componentName} as ${varName} couldn't be resolved.`,
+                        `Can't get value of ${stateVariable} of ${component.componentIdx} as ${varName} couldn't be resolved.`,
                     );
                 }
             }
 
             if (component.state[varName].justUpdatedForNewComponent) {
-                delete this._components[component.componentName].state[varName]
+                delete this._components[component.componentIdx].state[varName]
                     .justUpdatedForNewComponent;
                 justUpdatedForNewComponent = true;
             }
@@ -6952,7 +6951,7 @@ export default class Core {
             if (additionalStateVariablesDefined) {
                 noChanges.push(...additionalStateVariablesDefined);
             }
-            // console.log(`no changes for ${stateVariable} of ${component.componentName}`);
+            // console.log(`no changes for ${stateVariable} of ${component.componentIdx}`);
             // console.log(noChanges)
             result = { noChanges };
 
@@ -6976,13 +6975,13 @@ export default class Core {
             }
         }
 
-        // console.log(`result for ${stateVariable} of ${component.componentName}`)
+        // console.log(`result for ${stateVariable} of ${component.componentIdx}`)
         // console.log(result);
 
         for (let varName in result.setValue) {
             if (!(varName in component.state)) {
                 throw Error(
-                    `Definition of state variable ${stateVariable} of ${component.componentName} returned value of ${varName}, which isn't a state variable.`,
+                    `Definition of state variable ${stateVariable} of ${component.componentIdx} returned value of ${varName}, which isn't a state variable.`,
                 );
             }
 
@@ -7005,7 +7004,7 @@ export default class Core {
                 }
                 if (!matchingArrayEntry) {
                     throw Error(
-                        `Attempting to set value of stateVariable ${varName} in definition of ${stateVariable} of ${component.componentName}, but it's not listed as an additional state variable defined.`,
+                        `Attempting to set value of stateVariable ${varName} in definition of ${stateVariable} of ${component.componentIdx}, but it's not listed as an additional state variable defined.`,
                     );
                 }
             } else {
@@ -7026,7 +7025,7 @@ export default class Core {
                     !component.state[matchingArrayEntry].isResolved
                 ) {
                     throw Error(
-                        `Attempting to set value of stateVariable ${varName} of ${component.componentName} while it is still unresolved!`,
+                        `Attempting to set value of stateVariable ${varName} of ${component.componentIdx} while it is still unresolved!`,
                     );
                 }
             }
@@ -7079,7 +7078,7 @@ export default class Core {
                 // not an array
 
                 // if (!(Object.getOwnPropertyDescriptor(component.state[varName], 'value').get || component.state[varName].immutable)) {
-                //   throw Error(`${varName} of ${component.componentName} is not stale, but still setting its value!!`)
+                //   throw Error(`${varName} of ${component.componentIdx} is not stale, but still setting its value!!`)
                 // }
 
                 // delete before assigning value to remove any getter for the property
@@ -7114,13 +7113,13 @@ export default class Core {
         for (let varName in result.useEssentialOrDefaultValue) {
             if (!(varName in component.state)) {
                 throw Error(
-                    `Definition of state variable ${stateVariable} of ${component.componentName} requested essential or default value of ${varName}, which isn't a state variable.`,
+                    `Definition of state variable ${stateVariable} of ${component.componentIdx} requested essential or default value of ${varName}, which isn't a state variable.`,
                 );
             }
 
             if (!component.state[varName].hasEssential) {
                 throw Error(
-                    `Definition of state variable ${stateVariable} of ${component.componentName} requested essential or default value of ${varName}, but hasEssential is not set.`,
+                    `Definition of state variable ${stateVariable} of ${component.componentIdx} requested essential or default value of ${varName}, but hasEssential is not set.`,
                 );
             }
 
@@ -7143,7 +7142,7 @@ export default class Core {
                 }
                 if (!matchingArrayEntry) {
                     throw Error(
-                        `Attempting to set value of stateVariable ${varName} in definition of ${stateVariable} of ${component.componentName}, but it's not listed as an additional state variable defined.`,
+                        `Attempting to set value of stateVariable ${varName} in definition of ${stateVariable} of ${component.componentIdx}, but it's not listed as an additional state variable defined.`,
                     );
                 }
             } else {
@@ -7163,7 +7162,7 @@ export default class Core {
                     !component.state[matchingArrayEntry].isResolved
                 ) {
                     throw Error(
-                        `Attempting to set value of stateVariable ${varName} of ${component.componentName} while it is still unresolved!`,
+                        `Attempting to set value of stateVariable ${varName} of ${component.componentIdx} while it is still unresolved!`,
                     );
                 }
             }
@@ -7253,7 +7252,7 @@ export default class Core {
                             ] = true;
                         } else {
                             throw Error(
-                                `Neither value nor default value specified; state variable: ${varName}, component: ${component.componentName}, arrayKey: ${arrayKey}.`,
+                                `Neither value nor default value specified; state variable: ${varName}, component: ${component.componentIdx}, arrayKey: ${arrayKey}.`,
                             );
                         }
                     }
@@ -7298,7 +7297,7 @@ export default class Core {
                         component.state[varName].usedDefault = true;
                     } else {
                         throw Error(
-                            `Neither value nor default value specified; state variable: ${varName}, component: ${component.componentName}.`,
+                            `Neither value nor default value specified; state variable: ${varName}, component: ${component.componentIdx}.`,
                         );
                     }
                 }
@@ -7330,7 +7329,7 @@ export default class Core {
         for (let varName in result.markAsUsedDefault) {
             if (!component.state[varName].isResolved) {
                 throw Error(
-                    `Marking state variable as used default when it isn't yet resolved: ${varName} of ${component.componentName}`,
+                    `Marking state variable as used default when it isn't yet resolved: ${varName} of ${component.componentIdx}`,
                 );
             }
 
@@ -7350,7 +7349,7 @@ export default class Core {
                 }
                 if (!matchingArrayEntry) {
                     throw Error(
-                        `Marking state variable  ${varName} as used default in definition of ${stateVariable} of ${component.componentName}, but it's not listed as an additional state variable defined.`,
+                        `Marking state variable  ${varName} as used default in definition of ${stateVariable} of ${component.componentIdx}, but it's not listed as an additional state variable defined.`,
                     );
                 }
             }
@@ -7373,7 +7372,7 @@ export default class Core {
                     // TODO: is this the correct response to having no changes but a variable not resolved?
                     // This scenario was occasionally occurring with readyToExpandWhenResolved in tests
                     component.state[varName].isResolved = true;
-                    // throw Error(`Claiming state variable is unchanged when it isn't yet resolved: ${varName} of ${component.componentName}`)
+                    // throw Error(`Claiming state variable is unchanged when it isn't yet resolved: ${varName} of ${component.componentIdx}`)
                 }
 
                 if (!(varName in receivedValue)) {
@@ -7392,7 +7391,7 @@ export default class Core {
                     }
                     if (!matchingArrayEntry) {
                         throw Error(
-                            `Claiming stateVariable ${varName} is unchanged in definition of ${stateVariable} of ${component.componentName}, but it's not listed as an additional state variable defined.`,
+                            `Claiming stateVariable ${varName} is unchanged in definition of ${stateVariable} of ${component.componentIdx}, but it's not listed as an additional state variable defined.`,
                         );
                     }
                 }
@@ -7418,7 +7417,7 @@ export default class Core {
         for (let varName in result.setEssentialValue) {
             if (!(varName in component.state)) {
                 throw Error(
-                    `Definition of state variable ${stateVariable} of ${component.componentName} tried to make ${varName} essential, which isn't a state variable.`,
+                    `Definition of state variable ${stateVariable} of ${component.componentIdx} tried to make ${varName} essential, which isn't a state variable.`,
                 );
             }
 
@@ -7438,14 +7437,14 @@ export default class Core {
                 }
                 if (!matchingArrayEntry) {
                     throw Error(
-                        `Attempting to set essential value of stateVariable ${varName} in definition of ${stateVariable} of ${component.componentName}, but it's not listed as an additional state variable defined.`,
+                        `Attempting to set essential value of stateVariable ${varName} in definition of ${stateVariable} of ${component.componentIdx}, but it's not listed as an additional state variable defined.`,
                     );
                 }
             }
 
             if (!component.state[varName].hasEssential) {
                 throw Error(
-                    `Attempting to set the essential value of stateVariable ${varName} in definition of ${stateVariable} of ${component.componentName}, but it does not have an essential value`,
+                    `Attempting to set the essential value of stateVariable ${varName} in definition of ${stateVariable} of ${component.componentIdx}, but it does not have an essential value`,
                 );
             }
 
@@ -7464,14 +7463,14 @@ export default class Core {
                 )
             ) {
                 throw Error(
-                    `Attempting to set the essential value of stateVariable ${varName} in definition of ${stateVariable} of ${component.componentName}, but it is not allowed unless the state variable is shadowed or the essential state is not shadowed.`,
+                    `Attempting to set the essential value of stateVariable ${varName} in definition of ${stateVariable} of ${component.componentIdx}, but it is not allowed unless the state variable is shadowed or the essential state is not shadowed.`,
                 );
             }
 
             if (
-                !this.essentialValuesSavedInDefinition[component.componentName]
+                !this.essentialValuesSavedInDefinition[component.componentIdx]
             ) {
-                this.essentialValuesSavedInDefinition[component.componentName] =
+                this.essentialValuesSavedInDefinition[component.componentIdx] =
                     {};
             }
 
@@ -7495,14 +7494,14 @@ export default class Core {
 
                 if (
                     !this.essentialValuesSavedInDefinition[
-                        component.componentName
+                        component.componentIdx
                     ][varName]
                 ) {
                     // include key mergeObject to let external functions
                     // know that new attributes of the object
                     // should be merged into the old object
                     this.essentialValuesSavedInDefinition[
-                        component.componentName
+                        component.componentIdx
                     ][varName] = {
                         mergeObject: true,
                     };
@@ -7516,7 +7515,7 @@ export default class Core {
                     });
 
                     this.essentialValuesSavedInDefinition[
-                        component.componentName
+                        component.componentIdx
                     ][varName][arrayKey] =
                         result.setEssentialValue[varName][arrayKey];
                 }
@@ -7527,7 +7526,7 @@ export default class Core {
                 // Since setting an essential value during a definition,
                 // we also add the value to essentialValuesSavedInDefinition
                 // so that it will be saved to the database during the next update
-                this.essentialValuesSavedInDefinition[component.componentName][
+                this.essentialValuesSavedInDefinition[component.componentIdx][
                     varName
                 ] = result.setEssentialValue[varName];
             }
@@ -7540,7 +7539,7 @@ export default class Core {
                         ?.hasVariableComponentType
                 ) {
                     throw Error(
-                        `Cannot set type of ${varName} of ${component.componentName} as it it does not have the hasVariableComponentType attribute.`,
+                        `Cannot set type of ${varName} of ${component.componentIdx} as it it does not have the hasVariableComponentType attribute.`,
                     );
                 }
                 let changedComponentType = false;
@@ -7655,7 +7654,7 @@ export default class Core {
                 )
             ) {
                 throw Error(
-                    `definition of ${stateVariable} of ${component.componentName} didn't return value of ${varName}`,
+                    `definition of ${stateVariable} of ${component.componentIdx} didn't return value of ${varName}`,
                 );
             }
 
@@ -7724,7 +7723,7 @@ export default class Core {
         stateVariable,
         excludeDependencyValues,
     }) {
-        // console.log(`get state variable dependencies of ${component.componentName}, ${stateVariable}`)
+        // console.log(`get state variable dependencies of ${component.componentIdx}, ${stateVariable}`)
 
         let args;
         if (excludeDependencyValues) {
@@ -7736,7 +7735,7 @@ export default class Core {
             });
         }
 
-        args.componentName = component.componentName;
+        args.componentIdx = component.componentIdx;
 
         let stateVarObj = component.state[stateVariable];
         if (stateVarObj.isArrayEntry) {
@@ -7795,8 +7794,8 @@ export default class Core {
         return args;
     }
 
-    async recordActualChangeInStateVariable({ componentName, varName }) {
-        let component = this._components[componentName];
+    async recordActualChangeInStateVariable({ componentIdx, varName }) {
+        let component = this._components[componentIdx];
 
         // mark stale always includes additional state variables defined
         await this.markStateVariableAndUpstreamDependentsStale({
@@ -8060,7 +8059,7 @@ export default class Core {
     }) {
         if (!component.arrayEntryPrefixes) {
             throw Error(
-                `Unknown state variable ${stateVariable} of ${component.componentName}`,
+                `Unknown state variable ${stateVariable} of ${component.componentIdx}`,
             );
         }
 
@@ -8136,7 +8135,7 @@ export default class Core {
 
                     for (let varName of allStateVariablesAffected) {
                         this.dependencies.checkForCircularDependency({
-                            componentName: component.componentName,
+                            componentIdx: component.componentIdx,
                             varName,
                         });
 
@@ -8164,7 +8163,7 @@ export default class Core {
         }
 
         throw Error(
-            `Unknown state variable ${stateVariable} of ${component.componentName}`,
+            `Unknown state variable ${stateVariable} of ${component.componentIdx}`,
         );
     }
 
@@ -8175,7 +8174,7 @@ export default class Core {
             for (let ind of indicesToRender) {
                 let child = component.activeChildren[ind];
                 this.updateInfo.componentsToUpdateRenderers.add(
-                    child.componentName,
+                    child.componentIdx,
                 );
                 await this.markDescendantsToUpdateRenderers(child);
             }
@@ -8183,14 +8182,14 @@ export default class Core {
     }
 
     async markStateVariableAndUpstreamDependentsStale({ component, varName }) {
-        // console.log(`mark state variable ${varName} of ${component.componentName} and updeps stale`)
+        // console.log(`mark state variable ${varName} of ${component.componentIdx} and updeps stale`)
 
         if (
             varName in
             this.rendererVariablesByComponentType[component.componentType]
         ) {
             this.updateInfo.componentsToUpdateRenderers.add(
-                component.componentName,
+                component.componentIdx,
             );
         }
 
@@ -8287,7 +8286,7 @@ export default class Core {
 
             if (result.updateReplacements) {
                 this.updateInfo.compositesToUpdateReplacements.add(
-                    component.componentName,
+                    component.componentIdx,
                 );
             }
 
@@ -8302,7 +8301,7 @@ export default class Core {
                         // found non-composite ancestor
                         if (ancestorObj.componentClass.renderChildren) {
                             this.componentsWithChangedChildrenToRender.add(
-                                ancestorObj.componentName,
+                                ancestorObj.componentIdx,
                             );
                         }
                         break;
@@ -8312,7 +8311,7 @@ export default class Core {
 
             if (result.updateRenderedChildren) {
                 this.componentsWithChangedChildrenToRender.add(
-                    component.componentName,
+                    component.componentIdx,
                 );
             }
 
@@ -8323,11 +8322,11 @@ export default class Core {
             if (result.updateActionChaining) {
                 let chainObj =
                     this.updateInfo.componentsToUpdateActionChaining[
-                        component.componentName
+                        component.componentIdx
                     ];
                 if (!chainObj) {
                     chainObj = this.updateInfo.componentsToUpdateActionChaining[
-                        component.componentName
+                        component.componentIdx
                     ] = [];
                 }
                 for (let vName in allStateVariablesAffectedObj) {
@@ -8347,7 +8346,7 @@ export default class Core {
                 this.flags.autoSubmit &&
                 result.answerCreditPotentiallyChanged
             ) {
-                this.recordAnswerToAutoSubmit(component.componentName);
+                this.recordAnswerToAutoSubmit(component.componentIdx);
             }
         }
 
@@ -8466,7 +8465,7 @@ export default class Core {
             }
         }
 
-        // console.log(`result of lookUpCurrentFreshness of ${varName} of ${component.componentName}`)
+        // console.log(`result of lookUpCurrentFreshness of ${varName} of ${component.componentIdx}`)
         // console.log(JSON.parse(JSON.stringify(result)))
 
         return result;
@@ -8503,7 +8502,7 @@ export default class Core {
 
         let changes = {};
         let downDeps =
-            this.dependencies.downstreamDependencies[component.componentName][
+            this.dependencies.downstreamDependencies[component.componentIdx][
                 varName
             ];
 
@@ -8600,7 +8599,7 @@ export default class Core {
             }
         }
 
-        // console.log(`result of process mark stale of ${varName} of ${component.componentName}`)
+        // console.log(`result of process mark stale of ${varName} of ${component.componentIdx}`)
         // console.log(JSON.parse(JSON.stringify(result)))
 
         return result;
@@ -8614,13 +8613,13 @@ export default class Core {
         // Record additional information about the staleness from result of markStale,
         // and recurse only if markStale indicates variable is actually stale
 
-        let componentName = component.componentName;
+        let componentIdx = component.componentIdx;
         let getStateVar = this.getStateVariableValue;
 
-        // console.log(`marking upstream of ${varName} of ${componentName} as stale`);
+        // console.log(`marking upstream of ${varName} of ${componentIdx} as stale`);
 
         let upstream =
-            this.dependencies.upstreamDependencies[componentName][varName];
+            this.dependencies.upstreamDependencies[componentIdx][varName];
 
         let freshnessInfo;
 
@@ -8648,7 +8647,7 @@ export default class Core {
                     // must find which one of those components correspond to current component
 
                     let componentInd =
-                        upDep.downstreamComponentNames.indexOf(componentName);
+                        upDep.downstreamComponentNames.indexOf(componentIdx);
                     if (componentInd === -1) {
                         // presumably component was deleted
                         continue;
@@ -8856,7 +8855,7 @@ export default class Core {
                                             .renderChildren
                                     ) {
                                         this.componentsWithChangedChildrenToRender.add(
-                                            ancestorObj.componentName,
+                                            ancestorObj.componentIdx,
                                         );
                                     }
                                     break;
@@ -8866,7 +8865,7 @@ export default class Core {
 
                         if (result.updateRenderedChildren) {
                             this.componentsWithChangedChildrenToRender.add(
-                                upDepComponent.componentName,
+                                upDepComponent.componentIdx,
                             );
                         }
 
@@ -8880,12 +8879,12 @@ export default class Core {
                             let chainObj =
                                 this.updateInfo
                                     .componentsToUpdateActionChaining[
-                                    upDep.componentName
+                                    upDep.componentIdx
                                 ];
                             if (!chainObj) {
                                 chainObj =
                                     this.updateInfo.componentsToUpdateActionChaining[
-                                        upDep.componentName
+                                        upDep.componentIdx
                                     ] = [];
                             }
                             for (let vName in allStateVariablesAffectedObj) {
@@ -8908,7 +8907,7 @@ export default class Core {
                             result.answerCreditPotentiallyChanged
                         ) {
                             this.recordAnswerToAutoSubmit(
-                                upDepComponent.componentName,
+                                upDepComponent.componentIdx,
                             );
                         }
                     }
@@ -8968,22 +8967,22 @@ export default class Core {
     // }
 
     registerComponent(component) {
-        if (component.componentName in this._components) {
-            throw Error(`Duplicate component name: ${component.componentName}`);
+        if (component.componentIdx in this._components) {
+            throw Error(`Duplicate component name: ${component.componentIdx}`);
         }
-        this._components[component.componentName] = component;
+        this._components[component.componentIdx] = component;
     }
 
     deregisterComponent(component, recursive = true) {
         if (recursive === true) {
-            for (let childName in component.allChildren) {
+            for (let childIdx in component.allChildren) {
                 this.deregisterComponent(
-                    component.allChildren[childName].component,
+                    component.allChildren[childIdx].component,
                 );
             }
         }
 
-        delete this._components[component.componentName];
+        delete this._components[component.componentIdx];
     }
 
     setAncestors(component, ancestors = []) {
@@ -8995,14 +8994,14 @@ export default class Core {
 
         let ancestorsForChildren = [
             {
-                componentName: component.componentName,
+                componentIdx: component.componentIdx,
                 componentClass: component.constructor,
             },
             ...component.ancestors,
         ];
 
-        for (let childName in component.allChildren) {
-            let unproxiedChild = this._components[childName];
+        for (let childIdx in component.allChildren) {
+            let unproxiedChild = this._components[childIdx];
             // Note: when add and deleting replacements of shadowed composites,
             // it is possible that we end up processing the defining children of ancestors of the composite
             // while we were delaying processing the defining children of the composite's parent,
@@ -9047,7 +9046,7 @@ export default class Core {
 
         for (let child of newChildren) {
             if (typeof child === "object") {
-                addedComponents[child.componentName] = child;
+                addedComponents[child.componentIdx] = child;
             }
         }
 
@@ -9061,7 +9060,7 @@ export default class Core {
                 }
 
                 let composite =
-                    this._components[shadowingParent.shadows.compositeName];
+                    this._components[shadowingParent.shadows.compositeIdx];
                 let sourceAttributesToIgnore =
                     await composite.stateValues.sourceAttributesToIgnore;
 
@@ -9080,7 +9079,7 @@ export default class Core {
                 }
                 shadowingSerializeChildren = postProcessCopy({
                     serializedComponents: shadowingSerializeChildren,
-                    componentName: shadowingParent.shadows.compositeName,
+                    componentIdx: shadowingParent.shadows.compositeIdx,
                 });
 
                 let shadowingNewNamespace =
@@ -9091,7 +9090,7 @@ export default class Core {
                 let processResult = processAssignNames({
                     indOffset: assignNamesOffset,
                     serializedComponents: shadowingSerializeChildren,
-                    parentName: shadowingParent.componentName,
+                    parentIdx: shadowingParent.componentIdx,
                     parentCreatesNewNamespace: shadowingNewNamespace,
                     componentInfoObjects: this.componentInfoObjects,
                     originalNamesAreConsistent,
@@ -9108,7 +9107,7 @@ export default class Core {
                 shadowingSerializeChildren = processResult.serializedComponents;
 
                 let unproxiedShadowingParent =
-                    this._components[shadowingParent.componentName];
+                    this._components[shadowingParent.componentIdx];
                 this.parameterStack.push(
                     unproxiedShadowingParent.sharedParameters,
                     false,
@@ -9116,10 +9115,10 @@ export default class Core {
 
                 let namespaceForUnamed;
                 if (shadowingNewNamespace) {
-                    namespaceForUnamed = shadowingParent.componentName + "/";
+                    namespaceForUnamed = shadowingParent.componentIdx + "/";
                 } else {
                     namespaceForUnamed = getNamespaceFromName(
-                        shadowingParent.componentName,
+                        shadowingParent.componentIdx,
                     );
                 }
 
@@ -9127,7 +9126,7 @@ export default class Core {
                     serializedComponents: shadowingSerializeChildren,
                     ancestors: shadowingParent.ancestors,
                     createNameContext:
-                        shadowingParent.componentName +
+                        shadowingParent.componentIdx +
                         "|addChildren|" +
                         assignNamesOffset,
                     namespaceForUnamed,
@@ -9169,7 +9168,7 @@ export default class Core {
 
         let ancestorsForChildren = [
             {
-                componentName: parent.componentName,
+                componentIdx: parent.componentIdx,
                 componentClass: parent.constructor,
             },
             ...parent.ancestors,
@@ -9177,8 +9176,8 @@ export default class Core {
 
         // set ancestors for allChildren of parent
         // since could replace newChildren by adapters or via composites
-        for (let childName in parent.allChildren) {
-            let unproxiedChild = this._components[childName];
+        for (let childIdx in parent.allChildren) {
+            let unproxiedChild = this._components[childIdx];
             this.setAncestors(unproxiedChild, ancestorsForChildren);
         }
 
@@ -9240,26 +9239,26 @@ export default class Core {
 
         //Calculate parent set
         const parentsOfPotentiallyDeleted = {};
-        for (let componentName in componentsToDelete) {
-            let component = componentsToDelete[componentName];
-            let parent = this.components[component.parentName];
+        for (let componentIdx in componentsToDelete) {
+            let component = componentsToDelete[componentIdx];
+            let parent = this.components[component.parentIdx];
 
             // only add parent if it is not in componentsToDelete itself
             if (
                 parent === undefined ||
-                parent.componentName in componentsToDelete
+                parent.componentIdx in componentsToDelete
             ) {
                 continue;
             }
-            let parentObj = parentsOfPotentiallyDeleted[component.parentName];
+            let parentObj = parentsOfPotentiallyDeleted[component.parentIdx];
             if (parentObj === undefined) {
                 parentObj = {
-                    parent: this._components[component.parentName],
+                    parent: this._components[component.parentIdx],
                     childNamesToBeDeleted: new Set(),
                 };
-                parentsOfPotentiallyDeleted[component.parentName] = parentObj;
+                parentsOfPotentiallyDeleted[component.parentIdx] = parentObj;
             }
-            parentObj.childNamesToBeDeleted.add(componentName);
+            parentObj.childNamesToBeDeleted.add(componentIdx);
         }
 
         // if component is a replacement of another component,
@@ -9269,35 +9268,35 @@ export default class Core {
         // if the deletion is unsuccessful
         let replacementsDeletedFromComposites = [];
 
-        for (let componentName in componentsToDelete) {
-            let component = this._components[componentName];
+        for (let componentIdx in componentsToDelete) {
+            let component = this._components[componentIdx];
             if (component.replacementOf) {
                 let composite = component.replacementOf;
 
                 let replacementNames = composite.replacements.map(
-                    (x) => x.componentName,
+                    (x) => x.componentIdx,
                 );
 
-                let replacementInd = replacementNames.indexOf(componentName);
+                let replacementInd = replacementNames.indexOf(componentIdx);
                 if (replacementInd !== -1) {
                     composite.replacements.splice(replacementInd, 1);
                     if (
                         !replacementsDeletedFromComposites.includes(
-                            composite.componentName,
+                            composite.componentIdx,
                         )
                     ) {
                         replacementsDeletedFromComposites.push(
-                            composite.componentName,
+                            composite.componentIdx,
                         );
                     }
                 }
             }
         }
 
-        for (let compositeName of replacementsDeletedFromComposites) {
-            if (!(compositeName in componentsToDelete)) {
+        for (let compositeIdx of replacementsDeletedFromComposites) {
+            if (!(compositeIdx in componentsToDelete)) {
                 await this.dependencies.addBlockersFromChangedReplacements(
-                    this._components[compositeName],
+                    this._components[compositeIdx],
                 );
             }
         }
@@ -9305,8 +9304,8 @@ export default class Core {
         // delete component from parent's defining children
         // and record parents
         let allParents = [];
-        for (let parentName in parentsOfPotentiallyDeleted) {
-            let parentObj = parentsOfPotentiallyDeleted[parentName];
+        for (let parentIdx in parentsOfPotentiallyDeleted) {
+            let parentObj = parentsOfPotentiallyDeleted[parentIdx];
             let parent = parentObj.parent;
             allParents.push(parent);
 
@@ -9320,13 +9319,13 @@ export default class Core {
                 ind--
             ) {
                 let child = parent.definingChildren[ind];
-                if (parentObj.childNamesToBeDeleted.has(child.componentName)) {
+                if (parentObj.childNamesToBeDeleted.has(child.componentIdx)) {
                     parent.definingChildren.splice(ind, 1); // delete from array
                 }
             }
 
             if (
-                !skipProcessingChildrenOfParents.includes(parent.componentName)
+                !skipProcessingChildrenOfParents.includes(parent.componentIdx)
             ) {
                 await this.processNewDefiningChildren({
                     parent,
@@ -9335,12 +9334,12 @@ export default class Core {
             }
         }
 
-        for (let componentName in componentsToDelete) {
-            let component = this._components[componentName];
+        for (let componentIdx in componentsToDelete) {
+            let component = this._components[componentIdx];
 
             if (component.shadows) {
                 let shadowedComponent =
-                    this._components[component.shadows.componentName];
+                    this._components[component.shadows.componentIdx];
                 if (shadowedComponent.shadowedBy.length === 1) {
                     delete shadowedComponent.shadowedBy;
                 } else {
@@ -9353,15 +9352,15 @@ export default class Core {
 
             this.dependencies.deleteAllDownstreamDependencies({ component });
 
-            // record any upstream dependencies that depend directly on componentName
+            // record any upstream dependencies that depend directly on componentIdx
             // (componentIdentity, componentStateVariable*)
 
             for (let varName in this.dependencies.upstreamDependencies[
-                component.componentName
+                component.componentIdx
             ]) {
                 let upDeps =
                     this.dependencies.upstreamDependencies[
-                        component.componentName
+                        component.componentIdx
                     ][varName];
                 for (let upDep of upDeps) {
                     if (
@@ -9391,36 +9390,34 @@ export default class Core {
             });
 
             if (
-                !this.updateInfo.deletedStateVariables[component.componentName]
+                !this.updateInfo.deletedStateVariables[component.componentIdx]
             ) {
-                this.updateInfo.deletedStateVariables[component.componentName] =
+                this.updateInfo.deletedStateVariables[component.componentIdx] =
                     [];
             }
-            this.updateInfo.deletedStateVariables[component.componentName].push(
+            this.updateInfo.deletedStateVariables[component.componentIdx].push(
                 ...Object.keys(component.state),
             );
 
-            this.updateInfo.deletedComponents[component.componentName] = true;
-            delete this.unmatchedChildren[component.componentName];
+            this.updateInfo.deletedComponents[component.componentIdx] = true;
+            delete this.unmatchedChildren[component.componentIdx];
 
-            delete this.stateVariableChangeTriggers[component.componentName];
+            delete this.stateVariableChangeTriggers[component.componentIdx];
         }
 
-        for (let componentName in componentsToDelete) {
-            let component = this._components[componentName];
+        for (let componentIdx in componentsToDelete) {
+            let component = this._components[componentIdx];
 
-            // console.log(`deregistering ${componentName}`)
+            // console.log(`deregistering ${componentIdx}`)
 
             // don't use recursive form since all children should already be included
             this.deregisterComponent(component, false);
 
             // remove deleted components from this.updateInfo sets
-            this.updateInfo.componentsToUpdateRenderers.delete(componentName);
-            this.updateInfo.compositesToUpdateReplacements.delete(
-                componentName,
-            );
+            this.updateInfo.componentsToUpdateRenderers.delete(componentIdx);
+            this.updateInfo.compositesToUpdateReplacements.delete(componentIdx);
             this.updateInfo.inactiveCompositesToUpdateReplacements.delete(
-                componentName,
+                componentIdx,
             );
         }
 
@@ -9441,13 +9438,13 @@ export default class Core {
                 continue;
             }
 
-            if (component.componentName in componentsToDelete) {
+            if (component.componentIdx in componentsToDelete) {
                 continue;
             }
 
             // add unproxied component
-            componentsToDelete[component.componentName] =
-                this._components[component.componentName];
+            componentsToDelete[component.componentIdx] =
+                this._components[component.componentIdx];
 
             // recurse on allChildren and attributes
             let componentsToRecurse = Object.values(component.allChildren).map(
@@ -9496,7 +9493,7 @@ export default class Core {
         componentChanges,
         sourceOfUpdate,
     }) {
-        // console.log("updateCompositeReplacements " + component.componentName);
+        // console.log("updateCompositeReplacements " + component.componentIdx);
 
         let deletedComponents = {};
         let addedComponents = {};
@@ -9521,7 +9518,7 @@ export default class Core {
             return results;
         }
 
-        let proxiedComponent = this.components[component.componentName];
+        let proxiedComponent = this.components[component.componentIdx];
 
         if (!component.replacements) {
             component.replacements = [];
@@ -9570,9 +9567,9 @@ export default class Core {
             ];
         }
 
-        // console.log("replacement changes for " + component.componentName);
+        // console.log("replacement changes for " + component.componentIdx);
         // console.log(replacementChanges);
-        // console.log(component.replacements.map(x => x.componentName));
+        // console.log(component.replacements.map(x => x.componentIdx));
         // console.log(component.replacements);
         // console.log(component.unresolvedState);
         // console.log(component.unresolvedDependencies);
@@ -9591,7 +9588,7 @@ export default class Core {
                 }
 
                 let unproxiedComponent =
-                    this._components[component.componentName];
+                    this._components[component.componentIdx];
                 this.parameterStack.push(
                     unproxiedComponent.sharedParameters,
                     false,
@@ -9600,7 +9597,7 @@ export default class Core {
                 let newComponents;
 
                 let currentShadowedBy = {
-                    [component.componentName]:
+                    [component.componentIdx]:
                         calculateAllComponentsShadowing(component),
                 };
 
@@ -9626,15 +9623,15 @@ export default class Core {
 
                     let namespaceForUnamed;
                     if (component.attributes.newNamespace?.primitive) {
-                        namespaceForUnamed = component.componentName + "/";
+                        namespaceForUnamed = component.componentIdx + "/";
                     } else {
                         namespaceForUnamed = getNamespaceFromName(
-                            component.componentName,
+                            component.componentIdx,
                         );
                     }
 
                     let doenetMLrange =
-                        this.components[component.componentName].doenetMLrange;
+                        this.components[component.componentIdx].doenetMLrange;
                     let overwriteDoenetMLRange =
                         component.componentType === "copy";
 
@@ -9652,7 +9649,7 @@ export default class Core {
                                 serializedComponents: serializedReplacements,
                                 ancestors: component.ancestors,
                                 createNameContext:
-                                    component.componentName + "|replacements",
+                                    component.componentIdx + "|replacements",
                                 namespaceForUnamed,
                                 componentsReplacementOf: component,
                             });
@@ -9673,7 +9670,7 @@ export default class Core {
                 this.parameterStack.pop();
 
                 let newReplacementsByComposite = {
-                    [component.componentName]: {
+                    [component.componentIdx]: {
                         newComponents,
                         parent: change.parent,
                     },
@@ -9681,7 +9678,7 @@ export default class Core {
 
                 if (
                     unproxiedComponent.shadowedBy &&
-                    currentShadowedBy[unproxiedComponent.componentName].length >
+                    currentShadowedBy[unproxiedComponent.componentIdx].length >
                         0
                 ) {
                     let newReplacementsForShadows =
@@ -9704,8 +9701,8 @@ export default class Core {
                     );
                 }
 
-                for (let compositeName in newReplacementsByComposite) {
-                    let composite = this._components[compositeName];
+                for (let compositeIdx in newReplacementsByComposite) {
+                    let composite = this._components[compositeIdx];
 
                     // if composite was just deleted in previous pass of this loop, skip
                     if (!composite) {
@@ -9713,7 +9710,7 @@ export default class Core {
                     }
 
                     let newReplacements =
-                        newReplacementsByComposite[compositeName].newComponents;
+                        newReplacementsByComposite[compositeIdx].newComponents;
 
                     if (!composite.isExpanded) {
                         await this.expandCompositeComponent(composite);
@@ -9734,7 +9731,7 @@ export default class Core {
 
                     for (let comp of newReplacements) {
                         if (typeof comp === "object") {
-                            addedComponents[comp.componentName] = comp;
+                            addedComponents[comp.componentIdx] = comp;
                         }
 
                         // TODO: used to checkForDownstreamDependencies here
@@ -9742,7 +9739,7 @@ export default class Core {
                     }
 
                     if (change.changeTopLevelReplacements === true) {
-                        let parent = this._components[composite.parentName];
+                        let parent = this._components[composite.parentIdx];
 
                         // splice in new replacements
                         composite.replacements.splice(
@@ -9784,8 +9781,8 @@ export default class Core {
 
                         let parent =
                             this._components[
-                                newReplacementsByComposite[compositeName].parent
-                                    .componentName
+                                newReplacementsByComposite[compositeIdx].parent
+                                    .componentIdx
                             ];
 
                         this.spliceChildren(
@@ -9798,7 +9795,7 @@ export default class Core {
 
                         for (let repl of newReplacements) {
                             if (typeof repl === "object") {
-                                addedComponents[repl.componentName] = repl;
+                                addedComponents[repl.componentIdx] = repl;
                             }
                         }
 
@@ -9845,7 +9842,7 @@ export default class Core {
                 let newStateVariableValues = {};
                 for (let stateVariable in change.stateChanges) {
                     let instruction = {
-                        componentName: change.component.componentName,
+                        componentIdx: change.component.componentIdx,
                         stateVariable,
                         value: change.stateChanges[stateVariable],
                         overrideFixed: true,
@@ -9911,7 +9908,7 @@ export default class Core {
         let createResult = await this.createIsolatedComponentsSub({
             serializedComponents: errorReplacements,
             ancestors: composite.ancestors,
-            createNameContext: composite.componentName + "|replacements",
+            createNameContext: composite.componentIdx + "|replacements",
             namespaceForUnamed,
             componentsReplacementOf: composite,
         });
@@ -9960,8 +9957,8 @@ export default class Core {
                                     continue;
                                 }
                                 if (
-                                    cShadow.shadows.compositeName ===
-                                    shadowingComposite.shadows.compositeName
+                                    cShadow.shadows.compositeIdx ===
+                                    shadowingComposite.shadows.compositeIdx
                                 ) {
                                     shadowingCompToDelete = cShadow;
                                     break;
@@ -9970,7 +9967,7 @@ export default class Core {
                         }
                         if (!shadowingCompToDelete) {
                             console.error(
-                                `could not find shadowing component of ${compToDelete.componentName}`,
+                                `could not find shadowing component of ${compToDelete.componentIdx}`,
                             );
                         } else {
                             shadowingComponentsToDelete.push(
@@ -10019,13 +10016,13 @@ export default class Core {
                 components: replacementsToDelete,
                 componentChanges,
                 sourceOfUpdate,
-                skipProcessingChildrenOfParents: [composite.parentName],
+                skipProcessingChildrenOfParents: [composite.parentIdx],
             });
 
             if (processNewChildren) {
                 // since skipped, process children now but without expanding composites
                 await this.processNewDefiningChildren({
-                    parent: this._components[composite.parentName],
+                    parent: this._components[composite.parentIdx],
                     expandComposites: false,
                 });
             }
@@ -10034,7 +10031,7 @@ export default class Core {
                 throw Error("Couldn't delete components on composite update");
             }
             for (let parent of deleteResults.parentsOfDeleted) {
-                parentsOfDeleted.add(parent.componentName);
+                parentsOfDeleted.add(parent.componentIdx);
                 let componentsAffected =
                     await this.componentAndRenderedDescendants(parent);
                 componentsAffected.forEach((cName) =>
@@ -10044,7 +10041,7 @@ export default class Core {
             let deletedNamesByParent = {};
             for (let compName in deleteResults.deletedComponents) {
                 let comp = deleteResults.deletedComponents[compName];
-                let par = comp.parentName;
+                let par = comp.parentIdx;
                 if (deletedNamesByParent[par] === undefined) {
                     deletedNamesByParent[par] = [];
                 }
@@ -10061,7 +10058,7 @@ export default class Core {
             };
             componentChanges.push(newChange);
             Object.assign(deletedComponents, deleteResults.deletedComponents);
-            let parent = this._components[composite.parentName];
+            let parent = this._components[composite.parentIdx];
             let componentsAffected =
                 await this.componentAndRenderedDescendants(parent);
             componentsAffected.forEach((cName) =>
@@ -10083,7 +10080,7 @@ export default class Core {
                 );
             }
             for (let parent of deleteResults.parentsOfDeleted) {
-                parentsOfDeleted.add(parent.componentName);
+                parentsOfDeleted.add(parent.componentIdx);
                 let componentsAffected =
                     await this.componentAndRenderedDescendants(parent);
                 componentsAffected.forEach((cName) =>
@@ -10093,7 +10090,7 @@ export default class Core {
             let deletedNamesByParent = {};
             for (let compName in deleteResults.deletedComponents) {
                 let comp = deleteResults.deletedComponents[compName];
-                let par = comp.parentName;
+                let par = comp.parentIdx;
                 if (deletedNamesByParent[par] === undefined) {
                     deletedNamesByParent[par] = [];
                 }
@@ -10115,7 +10112,7 @@ export default class Core {
     }
 
     async processChildChangesAndRecurseToShadows(component) {
-        let parent = this._components[component.parentName];
+        let parent = this._components[component.parentIdx];
         await this.processNewDefiningChildren({
             parent,
             expandComposites: false,
@@ -10156,22 +10153,22 @@ export default class Core {
         let newShadowedBy = calculateAllComponentsShadowing(componentToShadow);
 
         if (
-            !currentShadowedBy[componentToShadow.componentName] ||
+            !currentShadowedBy[componentToShadow.componentIdx] ||
             !newShadowedBy.every((x) =>
-                currentShadowedBy[componentToShadow.componentName].includes(x),
+                currentShadowedBy[componentToShadow.componentIdx].includes(x),
             )
         ) {
             // If components shadowing componentToShadow increased
             // that means it is shadowed by one of its newly created replacements
             // so we have a circular dependency
             throw Error(
-                `Circular dependency involving ${componentToShadow.componentName}.`,
+                `Circular dependency involving ${componentToShadow.componentIdx}.`,
             );
         }
 
         // use compositesBeingExpanded to look for circular dependency
         this.updateInfo.compositesBeingExpanded.push(
-            componentToShadow.componentName,
+            componentToShadow.componentIdx,
         );
 
         let newComponentsForShadows = {};
@@ -10186,16 +10183,16 @@ export default class Core {
 
             if (
                 this.updateInfo.compositesBeingExpanded.includes(
-                    shadowingComponent.componentName,
+                    shadowingComponent.componentIdx,
                 )
             ) {
                 throw Error(
-                    `Circular dependency involving ${shadowingComponent.componentName}.`,
+                    `Circular dependency involving ${shadowingComponent.componentIdx}.`,
                 );
             }
 
             if (shadowingComponent.shadowedBy) {
-                currentShadowedBy[shadowingComponent.componentName] =
+                currentShadowedBy[shadowingComponent.componentIdx] =
                     calculateAllComponentsShadowing(shadowingComponent);
             }
 
@@ -10205,7 +10202,7 @@ export default class Core {
                 let newSerializedReplacements = [];
 
                 let compositeCreatingShadow =
-                    this._components[shadowingComponent.shadows.compositeName];
+                    this._components[shadowingComponent.shadows.compositeIdx];
                 let sourceAttributesToIgnore =
                     await compositeCreatingShadow.stateValues
                         .sourceAttributesToIgnore;
@@ -10224,7 +10221,7 @@ export default class Core {
                 }
                 newSerializedReplacements = postProcessCopy({
                     serializedComponents: newSerializedReplacements,
-                    componentName: shadowingComponent.shadows.compositeName,
+                    componentIdx: shadowingComponent.shadows.compositeIdx,
                 });
 
                 let shadowingNewNamespace =
@@ -10262,7 +10259,7 @@ export default class Core {
                 }
 
                 let nameOfCompositeMediatingTheShadow =
-                    shadowingComponent.shadows.compositeName;
+                    shadowingComponent.shadows.compositeIdx;
                 let compositeMediatingTheShadow =
                     this.components[nameOfCompositeMediatingTheShadow];
                 if (shadowingComponent.constructor.assignNamesToReplacements) {
@@ -10281,17 +10278,17 @@ export default class Core {
                         assignNames = assignNames.map((x) => [x]);
                     }
 
-                    let parentName = shadowingComponent.componentName;
+                    let parentIdx = shadowingComponent.componentIdx;
                     let parentCreatesNewNamespace = shadowingNewNamespace;
                     if (
                         shadowingComponent.doenetAttributes
                             .parentNameForAssignNames
                     ) {
-                        parentName =
+                        parentIdx =
                             shadowingComponent.doenetAttributes
                                 .parentNameForAssignNames;
                         parentCreatesNewNamespace =
-                            this._components[parentName].attributes.newNamespace
+                            this._components[parentIdx].attributes.newNamespace
                                 ?.primitive;
                     }
 
@@ -10307,7 +10304,7 @@ export default class Core {
                         await shadowingComponent.stateValues
                             .addLevelToAssignNames
                     ) {
-                        compositesParentNameForAssignNames = parentName;
+                        compositesParentNameForAssignNames = parentIdx;
                     }
                     let processResult = processAssignNames({
                         assignNames,
@@ -10316,7 +10313,7 @@ export default class Core {
                                 .assignNamesForCompositeReplacement,
                         indOffset: assignNamesOffset,
                         serializedComponents: newSerializedReplacements,
-                        parentName,
+                        parentIdx,
                         parentCreatesNewNamespace,
                         componentInfoObjects: this.componentInfoObjects,
                         originalNamesAreConsistent,
@@ -10343,7 +10340,7 @@ export default class Core {
                         // assignNames: shadowingComponent.doenetAttributes.assignNames,
                         indOffset: assignNamesOffset,
                         serializedComponents: newSerializedReplacements,
-                        parentName: shadowingComponent.componentName,
+                        parentIdx: shadowingComponent.componentIdx,
                         parentCreatesNewNamespace: shadowingNewNamespace,
                         componentInfoObjects: this.componentInfoObjects,
                         originalNamesAreConsistent,
@@ -10362,13 +10359,13 @@ export default class Core {
                         processResult.serializedComponents;
                 }
 
-                // console.log(`newSerializedReplacements for ${shadowingComponent.componentName} who shadows ${shadowingComponent.shadows.componentName}`)
+                // console.log(`newSerializedReplacements for ${shadowingComponent.componentIdx} who shadows ${shadowingComponent.shadows.componentIdx}`)
                 // console.log(deepClone(newSerializedReplacements));
 
                 let newComponents;
 
                 let unproxiedShadowingComponent =
-                    this._components[shadowingComponent.componentName];
+                    this._components[shadowingComponent.componentIdx];
                 this.parameterStack.push(
                     unproxiedShadowingComponent.sharedParameters,
                     false,
@@ -10376,10 +10373,10 @@ export default class Core {
 
                 let namespaceForUnamed;
                 if (shadowingNewNamespace) {
-                    namespaceForUnamed = shadowingComponent.componentName + "/";
+                    namespaceForUnamed = shadowingComponent.componentIdx + "/";
                 } else {
                     namespaceForUnamed = getNamespaceFromName(
-                        shadowingComponent.componentName,
+                        shadowingComponent.componentIdx,
                     );
                 }
 
@@ -10388,7 +10385,7 @@ export default class Core {
                         serializedComponents: newSerializedReplacements,
                         ancestors: shadowingComponent.ancestors,
                         createNameContext:
-                            shadowingComponent.componentName + "|replacements",
+                            shadowingComponent.componentIdx + "|replacements",
                         namespaceForUnamed,
                         componentsReplacementOf: shadowingComponent,
                     });
@@ -10415,8 +10412,8 @@ export default class Core {
                                 continue;
                             }
                             if (
-                                pShadow.shadows.compositeName ===
-                                shadowingComponent.shadows.compositeName
+                                pShadow.shadows.compositeIdx ===
+                                shadowingComponent.shadows.compositeIdx
                             ) {
                                 shadowingParent = pShadow;
                                 break;
@@ -10425,19 +10422,19 @@ export default class Core {
                     }
                     if (!shadowingParent) {
                         console.error(
-                            `could not find shadowing parent of ${parentToShadow.componentName}`,
+                            `could not find shadowing parent of ${parentToShadow.componentIdx}`,
                         );
                     }
                 }
 
-                newComponentsForShadows[shadowingComponent.componentName] = {
+                newComponentsForShadows[shadowingComponent.componentIdx] = {
                     newComponents,
                     parent: shadowingParent,
                 };
 
                 if (
                     shadowingComponent.shadowedBy &&
-                    currentShadowedBy[shadowingComponent.componentName].length >
+                    currentShadowedBy[shadowingComponent.componentIdx].length >
                         0
                 ) {
                     let recursionComponents =
@@ -10460,11 +10457,11 @@ export default class Core {
 
         // record that are finished expanding the composite
         let targetInd = this.updateInfo.compositesBeingExpanded.indexOf(
-            componentToShadow.componentName,
+            componentToShadow.componentIdx,
         );
         if (targetInd === -1) {
             throw Error(
-                `Something is wrong as we lost track that we were expanding ${componentToShadow.componentName}`,
+                `Something is wrong as we lost track that we were expanding ${componentToShadow.componentIdx}`,
             );
         }
         this.updateInfo.compositesBeingExpanded.splice(targetInd, 1);
@@ -10489,7 +10486,7 @@ export default class Core {
             changeInReplacementsToWithhold = replacementsToWithhold;
         }
         if (changeInReplacementsToWithhold < 0) {
-            compositesWithAdjustedReplacements.push(component.componentName);
+            compositesWithAdjustedReplacements.push(component.componentIdx);
             // Note: don't subtract one of this last ind, as slice doesn't include last ind
             let lastIndToStopWithholding =
                 component.replacements.length - replacementsToWithhold;
@@ -10511,7 +10508,7 @@ export default class Core {
             };
             componentChanges.push(newChange);
         } else if (changeInReplacementsToWithhold > 0) {
-            compositesWithAdjustedReplacements.push(component.componentName);
+            compositesWithAdjustedReplacements.push(component.componentIdx);
             let firstIndToStartWithholding =
                 component.replacements.length - replacementsToWithhold;
             let lastIndToStartWithholding =
@@ -10522,11 +10519,11 @@ export default class Core {
             );
             let withheldNamesByParent = {};
             for (let comp of withheldReplacements) {
-                let par = comp.parentName;
+                let par = comp.parentIdx;
                 if (withheldNamesByParent[par] === undefined) {
                     withheldNamesByParent[par] = [];
                 }
-                withheldNamesByParent[par].push(comp.componentName);
+                withheldNamesByParent[par].push(comp.componentIdx);
             }
             let newChange = {
                 changeType: "deletedReplacements",
@@ -10653,20 +10650,20 @@ export default class Core {
 
     //   let success = true;
 
-    //   for (let componentName in requestedValues) {
+    //   for (let componentIdx in requestedValues) {
 
-    //     let component = this._components[componentName];
+    //     let component = this._components[componentIdx];
     //     if (!component) {
-    //       console.error(`Component ${componentName} does not exist.  Cannot get value of its state variables.`);
+    //       console.error(`Component ${componentIdx} does not exist.  Cannot get value of its state variables.`);
     //       success = false;
     //     } else {
 
-    //       let valuesForComponent = retrievedValues[componentName] = {};
+    //       let valuesForComponent = retrievedValues[componentIdx] = {};
 
-    //       for (let stateVariable of requestedValues[componentName]) {
+    //       for (let stateVariable of requestedValues[componentIdx]) {
     //         let stateVarObj = component.state[stateVariable];
     //         if (!stateVarObj) {
-    //           console.error(`State variable ${stateVariable} of component ${componentName} does not exist.  Cannot get its value.`);
+    //           console.error(`State variable ${stateVariable} of component ${componentIdx} does not exist.  Cannot get its value.`);
     //           success = false;
     //         } else {
     //           valuesForComponent[stateVariable] = stateVarObj.value;
@@ -10679,13 +10676,13 @@ export default class Core {
     //   return Promise.resolve({ success, retrievedValues });
     // }
 
-    requestAction({ componentName, actionName, args }) {
+    requestAction({ componentIdx, actionName, args }) {
         return new Promise((resolve, reject) => {
             let skippable = args?.skippable;
 
             this.processQueue.push({
                 type: "action",
-                componentName,
+                componentIdx,
                 actionName,
                 args,
                 skippable,
@@ -10701,13 +10698,13 @@ export default class Core {
     }
 
     async performAction({
-        componentName,
+        componentIdx,
         actionName,
         args,
         event,
         caseInsensitiveMatch,
     }) {
-        if (actionName === "setTheme" && !componentName) {
+        if (actionName === "setTheme" && !componentIdx) {
             // For now, co-opting the action mechanism to let the viewer set the theme (dark mode) on document.
             // Don't have an actual action on document as don't want the ability for others to call it.
             // Theme doesn't affect the colors displayed, only the words in the styleDescriptions.
@@ -10715,7 +10712,7 @@ export default class Core {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.documentName,
+                        componentIdx: this.documentName,
                         stateVariable: "theme",
                         value: args.theme,
                     },
@@ -10726,7 +10723,7 @@ export default class Core {
             return { actionId: args.actionId };
         }
 
-        let component = this.components[componentName];
+        let component = this.components[componentIdx];
         if (component && component.actions) {
             let action = component.actions[actionName];
             if (!action && caseInsensitiveMatch) {
@@ -10763,7 +10760,7 @@ export default class Core {
             this.requestRecordEvent({
                 verb: "visibilityChanged",
                 object: {
-                    componentName,
+                    componentIdx,
                 },
                 result: { isVisible: false },
             });
@@ -10772,7 +10769,7 @@ export default class Core {
 
         if (component) {
             this.errorWarnings.warnings.push({
-                message: `Cannot run action ${actionName} on component ${componentName}`,
+                message: `Cannot run action ${actionName} on component ${componentIdx}`,
                 level: 1,
                 doenetMLrange: component.doenetMLrange,
             });
@@ -10783,7 +10780,7 @@ export default class Core {
     }
 
     async triggerChainedActions({
-        componentName,
+        componentIdx,
         triggeringAction,
         actionId,
         sourceInformation = {},
@@ -10801,7 +10798,7 @@ export default class Core {
 
         let actionsToChain = [];
 
-        let cName = componentName;
+        let cName = componentIdx;
 
         while (true) {
             let comp = this._components[cName];
@@ -10827,7 +10824,7 @@ export default class Core {
                 // TODO: if <point copySource="P" /> no longer has a name like "_point1",
                 // should triggerWhenObjectsClicked="P" be triggered from that point?
                 // Currently (Oct 2, 2023), it is not triggered.
-                cName = comp.shadows.componentName;
+                cName = comp.shadows.componentIdx;
             } else {
                 break;
             }
@@ -10876,10 +10873,10 @@ export default class Core {
 
             for (let instruction of updateInstructions) {
                 let componentSourceInformation =
-                    sourceInformation[instruction.componentName];
+                    sourceInformation[instruction.componentIdx];
                 if (!componentSourceInformation) {
                     componentSourceInformation = sourceInformation[
-                        instruction.componentName
+                        instruction.componentIdx
                     ] = {};
                 }
 
@@ -10893,7 +10890,7 @@ export default class Core {
 
             await this.updateRendererInstructions({
                 componentNamesToUpdate: updateInstructions.map(
-                    (x) => x.componentName,
+                    (x) => x.componentIdx,
                 ),
                 sourceOfUpdate: { sourceInformation },
             });
@@ -10963,10 +10960,10 @@ export default class Core {
             if (!canSkipUpdatingRenderer) {
                 for (let instruction of updateInstructions) {
                     let componentSourceInformation =
-                        sourceInformation[instruction.componentName];
+                        sourceInformation[instruction.componentIdx];
                     if (!componentSourceInformation) {
                         componentSourceInformation = sourceInformation[
-                            instruction.componentName
+                            instruction.componentIdx
                         ] = {};
                     }
 
@@ -10980,7 +10977,7 @@ export default class Core {
 
                 await this.updateRendererInstructions({
                     componentNamesToUpdate: updateInstructions.map(
-                        (x) => x.componentName,
+                        (x) => x.componentIdx,
                     ),
                     sourceOfUpdate: { sourceInformation },
                     actionId,
@@ -10996,12 +10993,12 @@ export default class Core {
         let recordComponentSubmissions = [];
 
         for (let instruction of updateInstructions) {
-            if (instruction.componentName) {
+            if (instruction.componentIdx) {
                 let componentSourceInformation =
-                    sourceInformation[instruction.componentName];
+                    sourceInformation[instruction.componentIdx];
                 if (!componentSourceInformation) {
                     componentSourceInformation = sourceInformation[
-                        instruction.componentName
+                        instruction.componentIdx
                     ] = {};
                 }
 
@@ -11022,19 +11019,19 @@ export default class Core {
             } else if (instruction.updateType === "addComponents") {
                 await this.addComponents({
                     serializedComponents: instruction.serializedComponents,
-                    parentName: instruction.parentName,
+                    parentIdx: instruction.parentIdx,
                     assignNamesOffset: instruction.assignNamesOffset,
                 });
             } else if (instruction.updateType === "deleteComponents") {
                 if (instruction.componentNames.length > 0) {
                     let componentsToDelete = [];
-                    for (let componentName of instruction.componentNames) {
-                        let component = this._components[componentName];
+                    for (let componentIdx of instruction.componentNames) {
+                        let component = this._components[componentIdx];
                         if (component) {
                             componentsToDelete.push(component);
                         } else {
                             this.errorWarnings.warnings.push({
-                                message: `Cannot delete ${componentName} as it doesn't exist.`,
+                                message: `Cannot delete ${componentIdx} as it doesn't exist.`,
                                 level: 2,
                             });
                             this.newErrorWarning = true;
@@ -11062,7 +11059,7 @@ export default class Core {
                 instruction.updateType === "setComponentNeedingUpdateValue"
             ) {
                 this.rendererState.__componentNeedingUpdateValue =
-                    instruction.componentName;
+                    instruction.componentIdx;
             } else if (
                 instruction.updateType === "unsetComponentNeedingUpdateValue"
             ) {
@@ -11079,9 +11076,9 @@ export default class Core {
         // so they can revert if the showed the changes before hearing back from core
         if (!canSkipUpdatingRenderer) {
             updateInstructions.forEach((comp) => {
-                if (comp.componentName) {
+                if (comp.componentIdx) {
                     this.updateInfo.componentsToUpdateRenderers.add(
-                        comp.componentName,
+                        comp.componentIdx,
                     );
                 }
             });
@@ -11127,20 +11124,20 @@ export default class Core {
 
         // start with any essential values saved when calculating definitions
         if (Object.keys(this.essentialValuesSavedInDefinition).length > 0) {
-            for (let componentName in this.essentialValuesSavedInDefinition) {
+            for (let componentIdx in this.essentialValuesSavedInDefinition) {
                 let essentialState =
-                    this._components[componentName]?.essentialState;
+                    this._components[componentIdx]?.essentialState;
                 if (essentialState) {
-                    if (!this.cumulativeStateVariableChanges[componentName]) {
-                        this.cumulativeStateVariableChanges[componentName] = {};
+                    if (!this.cumulativeStateVariableChanges[componentIdx]) {
+                        this.cumulativeStateVariableChanges[componentIdx] = {};
                     }
                     for (let varName in this.essentialValuesSavedInDefinition[
-                        componentName
+                        componentIdx
                     ]) {
                         if (essentialState[varName] !== undefined) {
                             let cumValues =
                                 this.cumulativeStateVariableChanges[
-                                    componentName
+                                    componentIdx
                                 ][varName];
                             // if cumValues is an object with mergeObject = true,
                             // then merge attributes from newStateVariableValues into cumValues
@@ -11157,7 +11154,7 @@ export default class Core {
                                 );
                             } else {
                                 this.cumulativeStateVariableChanges[
-                                    componentName
+                                    componentIdx
                                 ][varName] = removeFunctionsMathExpressionClass(
                                     essentialState[varName],
                                 );
@@ -11171,13 +11168,13 @@ export default class Core {
 
         // merge in new state variables set in update
         for (let newValuesProcessed of newStateVariableValuesProcessed) {
-            for (let componentName in newValuesProcessed) {
-                if (!this.cumulativeStateVariableChanges[componentName]) {
-                    this.cumulativeStateVariableChanges[componentName] = {};
+            for (let componentIdx in newValuesProcessed) {
+                if (!this.cumulativeStateVariableChanges[componentIdx]) {
+                    this.cumulativeStateVariableChanges[componentIdx] = {};
                 }
-                for (let varName in newValuesProcessed[componentName]) {
+                for (let varName in newValuesProcessed[componentIdx]) {
                     let cumValues =
-                        this.cumulativeStateVariableChanges[componentName][
+                        this.cumulativeStateVariableChanges[componentIdx][
                             varName
                         ];
                     // if cumValues is an object with mergeObject = true,
@@ -11190,14 +11187,14 @@ export default class Core {
                         Object.assign(
                             cumValues,
                             removeFunctionsMathExpressionClass(
-                                newValuesProcessed[componentName][varName],
+                                newValuesProcessed[componentIdx][varName],
                             ),
                         );
                     } else {
-                        this.cumulativeStateVariableChanges[componentName][
+                        this.cumulativeStateVariableChanges[componentIdx][
                             varName
                         ] = removeFunctionsMathExpressionClass(
-                            newValuesProcessed[componentName][varName],
+                            newValuesProcessed[componentIdx][varName],
                         );
                     }
                 }
@@ -11318,17 +11315,15 @@ export default class Core {
     }
 
     processVisibilityChangedEvent(event) {
-        let componentName = event.object.componentName;
+        let componentIdx = event.object.componentIdx;
         let isVisible = event.result.isVisible;
 
         if (isVisible) {
-            if (
-                !this.visibilityInfo.componentsCurrentlyVisible[componentName]
-            ) {
-                this.visibilityInfo.componentsCurrentlyVisible[componentName] =
+            if (!this.visibilityInfo.componentsCurrentlyVisible[componentIdx]) {
+                this.visibilityInfo.componentsCurrentlyVisible[componentIdx] =
                     new Date();
             }
-            if (componentName === this.documentName) {
+            if (componentIdx === this.documentName) {
                 if (!this.visibilityInfo.documentHasBeenVisible) {
                     this.visibilityInfo.documentHasBeenVisible = true;
                     this.onDocumentFirstVisible();
@@ -11336,10 +11331,10 @@ export default class Core {
             }
         } else {
             let begin =
-                this.visibilityInfo.componentsCurrentlyVisible[componentName];
+                this.visibilityInfo.componentsCurrentlyVisible[componentIdx];
             if (begin) {
                 delete this.visibilityInfo.componentsCurrentlyVisible[
-                    componentName
+                    componentIdx
                 ];
 
                 let timeInSeconds =
@@ -11347,11 +11342,11 @@ export default class Core {
                         Math.max(begin, this.visibilityInfo.timeLastSent)) /
                     1000;
 
-                if (this.visibilityInfo.infoToSend[componentName]) {
-                    this.visibilityInfo.infoToSend[componentName] +=
+                if (this.visibilityInfo.infoToSend[componentIdx]) {
+                    this.visibilityInfo.infoToSend[componentIdx] +=
                         timeInSeconds;
                 } else {
-                    this.visibilityInfo.infoToSend[componentName] =
+                    this.visibilityInfo.infoToSend[componentIdx] =
                         timeInSeconds;
                 }
             }
@@ -11367,23 +11362,23 @@ export default class Core {
             ...this.visibilityInfo.componentsCurrentlyVisible,
         };
 
-        for (let componentName in currentVisible) {
+        for (let componentIdx in currentVisible) {
             let timeInSeconds =
                 (this.visibilityInfo.timeLastSent -
-                    Math.max(timeLastSent, currentVisible[componentName])) /
+                    Math.max(timeLastSent, currentVisible[componentIdx])) /
                 1000;
-            if (infoToSend[componentName]) {
-                infoToSend[componentName] += timeInSeconds;
+            if (infoToSend[componentIdx]) {
+                infoToSend[componentIdx] += timeInSeconds;
             } else {
-                infoToSend[componentName] = timeInSeconds;
+                infoToSend[componentIdx] = timeInSeconds;
             }
         }
 
-        for (let componentName in infoToSend) {
-            infoToSend[componentName] = Math.round(infoToSend[componentName]);
-            if (!infoToSend[componentName]) {
+        for (let componentIdx in infoToSend) {
+            infoToSend[componentIdx] = Math.round(infoToSend[componentIdx]);
+            if (!infoToSend[componentIdx]) {
                 // delete if rounded down to zero
-                delete infoToSend[componentName];
+                delete infoToSend[componentIdx];
             }
         }
 
@@ -11392,7 +11387,7 @@ export default class Core {
         if (Object.keys(infoToSend).length > 0) {
             let event = {
                 object: {
-                    componentName: this.documentName,
+                    componentIdx: this.documentName,
                     componentType: "document",
                 },
                 verb: "isVisible",
@@ -11502,10 +11497,10 @@ export default class Core {
                     this.updateInfo.stateVariablesToEvaluate;
                 this.updateInfo.stateVariablesToEvaluate = [];
                 for (let {
-                    componentName,
+                    componentIdx,
                     stateVariable,
                 } of stateVariablesToEvaluate) {
-                    let comp = this._components[componentName];
+                    let comp = this._components[componentIdx];
                     if (comp && comp.state[stateVariable]) {
                         await this.getStateVariableValue({
                             component: comp,
@@ -11565,16 +11560,16 @@ export default class Core {
                                 },
                             );
 
-                            // for (let componentName in result.addedComponents) {
+                            // for (let componentIdx in result.addedComponents) {
                             //   updatedComposites = true;
-                            //   this.changedStateVariables[componentName] = {};
-                            //   for (let varName in this._components[componentName].state) {
-                            //     let stateVarObj = this._components[componentName].state[varName];
+                            //   this.changedStateVariables[componentIdx] = {};
+                            //   for (let varName in this._components[componentIdx].state) {
+                            //     let stateVarObj = this._components[componentIdx].state[varName];
                             //     if (stateVarObj.isArray) {
-                            //       this.changedStateVariables[componentName][varName] =
+                            //       this.changedStateVariables[componentIdx][varName] =
                             //         new Set(stateVarObj.getAllArrayKeys(await stateVarObj.arraySize))
                             //     } else if (!stateVarObj.isArrayEntry) {
-                            //       this.changedStateVariables[componentName][varName] = true;
+                            //       this.changedStateVariables[componentIdx][varName] = true;
                             //     }
                             //   }
                             // }
@@ -11718,7 +11713,7 @@ export default class Core {
                     this.rendererVariablesByComponentType[comp.componentType]
                 ) {
                     this.updateInfo.componentsToUpdateRenderers.add(
-                        comp.componentName,
+                        comp.componentIdx,
                     );
                 }
 
@@ -11787,7 +11782,7 @@ export default class Core {
 
                     for (let arrayEntryName of arrayEntryNamesAffected) {
                         await this.recordActualChangeInStateVariable({
-                            componentName: cName,
+                            componentIdx: cName,
                             varName: arrayEntryName,
                         });
                     }
@@ -11817,7 +11812,7 @@ export default class Core {
                 }
 
                 await this.recordActualChangeInStateVariable({
-                    componentName: cName,
+                    componentIdx: cName,
                     varName: vName,
                 });
             }
@@ -11837,17 +11832,17 @@ export default class Core {
         // console.log('overall workspace')
         // console.log(JSON.parse(JSON.stringify(workspace)))
 
-        let component = this._components[instruction.componentName];
+        let component = this._components[instruction.componentIdx];
 
         let stateVariable = this.substituteAliases({
             stateVariables: [instruction.stateVariable],
             componentClass: component.constructor,
         })[0];
 
-        if (workspace[instruction.componentName] === undefined) {
-            workspace[instruction.componentName] = {};
+        if (workspace[instruction.componentIdx] === undefined) {
+            workspace[instruction.componentIdx] = {};
         }
-        let componentWorkspace = workspace[instruction.componentName];
+        let componentWorkspace = workspace[instruction.componentIdx];
 
         let stateVarObj = component.state[stateVariable];
 
@@ -11862,7 +11857,7 @@ export default class Core {
         for (let varName of allStateVariablesAffected) {
             if (!component.state[varName].isResolved) {
                 let result = await this.dependencies.resolveItem({
-                    componentName: component.componentName,
+                    componentIdx: component.componentIdx,
                     type: "stateVariable",
                     stateVariable: varName,
                     force: true,
@@ -11870,7 +11865,7 @@ export default class Core {
 
                 if (!result.success) {
                     throw Error(
-                        `Can't get value of ${stateVariable} of ${component.componentName} as ${varName} couldn't be resolved.`,
+                        `Can't get value of ${stateVariable} of ${component.componentIdx} as ${varName} couldn't be resolved.`,
                     );
                 }
             }
@@ -11913,7 +11908,7 @@ export default class Core {
                         ] = await sObj.value;
                     } else {
                         throw Error(
-                            `Invalid instruction to change ${instruction.stateVariable} of ${instruction.componentName}, value of state variable ${instruction.valueOfStateVariable} not found.`,
+                            `Invalid instruction to change ${instruction.stateVariable} of ${instruction.componentIdx}, value of state variable ${instruction.valueOfStateVariable} not found.`,
                         );
                     }
                 }
@@ -11953,7 +11948,7 @@ export default class Core {
                     };
                 } else {
                     throw Error(
-                        `Invalid instruction to change ${instruction.stateVariable} of ${instruction.componentName}, value of state variable ${instruction.valueOfStateVariable} not found.`,
+                        `Invalid instruction to change ${instruction.stateVariable} of ${instruction.componentIdx}, value of state variable ${instruction.valueOfStateVariable} not found.`,
                     );
                 }
             }
@@ -12014,7 +12009,7 @@ export default class Core {
 
         if (!stateVarObj.inverseDefinition) {
             this.errorWarnings.warnings.push({
-                message: `Cannot change state variable ${stateVariable} of ${component.componentName} as it doesn't have an inverse definition`,
+                message: `Cannot change state variable ${stateVariable} of ${component.componentIdx} as it doesn't have an inverse definition`,
                 level: 2,
                 doenetMLrange: component.doenetMLrange,
             });
@@ -12028,7 +12023,7 @@ export default class Core {
             (await component.stateValues.fixed)
         ) {
             this.errorWarnings.warnings.push({
-                message: `Changing ${stateVariable} of ${component.componentName} did not succeed because fixed is true.`,
+                message: `Changing ${stateVariable} of ${component.componentIdx} did not succeed because fixed is true.`,
                 level: 2,
                 doenetMLrange: component.doenetMLrange,
             });
@@ -12042,7 +12037,7 @@ export default class Core {
             (await component.stateValues.fixLocation)
         ) {
             this.errorWarnings.warnings.push({
-                message: `Changing ${stateVariable} of ${component.componentName} did not succeed because fixLocation is true.`,
+                message: `Changing ${stateVariable} of ${component.componentIdx} did not succeed because fixLocation is true.`,
                 level: 2,
                 doenetMLrange: component.doenetMLrange,
             });
@@ -12057,7 +12052,7 @@ export default class Core {
             )
         ) {
             this.errorWarnings.warnings.push({
-                message: `Changing ${stateVariable} of ${component.componentName} did not succeed because modifyIndirectly is false.`,
+                message: `Changing ${stateVariable} of ${component.componentIdx} did not succeed because modifyIndirectly is false.`,
                 level: 2,
                 doenetMLrange: component.doenetMLrange,
             });
@@ -12082,7 +12077,7 @@ export default class Core {
         }
 
         if (!inverseResult.success) {
-            // console.log(`Changing ${stateVariable} of ${component.componentName} did not succeed.`);
+            // console.log(`Changing ${stateVariable} of ${component.componentIdx} did not succeed.`);
             return;
         }
 
@@ -12101,7 +12096,7 @@ export default class Core {
 
                 let dep =
                     this.dependencies.downstreamDependencies[
-                        component.componentName
+                        component.componentIdx
                     ][stateVariable][dependencyName];
                 if (
                     ["stateVariable", "parentStateVariable"].includes(
@@ -12128,7 +12123,7 @@ export default class Core {
                         if (
                             arrayInstructionInProgress &&
                             !(
-                                arrayInstructionInProgress.componentName ===
+                                arrayInstructionInProgress.componentIdx ===
                                     dComponentName &&
                                 arrayInstructionInProgress.stateVariable ===
                                     arrayStateVariable &&
@@ -12158,7 +12153,7 @@ export default class Core {
                             if (!arrayInstructionInProgress) {
                                 arrayInstructionInProgress = {
                                     combinedArray: true,
-                                    componentName: dComponentName,
+                                    componentIdx: dComponentName,
                                     stateVariable: arrayStateVariable,
                                     shadowedVariable:
                                         newInstruction.shadowedVariable,
@@ -12321,7 +12316,7 @@ export default class Core {
                     }
                     if (!foundArrayMatch) {
                         throw Error(
-                            `Invalid inverse definition of ${stateVariable} of ${component.componentName}: specified changing value of ${newInstruction.setEssentialValue}, which is not a state variable defined with ${stateVariable}.`,
+                            `Invalid inverse definition of ${stateVariable} of ${component.componentIdx}: specified changing value of ${newInstruction.setEssentialValue}, which is not a state variable defined with ${stateVariable}.`,
                         );
                     }
                 }
@@ -12331,13 +12326,13 @@ export default class Core {
                         .hasEssential
                 ) {
                     throw Error(
-                        `Invalid inverse definition of ${stateVariable} of ${component.componentName}: can't set essential value of ${newInstruction.setEssentialValue} if it is does not have an essential value.`,
+                        `Invalid inverse definition of ${stateVariable} of ${component.componentIdx}: can't set essential value of ${newInstruction.setEssentialValue} if it is does not have an essential value.`,
                     );
                 }
 
                 if (!("value" in newInstruction)) {
                     throw Error(
-                        `Invalid inverse definition of ${stateVariable} of ${component.componentName}: setEssentialValue must specify a value`,
+                        `Invalid inverse definition of ${stateVariable} of ${component.componentIdx}: setEssentialValue must specify a value`,
                     );
                 }
 
@@ -12382,12 +12377,12 @@ export default class Core {
                         (baseComponent.shadows.propVariable === undefined ||
                             (baseComponent.doenetAttributes.fromImplicitProp &&
                                 this._components[
-                                    baseComponent.shadows.componentName
+                                    baseComponent.shadows.componentIdx
                                 ].constructor.implicitPropReturnsSameType))
                     ) {
                         baseComponent =
                             this._components[
-                                baseComponent.shadows.componentName
+                                baseComponent.shadows.componentIdx
                             ];
 
                         // if any of the shadow sources are fixed, reject this change
@@ -12397,7 +12392,7 @@ export default class Core {
                             (await baseComponent.stateValues.fixed)
                         ) {
                             this.errorWarnings.warnings.push({
-                                message: `Changing ${stateVariable} of ${baseComponent.componentName} did not succeed because fixed is true.`,
+                                message: `Changing ${stateVariable} of ${baseComponent.componentIdx} did not succeed because fixed is true.`,
                                 level: 2,
                                 doenetMLrange: baseComponent.doenetMLrange,
                             });
@@ -12412,7 +12407,7 @@ export default class Core {
                             (await baseComponent.stateValues.fixLocation)
                         ) {
                             this.errorWarnings.warnings.push({
-                                message: `Changing ${stateVariable} of ${baseComponent.componentName} did not succeed because fixLocation is true.`,
+                                message: `Changing ${stateVariable} of ${baseComponent.componentIdx} did not succeed because fixLocation is true.`,
                                 level: 2,
                                 doenetMLrange: baseComponent.doenetMLrange,
                             });
@@ -12433,7 +12428,7 @@ export default class Core {
 
                 let dep =
                     this.dependencies.downstreamDependencies[
-                        component.componentName
+                        component.componentIdx
                     ][stateVariable][dependencyName];
 
                 if (dep.dependencyType === "child") {
@@ -12456,7 +12451,7 @@ export default class Core {
                             typeof newInstruction.desiredValue ===
                             typeof dep.downstreamPrimitives[childInd]
                         ) {
-                            let parent = this._components[dep.parentName];
+                            let parent = this._components[dep.parentIdx];
 
                             let activeChildInd =
                                 dep.activeChildrenIndices[childInd];
@@ -12470,7 +12465,7 @@ export default class Core {
                                         compositeObj.lastInd >= activeChildInd
                                     ) {
                                         console.log(
-                                            `parent: ${parent.componentName}, activeChildInd: ${activeChildInd}`,
+                                            `parent: ${parent.componentIdx}, activeChildInd: ${activeChildInd}`,
                                         );
                                         console.log(
                                             parent.compositeReplacementActiveRange,
@@ -12505,14 +12500,14 @@ export default class Core {
                             ) {
                                 baseParent =
                                     this._components[
-                                        baseParent.shadows.componentName
+                                        baseParent.shadows.componentIdx
                                     ];
                             }
 
                             let markToIgnoreForParent;
 
                             if (newInstruction.ignoreChildChangeForComponent) {
-                                markToIgnoreForParent = parent.componentName;
+                                markToIgnoreForParent = parent.componentIdx;
                             }
 
                             this.calculatePrimitiveChildChanges({
@@ -12534,7 +12529,7 @@ export default class Core {
                         let cName = dep.downstreamComponentNames[downstreamInd];
                         if (!cName) {
                             throw Error(
-                                `Invalid inverse definition of ${stateVariable} of ${component.componentName}: ${dependencyName} child of index ${newInstruction.childIndex} does not exist.`,
+                                `Invalid inverse definition of ${stateVariable} of ${component.componentIdx}: ${dependencyName} child of index ${newInstruction.childIndex} does not exist.`,
                             );
                         }
                         let varName =
@@ -12543,11 +12538,11 @@ export default class Core {
                             ][newInstruction.variableIndex];
                         if (!varName) {
                             throw Error(
-                                `Invalid inverse definition of ${stateVariable} of ${component.componentName}: ${dependencyName} variable of index ${newInstruction.variableIndex} does not exist.`,
+                                `Invalid inverse definition of ${stateVariable} of ${component.componentIdx}: ${dependencyName} variable of index ${newInstruction.variableIndex} does not exist.`,
                             );
                         }
                         let inst = {
-                            componentName: cName,
+                            componentIdx: cName,
                             stateVariable: varName,
                             value: newInstruction.desiredValue,
                             overrideFixed: instruction.overrideFixed,
@@ -12576,11 +12571,11 @@ export default class Core {
                         ];
                     if (!varName) {
                         throw Error(
-                            `Invalid inverse definition of ${stateVariable} of ${component.componentName}: ${dependencyName} variable of index ${newInstruction.variableIndex} does not exist.`,
+                            `Invalid inverse definition of ${stateVariable} of ${component.componentIdx}: ${dependencyName} variable of index ${newInstruction.variableIndex} does not exist.`,
                         );
                     }
                     let inst = {
-                        componentName: cName,
+                        componentIdx: cName,
                         stateVariable: varName,
                         value: newInstruction.desiredValue,
                         overrideFixed: instruction.overrideFixed,
@@ -12607,7 +12602,7 @@ export default class Core {
                         dep.mappedDownstreamVariableNamesByComponent[0][0];
 
                     let inst = {
-                        componentName: dComponentName,
+                        componentIdx: dComponentName,
                         stateVariable: dVarName,
                         value: newInstruction.desiredValue,
                         overrideFixed: instruction.overrideFixed,
@@ -12623,7 +12618,7 @@ export default class Core {
                         for (let dependencyName2 in newInstruction.additionalDependencyValues) {
                             let dep2 =
                                 this.dependencies.downstreamDependencies[
-                                    component.componentName
+                                    component.componentIdx
                                 ][stateVariable][dependencyName2];
                             if (
                                 !(
@@ -12688,7 +12683,7 @@ export default class Core {
                 }
             } else if (newInstruction.combinedArray) {
                 let inst = {
-                    componentName: newInstruction.componentName,
+                    componentIdx: newInstruction.componentIdx,
                     stateVariable: newInstruction.stateVariable,
                     value: newInstruction.desiredValue,
                     overrideFixed: instruction.overrideFixed,
@@ -12704,17 +12699,17 @@ export default class Core {
                 // } else if (newInstruction.deferSettingDependency) {
                 //   let dependencyName = newInstruction.deferSettingDependency;
 
-                //   let dep = this.dependencies.downstreamDependencies[component.componentName][stateVariable][dependencyName];
+                //   let dep = this.dependencies.downstreamDependencies[component.componentIdx][stateVariable][dependencyName];
 
                 //   if (dep.dependencyType === "child") {
                 //     let cName = dep.downstreamComponentNames[newInstruction.childIndex];
                 //     if (!cName) {
-                //       throw Error(`Invalid for deferSettingDependency in inverse definition of ${stateVariable} of ${component.componentName}: ${dependencyName} child of index ${newInstruction.childIndex} does not exist.`)
+                //       throw Error(`Invalid for deferSettingDependency in inverse definition of ${stateVariable} of ${component.componentIdx}: ${dependencyName} child of index ${newInstruction.childIndex} does not exist.`)
                 //     }
 
                 //     let varName = dep.mappedDownstreamVariableNamesByComponent[newInstruction.childIndex][newInstruction.variableIndex];
                 //     if (!varName) {
-                //       throw Error(`Invalid for deferSettingDependency in inverse definition of ${stateVariable} of ${component.componentName}: ${dependencyName} variable of index ${newInstruction.variableIndex} does not exist..`)
+                //       throw Error(`Invalid for deferSettingDependency in inverse definition of ${stateVariable} of ${component.componentIdx}: ${dependencyName} variable of index ${newInstruction.variableIndex} does not exist..`)
                 //     }
 
                 //     let componentToDefer = this._components[cName];
@@ -12748,7 +12743,7 @@ export default class Core {
             } else {
                 console.log(newInstruction);
                 throw Error(
-                    `Unrecognized instruction in inverse definition of ${stateVariable} of ${component.componentName}`,
+                    `Unrecognized instruction in inverse definition of ${stateVariable} of ${component.componentIdx}`,
                 );
             }
         }
@@ -12763,26 +12758,26 @@ export default class Core {
         newStateVariableValues,
         recurseToShadows = true,
     }) {
-        if (!newStateVariableValues[component.componentName]) {
-            newStateVariableValues[component.componentName] = {};
+        if (!newStateVariableValues[component.componentIdx]) {
+            newStateVariableValues[component.componentIdx] = {};
         }
 
         if (component.state[varName].isArray) {
-            if (!newStateVariableValues[component.componentName][varName]) {
+            if (!newStateVariableValues[component.componentIdx][varName]) {
                 // include key mergeObject to let external functions
                 // know that new attributes of the object
                 // should be merged into the old object
-                newStateVariableValues[component.componentName][varName] = {
+                newStateVariableValues[component.componentIdx][varName] = {
                     mergeObject: true,
                 };
             }
 
             Object.assign(
-                newStateVariableValues[component.componentName][varName],
+                newStateVariableValues[component.componentIdx][varName],
                 value,
             );
         } else {
-            newStateVariableValues[component.componentName][varName] = value;
+            newStateVariableValues[component.componentIdx][varName] = value;
         }
 
         if (recurseToShadows && component.shadowedBy) {
@@ -12812,15 +12807,15 @@ export default class Core {
         newStateVariableValues,
         markToIgnoreForParent,
     }) {
-        if (!newStateVariableValues[parent.componentName]) {
-            newStateVariableValues[parent.componentName] = {};
+        if (!newStateVariableValues[parent.componentIdx]) {
+            newStateVariableValues[parent.componentIdx] = {};
         }
-        if (parent.componentName === markToIgnoreForParent) {
-            newStateVariableValues[parent.componentName][
+        if (parent.componentIdx === markToIgnoreForParent) {
+            newStateVariableValues[parent.componentIdx][
                 `__def_primitive_ignore_${definingInd}`
             ] = newValue;
         } else {
-            newStateVariableValues[parent.componentName][
+            newStateVariableValues[parent.componentIdx][
                 `__def_primitive_${definingInd}`
             ] = newValue;
         }
@@ -12943,9 +12938,9 @@ export default class Core {
      * Note: this will occur only if the `solutionDisplayMode` flag is set to
      * "buttonRequirePermission".
      */
-    async requestSolutionView(componentName) {
+    async requestSolutionView(componentIdx) {
         const requestResult =
-            await this.requestSolutionViewCallback(componentName);
+            await this.requestSolutionViewCallback(componentIdx);
 
         return {
             allowView: requestResult.allowView,
@@ -12967,12 +12962,12 @@ export default class Core {
         }
     }
 
-    async handleNavigatingToComponent({ componentName, hash }) {
-        let component = this._components[componentName];
+    async handleNavigatingToComponent({ componentIdx, hash }) {
+        let component = this._components[componentIdx];
         if (component) {
             let componentAndAncestors = [
-                componentName,
-                ...component.ancestors.map((x) => x.componentName),
+                componentIdx,
+                ...component.ancestors.map((x) => x.componentIdx),
             ];
             let openedParent = false;
             for (let cName of componentAndAncestors) {
@@ -12982,10 +12977,10 @@ export default class Core {
 
                     if (isOpen === false) {
                         await this.performAction({
-                            componentName: cName,
+                            componentIdx: cName,
                             actionName: "revealSection",
                         });
-                        if (cName !== componentName) {
+                        if (cName !== componentIdx) {
                             openedParent = true;
                         }
                     }
@@ -13032,13 +13027,13 @@ export default class Core {
         await this.saveImmediately();
     }
 
-    recordAnswerToAutoSubmit(componentName) {
+    recordAnswerToAutoSubmit(componentIdx) {
         if (!this.answersToSubmit) {
             this.answersToSubmit = [];
         }
 
-        if (!this.answersToSubmit.includes(componentName)) {
-            this.answersToSubmit.push(componentName);
+        if (!this.answersToSubmit.includes(componentIdx)) {
+            this.answersToSubmit.push(componentIdx);
         }
 
         clearTimeout(this.submitAnswersTimeout);
@@ -13052,20 +13047,20 @@ export default class Core {
     async autoSubmitAnswers() {
         let toSubmit = this.answersToSubmit;
         this.answersToSubmit = [];
-        for (let componentName of toSubmit) {
-            let component = this._components[componentName];
+        for (let componentIdx of toSubmit) {
+            let component = this._components[componentIdx];
 
             if (component.actions.submitAnswer) {
                 await this.requestAction({
-                    componentName,
+                    componentIdx,
                     actionName: "submitAnswer",
                 });
             }
         }
     }
 
-    requestComponentDoenetML(componentName, displayOnlyChildren) {
-        let component = this.components[componentName];
+    requestComponentDoenetML(componentIdx, displayOnlyChildren) {
+        let component = this.components[componentIdx];
 
         if (!component) {
             return null;
@@ -13219,7 +13214,7 @@ function calculateAllComponentsShadowing(component) {
                 !comp2.shadows.propVariable &
                 !comp2.constructor.doNotExpandAsShadowed
             ) {
-                allShadowing.push(comp2.componentName);
+                allShadowing.push(comp2.componentIdx);
                 let additionalShadowing =
                     calculateAllComponentsShadowing(comp2);
                 allShadowing.push(...additionalShadowing);

--- a/packages/doenetml-worker-javascript/src/Core.js
+++ b/packages/doenetml-worker-javascript/src/Core.js
@@ -8721,12 +8721,12 @@ export default class Core {
                         if (
                             varName in
                             this.rendererVariablesByComponentType[
-                                this.components[upDep.upstreamComponentName]
+                                this.components[upDep.upstreamComponentIdx]
                                     .componentType
                             ]
                         ) {
                             this.updateInfo.componentsToUpdateRenderers.add(
-                                upDep.upstreamComponentName,
+                                upDep.upstreamComponentIdx,
                             );
                             break;
                         }
@@ -8734,7 +8734,7 @@ export default class Core {
 
                     let upVarName = upDep.upstreamVariableNames[0];
                     let upDepComponent =
-                        this._components[upDep.upstreamComponentName];
+                        this._components[upDep.upstreamComponentIdx];
                     // let upVar = upDepComponent.state[upVarName];
 
                     let allStateVariablesAffectedObj = {};
@@ -8837,7 +8837,7 @@ export default class Core {
 
                         if (result.updateReplacements) {
                             this.updateInfo.compositesToUpdateReplacements.add(
-                                upDep.upstreamComponentName,
+                                upDep.upstreamComponentIdx,
                             );
                         }
 

--- a/packages/doenetml-worker-javascript/src/CoreWorker.ts
+++ b/packages/doenetml-worker-javascript/src/CoreWorker.ts
@@ -16,7 +16,7 @@ export type UpdateRenderersCallback = (arg: {
 }) => void;
 export type ReportScoreAndStateCallback = (data: unknown) => void;
 export type RequestAnimationFrame = (args: {
-    action: { actionName: string; componentName?: string };
+    action: { actionName: string; componentIdx?: string };
     actionArgs: Record<string, any>;
     delay?: number;
     animationId: string;
@@ -27,7 +27,7 @@ export type CopyToClipboard = (args: {
     actionId?: string;
 }) => void;
 export type SendEvent = (data: any) => void;
-export type RequestSolutionView = (componentName: string) => Promise<{
+export type RequestSolutionView = (componentIdx: string) => Promise<{
     allowView: boolean;
 }>;
 
@@ -219,11 +219,11 @@ export class PublicDoenetMLCore {
     }
 
     /**
-     * Add the action `actionName` of `componentName` to the queue to be executed.
+     * Add the action `actionName` of `componentIdx` to the queue to be executed.
      */
     async requestAction(actionArgs: {
         actionName: string;
-        componentName: string | undefined;
+        componentIdx: string | undefined;
         args: Record<string, any>;
     }) {
         if (!this.core) {
@@ -271,7 +271,7 @@ export class PublicDoenetMLCore {
         const componentsObj: Record<
             string,
             {
-                componentName: string;
+                componentIdx: string;
                 componentType: string;
                 stateValues: Record<string, any>;
                 activeChildren: any[];
@@ -289,16 +289,16 @@ export class PublicDoenetMLCore {
             console.log(components);
         }
 
-        for (let componentName in components) {
-            let component = components[componentName];
-            componentsObj[componentName] = {
-                componentName,
+        for (let componentIdx in components) {
+            let component = components[componentIdx];
+            componentsObj[componentIdx] = {
+                componentIdx,
                 componentType: component.componentType,
                 stateValues: {},
                 activeChildren: [],
                 sharedParameters: null,
             };
-            let compObj = componentsObj[componentName];
+            let compObj = componentsObj[componentIdx];
             for (let vName in component.state) {
                 if (
                     [
@@ -320,18 +320,18 @@ export class PublicDoenetMLCore {
                     : removeFunctionsMathExpressionClass(value);
             }
             compObj.activeChildren = component.activeChildren.map((x: any) =>
-                x.componentName
+                x.componentIdx
                     ? {
-                          componentName: x.componentName,
+                          componentIdx: x.componentIdx,
                           componentType: x.componentType,
                       }
                     : x,
             );
             if (component.replacements) {
                 compObj.replacements = component.replacements.map((x: any) =>
-                    x.componentName
+                    x.componentIdx
                         ? {
-                              componentName: x.componentName,
+                              componentIdx: x.componentIdx,
                               componentType: x.componentType,
                           }
                         : x,
@@ -342,7 +342,7 @@ export class PublicDoenetMLCore {
                 }
             }
             if (component.replacementOf) {
-                compObj.replacementOf = component.replacementOf.componentName;
+                compObj.replacementOf = component.replacementOf.componentIdx;
             }
             compObj.sharedParameters = dontRemoveFunctionsMath
                 ? component.sharedParameters
@@ -372,9 +372,9 @@ export class PublicDoenetMLCore {
 
     // TODO: restore functionality that opens collapsible sections
     // when navigating to them or to items inside them
-    navigatingToComponent(componentName: string, hash: string) {
+    navigatingToComponent(componentIdx: string, hash: string) {
         // This function no longer works
-        this.core?.handleNavigatingToComponent({ componentName, hash });
+        this.core?.handleNavigatingToComponent({ componentIdx, hash });
     }
 
     /**
@@ -382,7 +382,7 @@ export class PublicDoenetMLCore {
      */
     async submitAllAnswers() {
         return await this.core?.requestAction({
-            componentName: this.core.documentName,
+            componentIdx: this.core.documentName,
             actionName: "submitAllAnswers",
             args: {},
         });

--- a/packages/doenetml-worker-javascript/src/Dependencies.js
+++ b/packages/doenetml-worker-javascript/src/Dependencies.js
@@ -50,14 +50,14 @@ export class DependencyHandler {
     async setUpComponentDependencies(component) {
         // if component already has downstream dependencies
         // delete them, and the corresponding upstream dependencies
-        if (this.downstreamDependencies[component.componentName]) {
+        if (this.downstreamDependencies[component.componentIdx]) {
             this.deleteAllDownstreamDependencies({ component });
         }
 
-        // console.log(`set up component dependencies of ${component.componentName}`)
-        this.downstreamDependencies[component.componentName] = {};
-        if (!this.upstreamDependencies[component.componentName]) {
-            this.upstreamDependencies[component.componentName] = {};
+        // console.log(`set up component dependencies of ${component.componentIdx}`)
+        this.downstreamDependencies[component.componentIdx] = {};
+        if (!this.upstreamDependencies[component.componentIdx]) {
+            this.upstreamDependencies[component.componentIdx] = {};
         }
 
         let stateVariablesToProccess = [];
@@ -140,7 +140,7 @@ export class DependencyHandler {
                 !(dependencyDefinition.dependencyType in this.dependencyTypes)
             ) {
                 throw Error(
-                    `Unrecognized dependency type ${dependencyDefinition.dependencyType} for ${dependencyName} of ${stateVariable} of ${component.componentName}`,
+                    `Unrecognized dependency type ${dependencyDefinition.dependencyType} for ${dependencyName} of ${stateVariable} of ${component.componentIdx}`,
                 );
             }
             let dep = new this.dependencyTypes[
@@ -163,16 +163,16 @@ export class DependencyHandler {
     }
 
     deleteAllDownstreamDependencies({ component, stateVariables = "__all__" }) {
-        // console.log(`delete all downstream dependencies of ${component.componentName}, ${stateVariables.toString()}`)
-        // console.log(deepClone(this.downstreamDependencies[component.componentName]))
+        // console.log(`delete all downstream dependencies of ${component.componentIdx}, ${stateVariables.toString()}`)
+        // console.log(deepClone(this.downstreamDependencies[component.componentIdx]))
         // console.log(deepClone(this.upstreamDependencies))
 
-        let componentName = component.componentName;
+        let componentIdx = component.componentIdx;
 
         let stateVariablesToAdddress;
         if (stateVariables === "__all__") {
             stateVariablesToAdddress = Object.keys(
-                this.downstreamDependencies[componentName],
+                this.downstreamDependencies[componentIdx],
             );
         } else {
             stateVariablesToAdddress = stateVariables;
@@ -180,21 +180,21 @@ export class DependencyHandler {
 
         for (let stateVariable of stateVariablesToAdddress) {
             let downDeps =
-                this.downstreamDependencies[componentName][stateVariable];
+                this.downstreamDependencies[componentIdx][stateVariable];
 
             for (let downDepName in downDeps) {
                 downDeps[downDepName].deleteDependency();
             }
 
-            delete this.downstreamDependencies[componentName][stateVariable];
+            delete this.downstreamDependencies[componentIdx][stateVariable];
         }
 
         if (
-            Object.keys(this.downstreamDependencies[componentName]).length ===
+            Object.keys(this.downstreamDependencies[componentIdx]).length ===
                 0 &&
-            !this.components[componentName]
+            !this.components[componentIdx]
         ) {
-            delete this.downstreamDependencies[componentName];
+            delete this.downstreamDependencies[componentIdx];
         }
     }
 
@@ -205,27 +205,27 @@ export class DependencyHandler {
     }) {
         // if completelyDelete is false, then just remove component from dependency
 
-        // console.log(`delete all upstream dependencies of ${component.componentName}, ${stateVariables.toString()}`)
+        // console.log(`delete all upstream dependencies of ${component.componentIdx}, ${stateVariables.toString()}`)
         // console.log(`completelyDelete: ${completelyDelete}`)
         // console.log(deepClone(this.downstreamDependencies))
         // console.log(deepClone(this.upstreamDependencies))
 
-        let componentName = component.componentName;
+        let componentIdx = component.componentIdx;
 
         let stateVariablesToAdddress;
         if (stateVariables === "__all__") {
             stateVariablesToAdddress = Object.keys(
-                this.upstreamDependencies[componentName],
+                this.upstreamDependencies[componentIdx],
             );
         } else {
             stateVariablesToAdddress = stateVariables;
         }
 
         for (let stateVariable of stateVariablesToAdddress) {
-            if (this.upstreamDependencies[componentName][stateVariable]) {
+            if (this.upstreamDependencies[componentIdx][stateVariable]) {
                 // loop over shallow copy, as upstream dependencies are changed in deleteDownstreamDependency
                 for (let upDep of [
-                    ...this.upstreamDependencies[componentName][stateVariable],
+                    ...this.upstreamDependencies[componentIdx][stateVariable],
                 ]) {
                     if (completelyDelete) {
                         // Note: this completely deletes the dependency even if there
@@ -253,7 +253,7 @@ export class DependencyHandler {
                         await upDep.removeDownstreamComponent({
                             indexToRemove:
                                 upDep.downstreamComponentNames.indexOf(
-                                    componentName,
+                                    componentIdx,
                                 ),
                         });
                     }
@@ -261,25 +261,24 @@ export class DependencyHandler {
             }
 
             // clean up by deleting entries that should now be empty objects
-            delete this.upstreamDependencies[componentName][stateVariable];
+            delete this.upstreamDependencies[componentIdx][stateVariable];
         }
 
         if (
-            Object.keys(this.upstreamDependencies[componentName]).length ===
-                0 &&
-            !this._components[componentName]
+            Object.keys(this.upstreamDependencies[componentIdx]).length === 0 &&
+            !this._components[componentIdx]
         ) {
-            delete this.upstreamDependencies[componentName];
+            delete this.upstreamDependencies[componentIdx];
         }
     }
 
     async addBlockersFromChangedStateVariableDependencies({
-        componentName,
+        componentIdx,
         stateVariables,
     }) {
         let triggersForComponent =
             this.updateTriggers.dependenciesBasedOnDependenciesOfStateVariables[
-                componentName
+                componentIdx
             ];
         if (triggersForComponent) {
             for (let varName of stateVariables) {
@@ -288,10 +287,10 @@ export class DependencyHandler {
                     for (let dep of triggersForVarName) {
                         if (dep.gettingValue) {
                             let compWithUpdated =
-                                dep.varsWithUpdatedDeps[componentName];
+                                dep.varsWithUpdatedDeps[componentIdx];
                             if (!compWithUpdated) {
                                 compWithUpdated = dep.varsWithUpdatedDeps[
-                                    componentName
+                                    componentIdx
                                 ] = [];
                             }
                             if (!compWithUpdated.includes(varName)) {
@@ -320,15 +319,15 @@ export class DependencyHandler {
     }
 
     async addBlockersFromChangedActiveChildren({ parent }) {
-        // console.log(`add blockers to dependencies of active children of ${parent.componentName}`)
+        // console.log(`add blockers to dependencies of active children of ${parent.componentIdx}`)
 
         await this.collateCountersAndPropagateToAncestors(parent);
 
         if (
-            this.updateTriggers.childDependenciesByParent[parent.componentName]
+            this.updateTriggers.childDependenciesByParent[parent.componentIdx]
         ) {
             for (let dep of this.updateTriggers.childDependenciesByParent[
-                parent.componentName
+                parent.componentIdx
             ]) {
                 for (let varName of dep.upstreamVariableNames) {
                     await this.addBlocker({
@@ -342,7 +341,7 @@ export class DependencyHandler {
                     });
                 }
                 await this.addBlockersFromChangedStateVariableDependencies({
-                    componentName: dep.upstreamComponentName,
+                    componentIdx: dep.upstreamComponentName,
                     stateVariables: dep.upstreamVariableNames,
                 });
             }
@@ -351,11 +350,11 @@ export class DependencyHandler {
         if (parent.ancestors) {
             if (
                 this.updateTriggers.parentDependenciesByParent[
-                    parent.componentName
+                    parent.componentIdx
                 ]
             ) {
                 for (let dep of this.updateTriggers.parentDependenciesByParent[
-                    parent.componentName
+                    parent.componentIdx
                 ]) {
                     for (let varName of dep.upstreamVariableNames) {
                         await this.addBlocker({
@@ -369,27 +368,27 @@ export class DependencyHandler {
                         });
                     }
                     await this.addBlockersFromChangedStateVariableDependencies({
-                        componentName: dep.upstreamComponentName,
+                        componentIdx: dep.upstreamComponentName,
                         stateVariables: dep.upstreamVariableNames,
                     });
                 }
             }
 
-            for (let ancestorName of [
-                parent.componentName,
+            for (let ancestorIdx of [
+                parent.componentIdx,
                 ...ancestorsIncludingComposites(parent, this.components),
             ]) {
-                await this.addDescendantBlockersToAncestor(ancestorName);
+                await this.addDescendantBlockersToAncestor(ancestorIdx);
             }
 
             if (
                 this.updateTriggers.ancestorDependenciesByPotentialAncestor[
-                    parent.componentName
+                    parent.componentIdx
                 ]
             ) {
                 for (let dep of this.updateTriggers
                     .ancestorDependenciesByPotentialAncestor[
-                    parent.componentName
+                    parent.componentIdx
                 ]) {
                     for (let varName of dep.upstreamVariableNames) {
                         await this.addBlocker({
@@ -403,7 +402,7 @@ export class DependencyHandler {
                         });
                     }
                     await this.addBlockersFromChangedStateVariableDependencies({
-                        componentName: dep.upstreamComponentName,
+                        componentIdx: dep.upstreamComponentName,
                         stateVariables: dep.upstreamVariableNames,
                     });
                 }
@@ -412,18 +411,18 @@ export class DependencyHandler {
     }
 
     async resolveBlockersFromChangedActiveChildren(parent, force = false) {
-        // console.log(`resolve blockers for dependencies of active children of ${parent.componentName}`)
+        // console.log(`resolve blockers for dependencies of active children of ${parent.componentIdx}`)
 
         await this.collateCountersAndPropagateToAncestors(parent);
 
         if (
-            this.updateTriggers.childDependenciesByParent[parent.componentName]
+            this.updateTriggers.childDependenciesByParent[parent.componentIdx]
         ) {
             for (let dep of this.updateTriggers.childDependenciesByParent[
-                parent.componentName
+                parent.componentIdx
             ]) {
                 await this.resolveIfReady({
-                    componentName: dep.upstreamComponentName,
+                    componentIdx: dep.upstreamComponentName,
                     type: "recalculateDownstreamComponents",
                     stateVariable: dep.representativeStateVariable,
                     dependency: dep.dependencyName,
@@ -436,14 +435,14 @@ export class DependencyHandler {
         if (parent.ancestors) {
             if (
                 this.updateTriggers.parentDependenciesByParent[
-                    parent.componentName
+                    parent.componentIdx
                 ]
             ) {
                 for (let dep of this.updateTriggers.parentDependenciesByParent[
-                    parent.componentName
+                    parent.componentIdx
                 ]) {
                     await this.resolveIfReady({
-                        componentName: dep.upstreamComponentName,
+                        componentIdx: dep.upstreamComponentName,
                         type: "recalculateDownstreamComponents",
                         stateVariable: dep.representativeStateVariable,
                         dependency: dep.dependencyName,
@@ -453,27 +452,27 @@ export class DependencyHandler {
                 }
             }
 
-            for (let ancestorName of [
-                parent.componentName,
+            for (let ancestorIdx of [
+                parent.componentIdx,
                 ...ancestorsIncludingComposites(parent, this.components),
             ]) {
                 await this.resolveDescendantBlockersToAncestor(
-                    ancestorName,
+                    ancestorIdx,
                     force,
                 );
             }
 
             if (
                 this.updateTriggers.ancestorDependenciesByPotentialAncestor[
-                    parent.componentName
+                    parent.componentIdx
                 ]
             ) {
                 for (let dep of this.updateTriggers
                     .ancestorDependenciesByPotentialAncestor[
-                    parent.componentName
+                    parent.componentIdx
                 ]) {
                     await this.resolveIfReady({
-                        componentName: dep.upstreamComponentName,
+                        componentIdx: dep.upstreamComponentName,
                         type: "recalculateDownstreamComponents",
                         stateVariable: dep.representativeStateVariable,
                         dependency: dep.dependencyName,
@@ -485,14 +484,12 @@ export class DependencyHandler {
         }
     }
 
-    async addDescendantBlockersToAncestor(ancestorName) {
-        // console.log(`update descendant dependencies for ${ancestorName}`)
+    async addDescendantBlockersToAncestor(ancestorIdx) {
+        // console.log(`update descendant dependencies for ${ancestorIdx}`)
 
-        if (
-            this.updateTriggers.descendantDependenciesByAncestor[ancestorName]
-        ) {
+        if (this.updateTriggers.descendantDependenciesByAncestor[ancestorIdx]) {
             for (let dep of this.updateTriggers
-                .descendantDependenciesByAncestor[ancestorName]) {
+                .descendantDependenciesByAncestor[ancestorIdx]) {
                 for (let varName of dep.upstreamVariableNames) {
                     await this.addBlocker({
                         blockerComponentName: dep.upstreamComponentName,
@@ -505,23 +502,21 @@ export class DependencyHandler {
                     });
                 }
                 await this.addBlockersFromChangedStateVariableDependencies({
-                    componentName: dep.upstreamComponentName,
+                    componentIdx: dep.upstreamComponentName,
                     stateVariables: dep.upstreamVariableNames,
                 });
             }
         }
     }
 
-    async resolveDescendantBlockersToAncestor(ancestorName, force = false) {
-        // console.log(`update descendant dependencies for ${ancestorName}`)
+    async resolveDescendantBlockersToAncestor(ancestorIdx, force = false) {
+        // console.log(`update descendant dependencies for ${ancestorIdx}`)
 
-        if (
-            this.updateTriggers.descendantDependenciesByAncestor[ancestorName]
-        ) {
+        if (this.updateTriggers.descendantDependenciesByAncestor[ancestorIdx]) {
             for (let dep of this.updateTriggers
-                .descendantDependenciesByAncestor[ancestorName]) {
+                .descendantDependenciesByAncestor[ancestorIdx]) {
                 await this.resolveIfReady({
-                    componentName: dep.upstreamComponentName,
+                    componentIdx: dep.upstreamComponentName,
                     type: "recalculateDownstreamComponents",
                     stateVariable: dep.representativeStateVariable,
                     dependency: dep.dependencyName,
@@ -535,11 +530,11 @@ export class DependencyHandler {
     async addBlockersFromChangedReplacements(composite) {
         if (
             this.updateTriggers.replacementDependenciesByComposite[
-                composite.componentName
+                composite.componentIdx
             ]
         ) {
             for (let dep of this.updateTriggers
-                .replacementDependenciesByComposite[composite.componentName]) {
+                .replacementDependenciesByComposite[composite.componentIdx]) {
                 for (let varName of dep.upstreamVariableNames) {
                     await this.addBlocker({
                         blockerComponentName: dep.upstreamComponentName,
@@ -554,20 +549,20 @@ export class DependencyHandler {
             }
         }
 
-        for (let ancestorName of [
-            composite.componentName,
+        for (let ancestorIdx of [
+            composite.componentIdx,
             ...ancestorsIncludingComposites(composite, this.components),
         ]) {
-            await this.addDescendantBlockersToAncestor(ancestorName);
+            await this.addDescendantBlockersToAncestor(ancestorIdx);
         }
     }
 
     checkForCircularDependency({
-        componentName,
+        componentIdx,
         varName,
         previouslyVisited = [],
     }) {
-        let stateVariableIdentifier = componentName + ":" + varName;
+        let stateVariableIdentifier = componentIdx + ":" + varName;
 
         if (previouslyVisited.includes(stateVariableIdentifier)) {
             // Found circular dependency
@@ -595,9 +590,9 @@ export class DependencyHandler {
         if (!this.circularCheckPassed[stateVariableIdentifier]) {
             this.circularCheckPassed[stateVariableIdentifier] = true;
 
-            if (componentName in this.downstreamDependencies) {
+            if (componentIdx in this.downstreamDependencies) {
                 let downDeps =
-                    this.downstreamDependencies[componentName][varName];
+                    this.downstreamDependencies[componentIdx][varName];
                 for (let dependencyName in downDeps) {
                     let dep = downDeps[dependencyName];
 
@@ -619,7 +614,7 @@ export class DependencyHandler {
                             mappedDownstreamVariableNamesByComponent[ind];
                         for (let vname of varNames) {
                             this.checkForCircularDependency({
-                                componentName: cname,
+                                componentIdx: cname,
                                 varName: vname,
                                 previouslyVisited,
                             });
@@ -630,12 +625,12 @@ export class DependencyHandler {
         }
     }
 
-    resetCircularCheckPassed(componentName, varName) {
-        let stateVariableIdentifier = componentName + ":" + varName;
+    resetCircularCheckPassed(componentIdx, varName) {
+        let stateVariableIdentifier = componentIdx + ":" + varName;
         if (this.circularCheckPassed[stateVariableIdentifier]) {
             delete this.circularCheckPassed[stateVariableIdentifier];
 
-            let upstream = this.upstreamDependencies[componentName][varName];
+            let upstream = this.upstreamDependencies[componentIdx][varName];
 
             if (upstream) {
                 for (let upDep of upstream) {
@@ -652,10 +647,10 @@ export class DependencyHandler {
         }
     }
 
-    async updateDependencies({ componentName, stateVariable, dependency }) {
-        // console.log(`update dependencies of ${stateVariable} of ${componentName}`)
+    async updateDependencies({ componentIdx, stateVariable, dependency }) {
+        // console.log(`update dependencies of ${stateVariable} of ${componentIdx}`)
 
-        let component = this._components[componentName];
+        let component = this._components[componentIdx];
         let stateVarObj = component.state[stateVariable];
         let allStateVariablesAffected = [stateVariable];
         if (stateVarObj.additionalStateVariablesDefined) {
@@ -665,7 +660,7 @@ export class DependencyHandler {
         }
 
         let determineDeps =
-            this.downstreamDependencies[componentName][stateVariable]
+            this.downstreamDependencies[componentIdx][stateVariable]
                 .__determine_dependencies;
         let dependencyResult;
 
@@ -685,7 +680,7 @@ export class DependencyHandler {
 
                         if (!resolved) {
                             let result = await this.resolveItem({
-                                componentName: cName,
+                                componentIdx: cName,
                                 type: "stateVariable",
                                 stateVariable: vName,
                             });
@@ -700,7 +695,7 @@ export class DependencyHandler {
                                     blockerComponentName: cName,
                                     blockerType: "stateVariable",
                                     blockerStateVariable: vName,
-                                    componentNameBlocked: componentName,
+                                    componentNameBlocked: componentIdx,
                                     typeBlocked: "determineDependencies",
                                     stateVariableBlocked: vName2,
                                     dependencyBlocked: dependency,
@@ -773,11 +768,11 @@ export class DependencyHandler {
             !(changeResult.changedDependency || returnDepArgs.changedDependency)
         ) {
             // || arraySizeChanged) {
-            // console.log(`didn't actually change a dependency for ${stateVariable} of ${component.componentName}`)
+            // console.log(`didn't actually change a dependency for ${stateVariable} of ${component.componentIdx}`)
             return { success: true };
         }
 
-        // console.log(`actually did change a dependency for ${stateVariable} of ${component.componentName}`)
+        // console.log(`actually did change a dependency for ${stateVariable} of ${component.componentIdx}`)
 
         for (let dep of changeResult.newlyCreatedDependencies) {
             dep.checkForCircular();
@@ -785,7 +780,7 @@ export class DependencyHandler {
 
         for (let varName of allStateVariablesAffected) {
             this.checkForCircularDependency({
-                componentName: component.componentName,
+                componentIdx: component.componentIdx,
                 varName,
             });
             component.state[varName].forceRecalculation = true;
@@ -810,11 +805,11 @@ export class DependencyHandler {
         }
 
         await this.addBlockersFromChangedStateVariableDependencies({
-            componentName,
+            componentIdx,
             stateVariables: allStateVariablesAffected,
         });
 
-        // console.log(`finished updating dependencies of ${stateVariable} of ${component.componentName}`)
+        // console.log(`finished updating dependencies of ${stateVariable} of ${component.componentIdx}`)
 
         return { success: true };
     }
@@ -828,7 +823,7 @@ export class DependencyHandler {
         // Note: currentDeps object is downstream dependencies
         // of allStateVariablesAffected
         let currentDeps =
-            this.downstreamDependencies[component.componentName][stateVariable];
+            this.downstreamDependencies[component.componentIdx][stateVariable];
 
         let changedDependency = false;
 
@@ -888,8 +883,8 @@ export class DependencyHandler {
         return { changedDependency, newlyCreatedDependencies };
     }
 
-    async checkForDependenciesOnNewComponent(componentName) {
-        // console.log(`check for dependencies on new component ${componentName}`)
+    async checkForDependenciesOnNewComponent(componentIdx) {
+        // console.log(`check for dependencies on new component ${componentIdx}`)
 
         let variablesChanged = [];
 
@@ -897,11 +892,11 @@ export class DependencyHandler {
 
         if (
             this.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                componentName
+                componentIdx
             ]
         ) {
             for (let dep of this.updateTriggers
-                .dependenciesMissingComponentBySpecifiedName[componentName]) {
+                .dependenciesMissingComponentBySpecifiedName[componentIdx]) {
                 let upComponent = this._components[dep.upstreamComponentName];
 
                 if (!upComponent) {
@@ -937,7 +932,7 @@ export class DependencyHandler {
                             // console.log(`****** a variable value changed because have a new component ******`)
                             // console.log(`${dep.dependencyName} of ${varName} of ${dep.upstreamComponentName}`)
                             variablesChanged.push({
-                                componentName: dep.upstreamComponentName,
+                                componentIdx: dep.upstreamComponentName,
                                 varName,
                             });
                         }
@@ -950,14 +945,14 @@ export class DependencyHandler {
                         typeBlocked: "recalculateDownstreamComponents",
                         stateVariableBlocked: varName,
                         dependencyBlocked: dep.dependencyName,
-                        blockerComponentName: componentName,
+                        blockerComponentName: componentIdx,
                         blockerType: "componentIdentity",
                     });
                 }
 
                 // resolving for one variable will resolve for all upstreamVariableNames
                 let result = await this.resolveIfReady({
-                    componentName: dep.upstreamComponentName,
+                    componentIdx: dep.upstreamComponentName,
                     type: "recalculateDownstreamComponents",
                     stateVariable: dep.representativeStateVariable,
                     dependency: dep.dependencyName,
@@ -998,7 +993,7 @@ export class DependencyHandler {
             }
 
             delete this.updateTriggers
-                .dependenciesMissingComponentBySpecifiedName[componentName];
+                .dependenciesMissingComponentBySpecifiedName[componentIdx];
         }
 
         return variablesChanged;
@@ -1010,7 +1005,7 @@ export class DependencyHandler {
         let dependencyUsedDefault = {};
 
         let downDeps =
-            this.downstreamDependencies[component.componentName][stateVariable];
+            this.downstreamDependencies[component.componentIdx][stateVariable];
 
         for (let dependencyName in downDeps) {
             let dep = downDeps[dependencyName];
@@ -1038,18 +1033,18 @@ export class DependencyHandler {
     }
 
     recordActualChangeInUpstreamDependencies({ component, varName, changes }) {
-        // console.log(`record actual change in ${varName} of ${component.componentName}`)
+        // console.log(`record actual change in ${varName} of ${component.componentIdx}`)
         // console.log(deepClone(changes))
 
-        let componentName = component.componentName;
+        let componentIdx = component.componentIdx;
 
-        let upstream = this.upstreamDependencies[componentName][varName];
+        let upstream = this.upstreamDependencies[componentIdx][varName];
 
         if (upstream) {
             for (let upDep of upstream) {
                 if (upDep.valuesChanged) {
                     let ind =
-                        upDep.downstreamComponentNames.indexOf(componentName);
+                        upDep.downstreamComponentNames.indexOf(componentIdx);
                     let upValuesChanged = upDep.valuesChanged[ind][varName];
 
                     // Note (dated July 20, 2023):
@@ -1081,7 +1076,7 @@ export class DependencyHandler {
                     if (!upValuesChanged) {
                         if (!component.state[varName].isArrayEntry) {
                             throw Error(
-                                `Something is wrong, as a variable ${varName} of ${component.componentName} actually changed, but wasn't marked with a potential change`,
+                                `Something is wrong, as a variable ${varName} of ${component.componentIdx} actually changed, but wasn't marked with a potential change`,
                             );
                         }
                         upValuesChanged = upValuesChangedSub[varName] = {
@@ -1124,8 +1119,8 @@ export class DependencyHandler {
 
     async collateCountersAndPropagateToAncestors(component) {
         let allCounterNames = Object.keys(component.counters);
-        for (let childName of component.allChildrenOrdered) {
-            let child = this._components[childName];
+        for (let childIdx of component.allChildrenOrdered) {
+            let child = this._components[childIdx];
             if (child) {
                 // skip placeholders
                 for (let counterName in child.counters) {
@@ -1150,11 +1145,11 @@ export class DependencyHandler {
             let componentList = [];
             if (counters.dependencies.length > 0) {
                 // counter is in component itself
-                componentList.push(component.componentName);
+                componentList.push(component.componentIdx);
             }
 
-            for (let childName of component.allChildrenOrdered) {
-                let child = this._components[childName];
+            for (let childIdx of component.allChildrenOrdered) {
+                let child = this._components[childIdx];
                 if (child) {
                     //skip placeholders
                     let childCounters = child.counters[counterName];
@@ -1217,11 +1212,11 @@ export class DependencyHandler {
             return { foundChange: true, finishedPropagation: true };
         }
 
-        let parent = this._components[component.ancestors[0].componentName];
+        let parent = this._components[component.ancestors[0].componentIdx];
         if (
             !(
                 parent &&
-                parent.allChildrenOrdered.includes(component.componentName)
+                parent.allChildrenOrdered.includes(component.componentIdx)
             )
         ) {
             return { foundChange: true, finishedPropagation: false };
@@ -1232,7 +1227,7 @@ export class DependencyHandler {
 
         if (!parentResult.foundChange) {
             console.error(
-                `we found a change in propagating counters for ${component.componentName}, but no change for ancestors!`,
+                `we found a change in propagating counters for ${component.componentIdx}, but no change for ancestors!`,
             );
         }
 
@@ -1242,12 +1237,12 @@ export class DependencyHandler {
         };
     }
 
-    getNeededToResolve({ componentName, type, stateVariable, dependency }) {
+    getNeededToResolve({ componentIdx, type, stateVariable, dependency }) {
         let neededToResolveForComponent =
-            this.resolveBlockers.neededToResolve[componentName];
+            this.resolveBlockers.neededToResolve[componentIdx];
         if (!neededToResolveForComponent) {
             neededToResolveForComponent = this.resolveBlockers.neededToResolve[
-                componentName
+                componentIdx
             ] = {};
         }
 
@@ -1457,13 +1452,13 @@ export class DependencyHandler {
     }
 
     checkIfHaveNeededToResolve({
-        componentName,
+        componentIdx,
         type,
         stateVariable,
         dependency,
     }) {
         let neededToResolveForComponent =
-            this.resolveBlockers.neededToResolve[componentName];
+            this.resolveBlockers.neededToResolve[componentIdx];
         if (!neededToResolveForComponent) {
             return false;
         }
@@ -1494,12 +1489,12 @@ export class DependencyHandler {
         return Object.keys(neededToResolve).length > 0;
     }
 
-    getResolveBlockedBy({ componentName, type, stateVariable, dependency }) {
+    getResolveBlockedBy({ componentIdx, type, stateVariable, dependency }) {
         let resolveBlockedByComponent =
-            this.resolveBlockers.resolveBlockedBy[componentName];
+            this.resolveBlockers.resolveBlockedBy[componentIdx];
         if (!resolveBlockedByComponent) {
             resolveBlockedByComponent = this.resolveBlockers.resolveBlockedBy[
-                componentName
+                componentIdx
             ] = {};
         }
 
@@ -1735,7 +1730,7 @@ export class DependencyHandler {
         }
 
         let neededForBlocked = this.getNeededToResolve({
-            componentName: componentNameBlocked,
+            componentIdx: componentNameBlocked,
             type: typeBlocked,
             stateVariable: stateVariableBlocked,
             dependency: dependencyBlocked,
@@ -1798,7 +1793,7 @@ export class DependencyHandler {
 
         // record that blocked by blocker
         let resolvedBlockedByBlocker = this.getResolveBlockedBy({
-            componentName: blockerComponentName,
+            componentIdx: blockerComponentName,
             type: blockerType,
             stateVariable: blockerStateVariable,
             dependency: blockerDependency,
@@ -1813,14 +1808,14 @@ export class DependencyHandler {
         }
 
         this.resetCircularResolveBlockerCheckPassed({
-            componentName: componentNameBlocked,
+            componentIdx: componentNameBlocked,
             type: typeBlocked,
             stateVariable: stateVariableBlocked,
             dependency: dependencyBlocked,
         });
 
         this.checkForCircularResolveBlocker({
-            componentName: componentNameBlocked,
+            componentIdx: componentNameBlocked,
             type: typeBlocked,
             stateVariable: stateVariableBlocked,
             dependency: dependencyBlocked,
@@ -1899,7 +1894,7 @@ export class DependencyHandler {
                     }
                     for (let varName of dep.upstreamVariableNames) {
                         await this.resolveIfReady({
-                            componentName: dep.upstreamComponentName,
+                            componentIdx: dep.upstreamComponentName,
                             type: "stateVariable",
                             stateVariable: varName,
                             expandComposites,
@@ -1928,7 +1923,7 @@ export class DependencyHandler {
                 if (dep) {
                     // check if there are any other determineDependencies blocking state variable
                     let neededForItem = this.getNeededToResolve({
-                        componentName: componentNameNewlyResolved,
+                        componentIdx: componentNameNewlyResolved,
                         type: "stateVariable",
                         stateVariable: stateVariableNewlyResolved,
                     });
@@ -1945,7 +1940,7 @@ export class DependencyHandler {
 
                             if (
                                 this.checkIfHaveNeededToResolve({
-                                    componentName: componentNameNewlyResolved,
+                                    componentIdx: componentNameNewlyResolved,
                                     type: "determineDependency",
                                     stateVariable: stateVariableNewlyResolved,
                                     dependency: blockerDependency,
@@ -1968,7 +1963,7 @@ export class DependencyHandler {
                     // if all determine dependences have been resolved
                     // recalculate dependencies for state variable
                     let result = await this.updateDependencies({
-                        componentName: componentNameNewlyResolved,
+                        componentIdx: componentNameNewlyResolved,
                         stateVariable: stateVariableNewlyResolved,
                         dependency: dependencyNewlyResolved,
                     });
@@ -1990,7 +1985,7 @@ export class DependencyHandler {
                             });
                         }
                         await this.resolveIfReady({
-                            componentName: componentNameNewlyResolved,
+                            componentIdx: componentNameNewlyResolved,
                             type: "stateVariable",
                             stateVariable: varName,
                             expandComposites,
@@ -2053,7 +2048,7 @@ export class DependencyHandler {
         }
 
         let resolveBlockedByNewlyResolved = this.getResolveBlockedBy({
-            componentName: componentNameNewlyResolved,
+            componentIdx: componentNameNewlyResolved,
             type: typeNewlyResolved,
             stateVariable: stateVariableNewlyResolved,
             dependency: dependencyNewlyResolved,
@@ -2081,7 +2076,7 @@ export class DependencyHandler {
                     let [cName, vName, depName] = code.split("|");
 
                     await this.resolveIfReady({
-                        componentName: cName,
+                        componentIdx: cName,
                         type,
                         stateVariable: vName,
                         dependency: depName,
@@ -2097,13 +2092,13 @@ export class DependencyHandler {
     }
 
     async resolveStateVariablesIfReady({ component, stateVariables }) {
-        // console.log(`resolve state variables if ready for ${component.componentName}`);
+        // console.log(`resolve state variables if ready for ${component.componentIdx}`);
 
-        let componentName = component.componentName;
+        let componentIdx = component.componentIdx;
 
         if (!stateVariables) {
             await this.resolveIfReady({
-                componentName,
+                componentIdx,
                 type: "componentIdentity",
                 expandComposites: false,
                 // recurseUpstream: true
@@ -2117,7 +2112,7 @@ export class DependencyHandler {
 
             if (stateVarObj && stateVarObj.determineDependenciesImmediately) {
                 let neededForItem = this.getNeededToResolve({
-                    componentName,
+                    componentIdx,
                     type: "stateVariable",
                     stateVariable: varName,
                 });
@@ -2132,7 +2127,7 @@ export class DependencyHandler {
                         ] = blockerCode.split("|");
 
                         await this.resolveIfReady({
-                            componentName: blockerComponentName,
+                            componentIdx: blockerComponentName,
                             type: "determineDependencies",
                             stateVariable: blockerStateVariable,
                             dependency: blockerDependency,
@@ -2143,7 +2138,7 @@ export class DependencyHandler {
                 }
             }
             await this.resolveIfReady({
-                componentName,
+                componentIdx,
                 type: "stateVariable",
                 stateVariable: varName,
                 expandComposites: false,
@@ -2151,12 +2146,12 @@ export class DependencyHandler {
             });
         }
 
-        // console.log(`finished resolving state variables if ready ${component.componentName}`);
+        // console.log(`finished resolving state variables if ready ${component.componentIdx}`);
         // console.log(JSON.parse(JSON.stringify(this.resolveBlockers)))
     }
 
     async resolveIfReady({
-        componentName,
+        componentIdx,
         type,
         stateVariable,
         dependency,
@@ -2164,10 +2159,10 @@ export class DependencyHandler {
         force = false,
         recurseUpstream = false,
     }) {
-        // console.log(`resolve if ready ${componentName}, ${type}, ${stateVariable}, ${dependency}`)
+        // console.log(`resolve if ready ${componentIdx}, ${type}, ${stateVariable}, ${dependency}`)
 
         let haveNeededToResolve = this.checkIfHaveNeededToResolve({
-            componentName,
+            componentIdx,
             type,
             stateVariable,
             dependency,
@@ -2181,14 +2176,14 @@ export class DependencyHandler {
         // running deleteFromNeededToResolve will remove
         // the empty data structures
         this.deleteFromNeededToResolve({
-            componentNameBlocked: componentName,
+            componentNameBlocked: componentIdx,
             typeBlocked: type,
             stateVariableBlocked: stateVariable,
             dependencyBlocked: dependency,
         });
 
         let result = await this.processNewlyResolved({
-            componentNameNewlyResolved: componentName,
+            componentNameNewlyResolved: componentIdx,
             typeNewlyResolved: type,
             stateVariableNewlyResolved: stateVariable,
             dependencyNewlyResolved: dependency,
@@ -2201,7 +2196,7 @@ export class DependencyHandler {
     }
 
     async resolveItem({
-        componentName,
+        componentIdx,
         type,
         stateVariable,
         dependency,
@@ -2215,7 +2210,7 @@ export class DependencyHandler {
         // }
         // this.resolveLevels++;
 
-        // console.log(`${" ".repeat(this.resolveLevels - 1)}${this.resolveLevels}. resolve item ${componentName}, ${type}, ${stateVariable}, ${dependency}, ${expandComposites}, ${force}`)
+        // console.log(`${" ".repeat(this.resolveLevels - 1)}${this.resolveLevels}. resolve item ${componentIdx}, ${type}, ${stateVariable}, ${dependency}, ${expandComposites}, ${force}`)
 
         // Note: even if expandComposites=false and force=false
         // we still might expand composites and force evaluate
@@ -2224,7 +2219,7 @@ export class DependencyHandler {
         // the state variables determining dependencies
 
         let neededForItem = this.getNeededToResolve({
-            componentName,
+            componentIdx,
             type,
             stateVariable,
             dependency,
@@ -2243,7 +2238,7 @@ export class DependencyHandler {
                 ] = blockerCode.split("|");
 
                 let result = await this.resolveItem({
-                    componentName: blockerComponentName,
+                    componentIdx: blockerComponentName,
                     type: "determineDependencies",
                     stateVariable: blockerStateVariable,
                     dependency: blockerDependency,
@@ -2252,7 +2247,7 @@ export class DependencyHandler {
                 });
 
                 if (!result.success) {
-                    // console.log(`${" ".repeat(this.resolveLevels - 1)}${this.resolveLevels}. couldn't resolve ${componentName}, ${type}, ${stateVariable}, ${dependency}`)
+                    // console.log(`${" ".repeat(this.resolveLevels - 1)}${this.resolveLevels}. couldn't resolve ${componentIdx}, ${type}, ${stateVariable}, ${dependency}`)
                     // this.resolveLevels--;
                     return result;
                 }
@@ -2260,8 +2255,8 @@ export class DependencyHandler {
         }
 
         let stateVarObj;
-        if (type === "stateVariable" && this._components[componentName]) {
-            stateVarObj = this._components[componentName].state[stateVariable];
+        if (type === "stateVariable" && this._components[componentIdx]) {
+            stateVarObj = this._components[componentIdx].state[stateVariable];
             if (stateVarObj) {
                 stateVarObj.currentlyResolving = true;
             }
@@ -2281,7 +2276,7 @@ export class DependencyHandler {
             }
             if (nFailures > 0) {
                 neededForItem = this.getNeededToResolve({
-                    componentName,
+                    componentIdx,
                     type,
                     stateVariable,
                     dependency,
@@ -2293,7 +2288,7 @@ export class DependencyHandler {
             for (let blockerType in neededForItem) {
                 if (blockerType === "determineDependencies") {
                     throw Error(
-                        `Shouldn't have determine dependencies blocker after determining dependencies: ${componentName}, ${type}, ${stateVariable}, ${dependency}`,
+                        `Shouldn't have determine dependencies blocker after determining dependencies: ${componentIdx}, ${type}, ${stateVariable}, ${dependency}`,
                     );
                 }
 
@@ -2306,7 +2301,7 @@ export class DependencyHandler {
                     ] = code.split("|");
 
                     let result = await this.resolveItem({
-                        componentName: blockerComponentName,
+                        componentIdx: blockerComponentName,
                         type: blockerType,
                         stateVariable: blockerStateVariable,
                         dependency: blockerDependency,
@@ -2318,7 +2313,7 @@ export class DependencyHandler {
                         if (force) {
                             nFailures++;
                         } else {
-                            // console.log(`${" ".repeat(this.resolveLevels - 1)}couldn't resolve ${componentName}, ${type}, ${stateVariable}, ${dependency}`)
+                            // console.log(`${" ".repeat(this.resolveLevels - 1)}couldn't resolve ${componentIdx}, ${type}, ${stateVariable}, ${dependency}`)
                             // this.resolveLevels--;
                             return result;
                         }
@@ -2333,7 +2328,7 @@ export class DependencyHandler {
             // Try one more time while passing force to resolveItem
 
             neededForItem = this.getNeededToResolve({
-                componentName,
+                componentIdx,
                 type,
                 stateVariable,
                 dependency,
@@ -2343,7 +2338,7 @@ export class DependencyHandler {
                 for (let blockerType in neededForItem) {
                     if (blockerType === "determineDependencies") {
                         throw Error(
-                            `Shouldn't have determine dependencies blocker after determining dependencies: ${componentName}, ${type}, ${stateVariable}, ${dependency}`,
+                            `Shouldn't have determine dependencies blocker after determining dependencies: ${componentIdx}, ${type}, ${stateVariable}, ${dependency}`,
                         );
                     }
 
@@ -2356,7 +2351,7 @@ export class DependencyHandler {
                         ] = code.split("|");
 
                         let result = await this.resolveItem({
-                            componentName: blockerComponentName,
+                            componentIdx: blockerComponentName,
                             type: blockerType,
                             stateVariable: blockerStateVariable,
                             dependency: blockerDependency,
@@ -2365,7 +2360,7 @@ export class DependencyHandler {
                         });
 
                         if (!result.success) {
-                            // console.log(`${" ".repeat(this.resolveLevels - 1)}couldn't resolve ${componentName}, ${type}, ${stateVariable}, ${dependency}`)
+                            // console.log(`${" ".repeat(this.resolveLevels - 1)}couldn't resolve ${componentIdx}, ${type}, ${stateVariable}, ${dependency}`)
                             // this.resolveLevels--;
                             return result;
                         }
@@ -2380,7 +2375,7 @@ export class DependencyHandler {
 
         // item is resolved
         let finalResult = await this.resolveIfReady({
-            componentName,
+            componentIdx,
             type,
             stateVariable,
             dependency,
@@ -2393,7 +2388,7 @@ export class DependencyHandler {
             // after removing all blockers, we still can't resolve
 
             let stillNeededForItem = this.getNeededToResolve({
-                componentName,
+                componentIdx,
                 type,
                 stateVariable,
                 dependency,
@@ -2410,7 +2405,7 @@ export class DependencyHandler {
                     // then we can try again
 
                     finalResult = await this.resolveItem({
-                        componentName,
+                        componentIdx,
                         type,
                         stateVariable,
                         dependency,
@@ -2423,20 +2418,20 @@ export class DependencyHandler {
             }
         }
 
-        // console.log(`${" ".repeat(this.resolveLevels - 1)}${this.resolveLevels}. done resolving item ${componentName}, ${type}, ${stateVariable}, ${dependency}, ${expandComposites}, ${force}`)
+        // console.log(`${" ".repeat(this.resolveLevels - 1)}${this.resolveLevels}. done resolving item ${componentIdx}, ${type}, ${stateVariable}, ${dependency}, ${expandComposites}, ${force}`)
         // this.resolveLevels--;
 
         return finalResult;
     }
 
     checkForCircularResolveBlocker({
-        componentName,
+        componentIdx,
         type,
         stateVariable,
         dependency,
         previouslyVisited = [],
     }) {
-        let code = componentName;
+        let code = componentIdx;
         if (stateVariable) {
             code += "|" + stateVariable;
             if (dependency) {
@@ -2470,7 +2465,7 @@ export class DependencyHandler {
             this.circularResolveBlockedCheckPassed[identifier] = true;
 
             let neededForItem = this.getNeededToResolve({
-                componentName,
+                componentIdx,
                 type,
                 stateVariable,
                 dependency,
@@ -2485,7 +2480,7 @@ export class DependencyHandler {
                     ] = blockerCode.split("|");
 
                     this.checkForCircularResolveBlocker({
-                        componentName: blockerComponentName,
+                        componentIdx: blockerComponentName,
                         type: blockerType,
                         stateVariable: blockerStateVariable,
                         dependency: blockerDependency,
@@ -2504,7 +2499,7 @@ export class DependencyHandler {
         // remove namespaces and internally created component names
         // and deduplicate while keeping order (so don't use Set)
         for (let comp of componentsInvolved) {
-            let name = comp.componentName;
+            let name = comp.componentIdx;
             let relativeName = name;
             if (relativeName) {
                 let lastSlash = name.lastIndexOf("/");
@@ -2552,10 +2547,10 @@ export class DependencyHandler {
             }
         }
 
-        // If had only internally created component names, just give first componentName
+        // If had only internally created component names, just give first componentIdx
         if (uniqueComponentNames.length === 0) {
             let comp = componentsInvolved[0];
-            let name = comp.componentName;
+            let name = comp.componentIdx;
             let relativeName = name;
             if (relativeName) {
                 let lastSlash = name.lastIndexOf("/");
@@ -2590,12 +2585,12 @@ export class DependencyHandler {
     }
 
     resetCircularResolveBlockerCheckPassed({
-        componentName,
+        componentIdx,
         type,
         stateVariable,
         dependency,
     }) {
-        let code = componentName;
+        let code = componentIdx;
         if (stateVariable) {
             code += "|" + stateVariable;
             if (dependency) {
@@ -2609,7 +2604,7 @@ export class DependencyHandler {
             delete this.circularResolveBlockedCheckPassed[identifier];
 
             let resolveBlockedBy = this.getResolveBlockedBy({
-                componentName,
+                componentIdx,
                 type,
                 stateVariable,
                 dependency,
@@ -2624,7 +2619,7 @@ export class DependencyHandler {
                     ] = codeBlocked.split("|");
 
                     this.resetCircularResolveBlockerCheckPassed({
-                        componentName: componentNameBlocked,
+                        componentIdx: componentNameBlocked,
                         type: typeBlocked,
                         stateVariable: stateVariableBlocked,
                         dependency: dependencyBlocked,
@@ -2656,7 +2651,7 @@ class Dependency {
         this.dependencyName = dependencyName;
         this.dependencyHandler = dependencyHandler;
 
-        this.upstreamComponentName = component.componentName;
+        this.upstreamComponentName = component.componentIdx;
         this.upstreamVariableNames = allStateVariablesAffected;
 
         this.definition = Object.assign({}, dependencyDefinition);
@@ -3029,12 +3024,12 @@ class Dependency {
             this.componentIdentitiesChanged = true;
         }
 
-        let componentName = this.downstreamComponentNames[indexToRemove];
+        let componentIdx = this.downstreamComponentNames[indexToRemove];
 
         this.downstreamComponentNames.splice(indexToRemove, 1);
         this.downstreamComponentTypes.splice(indexToRemove, 1);
 
-        if (componentName in this.dependencyHandler._components) {
+        if (componentIdx in this.dependencyHandler._components) {
             let affectedDownstreamVariableNames;
 
             if (!this.mappedDownstreamVariableNamesByComponent) {
@@ -3067,7 +3062,7 @@ class Dependency {
             // delete from upstream dependencies of downstream component
             for (let vName of affectedDownstreamVariableNames) {
                 let downCompUpDeps =
-                    this.dependencyHandler.upstreamDependencies[componentName][
+                    this.dependencyHandler.upstreamDependencies[componentIdx][
                         vName
                     ];
                 if (downCompUpDeps) {
@@ -3076,7 +3071,7 @@ class Dependency {
                     if (ind !== -1) {
                         if (downCompUpDeps.length === 1) {
                             delete this.dependencyHandler.upstreamDependencies[
-                                componentName
+                                componentIdx
                             ][vName];
                         } else {
                             downCompUpDeps.splice(ind, 1);
@@ -3246,7 +3241,7 @@ class Dependency {
 
                 for (let upVar of this.upstreamVariableNames) {
                     this.dependencyHandler.deleteFromNeededToResolve({
-                        componentNameBlocked: this.componentName,
+                        componentNameBlocked: this.componentIdx,
                         typeBlocked: "stateVariable",
                         stateVariableBlocked: upVar,
                         blockerType: "stateVariable",
@@ -3294,10 +3289,9 @@ class Dependency {
 
         for (let [
             componentInd,
-            componentName,
+            componentIdx,
         ] of this.downstreamComponentNames.entries()) {
-            let depComponent =
-                this.dependencyHandler._components[componentName];
+            let depComponent = this.dependencyHandler._components[componentIdx];
 
             usedDefault[componentInd] = false;
 
@@ -3307,7 +3301,7 @@ class Dependency {
                 };
 
                 if (!this.skipComponentNames) {
-                    componentObj.componentName = componentName;
+                    componentObj.componentIdx = componentIdx;
                 }
 
                 let originalVarNames;
@@ -3483,7 +3477,7 @@ class Dependency {
         }
         for (let varName of this.upstreamVariableNames) {
             this.dependencyHandler.checkForCircularDependency({
-                componentName: this.upstreamComponentName,
+                componentIdx: this.upstreamComponentName,
                 varName,
             });
         }
@@ -3584,11 +3578,11 @@ class StateVariableDependency extends Dependency {
     static dependencyType = "stateVariable";
 
     setUpParameters() {
-        if (this.definition.componentName) {
-            this.componentName = this.definition.componentName;
-            this.specifiedComponentName = this.componentName;
+        if (this.definition.componentIdx) {
+            this.componentIdx = this.definition.componentIdx;
+            this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentName = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentName;
         }
 
         if (this.definition.variableName === undefined) {
@@ -3615,18 +3609,18 @@ class StateVariableDependency extends Dependency {
     }
 
     async determineDownstreamComponents() {
-        let component = this.dependencyHandler._components[this.componentName];
+        let component = this.dependencyHandler._components[this.componentIdx];
 
         if (!component) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.componentName
+                    this.componentIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.componentName
+                        this.componentIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -3635,7 +3629,7 @@ class StateVariableDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentName,
+                    blockerComponentName: this.componentIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -3663,7 +3657,7 @@ class StateVariableDependency extends Dependency {
 
         return {
             success: true,
-            downstreamComponentNames: [this.componentName],
+            downstreamComponentNames: [this.componentIdx],
             downstreamComponentTypes: [component.componentType],
         };
     }
@@ -3691,11 +3685,11 @@ class MultipleStateVariablesDependency extends Dependency {
     static dependencyType = "multipleStateVariables";
 
     setUpParameters() {
-        if (this.definition.componentName) {
-            this.componentName = this.definition.componentName;
-            this.specifiedComponentName = this.componentName;
+        if (this.definition.componentIdx) {
+            this.componentIdx = this.definition.componentIdx;
+            this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentName = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentName;
         }
 
         if (!Array.isArray(this.definition.variableNames)) {
@@ -3709,18 +3703,18 @@ class MultipleStateVariablesDependency extends Dependency {
     }
 
     async determineDownstreamComponents() {
-        let component = this.dependencyHandler._components[this.componentName];
+        let component = this.dependencyHandler._components[this.componentIdx];
 
         if (!component) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.componentName
+                    this.componentIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.componentName
+                        this.componentIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -3729,7 +3723,7 @@ class MultipleStateVariablesDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentName,
+                    blockerComponentName: this.componentIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -3757,7 +3751,7 @@ class MultipleStateVariablesDependency extends Dependency {
 
         return {
             success: true,
-            downstreamComponentNames: [this.componentName],
+            downstreamComponentNames: [this.componentIdx],
             downstreamComponentTypes: [component.componentType],
         };
     }
@@ -3797,12 +3791,12 @@ class StateVariableComponentTypeDependency extends StateVariableDependency {
             }
 
             if (this.downstreamComponentNames.length === 1) {
-                let componentName = this.downstreamComponentNames[0];
+                let componentIdx = this.downstreamComponentNames[0];
                 let depComponent =
-                    this.dependencyHandler.components[componentName];
+                    this.dependencyHandler.components[componentIdx];
 
                 let componentObj = {
-                    componentName: depComponent.componentName,
+                    componentIdx: depComponent.componentIdx,
                     componentType: depComponent.componentType,
                 };
 
@@ -3943,11 +3937,11 @@ class RecursiveDependencyValuesDependency extends Dependency {
     static dependencyType = "recursiveDependencyValues";
 
     setUpParameters() {
-        if (this.definition.componentName) {
-            this.componentName = this.definition.componentName;
-            this.specifiedComponentName = this.componentName;
+        if (this.definition.componentIdx) {
+            this.componentIdx = this.definition.componentIdx;
+            this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentName = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentName;
         }
 
         if (this.definition.variableNames === undefined) {
@@ -3977,7 +3971,7 @@ class RecursiveDependencyValuesDependency extends Dependency {
         this.originalDownstreamVariableNamesByComponent = [];
 
         let result = await this.getRecursiveDependencyVariables({
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             variableNames: this.startingVariableNames,
             force,
         });
@@ -3993,12 +3987,12 @@ class RecursiveDependencyValuesDependency extends Dependency {
         let downstreamComponentNames = [];
         let downstreamComponentTypes = [];
 
-        for (let componentName in result.components) {
+        for (let componentIdx in result.components) {
             if (this.includeOnlyEssentialValues) {
                 let essentialVarNames = [];
                 let component =
-                    this.dependencyHandler._components[componentName];
-                for (let vName of result.components[componentName]
+                    this.dependencyHandler._components[componentIdx];
+                for (let vName of result.components[componentIdx]
                     .variableNames) {
                     if (component.state[vName]?.hasEssential) {
                         essentialVarNames.push(vName);
@@ -4013,21 +4007,21 @@ class RecursiveDependencyValuesDependency extends Dependency {
                     }
                 }
                 if (essentialVarNames.length > 0) {
-                    downstreamComponentNames.push(componentName);
+                    downstreamComponentNames.push(componentIdx);
                     downstreamComponentTypes.push(
-                        result.components[componentName].componentType,
+                        result.components[componentIdx].componentType,
                     );
                     this.originalDownstreamVariableNamesByComponent.push(
                         essentialVarNames,
                     );
                 }
             } else {
-                downstreamComponentNames.push(componentName);
+                downstreamComponentNames.push(componentIdx);
                 downstreamComponentTypes.push(
-                    result.components[componentName].componentType,
+                    result.components[componentIdx].componentType,
                 );
                 this.originalDownstreamVariableNamesByComponent.push(
-                    result.components[componentName].variableNames,
+                    result.components[componentIdx].variableNames,
                 );
             }
         }
@@ -4040,26 +4034,26 @@ class RecursiveDependencyValuesDependency extends Dependency {
     }
 
     async getRecursiveDependencyVariables({
-        componentName,
+        componentIdx,
         variableNames,
         force,
         components = {},
     }) {
-        // console.log(`get recursive dependency variables for ${componentName}`, variableNames)
+        // console.log(`get recursive dependency variables for ${componentIdx}`, variableNames)
 
-        let component = this.dependencyHandler._components[componentName];
+        let component = this.dependencyHandler._components[componentIdx];
 
         if (!component) {
-            if (!this.missingComponents.includes(componentName)) {
+            if (!this.missingComponents.includes(componentIdx)) {
                 let dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers
                         .dependenciesMissingComponentBySpecifiedName[
-                        componentName
+                        componentIdx
                     ];
                 if (!dependenciesMissingComponent) {
                     dependenciesMissingComponent =
                         this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                            componentName
+                            componentIdx
                         ] = [];
                 }
                 if (!dependenciesMissingComponent.includes(this)) {
@@ -4069,7 +4063,7 @@ class RecursiveDependencyValuesDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: componentName,
+                    blockerComponentName: componentIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -4111,10 +4105,10 @@ class RecursiveDependencyValuesDependency extends Dependency {
             variableNames = [...variableNames, "rawRendererValue"];
         }
 
-        let thisComponentObj = components[componentName];
+        let thisComponentObj = components[componentIdx];
         if (!thisComponentObj) {
-            thisComponentObj = components[componentName] = {
-                componentName,
+            thisComponentObj = components[componentIdx] = {
+                componentIdx,
                 componentType: component.componentType,
                 variableNames: [],
             };
@@ -4122,11 +4116,11 @@ class RecursiveDependencyValuesDependency extends Dependency {
 
         let triggersForComponent =
             this.dependencyHandler.updateTriggers
-                .dependenciesBasedOnDependenciesOfStateVariables[componentName];
+                .dependenciesBasedOnDependenciesOfStateVariables[componentIdx];
         if (!triggersForComponent) {
             triggersForComponent =
                 this.dependencyHandler.updateTriggers.dependenciesBasedOnDependenciesOfStateVariables[
-                    componentName
+                    componentIdx
                 ] = {};
         }
 
@@ -4151,7 +4145,7 @@ class RecursiveDependencyValuesDependency extends Dependency {
                         } else {
                             for (let vName of this.upstreamVariableNames) {
                                 await this.dependencyHandler.addBlocker({
-                                    blockerComponentName: componentName,
+                                    blockerComponentName: componentIdx,
                                     blockerType: "stateVariable",
                                     blockerStateVariable: varName,
                                     componentNameBlocked:
@@ -4181,7 +4175,7 @@ class RecursiveDependencyValuesDependency extends Dependency {
 
                     let downDeps =
                         this.dependencyHandler.downstreamDependencies[
-                            component.componentName
+                            component.componentIdx
                         ][varName];
 
                     for (let dependencyName in downDeps) {
@@ -4207,7 +4201,7 @@ class RecursiveDependencyValuesDependency extends Dependency {
                             }
                             let result =
                                 await this.getRecursiveDependencyVariables({
-                                    componentName: cName,
+                                    componentIdx: cName,
                                     variableNames: varNames,
                                     force,
                                     components,
@@ -4288,10 +4282,10 @@ class RecursiveDependencyValuesDependency extends Dependency {
     }
 
     deleteFromUpdateTriggers() {
-        for (let componentName of this.missingComponents) {
+        for (let componentIdx of this.missingComponents) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
-                    .dependenciesMissingComponentBySpecifiedName[componentName];
+                    .dependenciesMissingComponentBySpecifiedName[componentIdx];
             if (dependenciesMissingComponent) {
                 let ind = dependenciesMissingComponent.indexOf(this);
                 if (ind !== -1) {
@@ -4308,29 +4302,29 @@ class ComponentIdentityDependency extends Dependency {
     static dependencyType = "componentIdentity";
 
     setUpParameters() {
-        if (this.definition.componentName) {
-            this.componentName = this.definition.componentName;
-            this.specifiedComponentName = this.componentName;
+        if (this.definition.componentIdx) {
+            this.componentIdx = this.definition.componentIdx;
+            this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentName = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentName;
         }
 
         this.returnSingleComponent = true;
     }
 
     async determineDownstreamComponents() {
-        let component = this.dependencyHandler._components[this.componentName];
+        let component = this.dependencyHandler._components[this.componentIdx];
 
         if (!component) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.componentName
+                    this.componentIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.componentName
+                        this.componentIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -4339,7 +4333,7 @@ class ComponentIdentityDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentName,
+                    blockerComponentName: this.componentIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -4367,7 +4361,7 @@ class ComponentIdentityDependency extends Dependency {
 
         return {
             success: true,
-            downstreamComponentNames: [this.componentName],
+            downstreamComponentNames: [this.componentIdx],
             downstreamComponentTypes: [component.componentType],
         };
     }
@@ -4395,11 +4389,11 @@ class AttributeComponentDependency extends Dependency {
     static dependencyType = "attributeComponent";
 
     setUpParameters() {
-        if (this.definition.parentName) {
-            this.parentName = this.definition.parentName;
-            this.specifiedComponentName = this.parentName;
+        if (this.definition.parentIdx) {
+            this.parentIdx = this.definition.parentIdx;
+            this.specifiedComponentName = this.parentIdx;
         } else {
-            this.parentName = this.upstreamComponentName;
+            this.parentIdx = this.upstreamComponentName;
         }
 
         if (this.definition.variableNames) {
@@ -4424,18 +4418,18 @@ class AttributeComponentDependency extends Dependency {
     }
 
     async determineDownstreamComponents() {
-        let parent = this.dependencyHandler._components[this.parentName];
+        let parent = this.dependencyHandler._components[this.parentIdx];
 
         if (!parent) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.parentName
+                    this.parentIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.parentName
+                        this.parentIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -4444,7 +4438,7 @@ class AttributeComponentDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.parentName,
+                    blockerComponentName: this.parentIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -4506,7 +4500,7 @@ class AttributeComponentDependency extends Dependency {
             }
             return {
                 success: true,
-                downstreamComponentNames: [attribute.component.componentName],
+                downstreamComponentNames: [attribute.component.componentIdx],
                 downstreamComponentTypes: [attribute.component.componentType],
             };
         }
@@ -4536,7 +4530,7 @@ class AttributeComponentDependency extends Dependency {
                 break;
             }
 
-            comp = this.dependencyHandler._components[shadows.componentName];
+            comp = this.dependencyHandler._components[shadows.componentIdx];
             if (!comp) {
                 break;
             }
@@ -4567,7 +4561,7 @@ class AttributeComponentDependency extends Dependency {
                 }
             } else {
                 let composite =
-                    this.dependencyHandler._components[shadows.compositeName];
+                    this.dependencyHandler._components[shadows.compositeIdx];
                 if ("sourceAttributesToIgnore" in composite.state) {
                     let sourceAttributesToIgnore =
                         await composite.stateValues.sourceAttributesToIgnore;
@@ -4583,7 +4577,7 @@ class AttributeComponentDependency extends Dependency {
                 return {
                     success: true,
                     downstreamComponentNames: [
-                        attribute.component.componentName,
+                        attribute.component.componentIdx,
                     ],
                     downstreamComponentTypes: [
                         attribute.component.componentType,
@@ -4632,11 +4626,11 @@ class ChildDependency extends Dependency {
     static dependencyType = "child";
 
     setUpParameters() {
-        if (this.definition.parentName) {
-            this.parentName = this.definition.parentName;
-            this.specifiedComponentName = this.parentName;
+        if (this.definition.parentIdx) {
+            this.parentIdx = this.definition.parentIdx;
+            this.specifiedComponentName = this.parentIdx;
         } else {
-            this.parentName = this.upstreamComponentName;
+            this.parentIdx = this.upstreamComponentName;
         }
 
         if (this.definition.variableNames) {
@@ -4684,18 +4678,18 @@ class ChildDependency extends Dependency {
 
         this.downstreamPrimitives = [];
 
-        let parent = this.dependencyHandler._components[this.parentName];
+        let parent = this.dependencyHandler._components[this.parentIdx];
 
         if (!parent) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.parentName
+                    this.parentIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.parentName
+                        this.parentIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -4704,7 +4698,7 @@ class ChildDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.parentName,
+                    blockerComponentName: this.parentIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -4732,12 +4726,12 @@ class ChildDependency extends Dependency {
 
         let childDependencies =
             this.dependencyHandler.updateTriggers.childDependenciesByParent[
-                this.parentName
+                this.parentIdx
             ];
         if (!childDependencies) {
             childDependencies =
                 this.dependencyHandler.updateTriggers.childDependenciesByParent[
-                    this.parentName
+                    this.parentIdx
                 ] = [];
         }
         if (!childDependencies.includes(this)) {
@@ -4780,7 +4774,7 @@ class ChildDependency extends Dependency {
                     this.skipComponentNames &&
                     this.originalDownstreamVariableNames.length === 0
                 ) {
-                    // if skipping componentName and there are no variable names,
+                    // if skipping componentIdx and there are no variable names,
                     // then only information to get is componentTypes of children,
                     // which one can do even with placeholders
                     canProceedWithPlaceholders = true;
@@ -4809,7 +4803,7 @@ class ChildDependency extends Dependency {
                     // then recalculating the downstream components,
                     for (let varName of this.upstreamVariableNames) {
                         await this.dependencyHandler.addBlocker({
-                            blockerComponentName: this.parentName,
+                            blockerComponentName: this.parentIdx,
                             blockerType: "childMatches",
                             blockerStateVariable: varName, // add so that can have different blockers of child logic
                             componentNameBlocked: this.upstreamComponentName,
@@ -4839,7 +4833,7 @@ class ChildDependency extends Dependency {
                 if (haveCompositesNotReady) {
                     for (let varName of this.upstreamVariableNames) {
                         await this.dependencyHandler.addBlocker({
-                            blockerComponentName: this.parentName,
+                            blockerComponentName: this.parentIdx,
                             blockerType: "childMatches",
                             blockerStateVariable: varName, // add so that can have different blockers of child logic
                             componentNameBlocked: this.upstreamComponentName,
@@ -4956,8 +4950,8 @@ class ChildDependency extends Dependency {
                 if (
                     !(
                         child.shadows &&
-                        child.shadows.compositeName ===
-                            parent?.shadows?.compositeName
+                        child.shadows.compositeIdx ===
+                            parent?.shadows?.compositeIdx
                     )
                 ) {
                     activeChildrenMatched.push(child);
@@ -5008,7 +5002,7 @@ class ChildDependency extends Dependency {
 
                     if (translatedLastInd !== undefined) {
                         this.compositeReplacementRange.push({
-                            compositeName: compositeInfo.compositeName,
+                            compositeIdx: compositeInfo.compositeIdx,
                             target: compositeInfo.target,
                             firstInd: translatedFirstInd,
                             lastInd: translatedLastInd,
@@ -5026,16 +5020,16 @@ class ChildDependency extends Dependency {
 
                 while (
                     childSource?.shadows &&
-                    childSource.shadows.compositeName ===
-                        parentSource?.shadows?.compositeName
+                    childSource.shadows.compositeIdx ===
+                        parentSource?.shadows?.compositeIdx
                 ) {
                     parentSource =
                         this.dependencyHandler._components[
-                            parentSource.shadows.componentName
+                            parentSource.shadows.componentIdx
                         ];
                     childSource =
                         this.dependencyHandler._components[
-                            childSource.shadows.componentName
+                            childSource.shadows.componentIdx
                         ];
                 }
             }
@@ -5055,8 +5049,8 @@ class ChildDependency extends Dependency {
             this.downstreamPrimitives.push(null);
 
             downstreamComponentNames.push(
-                child.componentName
-                    ? child.componentName
+                child.componentIdx
+                    ? child.componentIdx
                     : `__placeholder_${ind}`,
             );
             downstreamComponentTypes.push(child.componentType);
@@ -5071,10 +5065,10 @@ class ChildDependency extends Dependency {
             // of the composite.
 
             for (let compositeObj of this.compositeReplacementRange) {
-                downstreamComponentNames.push(compositeObj.compositeName);
+                downstreamComponentNames.push(compositeObj.compositeIdx);
                 downstreamComponentTypes.push(
                     this.dependencyHandler._components[
-                        compositeObj.compositeName
+                        compositeObj.compositeIdx
                     ].componentType,
                 );
 
@@ -5164,7 +5158,7 @@ class ChildDependency extends Dependency {
     deleteFromUpdateTriggers() {
         let childDeps =
             this.dependencyHandler.updateTriggers.childDependenciesByParent[
-                this.parentName
+                this.parentIdx
             ];
         if (childDeps) {
             let ind = childDeps.indexOf(this);
@@ -5195,11 +5189,11 @@ class DescendantDependency extends Dependency {
     static dependencyType = "descendant";
 
     setUpParameters() {
-        if (this.definition.ancestorName) {
-            this.ancestorName = this.definition.ancestorName;
-            this.specifiedComponentName = this.ancestorName;
+        if (this.definition.ancestorIdx) {
+            this.ancestorIdx = this.definition.ancestorIdx;
+            this.specifiedComponentName = this.ancestorIdx;
         } else {
-            this.ancestorName = this.upstreamComponentName;
+            this.ancestorIdx = this.upstreamComponentName;
         }
 
         if (this.definition.variableNames) {
@@ -5247,18 +5241,18 @@ class DescendantDependency extends Dependency {
     async determineDownstreamComponents() {
         // console.log(`deterine downstream components of descendancy dependency ${this.dependencyName} of ${this.representativeStateVariable} of ${this.upstreamComponentName}`)
 
-        let ancestor = this.dependencyHandler._components[this.ancestorName];
+        let ancestor = this.dependencyHandler._components[this.ancestorIdx];
 
         if (!ancestor) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.ancestorName
+                    this.ancestorIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.ancestorName
+                        this.ancestorIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -5267,7 +5261,7 @@ class DescendantDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.ancestorName,
+                    blockerComponentName: this.ancestorIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -5295,11 +5289,11 @@ class DescendantDependency extends Dependency {
 
         let descendantDependencies =
             this.dependencyHandler.updateTriggers
-                .descendantDependenciesByAncestor[this.ancestorName];
+                .descendantDependenciesByAncestor[this.ancestorIdx];
         if (!descendantDependencies) {
             descendantDependencies =
                 this.dependencyHandler.updateTriggers.descendantDependenciesByAncestor[
-                    this.ancestorName
+                    this.ancestorIdx
                 ] = [];
         }
         if (!descendantDependencies.includes(this)) {
@@ -5323,9 +5317,9 @@ class DescendantDependency extends Dependency {
                     stateVariableBlocked: varName,
                 });
 
-                for (let parentName in result.unexpandedCompositesReadyByParentName) {
+                for (let parentIdx in result.unexpandedCompositesReadyByParentName) {
                     await this.dependencyHandler.addBlocker({
-                        blockerComponentName: parentName,
+                        blockerComponentName: parentIdx,
                         blockerType: "childMatches",
                         blockerStateVariable: varName,
                         componentNameBlocked: this.upstreamComponentName,
@@ -5335,9 +5329,9 @@ class DescendantDependency extends Dependency {
                     });
                 }
 
-                for (let parentName in result.unexpandedCompositesNotReadyByParentName) {
+                for (let parentIdx in result.unexpandedCompositesNotReadyByParentName) {
                     await this.dependencyHandler.addBlocker({
-                        blockerComponentName: parentName,
+                        blockerComponentName: parentIdx,
                         blockerType: "childMatches",
                         blockerStateVariable: varName,
                         componentNameBlocked: this.upstreamComponentName,
@@ -5352,7 +5346,7 @@ class DescendantDependency extends Dependency {
                     // but not sure if it is the most efficient solution.
                     // Does this lead to unnecessary recalculations?
 
-                    // for (let compositeNotReady of result.unexpandedCompositesNotReadyByParentName[parentName]) {
+                    // for (let compositeNotReady of result.unexpandedCompositesNotReadyByParentName[parentIdx]) {
                     //   this.dependencyHandler.addBlocker({
                     //     blockerComponentName: compositeNotReady,
                     //     blockerType: "stateVariable",
@@ -5400,7 +5394,7 @@ class DescendantDependency extends Dependency {
 
         return {
             success: true,
-            downstreamComponentNames: descendants.map((x) => x.componentName),
+            downstreamComponentNames: descendants.map((x) => x.componentIdx),
             downstreamComponentTypes: descendants.map((x) => x.componentType),
         };
     }
@@ -5427,7 +5421,7 @@ class DescendantDependency extends Dependency {
                         );
                     if (unexpandedReady.length > 0) {
                         unexpandedCompositesReadyByParentName[
-                            component.componentName
+                            component.componentIdx
                         ] = unexpandedReady;
                         haveUnexpandedCompositeReady = true;
                     }
@@ -5440,7 +5434,7 @@ class DescendantDependency extends Dependency {
                         );
                     if (unexpandedNotReady.length > 0) {
                         unexpandedCompositesNotReadyByParentName[
-                            component.componentName
+                            component.componentIdx
                         ] = unexpandedNotReady;
                         haveCompositesNotReady = true;
                     }
@@ -5448,21 +5442,21 @@ class DescendantDependency extends Dependency {
             } else {
                 if (component.unexpandedCompositesReady.length > 0) {
                     unexpandedCompositesReadyByParentName[
-                        component.componentName
+                        component.componentIdx
                     ] = component.unexpandedCompositesReady;
                     haveUnexpandedCompositeReady = true;
                 }
                 if (component.unexpandedCompositesNotReady.length > 0) {
                     unexpandedCompositesNotReadyByParentName[
-                        component.componentName
+                        component.componentIdx
                     ] = component.unexpandedCompositesNotReady;
                     haveCompositesNotReady = true;
                 }
             }
         }
 
-        for (let childName in component.allChildren) {
-            let child = component.allChildren[childName].component;
+        for (let childIdx in component.allChildren) {
+            let child = component.allChildren[childIdx].component;
             if (typeof child === "object") {
                 let result = this.gatherUnexpandedComposites(child);
                 if (result.haveUnexpandedCompositeReady) {
@@ -5495,8 +5489,8 @@ class DescendantDependency extends Dependency {
         placeholdersOKForMatchedDescendants,
     ) {
         let adjustedUnexpanded = [];
-        for (let compositeName of unexpandedComposites) {
-            let composite = this.dependencyHandler._components[compositeName];
+        for (let compositeIdx of unexpandedComposites) {
+            let composite = this.dependencyHandler._components[compositeIdx];
             if (composite.attributes.createComponentOfType) {
                 let placeholderType =
                     this.dependencyHandler.componentInfoObjects
@@ -5515,17 +5509,17 @@ class DescendantDependency extends Dependency {
 
                 if (matches) {
                     if (!placeholdersOKForMatchedDescendants) {
-                        adjustedUnexpanded.push(compositeName);
+                        adjustedUnexpanded.push(compositeIdx);
                     }
                 } else {
                     // Composite is a placeholder that is not matched by componentTypes.
                     // Could that placeholder later have a descendant that is matched by componentTypes?
 
-                    adjustedUnexpanded.push(compositeName);
+                    adjustedUnexpanded.push(compositeIdx);
                 }
             } else {
                 // no componentType specified
-                adjustedUnexpanded.push(compositeName);
+                adjustedUnexpanded.push(compositeIdx);
             }
         }
 
@@ -5535,7 +5529,7 @@ class DescendantDependency extends Dependency {
     deleteFromUpdateTriggers() {
         let descendantDeps =
             this.dependencyHandler.updateTriggers
-                .descendantDependenciesByAncestor[this.ancestorName];
+                .descendantDependenciesByAncestor[this.ancestorIdx];
         if (descendantDeps) {
             let ind = descendantDeps.indexOf(this);
             if (ind !== -1) {
@@ -5565,11 +5559,11 @@ class ParentDependency extends Dependency {
     static dependencyType = "parentStateVariable";
 
     setUpParameters() {
-        if (this.definition.childName) {
-            this.childName = this.definition.childName;
-            this.specifiedComponentName = this.childName;
+        if (this.definition.childIdx) {
+            this.childIdx = this.definition.childIdx;
+            this.specifiedComponentName = this.childIdx;
         } else {
-            this.childName = this.upstreamComponentName;
+            this.childIdx = this.upstreamComponentName;
         }
 
         if (!this.definition.variableName) {
@@ -5595,18 +5589,16 @@ class ParentDependency extends Dependency {
     }
 
     async determineDownstreamComponents() {
-        let child = this.dependencyHandler._components[this.childName];
+        let child = this.dependencyHandler._components[this.childIdx];
 
         if (!child) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
-                    .dependenciesMissingComponentBySpecifiedName[
-                    this.childName
-                ];
+                    .dependenciesMissingComponentBySpecifiedName[this.childIdx];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.childName
+                        this.childIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -5615,7 +5607,7 @@ class ParentDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.childName,
+                    blockerComponentName: this.childIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -5641,7 +5633,7 @@ class ParentDependency extends Dependency {
             };
         }
 
-        if (!child.parentName) {
+        if (!child.parentIdx) {
             return {
                 success: true,
                 downstreamComponentNames: [],
@@ -5649,9 +5641,9 @@ class ParentDependency extends Dependency {
             };
         }
 
-        this.parentName = child.parentName;
+        this.parentIdx = child.parentIdx;
 
-        let parent = this.dependencyHandler._components[this.parentName];
+        let parent = this.dependencyHandler._components[this.parentIdx];
 
         if (!parent) {
             // Note: since parent is created after children,
@@ -5659,12 +5651,12 @@ class ParentDependency extends Dependency {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.parentName
+                    this.parentIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.parentName
+                        this.parentIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -5673,7 +5665,7 @@ class ParentDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.parentName,
+                    blockerComponentName: this.parentIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -5719,12 +5711,12 @@ class ParentDependency extends Dependency {
 
         let parentDependencies =
             this.dependencyHandler.updateTriggers.parentDependenciesByParent[
-                this.parentName
+                this.parentIdx
             ];
         if (!parentDependencies) {
             parentDependencies =
                 this.dependencyHandler.updateTriggers.parentDependenciesByParent[
-                    this.parentName
+                    this.parentIdx
                 ] = [];
         }
         if (!parentDependencies.includes(this)) {
@@ -5733,7 +5725,7 @@ class ParentDependency extends Dependency {
 
         return {
             success: true,
-            downstreamComponentNames: [this.parentName],
+            downstreamComponentNames: [this.parentIdx],
             downstreamComponentTypes: [parent.componentType],
         };
     }
@@ -5741,7 +5733,7 @@ class ParentDependency extends Dependency {
     deleteFromUpdateTriggers() {
         let parentDeps =
             this.dependencyHandler.updateTriggers.parentDependenciesByParent[
-                this.parentName
+                this.parentIdx
             ];
         if (parentDeps) {
             let ind = parentDeps.indexOf(this);
@@ -5766,7 +5758,7 @@ class ParentDependency extends Dependency {
 
         let dependenciesMissingComponent =
             this.dependencyHandler.updateTriggers
-                .dependenciesMissingComponentBySpecifiedName[this.parentName];
+                .dependenciesMissingComponentBySpecifiedName[this.parentIdx];
         if (dependenciesMissingComponent) {
             let ind = dependenciesMissingComponent.indexOf(this);
             if (ind !== -1) {
@@ -5782,11 +5774,11 @@ class ParentIdentityDependency extends Dependency {
     static dependencyType = "parentIdentity";
 
     setUpParameters() {
-        if (this.definition.childName) {
-            this.childName = this.definition.childName;
-            this.specifiedComponentName = this.childName;
+        if (this.definition.childIdx) {
+            this.childIdx = this.definition.childIdx;
+            this.specifiedComponentName = this.childIdx;
         } else {
-            this.childName = this.upstreamComponentName;
+            this.childIdx = this.upstreamComponentName;
         }
 
         if (this.definition.parentComponentType) {
@@ -5797,18 +5789,16 @@ class ParentIdentityDependency extends Dependency {
     }
 
     async determineDownstreamComponents() {
-        let child = this.dependencyHandler._components[this.childName];
+        let child = this.dependencyHandler._components[this.childIdx];
 
         if (!child) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
-                    .dependenciesMissingComponentBySpecifiedName[
-                    this.childName
-                ];
+                    .dependenciesMissingComponentBySpecifiedName[this.childIdx];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.childName
+                        this.childIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -5817,7 +5807,7 @@ class ParentIdentityDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.childName,
+                    blockerComponentName: this.childIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -5843,7 +5833,7 @@ class ParentIdentityDependency extends Dependency {
             };
         }
 
-        if (!child.parentName) {
+        if (!child.parentIdx) {
             return {
                 success: true,
                 downstreamComponentNames: [],
@@ -5851,9 +5841,9 @@ class ParentIdentityDependency extends Dependency {
             };
         }
 
-        this.parentName = child.parentName;
+        this.parentIdx = child.parentIdx;
 
-        let parent = this.dependencyHandler._components[this.parentName];
+        let parent = this.dependencyHandler._components[this.parentIdx];
 
         if (!parent) {
             // Note: since parent is created after children,
@@ -5861,12 +5851,12 @@ class ParentIdentityDependency extends Dependency {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.parentName
+                    this.parentIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.parentName
+                        this.parentIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -5875,7 +5865,7 @@ class ParentIdentityDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.parentName,
+                    blockerComponentName: this.parentIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -5921,12 +5911,12 @@ class ParentIdentityDependency extends Dependency {
 
         let parentDependencies =
             this.dependencyHandler.updateTriggers.parentDependenciesByParent[
-                this.parentName
+                this.parentIdx
             ];
         if (!parentDependencies) {
             parentDependencies =
                 this.dependencyHandler.updateTriggers.parentDependenciesByParent[
-                    this.parentName
+                    this.parentIdx
                 ] = [];
         }
         if (!parentDependencies.includes(this)) {
@@ -5935,7 +5925,7 @@ class ParentIdentityDependency extends Dependency {
 
         return {
             success: true,
-            downstreamComponentNames: [this.parentName],
+            downstreamComponentNames: [this.parentIdx],
             downstreamComponentTypes: [parent.componentType],
         };
     }
@@ -5943,7 +5933,7 @@ class ParentIdentityDependency extends Dependency {
     deleteFromUpdateTriggers() {
         let parentDeps =
             this.dependencyHandler.updateTriggers.parentDependenciesByParent[
-                this.parentName
+                this.parentIdx
             ];
         if (parentDeps) {
             let ind = parentDeps.indexOf(this);
@@ -5968,7 +5958,7 @@ class ParentIdentityDependency extends Dependency {
 
         let dependenciesMissingComponent =
             this.dependencyHandler.updateTriggers
-                .dependenciesMissingComponentBySpecifiedName[this.parentName];
+                .dependenciesMissingComponentBySpecifiedName[this.parentIdx];
         if (dependenciesMissingComponent) {
             let ind = dependenciesMissingComponent.indexOf(this);
             if (ind !== -1) {
@@ -5984,11 +5974,11 @@ class AncestorDependency extends Dependency {
     static dependencyType = "ancestor";
 
     setUpParameters() {
-        if (this.definition.descendantName) {
-            this.descendantName = this.definition.descendantName;
-            this.specifiedComponentName = this.descendantName;
+        if (this.definition.descendantIdx) {
+            this.descendantIdx = this.definition.descendantIdx;
+            this.specifiedComponentName = this.descendantIdx;
         } else {
-            this.descendantName = this.upstreamComponentName;
+            this.descendantIdx = this.upstreamComponentName;
         }
 
         if (this.definition.variableNames) {
@@ -6011,19 +6001,18 @@ class AncestorDependency extends Dependency {
     }
 
     async determineDownstreamComponents() {
-        let descendant =
-            this.dependencyHandler._components[this.descendantName];
+        let descendant = this.dependencyHandler._components[this.descendantIdx];
 
         if (!descendant) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.descendantName
+                    this.descendantIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.descendantName
+                        this.descendantIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -6032,7 +6021,7 @@ class AncestorDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.descendantName,
+                    blockerComponentName: this.descendantIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -6142,14 +6131,14 @@ class AncestorDependency extends Dependency {
             };
         }
 
-        for (let ancestorName of ancestorResults.ancestorsExamined) {
+        for (let ancestorIdx of ancestorResults.ancestorsExamined) {
             let ancestorDependencies =
                 this.dependencyHandler.updateTriggers
-                    .ancestorDependenciesByPotentialAncestor[ancestorName];
+                    .ancestorDependenciesByPotentialAncestor[ancestorIdx];
             if (!ancestorDependencies) {
                 ancestorDependencies =
                     this.dependencyHandler.updateTriggers.ancestorDependenciesByPotentialAncestor[
-                        ancestorName
+                        ancestorIdx
                     ] = [];
             }
             if (!ancestorDependencies.includes(this)) {
@@ -6162,7 +6151,7 @@ class AncestorDependency extends Dependency {
             return {
                 success: true,
                 downstreamComponentNames: [
-                    ancestorResults.ancestorFound.componentName,
+                    ancestorResults.ancestorFound.componentIdx,
                 ],
                 downstreamComponentTypes: [
                     ancestorResults.ancestorFound.componentClass.componentType,
@@ -6183,12 +6172,12 @@ class AncestorDependency extends Dependency {
         if (this.componentType) {
             for (let ancestor of descendant.ancestors) {
                 let ancestorComponent =
-                    this.dependencyHandler._components[ancestor.componentName];
+                    this.dependencyHandler._components[ancestor.componentIdx];
                 if (!ancestorComponent) {
-                    return { missingComponentName: ancestor.componentName };
+                    return { missingComponentName: ancestor.componentIdx };
                 }
 
-                ancestorsExamined.push(ancestor.componentName);
+                ancestorsExamined.push(ancestor.componentIdx);
 
                 if (
                     this.dependencyHandler.componentInfoObjects.isInheritedComponentType(
@@ -6225,12 +6214,12 @@ class AncestorDependency extends Dependency {
 
         for (let ancestor of descendant.ancestors) {
             let ancestorComponent =
-                this.dependencyHandler._components[ancestor.componentName];
+                this.dependencyHandler._components[ancestor.componentIdx];
             if (!ancestorComponent) {
-                return { missingComponentName: ancestor.componentName };
+                return { missingComponentName: ancestor.componentIdx };
             }
 
-            ancestorsExamined.push(ancestor.componentName);
+            ancestorsExamined.push(ancestor.componentIdx);
 
             let foundAllVarNames = true;
             for (let vName of variableNames) {
@@ -6259,10 +6248,10 @@ class AncestorDependency extends Dependency {
     }
 
     deleteFromUpdateTriggers() {
-        for (let ancestorName of this.ancestorResults.ancestorsExamined) {
+        for (let ancestorIdx of this.ancestorResults.ancestorsExamined) {
             let ancestorDeps =
                 this.dependencyHandler.updateTriggers
-                    .ancestorDependenciesByPotentialAncestor[ancestorName];
+                    .ancestorDependenciesByPotentialAncestor[ancestorIdx];
             if (ancestorDeps) {
                 let ind = ancestorDeps.indexOf(this);
                 if (ind !== -1) {
@@ -6307,11 +6296,11 @@ class ReplacementDependency extends Dependency {
     static dependencyType = "replacement";
 
     setUpParameters() {
-        if (this.definition.compositeName) {
-            this.compositeName = this.definition.compositeName;
-            this.specifiedComponentName = this.compositeName;
+        if (this.definition.compositeIdx) {
+            this.compositeIdx = this.definition.compositeIdx;
+            this.specifiedComponentName = this.compositeIdx;
         } else {
-            this.compositeName = this.upstreamComponentName;
+            this.compositeIdx = this.upstreamComponentName;
         }
 
         if (this.definition.variableNames) {
@@ -6377,18 +6366,18 @@ class ReplacementDependency extends Dependency {
 
         this.replacementPrimitives = [];
 
-        let composite = this.dependencyHandler._components[this.compositeName];
+        let composite = this.dependencyHandler._components[this.compositeIdx];
 
         if (!composite) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.compositeName
+                    this.compositeIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.compositeName
+                        this.compositeIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -6397,7 +6386,7 @@ class ReplacementDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.compositeName,
+                    blockerComponentName: this.compositeIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -6436,7 +6425,7 @@ class ReplacementDependency extends Dependency {
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.compositeName,
+                    blockerComponentName: this.compositeIdx,
                     blockerType: "expandComposite",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -6447,10 +6436,10 @@ class ReplacementDependency extends Dependency {
 
             if (!composite.state.readyToExpandWhenResolved.isResolved) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.compositeName,
+                    blockerComponentName: this.compositeIdx,
                     blockerType: "stateVariable",
                     blockerStateVariable: "readyToExpandWhenResolved",
-                    componentNameBlocked: this.compositeName,
+                    componentNameBlocked: this.compositeIdx,
                     typeBlocked: "expandComposite",
                 });
             }
@@ -6462,7 +6451,7 @@ class ReplacementDependency extends Dependency {
             };
         }
 
-        this.compositesFound = [this.compositeName];
+        this.compositesFound = [this.compositeIdx];
         let replacements = composite.replacements;
         if (
             !this.includeWithheldReplacements &&
@@ -6501,12 +6490,12 @@ class ReplacementDependency extends Dependency {
                         stateVariableBlocked: varName,
                     });
 
-                    for (let compositeName of [
+                    for (let compositeIdx of [
                         ...result.unexpandedCompositesReady,
                         ...result.unexpandedCompositesNotReady,
                     ]) {
                         await this.dependencyHandler.addBlocker({
-                            blockerComponentName: compositeName,
+                            blockerComponentName: compositeIdx,
                             blockerType: "expandComposite",
                             componentNameBlocked: this.upstreamComponentName,
                             typeBlocked: "recalculateDownstreamComponents",
@@ -6516,12 +6505,12 @@ class ReplacementDependency extends Dependency {
                     }
                 }
 
-                for (let compositeName of result.unexpandedCompositesNotReady) {
+                for (let compositeIdx of result.unexpandedCompositesNotReady) {
                     await this.dependencyHandler.addBlocker({
-                        blockerComponentName: compositeName,
+                        blockerComponentName: compositeIdx,
                         blockerType: "stateVariable",
                         blockerStateVariable: "readyToExpandWhenResolved",
-                        componentNameBlocked: compositeName,
+                        componentNameBlocked: compositeIdx,
                         typeBlocked: "expandComposite",
                     });
                 }
@@ -6585,7 +6574,7 @@ class ReplacementDependency extends Dependency {
                 let newComponents = [];
 
                 for (let comp of components) {
-                    let newCname = comp.componentName + "/" + subNames[0];
+                    let newCname = comp.componentIdx + "/" + subNames[0];
 
                     let newComp = dep.dependencyHandler._components[newCname];
                     if (!newComp) {
@@ -6638,7 +6627,7 @@ class ReplacementDependency extends Dependency {
 
             this.replacementPrimitives.push(null);
 
-            downstreamComponentNames.push(repl.componentName);
+            downstreamComponentNames.push(repl.componentIdx);
             downstreamComponentTypes.push(repl.componentType);
         }
 
@@ -6691,10 +6680,10 @@ class ReplacementDependency extends Dependency {
 
     deleteFromUpdateTriggers() {
         if (this.compositesFound) {
-            for (let compositeName of this.compositesFound) {
+            for (let compositeIdx of this.compositesFound) {
                 let replacementDeps =
                     this.dependencyHandler.updateTriggers
-                        .replacementDependenciesByComposite[compositeName];
+                        .replacementDependenciesByComposite[compositeIdx];
                 if (replacementDeps) {
                     let ind = replacementDeps.indexOf(this);
                     if (ind !== -1) {
@@ -6837,7 +6826,7 @@ class SourceCompositeStateVariableDependency extends Dependency {
 
         return {
             success: true,
-            downstreamComponentNames: [sourceComposite.componentName],
+            downstreamComponentNames: [sourceComposite.componentIdx],
             downstreamComponentTypes: [sourceComposite.componentType],
         };
     }
@@ -6935,7 +6924,7 @@ class SourceCompositeIdentityDependency extends Dependency {
 
         return {
             success: true,
-            downstreamComponentNames: [sourceComposite.componentName],
+            downstreamComponentNames: [sourceComposite.componentIdx],
             downstreamComponentTypes: [sourceComposite.componentType],
         };
     }
@@ -6963,11 +6952,11 @@ class ShadowSourceDependency extends Dependency {
     static dependencyType = "shadowSource";
 
     setUpParameters() {
-        if (this.definition.componentName) {
-            this.componentName = this.definition.componentName;
-            this.specifiedComponentName = this.componentName;
+        if (this.definition.componentIdx) {
+            this.componentIdx = this.definition.componentIdx;
+            this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentName = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentName;
         }
 
         if (this.definition.variableNames) {
@@ -6991,18 +6980,18 @@ class ShadowSourceDependency extends Dependency {
     }
 
     async determineDownstreamComponents() {
-        let component = this.dependencyHandler._components[this.componentName];
+        let component = this.dependencyHandler._components[this.componentIdx];
 
         if (!component) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.componentName
+                    this.componentIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.componentName
+                        this.componentIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -7011,7 +7000,7 @@ class ShadowSourceDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentName,
+                    blockerComponentName: this.componentIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -7058,7 +7047,7 @@ class ShadowSourceDependency extends Dependency {
             };
         }
 
-        let shadowSourceComponentName = component.shadows.componentName;
+        let shadowSourceComponentName = component.shadows.componentIdx;
         let shadowSource =
             this.dependencyHandler._components[shadowSourceComponentName];
 
@@ -7072,7 +7061,7 @@ class ShadowSourceDependency extends Dependency {
 
         return {
             success: true,
-            downstreamComponentNames: [shadowSource.componentName],
+            downstreamComponentNames: [shadowSource.componentIdx],
             downstreamComponentTypes: [shadowSource.componentType],
         };
     }
@@ -7100,11 +7089,11 @@ class UnlinkedCopySourceDependency extends Dependency {
     static dependencyType = "unlinkedCopySource";
 
     setUpParameters() {
-        if (this.definition.componentName) {
-            this.componentName = this.definition.componentName;
-            this.specifiedComponentName = this.componentName;
+        if (this.definition.componentIdx) {
+            this.componentIdx = this.definition.componentIdx;
+            this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentName = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentName;
         }
 
         if (this.definition.variableNames) {
@@ -7128,18 +7117,18 @@ class UnlinkedCopySourceDependency extends Dependency {
     }
 
     async determineDownstreamComponents() {
-        let component = this.dependencyHandler._components[this.componentName];
+        let component = this.dependencyHandler._components[this.componentIdx];
 
         if (!component) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.componentName
+                    this.componentIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.componentName
+                        this.componentIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -7148,7 +7137,7 @@ class UnlinkedCopySourceDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentName,
+                    blockerComponentName: this.componentIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -7196,7 +7185,7 @@ class UnlinkedCopySourceDependency extends Dependency {
 
         return {
             success: true,
-            downstreamComponentNames: [unlinkedCopySource.componentName],
+            downstreamComponentNames: [unlinkedCopySource.componentIdx],
             downstreamComponentTypes: [unlinkedCopySource.componentType],
         };
     }
@@ -7224,11 +7213,11 @@ class PrimaryShadowDependency extends Dependency {
     static dependencyType = "primaryShadow";
 
     setUpParameters() {
-        if (this.definition.componentName) {
-            this.componentName = this.definition.componentName;
-            this.specifiedComponentName = this.componentName;
+        if (this.definition.componentIdx) {
+            this.componentIdx = this.definition.componentIdx;
+            this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentName = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentName;
         }
 
         if (this.definition.variableNames) {
@@ -7252,18 +7241,18 @@ class PrimaryShadowDependency extends Dependency {
     }
 
     async determineDownstreamComponents() {
-        let component = this.dependencyHandler._components[this.componentName];
+        let component = this.dependencyHandler._components[this.componentIdx];
 
         if (!component) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.componentName
+                    this.componentIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.componentName
+                        this.componentIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -7272,7 +7261,7 @@ class PrimaryShadowDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentName,
+                    blockerComponentName: this.componentIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -7300,12 +7289,12 @@ class PrimaryShadowDependency extends Dependency {
 
         let primaryShadowDependencies =
             this.dependencyHandler.updateTriggers.primaryShadowDependencies[
-                this.componentName
+                this.componentIdx
             ];
         if (!primaryShadowDependencies) {
             primaryShadowDependencies =
                 this.dependencyHandler.updateTriggers.primaryShadowDependencies[
-                    this.componentName
+                    this.componentIdx
                 ] = [];
         }
         if (!primaryShadowDependencies.includes(this)) {
@@ -7334,7 +7323,7 @@ class PrimaryShadowDependency extends Dependency {
 
         return {
             success: true,
-            downstreamComponentNames: [primaryShadow.componentName],
+            downstreamComponentNames: [primaryShadow.componentIdx],
             downstreamComponentTypes: [primaryShadow.componentType],
         };
     }
@@ -7362,11 +7351,11 @@ class AdapterSourceStateVariableDependency extends Dependency {
     static dependencyType = "adapterSourceStateVariable";
 
     setUpParameters() {
-        if (this.definition.componentName) {
-            this.componentName = this.definition.componentName;
-            this.specifiedComponentName = this.componentName;
+        if (this.definition.componentIdx) {
+            this.componentIdx = this.definition.componentIdx;
+            this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentName = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentName;
         }
 
         if (!this.definition.variableName) {
@@ -7388,18 +7377,18 @@ class AdapterSourceStateVariableDependency extends Dependency {
     }
 
     async determineDownstreamComponents() {
-        let component = this.dependencyHandler._components[this.componentName];
+        let component = this.dependencyHandler._components[this.componentIdx];
 
         if (!component) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.componentName
+                    this.componentIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.componentName
+                        this.componentIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -7408,7 +7397,7 @@ class AdapterSourceStateVariableDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentName,
+                    blockerComponentName: this.componentIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -7446,7 +7435,7 @@ class AdapterSourceStateVariableDependency extends Dependency {
 
         return {
             success: true,
-            downstreamComponentNames: [sourceComposite.componentName],
+            downstreamComponentNames: [sourceComposite.componentIdx],
             downstreamComponentTypes: [sourceComposite.componentType],
         };
     }
@@ -7474,11 +7463,11 @@ class AdapterSourceDependency extends Dependency {
     static dependencyType = "adapterSource";
 
     setUpParameters() {
-        if (this.definition.componentName) {
-            this.componentName = this.definition.componentName;
-            this.specifiedComponentName = this.componentName;
+        if (this.definition.componentIdx) {
+            this.componentIdx = this.definition.componentIdx;
+            this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentName = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentName;
         }
 
         if (this.definition.variableNames) {
@@ -7502,18 +7491,18 @@ class AdapterSourceDependency extends Dependency {
     }
 
     async determineDownstreamComponents() {
-        let component = this.dependencyHandler._components[this.componentName];
+        let component = this.dependencyHandler._components[this.componentIdx];
 
         if (!component) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.componentName
+                    this.componentIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.componentName
+                        this.componentIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -7522,7 +7511,7 @@ class AdapterSourceDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentName,
+                    blockerComponentName: this.componentIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -7560,7 +7549,7 @@ class AdapterSourceDependency extends Dependency {
 
         return {
             success: true,
-            downstreamComponentNames: [sourceComposite.componentName],
+            downstreamComponentNames: [sourceComposite.componentIdx],
             downstreamComponentTypes: [sourceComposite.componentType],
         };
     }
@@ -7588,11 +7577,11 @@ class CountAmongSiblingsDependency extends Dependency {
     static dependencyType = "countAmongSiblings";
 
     setUpParameters() {
-        if (this.definition.componentName) {
-            this.componentName = this.definition.componentName;
-            this.specifiedComponentName = this.componentName;
+        if (this.definition.componentIdx) {
+            this.componentIdx = this.definition.componentIdx;
+            this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentName = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentName;
         }
         if (this.definition.componentType) {
             this.componentType = this.definition.componentType;
@@ -7606,18 +7595,18 @@ class CountAmongSiblingsDependency extends Dependency {
     }
 
     async determineDownstreamComponents() {
-        let component = this.dependencyHandler._components[this.componentName];
+        let component = this.dependencyHandler._components[this.componentIdx];
 
         if (!component) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.componentName
+                    this.componentIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.componentName
+                        this.componentIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -7626,7 +7615,7 @@ class CountAmongSiblingsDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentName,
+                    blockerComponentName: this.componentIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -7652,9 +7641,9 @@ class CountAmongSiblingsDependency extends Dependency {
             };
         }
 
-        if (!component.parentName) {
+        if (!component.parentIdx) {
             console.warn(
-                `component ${this.componentName} does not have a parent for state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}.`,
+                `component ${this.componentIdx} does not have a parent for state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}.`,
             );
             return {
                 success: true,
@@ -7663,8 +7652,8 @@ class CountAmongSiblingsDependency extends Dependency {
             };
         }
 
-        this.parentName = component.parentName;
-        let parent = this.dependencyHandler._components[this.parentName];
+        this.parentIdx = component.parentIdx;
+        let parent = this.dependencyHandler._components[this.parentIdx];
 
         if (!parent) {
             // Note: since parent is created after children,
@@ -7672,12 +7661,12 @@ class CountAmongSiblingsDependency extends Dependency {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.parentName
+                    this.parentIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.parentName
+                        this.parentIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -7686,7 +7675,7 @@ class CountAmongSiblingsDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.parentName,
+                    blockerComponentName: this.parentIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -7714,12 +7703,12 @@ class CountAmongSiblingsDependency extends Dependency {
 
         let childDependencies =
             this.dependencyHandler.updateTriggers.childDependenciesByParent[
-                this.parentName
+                this.parentIdx
             ];
         if (!childDependencies) {
             childDependencies =
                 this.dependencyHandler.updateTriggers.childDependenciesByParent[
-                    this.parentName
+                    this.parentIdx
                 ] = [];
         }
         if (!childDependencies.includes(this)) {
@@ -7742,7 +7731,7 @@ class CountAmongSiblingsDependency extends Dependency {
                     // then recalculating the downstream components
                     for (let varName of this.upstreamVariableNames) {
                         await this.dependencyHandler.addBlocker({
-                            blockerComponentName: this.parentName,
+                            blockerComponentName: this.parentIdx,
                             blockerType: "childMatches",
                             blockerStateVariable: varName, // add so that can have different blockers of child logic
                             componentNameBlocked: this.upstreamComponentName,
@@ -7772,7 +7761,7 @@ class CountAmongSiblingsDependency extends Dependency {
                 if (haveCompositesNotReady) {
                     for (let varName of this.upstreamVariableNames) {
                         await this.dependencyHandler.addBlocker({
-                            blockerComponentName: this.parentName,
+                            blockerComponentName: this.parentIdx,
                             blockerType: "childMatches",
                             blockerStateVariable: varName, // add so that can have different blockers of child logic
                             componentNameBlocked: this.upstreamComponentName,
@@ -7824,7 +7813,7 @@ class CountAmongSiblingsDependency extends Dependency {
         // Removed dependence on siblings so works even if they are placeholders
         return {
             success: true,
-            // downstreamComponentNames: parent.activeChildren.map(x => x.componentName),
+            // downstreamComponentNames: parent.activeChildren.map(x => x.componentIdx),
             // downstreamComponentTypes: parent.activeChildren.map(x => x.componentType),
             downstreamComponentNames: [],
             downstreamComponentTypes: [],
@@ -7834,7 +7823,7 @@ class CountAmongSiblingsDependency extends Dependency {
     deleteFromUpdateTriggers() {
         let childDeps =
             this.dependencyHandler.updateTriggers.childDependenciesByParent[
-                this.parentName
+                this.parentIdx
             ];
         if (childDeps) {
             let ind = childDeps.indexOf(this);
@@ -7859,7 +7848,7 @@ class CountAmongSiblingsDependency extends Dependency {
 
         let dependenciesMissingComponent =
             this.dependencyHandler.updateTriggers
-                .dependenciesMissingComponentBySpecifiedName[this.parentName];
+                .dependenciesMissingComponentBySpecifiedName[this.parentIdx];
         if (dependenciesMissingComponent) {
             let ind = dependenciesMissingComponent.indexOf(this);
             if (ind !== -1) {
@@ -7879,7 +7868,7 @@ class CountAmongSiblingsDependency extends Dependency {
         }
 
         let children =
-            this.dependencyHandler.components[this.parentName].activeChildren;
+            this.dependencyHandler.components[this.parentIdx].activeChildren;
         if (childComponentType) {
             if (this.includeInheritedComponentTypes) {
                 children = children.filter((x) =>
@@ -7900,12 +7889,12 @@ class CountAmongSiblingsDependency extends Dependency {
         // This could be 0 if the component doesn't match the specified componentType
         let value =
             children
-                .map((x) => x.componentName)
+                .map((x) => x.componentIdx)
                 .indexOf(this.upstreamComponentName) + 1;
 
         // if `initializeCounters` was passed into core with a key that matches the component type
         // then increment `value` so that the first instance would yield that initial counter.
-        if (this.parentName === this.dependencyHandler.core.documentName) {
+        if (this.parentIdx === this.dependencyHandler.core.documentName) {
             let initializeCounters =
                 this.dependencyHandler.core.initializeCounters;
 
@@ -7948,11 +7937,11 @@ class AttributeTargetComponentNamesDependency extends StateVariableDependency {
     setUpParameters() {
         this.attributeName = this.definition.attributeName;
 
-        if (this.definition.parentName) {
-            this.componentName = this.definition.parentName;
-            this.specifiedComponentName = this.componentName;
+        if (this.definition.parentIdx) {
+            this.componentIdx = this.definition.parentIdx;
+            this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentName = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentName;
         }
     }
 
@@ -7966,7 +7955,7 @@ class AttributeTargetComponentNamesDependency extends StateVariableDependency {
         }
 
         if (this.downstreamComponentNames.length === 1) {
-            let parent = this.dependencyHandler.components[this.componentName];
+            let parent = this.dependencyHandler.components[this.componentIdx];
 
             if (parent) {
                 value = parent.attributes[this.attributeName];
@@ -8130,11 +8119,11 @@ class DoenetAttributeDependency extends StateVariableDependency {
     setUpParameters() {
         this.attributeName = this.definition.attributeName;
 
-        if (this.definition.componentName) {
-            this.componentName = this.definition.componentName;
-            this.specifiedComponentName = this.componentName;
+        if (this.definition.componentIdx) {
+            this.componentIdx = this.definition.componentIdx;
+            this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentName = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentName;
         }
     }
 
@@ -8172,11 +8161,11 @@ class AttributePrimitiveDependency extends StateVariableDependency {
     setUpParameters() {
         this.attributeName = this.definition.attributeName;
 
-        if (this.definition.parentName) {
-            this.componentName = this.definition.parentName;
-            this.specifiedComponentName = this.componentName;
+        if (this.definition.parentIdx) {
+            this.componentIdx = this.definition.parentIdx;
+            this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentName = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentName;
         }
     }
 
@@ -8190,7 +8179,7 @@ class AttributePrimitiveDependency extends StateVariableDependency {
         }
 
         if (this.downstreamComponentNames.length === 1) {
-            let parent = this.dependencyHandler.components[this.componentName];
+            let parent = this.dependencyHandler.components[this.componentIdx];
 
             if (parent) {
                 value = parent.attributes[this.attributeName];
@@ -8216,27 +8205,27 @@ class SerializedChildrenDependency extends Dependency {
     static dependencyType = "serializedChildren";
 
     setUpParameters() {
-        if (this.definition.parentName) {
-            this.parentName = this.definition.parentName;
-            this.specifiedComponentName = this.parentName;
+        if (this.definition.parentIdx) {
+            this.parentIdx = this.definition.parentIdx;
+            this.specifiedComponentName = this.parentIdx;
         } else {
-            this.parentName = this.upstreamComponentName;
+            this.parentIdx = this.upstreamComponentName;
         }
     }
 
     async determineDownstreamComponents() {
-        let parent = this.dependencyHandler._components[this.parentName];
+        let parent = this.dependencyHandler._components[this.parentIdx];
 
         if (!parent) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.parentName
+                    this.parentIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.parentName
+                        this.parentIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -8245,7 +8234,7 @@ class SerializedChildrenDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.parentName,
+                    blockerComponentName: this.parentIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -8273,13 +8262,13 @@ class SerializedChildrenDependency extends Dependency {
 
         return {
             success: true,
-            downstreamComponentNames: [this.parentName],
+            downstreamComponentNames: [this.parentIdx],
             downstreamComponentTypes: [parent.componentType],
         };
     }
 
     async getValue() {
-        let parent = this.dependencyHandler._components[this.parentName];
+        let parent = this.dependencyHandler._components[this.parentIdx];
 
         return {
             value: parent.serializedChildren,
@@ -8310,29 +8299,29 @@ class DoenetMLDependency extends Dependency {
     static dependencyType = "doenetML";
 
     setUpParameters() {
-        if (this.definition.componentName) {
-            this.componentName = this.definition.componentName;
-            this.specifiedComponentName = this.componentName;
+        if (this.definition.componentIdx) {
+            this.componentIdx = this.definition.componentIdx;
+            this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentName = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentName;
         }
 
         this.displayOnlyChildren = this.definition.displayOnlyChildren;
     }
 
     async determineDownstreamComponents() {
-        let component = this.dependencyHandler._components[this.componentName];
+        let component = this.dependencyHandler._components[this.componentIdx];
 
         if (!component) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.componentName
+                    this.componentIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.componentName
+                        this.componentIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -8341,7 +8330,7 @@ class DoenetMLDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentName,
+                    blockerComponentName: this.componentIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -8369,14 +8358,14 @@ class DoenetMLDependency extends Dependency {
 
         return {
             success: true,
-            downstreamComponentNames: [this.componentName],
+            downstreamComponentNames: [this.componentIdx],
             downstreamComponentTypes: [component.componentType],
         };
     }
 
     async getValue() {
         let doenetML = this.dependencyHandler.core.requestComponentDoenetML(
-            this.componentName,
+            this.componentIdx,
             this.displayOnlyChildren,
         );
 
@@ -8409,27 +8398,27 @@ class DoenetMLRangeDependency extends Dependency {
     static dependencyType = "doenetMLrange";
 
     setUpParameters() {
-        if (this.definition.componentName) {
-            this.componentName = this.definition.componentName;
-            this.specifiedComponentName = this.componentName;
+        if (this.definition.componentIdx) {
+            this.componentIdx = this.definition.componentIdx;
+            this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentName = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentName;
         }
     }
 
     async determineDownstreamComponents() {
-        let component = this.dependencyHandler._components[this.componentName];
+        let component = this.dependencyHandler._components[this.componentIdx];
 
         if (!component) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.componentName
+                    this.componentIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.componentName
+                        this.componentIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -8438,7 +8427,7 @@ class DoenetMLRangeDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentName,
+                    blockerComponentName: this.componentIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -8466,13 +8455,13 @@ class DoenetMLRangeDependency extends Dependency {
 
         return {
             success: true,
-            downstreamComponentNames: [this.componentName],
+            downstreamComponentNames: [this.componentIdx],
             downstreamComponentTypes: [component.componentType],
         };
     }
 
     async getValue() {
-        let component = this.dependencyHandler._components[this.componentName];
+        let component = this.dependencyHandler._components[this.componentIdx];
 
         let doenetMLrange = component.doenetMLrange;
         if (doenetMLrange?.doenetMLId === 0) {
@@ -8519,27 +8508,27 @@ class VariantsDependency extends Dependency {
     static dependencyType = "variants";
 
     setUpParameters() {
-        if (this.definition.componentName) {
-            this.componentName = this.definition.componentName;
-            this.specifiedComponentName = this.componentName;
+        if (this.definition.componentIdx) {
+            this.componentIdx = this.definition.componentIdx;
+            this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentName = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentName;
         }
     }
 
     async determineDownstreamComponents() {
-        let component = this.dependencyHandler._components[this.componentName];
+        let component = this.dependencyHandler._components[this.componentIdx];
 
         if (!component) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.componentName
+                    this.componentIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.componentName
+                        this.componentIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -8548,7 +8537,7 @@ class VariantsDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentName,
+                    blockerComponentName: this.componentIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -8576,13 +8565,13 @@ class VariantsDependency extends Dependency {
 
         return {
             success: true,
-            downstreamComponentNames: [this.componentName],
+            downstreamComponentNames: [this.componentIdx],
             downstreamComponentTypes: [component.componentType],
         };
     }
 
     async getValue() {
-        let component = this.dependencyHandler._components[this.componentName];
+        let component = this.dependencyHandler._components[this.componentIdx];
 
         return {
             value: component.variants,
@@ -8615,11 +8604,11 @@ class CounterDependency extends Dependency {
     setUpParameters() {
         this.counterName = this.definition.counterName;
 
-        this.componentName = this.upstreamComponentName;
+        this.componentIdx = this.upstreamComponentName;
     }
 
     async determineDownstreamComponents() {
-        let component = this.dependencyHandler._components[this.componentName];
+        let component = this.dependencyHandler._components[this.componentIdx];
 
         let counters = component.counters[this.counterName];
         if (!counters) {
@@ -8646,7 +8635,7 @@ class CounterDependency extends Dependency {
     }
 
     async getValue() {
-        let component = this.dependencyHandler._components[this.componentName];
+        let component = this.dependencyHandler._components[this.componentIdx];
 
         return {
             value: component.counters[this.counterName].value,
@@ -8665,10 +8654,10 @@ class DetermineDependenciesDependency extends Dependency {
         // and turned off after dependencies are recalculated
         this.recalculateDependencies = true;
 
-        if (this.definition.componentName) {
-            this.componentName = this.definition.componentName;
+        if (this.definition.componentIdx) {
+            this.componentIdx = this.definition.componentIdx;
         } else {
-            this.componentName = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentName;
         }
 
         if (this.definition.variableNames === undefined) {
@@ -8684,18 +8673,18 @@ class DetermineDependenciesDependency extends Dependency {
     async determineDownstreamComponents() {
         // console.log(`deterine downstream components of determine deps dependency ${this.dependencyName} of ${this.representativeStateVariable} of ${this.upstreamComponentName}`)
 
-        let component = this.dependencyHandler._components[this.componentName];
+        let component = this.dependencyHandler._components[this.componentIdx];
 
         if (!component) {
             let dependenciesMissingComponent =
                 this.dependencyHandler.updateTriggers
                     .dependenciesMissingComponentBySpecifiedName[
-                    this.componentName
+                    this.componentIdx
                 ];
             if (!dependenciesMissingComponent) {
                 dependenciesMissingComponent =
                     this.dependencyHandler.updateTriggers.dependenciesMissingComponentBySpecifiedName[
-                        this.componentName
+                        this.componentIdx
                     ] = [];
             }
             if (!dependenciesMissingComponent.includes(this)) {
@@ -8704,7 +8693,7 @@ class DetermineDependenciesDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentName,
+                    blockerComponentName: this.componentIdx,
                     blockerType: "componentIdentity",
                     componentNameBlocked: this.upstreamComponentName,
                     typeBlocked: "recalculateDownstreamComponents",
@@ -8744,7 +8733,7 @@ class DetermineDependenciesDependency extends Dependency {
 
         return {
             success: true,
-            downstreamComponentNames: [this.componentName],
+            downstreamComponentNames: [this.componentIdx],
             downstreamComponentTypes: [component.componentType],
         };
     }

--- a/packages/doenetml-worker-javascript/src/Dependencies.js
+++ b/packages/doenetml-worker-javascript/src/Dependencies.js
@@ -232,14 +232,14 @@ export class DependencyHandler {
                         // were other downstream components involved
                         for (let upVarName of upDep.upstreamVariableNames) {
                             if (
-                                this._components[upDep.upstreamComponentName]
+                                this._components[upDep.upstreamComponentIdx]
                                     .state[upVarName].initiallyResolved
                             ) {
                                 await this.core.markStateVariableAndUpstreamDependentsStale(
                                     {
                                         component:
                                             this.components[
-                                                upDep.upstreamComponentName
+                                                upDep.upstreamComponentIdx
                                             ],
                                         varName: upVarName,
                                     },
@@ -299,14 +299,14 @@ export class DependencyHandler {
                         } else {
                             for (let vName of dep.upstreamVariableNames) {
                                 await this.addBlocker({
-                                    blockerComponentName:
-                                        dep.upstreamComponentName,
+                                    blockerComponentIdx:
+                                        dep.upstreamComponentIdx,
                                     blockerType:
                                         "recalculateDownstreamComponents",
                                     blockerStateVariable: vName,
                                     blockerDependency: dep.dependencyName,
-                                    componentNameBlocked:
-                                        dep.upstreamComponentName,
+                                    componentIdxBlocked:
+                                        dep.upstreamComponentIdx,
                                     typeBlocked: "stateVariable",
                                     stateVariableBlocked: vName,
                                 });
@@ -331,17 +331,17 @@ export class DependencyHandler {
             ]) {
                 for (let varName of dep.upstreamVariableNames) {
                     await this.addBlocker({
-                        blockerComponentName: dep.upstreamComponentName,
+                        blockerComponentIdx: dep.upstreamComponentIdx,
                         blockerType: "recalculateDownstreamComponents",
                         blockerStateVariable: varName,
                         blockerDependency: dep.dependencyName,
-                        componentNameBlocked: dep.upstreamComponentName,
+                        componentIdxBlocked: dep.upstreamComponentIdx,
                         typeBlocked: "stateVariable",
                         stateVariableBlocked: varName,
                     });
                 }
                 await this.addBlockersFromChangedStateVariableDependencies({
-                    componentIdx: dep.upstreamComponentName,
+                    componentIdx: dep.upstreamComponentIdx,
                     stateVariables: dep.upstreamVariableNames,
                 });
             }
@@ -358,17 +358,17 @@ export class DependencyHandler {
                 ]) {
                     for (let varName of dep.upstreamVariableNames) {
                         await this.addBlocker({
-                            blockerComponentName: dep.upstreamComponentName,
+                            blockerComponentIdx: dep.upstreamComponentIdx,
                             blockerType: "recalculateDownstreamComponents",
                             blockerStateVariable: varName,
                             blockerDependency: dep.dependencyName,
-                            componentNameBlocked: dep.upstreamComponentName,
+                            componentIdxBlocked: dep.upstreamComponentIdx,
                             typeBlocked: "stateVariable",
                             stateVariableBlocked: varName,
                         });
                     }
                     await this.addBlockersFromChangedStateVariableDependencies({
-                        componentIdx: dep.upstreamComponentName,
+                        componentIdx: dep.upstreamComponentIdx,
                         stateVariables: dep.upstreamVariableNames,
                     });
                 }
@@ -392,17 +392,17 @@ export class DependencyHandler {
                 ]) {
                     for (let varName of dep.upstreamVariableNames) {
                         await this.addBlocker({
-                            blockerComponentName: dep.upstreamComponentName,
+                            blockerComponentIdx: dep.upstreamComponentIdx,
                             blockerType: "recalculateDownstreamComponents",
                             blockerStateVariable: varName,
                             blockerDependency: dep.dependencyName,
-                            componentNameBlocked: dep.upstreamComponentName,
+                            componentIdxBlocked: dep.upstreamComponentIdx,
                             typeBlocked: "stateVariable",
                             stateVariableBlocked: varName,
                         });
                     }
                     await this.addBlockersFromChangedStateVariableDependencies({
-                        componentIdx: dep.upstreamComponentName,
+                        componentIdx: dep.upstreamComponentIdx,
                         stateVariables: dep.upstreamVariableNames,
                     });
                 }
@@ -422,7 +422,7 @@ export class DependencyHandler {
                 parent.componentIdx
             ]) {
                 await this.resolveIfReady({
-                    componentIdx: dep.upstreamComponentName,
+                    componentIdx: dep.upstreamComponentIdx,
                     type: "recalculateDownstreamComponents",
                     stateVariable: dep.representativeStateVariable,
                     dependency: dep.dependencyName,
@@ -442,7 +442,7 @@ export class DependencyHandler {
                     parent.componentIdx
                 ]) {
                     await this.resolveIfReady({
-                        componentIdx: dep.upstreamComponentName,
+                        componentIdx: dep.upstreamComponentIdx,
                         type: "recalculateDownstreamComponents",
                         stateVariable: dep.representativeStateVariable,
                         dependency: dep.dependencyName,
@@ -472,7 +472,7 @@ export class DependencyHandler {
                     parent.componentIdx
                 ]) {
                     await this.resolveIfReady({
-                        componentIdx: dep.upstreamComponentName,
+                        componentIdx: dep.upstreamComponentIdx,
                         type: "recalculateDownstreamComponents",
                         stateVariable: dep.representativeStateVariable,
                         dependency: dep.dependencyName,
@@ -492,17 +492,17 @@ export class DependencyHandler {
                 .descendantDependenciesByAncestor[ancestorIdx]) {
                 for (let varName of dep.upstreamVariableNames) {
                     await this.addBlocker({
-                        blockerComponentName: dep.upstreamComponentName,
+                        blockerComponentIdx: dep.upstreamComponentIdx,
                         blockerType: "recalculateDownstreamComponents",
                         blockerStateVariable: varName,
                         blockerDependency: dep.dependencyName,
-                        componentNameBlocked: dep.upstreamComponentName,
+                        componentIdxBlocked: dep.upstreamComponentIdx,
                         typeBlocked: "stateVariable",
                         stateVariableBlocked: varName,
                     });
                 }
                 await this.addBlockersFromChangedStateVariableDependencies({
-                    componentIdx: dep.upstreamComponentName,
+                    componentIdx: dep.upstreamComponentIdx,
                     stateVariables: dep.upstreamVariableNames,
                 });
             }
@@ -516,7 +516,7 @@ export class DependencyHandler {
             for (let dep of this.updateTriggers
                 .descendantDependenciesByAncestor[ancestorIdx]) {
                 await this.resolveIfReady({
-                    componentIdx: dep.upstreamComponentName,
+                    componentIdx: dep.upstreamComponentIdx,
                     type: "recalculateDownstreamComponents",
                     stateVariable: dep.representativeStateVariable,
                     dependency: dep.dependencyName,
@@ -537,11 +537,11 @@ export class DependencyHandler {
                 .replacementDependenciesByComposite[composite.componentIdx]) {
                 for (let varName of dep.upstreamVariableNames) {
                     await this.addBlocker({
-                        blockerComponentName: dep.upstreamComponentName,
+                        blockerComponentIdx: dep.upstreamComponentIdx,
                         blockerType: "recalculateDownstreamComponents",
                         blockerStateVariable: varName,
                         blockerDependency: dep.dependencyName,
-                        componentNameBlocked: dep.upstreamComponentName,
+                        componentIdxBlocked: dep.upstreamComponentIdx,
                         typeBlocked: "stateVariable",
                         stateVariableBlocked: varName,
                     });
@@ -637,7 +637,7 @@ export class DependencyHandler {
                     for (let vName of upDep.upstreamVariableNames) {
                         if (vName !== "__identity") {
                             this.resetCircularCheckPassed(
-                                upDep.upstreamComponentName,
+                                upDep.upstreamComponentIdx,
                                 vName,
                             );
                         }
@@ -692,10 +692,10 @@ export class DependencyHandler {
 
                             for (let vName2 of allStateVariablesAffected) {
                                 await this.addBlocker({
-                                    blockerComponentName: cName,
+                                    blockerComponentIdx: cName,
                                     blockerType: "stateVariable",
                                     blockerStateVariable: vName,
-                                    componentNameBlocked: componentIdx,
+                                    componentIdxBlocked: componentIdx,
                                     typeBlocked: "determineDependencies",
                                     stateVariableBlocked: vName2,
                                     dependencyBlocked: dependency,
@@ -897,7 +897,7 @@ export class DependencyHandler {
         ) {
             for (let dep of this.updateTriggers
                 .dependenciesMissingComponentBySpecifiedName[componentIdx]) {
-                let upComponent = this._components[dep.upstreamComponentName];
+                let upComponent = this._components[dep.upstreamComponentIdx];
 
                 if (!upComponent) {
                     continue;
@@ -922,17 +922,17 @@ export class DependencyHandler {
                         if (
                             !(
                                 variablesJustResolved[
-                                    dep.upstreamComponentName
+                                    dep.upstreamComponentIdx
                                 ] &&
-                                variablesJustResolved[
-                                    dep.upstreamComponentName
-                                ][varName]
+                                variablesJustResolved[dep.upstreamComponentIdx][
+                                    varName
+                                ]
                             )
                         ) {
                             // console.log(`****** a variable value changed because have a new component ******`)
-                            // console.log(`${dep.dependencyName} of ${varName} of ${dep.upstreamComponentName}`)
+                            // console.log(`${dep.dependencyName} of ${varName} of ${dep.upstreamComponentIdx}`)
                             variablesChanged.push({
-                                componentIdx: dep.upstreamComponentName,
+                                componentIdx: dep.upstreamComponentIdx,
                                 varName,
                             });
                         }
@@ -941,18 +941,18 @@ export class DependencyHandler {
 
                 for (let varName of dep.upstreamVariableNames) {
                     this.deleteFromNeededToResolve({
-                        componentNameBlocked: dep.upstreamComponentName,
+                        componentIdxBlocked: dep.upstreamComponentIdx,
                         typeBlocked: "recalculateDownstreamComponents",
                         stateVariableBlocked: varName,
                         dependencyBlocked: dep.dependencyName,
-                        blockerComponentName: componentIdx,
+                        blockerComponentIdx: componentIdx,
                         blockerType: "componentIdentity",
                     });
                 }
 
                 // resolving for one variable will resolve for all upstreamVariableNames
                 let result = await this.resolveIfReady({
-                    componentIdx: dep.upstreamComponentName,
+                    componentIdx: dep.upstreamComponentIdx,
                     type: "recalculateDownstreamComponents",
                     stateVariable: dep.representativeStateVariable,
                     dependency: dep.dependencyName,
@@ -964,15 +964,13 @@ export class DependencyHandler {
                     for (let varName of dep.upstreamVariableNames) {
                         if (!upComponent.state[varName].initiallyResolved) {
                             if (
-                                !variablesJustResolved[
-                                    dep.upstreamComponentName
-                                ]
+                                !variablesJustResolved[dep.upstreamComponentIdx]
                             ) {
                                 variablesJustResolved[
-                                    dep.upstreamComponentName
+                                    dep.upstreamComponentIdx
                                 ] = {};
                             }
-                            variablesJustResolved[dep.upstreamComponentName][
+                            variablesJustResolved[dep.upstreamComponentIdx][
                                 varName
                             ] = true;
                         }
@@ -980,11 +978,11 @@ export class DependencyHandler {
                 } else {
                     for (let varName of dep.upstreamVariableNames) {
                         await this.addBlocker({
-                            blockerComponentName: dep.upstreamComponentName,
+                            blockerComponentIdx: dep.upstreamComponentIdx,
                             blockerType: "recalculateDownstreamComponents",
                             blockerStateVariable: varName,
                             blockerDependency: dep.dependencyName,
-                            componentNameBlocked: dep.upstreamComponentName,
+                            componentIdxBlocked: dep.upstreamComponentIdx,
                             typeBlocked: "stateVariable",
                             stateVariableBlocked: varName,
                         });
@@ -1273,7 +1271,7 @@ export class DependencyHandler {
     }
 
     deleteFromNeededToResolve({
-        componentNameBlocked,
+        componentIdxBlocked,
         typeBlocked,
         stateVariableBlocked,
         dependencyBlocked,
@@ -1281,10 +1279,10 @@ export class DependencyHandler {
         blockerCode,
         deleteFromReciprocal = true,
     }) {
-        // console.log(`delete from needed to resolve ${componentNameBlocked}, ${typeBlocked}, ${stateVariableBlocked}, ${dependencyBlocked}, ${blockerType}, ${blockerCode}`)
+        // console.log(`delete from needed to resolve ${componentIdxBlocked}, ${typeBlocked}, ${stateVariableBlocked}, ${dependencyBlocked}, ${blockerType}, ${blockerCode}`)
         // console.log(JSON.parse(JSON.stringify(this.resolveBlockers)))
 
-        let codeBlocked = componentNameBlocked;
+        let codeBlocked = componentIdxBlocked;
         if (stateVariableBlocked) {
             codeBlocked += "|" + stateVariableBlocked;
             if (dependencyBlocked) {
@@ -1305,12 +1303,12 @@ export class DependencyHandler {
                         }
                         if (deleteFromReciprocal) {
                             let [
-                                blockerComponentName,
+                                blockerComponentIdx,
                                 blockerStateVariable,
                                 blockerDependency,
                             ] = blockerCode.split("|");
                             this.deleteFromResolveBlockedBy({
-                                blockerComponentName,
+                                blockerComponentIdx,
                                 blockerType,
                                 blockerStateVariable,
                                 blockerDependency,
@@ -1326,12 +1324,12 @@ export class DependencyHandler {
                         if (deleteFromReciprocal) {
                             for (let code of neededObj[blockerType]) {
                                 let [
-                                    blockerComponentName,
+                                    blockerComponentIdx,
                                     blockerStateVariable,
                                     blockerDependency,
                                 ] = code.split("|");
                                 this.deleteFromResolveBlockedBy({
-                                    blockerComponentName,
+                                    blockerComponentIdx,
                                     blockerType,
                                     blockerStateVariable,
                                     blockerDependency,
@@ -1351,12 +1349,12 @@ export class DependencyHandler {
                     for (let type in neededObj) {
                         for (let code of neededObj[type]) {
                             let [
-                                blockerComponentName,
+                                blockerComponentIdx,
                                 blockerStateVariable,
                                 blockerDependency,
                             ] = code.split("|");
                             this.deleteFromResolveBlockedBy({
-                                blockerComponentName,
+                                blockerComponentIdx,
                                 blockerType: type,
                                 blockerStateVariable,
                                 blockerDependency,
@@ -1371,7 +1369,7 @@ export class DependencyHandler {
         }.bind(this);
 
         let neededToResolveForComponent =
-            this.resolveBlockers.neededToResolve[componentNameBlocked];
+            this.resolveBlockers.neededToResolve[componentIdxBlocked];
 
         if (neededToResolveForComponent) {
             let neededToResolveForType =
@@ -1442,12 +1440,12 @@ export class DependencyHandler {
 
             if (Object.keys(neededToResolveForComponent).length === 0) {
                 delete this.resolveBlockers.neededToResolve[
-                    componentNameBlocked
+                    componentIdxBlocked
                 ];
             }
         }
 
-        // console.log(`done deleting from needed to resolve ${componentNameBlocked}, ${typeBlocked}, ${stateVariableBlocked}, ${dependencyBlocked}, ${blockerType}, ${blockerCode}`)
+        // console.log(`done deleting from needed to resolve ${componentIdxBlocked}, ${typeBlocked}, ${stateVariableBlocked}, ${dependencyBlocked}, ${blockerType}, ${blockerCode}`)
         // console.log(JSON.parse(JSON.stringify(this.resolveBlockers)))
     }
 
@@ -1525,7 +1523,7 @@ export class DependencyHandler {
     }
 
     deleteFromResolveBlockedBy({
-        blockerComponentName,
+        blockerComponentIdx,
         blockerType,
         blockerStateVariable,
         blockerDependency,
@@ -1533,10 +1531,10 @@ export class DependencyHandler {
         codeBlocked,
         deleteFromReciprocal = true,
     }) {
-        // console.log(`delete from resolve blocked by ${blockerComponentName}, ${blockerType}, ${blockerStateVariable}, ${blockerDependency}, ${typeBlocked}, ${codeBlocked}`)
+        // console.log(`delete from resolve blocked by ${blockerComponentIdx}, ${blockerType}, ${blockerStateVariable}, ${blockerDependency}, ${typeBlocked}, ${codeBlocked}`)
         // console.log(JSON.parse(JSON.stringify(this.resolveBlockers)))
 
-        let blockerCode = blockerComponentName;
+        let blockerCode = blockerComponentIdx;
         if (blockerStateVariable) {
             blockerCode += "|" + blockerStateVariable;
             if (blockerDependency) {
@@ -1557,12 +1555,12 @@ export class DependencyHandler {
                         }
                         if (deleteFromReciprocal) {
                             let [
-                                componentNameBlocked,
+                                componentIdxBlocked,
                                 stateVariableBlocked,
                                 dependencyBlocked,
                             ] = codeBlocked.split("|");
                             this.deleteFromNeededToResolve({
-                                componentNameBlocked,
+                                componentIdxBlocked,
                                 typeBlocked,
                                 stateVariableBlocked,
                                 dependencyBlocked,
@@ -1576,12 +1574,12 @@ export class DependencyHandler {
                         if (deleteFromReciprocal) {
                             for (let code of neededObj[typeBlocked]) {
                                 let [
-                                    componentNameBlocked,
+                                    componentIdxBlocked,
                                     stateVariableBlocked,
                                     dependencyBlocked,
                                 ] = code.split("|");
                                 this.deleteFromNeededToResolve({
-                                    componentNameBlocked,
+                                    componentIdxBlocked,
                                     typeBlocked,
                                     stateVariableBlocked,
                                     dependencyBlocked,
@@ -1603,12 +1601,12 @@ export class DependencyHandler {
                     for (let type in neededObj) {
                         for (let code of neededObj[type]) {
                             let [
-                                componentNameBlocked,
+                                componentIdxBlocked,
                                 stateVariableBlocked,
                                 dependencyBlocked,
                             ] = code.split("|");
                             this.deleteFromNeededToResolve({
-                                componentNameBlocked,
+                                componentIdxBlocked,
                                 typeBlocked: type,
                                 stateVariableBlocked,
                                 dependencyBlocked,
@@ -1623,7 +1621,7 @@ export class DependencyHandler {
         }.bind(this);
 
         let resolveBlockedByForComponent =
-            this.resolveBlockers.resolveBlockedBy[blockerComponentName];
+            this.resolveBlockers.resolveBlockedBy[blockerComponentIdx];
 
         if (resolveBlockedByForComponent) {
             let resolveBlockedByForType =
@@ -1694,26 +1692,26 @@ export class DependencyHandler {
 
             if (Object.keys(resolveBlockedByForComponent).length === 0) {
                 delete this.resolveBlockers.resolveBlockedBy[
-                    blockerComponentName
+                    blockerComponentIdx
                 ];
             }
         }
 
-        // console.log(`done deleting from resolve blocked by ${blockerComponentName}, ${blockerType}, ${blockerStateVariable}, ${blockerDependency}, ${typeBlocked}, ${codeBlocked}`)
+        // console.log(`done deleting from resolve blocked by ${blockerComponentIdx}, ${blockerType}, ${blockerStateVariable}, ${blockerDependency}, ${typeBlocked}, ${codeBlocked}`)
         // console.log(JSON.parse(JSON.stringify(this.resolveBlockers)))
     }
 
     async addBlocker({
-        blockerComponentName,
+        blockerComponentIdx,
         blockerType,
         blockerStateVariable,
         blockerDependency,
-        componentNameBlocked,
+        componentIdxBlocked,
         typeBlocked,
         stateVariableBlocked,
         dependencyBlocked,
     }) {
-        let blockerCode = blockerComponentName;
+        let blockerCode = blockerComponentIdx;
         if (blockerStateVariable) {
             blockerCode += "|" + blockerStateVariable;
             if (blockerDependency) {
@@ -1721,7 +1719,7 @@ export class DependencyHandler {
             }
         }
 
-        let codeBlocked = componentNameBlocked;
+        let codeBlocked = componentIdxBlocked;
         if (stateVariableBlocked) {
             codeBlocked += "|" + stateVariableBlocked;
             if (dependencyBlocked) {
@@ -1730,7 +1728,7 @@ export class DependencyHandler {
         }
 
         let neededForBlocked = this.getNeededToResolve({
-            componentIdx: componentNameBlocked,
+            componentIdx: componentIdxBlocked,
             type: typeBlocked,
             stateVariable: stateVariableBlocked,
             dependency: dependencyBlocked,
@@ -1749,7 +1747,7 @@ export class DependencyHandler {
         neededToResolveBlocked.push(blockerCode);
 
         if (typeBlocked === "stateVariable") {
-            let component = this._components[componentNameBlocked];
+            let component = this._components[componentIdxBlocked];
             if (component) {
                 let stateVarObj = component.state[stateVariableBlocked];
                 stateVarObj.isResolved = false;
@@ -1765,21 +1763,21 @@ export class DependencyHandler {
 
                     // record that stateVarObj is blocking its upstream dependencies
                     let upDeps =
-                        this.upstreamDependencies[componentNameBlocked][
+                        this.upstreamDependencies[componentIdxBlocked][
                             stateVariableBlocked
                         ];
                     if (upDeps) {
                         for (let dep of upDeps) {
-                            if (this._components[dep.upstreamComponentName]) {
+                            if (this._components[dep.upstreamComponentIdx]) {
                                 for (let vName of dep.upstreamVariableNames) {
                                     await this.addBlocker({
-                                        blockerComponentName:
-                                            componentNameBlocked,
+                                        blockerComponentIdx:
+                                            componentIdxBlocked,
                                         blockerType: "stateVariable",
                                         blockerStateVariable:
                                             stateVariableBlocked,
-                                        componentNameBlocked:
-                                            dep.upstreamComponentName,
+                                        componentIdxBlocked:
+                                            dep.upstreamComponentIdx,
                                         typeBlocked: "stateVariable",
                                         stateVariableBlocked: vName,
                                     });
@@ -1793,7 +1791,7 @@ export class DependencyHandler {
 
         // record that blocked by blocker
         let resolvedBlockedByBlocker = this.getResolveBlockedBy({
-            componentIdx: blockerComponentName,
+            componentIdx: blockerComponentIdx,
             type: blockerType,
             stateVariable: blockerStateVariable,
             dependency: blockerDependency,
@@ -1808,14 +1806,14 @@ export class DependencyHandler {
         }
 
         this.resetCircularResolveBlockerCheckPassed({
-            componentIdx: componentNameBlocked,
+            componentIdx: componentIdxBlocked,
             type: typeBlocked,
             stateVariable: stateVariableBlocked,
             dependency: dependencyBlocked,
         });
 
         this.checkForCircularResolveBlocker({
-            componentIdx: componentNameBlocked,
+            componentIdx: componentIdxBlocked,
             type: typeBlocked,
             stateVariable: stateVariableBlocked,
             dependency: dependencyBlocked,
@@ -1880,12 +1878,12 @@ export class DependencyHandler {
 
                     for (let varName of dep.upstreamVariableNames) {
                         this.deleteFromNeededToResolve({
-                            componentNameBlocked: dep.upstreamComponentName,
+                            componentIdxBlocked: dep.upstreamComponentIdx,
                             typeBlocked: "stateVariable",
                             stateVariableBlocked: varName,
                             blockerType: "recalculateDownstreamComponents",
                             blockerCode:
-                                dep.upstreamComponentName +
+                                dep.upstreamComponentIdx +
                                 "|" +
                                 varName +
                                 "|" +
@@ -1894,7 +1892,7 @@ export class DependencyHandler {
                     }
                     for (let varName of dep.upstreamVariableNames) {
                         await this.resolveIfReady({
-                            componentIdx: dep.upstreamComponentName,
+                            componentIdx: dep.upstreamComponentIdx,
                             type: "stateVariable",
                             stateVariable: varName,
                             expandComposites,
@@ -1933,7 +1931,7 @@ export class DependencyHandler {
                     if (neededForItem.determineDependencies) {
                         for (let code of neededForItem.determineDependencies) {
                             let [
-                                blockerComponentName,
+                                blockerComponentIdx,
                                 blockerStateVariable,
                                 blockerDependency,
                             ] = code.split("|");
@@ -1978,7 +1976,7 @@ export class DependencyHandler {
                     for (let varName of dep.upstreamVariableNames) {
                         for (let dependency of determineDepsDependencies) {
                             this.deleteFromResolveBlockedBy({
-                                blockerComponentName: dep.upstreamComponentName,
+                                blockerComponentIdx: dep.upstreamComponentIdx,
                                 blockerType: "determineDependencies",
                                 blockerStateVariable: varName,
                                 blockerDependency: dependency,
@@ -2064,7 +2062,7 @@ export class DependencyHandler {
             for (let code of [...resolveBlockedByNewlyResolved[type]]) {
                 // first delete
                 this.deleteFromResolveBlockedBy({
-                    blockerComponentName: componentNameNewlyResolved,
+                    blockerComponentIdx: componentNameNewlyResolved,
                     blockerType: typeNewlyResolved,
                     blockerStateVariable: stateVariableNewlyResolved,
                     blockerDependency: dependencyNewlyResolved,
@@ -2121,13 +2119,13 @@ export class DependencyHandler {
                 if (determineDepsBlockers) {
                     for (let blockerCode of determineDepsBlockers) {
                         let [
-                            blockerComponentName,
+                            blockerComponentIdx,
                             blockerStateVariable,
                             blockerDependency,
                         ] = blockerCode.split("|");
 
                         await this.resolveIfReady({
-                            componentIdx: blockerComponentName,
+                            componentIdx: blockerComponentIdx,
                             type: "determineDependencies",
                             stateVariable: blockerStateVariable,
                             dependency: blockerDependency,
@@ -2176,7 +2174,7 @@ export class DependencyHandler {
         // running deleteFromNeededToResolve will remove
         // the empty data structures
         this.deleteFromNeededToResolve({
-            componentNameBlocked: componentIdx,
+            componentIdxBlocked: componentIdx,
             typeBlocked: type,
             stateVariableBlocked: stateVariable,
             dependencyBlocked: dependency,
@@ -2232,13 +2230,13 @@ export class DependencyHandler {
         if (determineDepsBlockers && determineDepsBlockers.length > 0) {
             for (let blockerCode of [...determineDepsBlockers]) {
                 let [
-                    blockerComponentName,
+                    blockerComponentIdx,
                     blockerStateVariable,
                     blockerDependency,
                 ] = blockerCode.split("|");
 
                 let result = await this.resolveItem({
-                    componentIdx: blockerComponentName,
+                    componentIdx: blockerComponentIdx,
                     type: "determineDependencies",
                     stateVariable: blockerStateVariable,
                     dependency: blockerDependency,
@@ -2295,13 +2293,13 @@ export class DependencyHandler {
                 // shallow copy, as items may be deleted as resolve items
                 for (let code of [...neededForItem[blockerType]]) {
                     let [
-                        blockerComponentName,
+                        blockerComponentIdx,
                         blockerStateVariable,
                         blockerDependency,
                     ] = code.split("|");
 
                     let result = await this.resolveItem({
-                        componentIdx: blockerComponentName,
+                        componentIdx: blockerComponentIdx,
                         type: blockerType,
                         stateVariable: blockerStateVariable,
                         dependency: blockerDependency,
@@ -2345,13 +2343,13 @@ export class DependencyHandler {
                     // shallow copy, as items may be deleted as resolve items
                     for (let code of [...neededForItem[blockerType]]) {
                         let [
-                            blockerComponentName,
+                            blockerComponentIdx,
                             blockerStateVariable,
                             blockerDependency,
                         ] = code.split("|");
 
                         let result = await this.resolveItem({
-                            componentIdx: blockerComponentName,
+                            componentIdx: blockerComponentIdx,
                             type: blockerType,
                             stateVariable: blockerStateVariable,
                             dependency: blockerDependency,
@@ -2474,13 +2472,13 @@ export class DependencyHandler {
             for (let blockerType in neededForItem) {
                 for (let blockerCode of neededForItem[blockerType]) {
                     let [
-                        blockerComponentName,
+                        blockerComponentIdx,
                         blockerStateVariable,
                         blockerDependency,
                     ] = blockerCode.split("|");
 
                     this.checkForCircularResolveBlocker({
-                        componentIdx: blockerComponentName,
+                        componentIdx: blockerComponentIdx,
                         type: blockerType,
                         stateVariable: blockerStateVariable,
                         dependency: blockerDependency,
@@ -2613,13 +2611,13 @@ export class DependencyHandler {
             for (let typeBlocked in resolveBlockedBy) {
                 for (let codeBlocked of resolveBlockedBy[typeBlocked]) {
                     let [
-                        componentNameBlocked,
+                        componentIdxBlocked,
                         stateVariableBlocked,
                         dependencyBlocked,
                     ] = codeBlocked.split("|");
 
                     this.resetCircularResolveBlockerCheckPassed({
-                        componentIdx: componentNameBlocked,
+                        componentIdx: componentIdxBlocked,
                         type: typeBlocked,
                         stateVariable: stateVariableBlocked,
                         dependency: dependencyBlocked,
@@ -2651,7 +2649,7 @@ class Dependency {
         this.dependencyName = dependencyName;
         this.dependencyHandler = dependencyHandler;
 
-        this.upstreamComponentName = component.componentIdx;
+        this.upstreamComponentIdx = component.componentIdx;
         this.upstreamVariableNames = allStateVariablesAffected;
 
         this.definition = Object.assign({}, dependencyDefinition);
@@ -2687,13 +2685,13 @@ class Dependency {
 
         // if returnSingleVariableValue, then
         // return just the value of the state variable when there is
-        // exactly one (downstreamComponentName, downstreamVariableName)
+        // exactly one (downstreamComponentIdx, downstreamVariableName)
         // and return null otherwise
         this.returnSingleVariableValue = false;
 
         // if returnSingleComponent, then
         // return just the component object (rather than an array) when there
-        // is exactly one downstreamComponentName
+        // is exactly one downstreamComponentIdx
         // and return null otherwise
         this.returnSingleComponent = false;
 
@@ -2724,7 +2722,7 @@ class Dependency {
         // 1. set up parameters
         // 2. determine downstream components
         // 3. add this dependency to the downstreamDependencies of the upstream component
-        // 4. for each downstreamComponentName, add this dependency to upstreamDependencies
+        // 4. for each downstreamComponentIdx, add this dependency to upstreamDependencies
         // 5. map originalDownstreamVariableNames to mappedDownstreamVariableNamesByComponent
         // 6. possibly create array entry variables in downstream components if they don't exist
         // 7. keep track of any unresolved dependencies
@@ -2742,11 +2740,11 @@ class Dependency {
 
         let upCompDownDeps =
             this.dependencyHandler.downstreamDependencies[
-                this.upstreamComponentName
+                this.upstreamComponentIdx
             ];
         if (!upCompDownDeps) {
             upCompDownDeps = this.dependencyHandler.downstreamDependencies[
-                this.upstreamComponentName
+                this.upstreamComponentIdx
             ] = {};
         }
 
@@ -2773,10 +2771,10 @@ class Dependency {
 
         for (let [
             index,
-            downstreamComponentName,
+            downstreamComponentIdx,
         ] of downstreamComponentNames.entries()) {
             await this.addDownstreamComponent({
-                downstreamComponentName,
+                downstreamComponentIdx,
                 downstreamComponentType: downstreamComponentTypes[index],
                 index,
             });
@@ -2784,17 +2782,17 @@ class Dependency {
     }
 
     async addDownstreamComponent({
-        downstreamComponentName,
+        downstreamComponentIdx,
         downstreamComponentType,
         index,
     }) {
         this.componentIdentitiesChanged = true;
 
-        this.downstreamComponentNames.splice(index, 0, downstreamComponentName);
+        this.downstreamComponentNames.splice(index, 0, downstreamComponentIdx);
         this.downstreamComponentTypes.splice(index, 0, downstreamComponentType);
 
         let downComponent =
-            this.dependencyHandler._components[downstreamComponentName];
+            this.dependencyHandler._components[downstreamComponentIdx];
 
         if (downComponent) {
             let originalVarNames;
@@ -2934,11 +2932,10 @@ class Dependency {
                     if (!downComponent.state[downVar].isResolved) {
                         for (let varName of this.upstreamVariableNames) {
                             await this.dependencyHandler.addBlocker({
-                                blockerComponentName: downstreamComponentName,
+                                blockerComponentIdx: downstreamComponentIdx,
                                 blockerType: "stateVariable",
                                 blockerStateVariable: downVar,
-                                componentNameBlocked:
-                                    this.upstreamComponentName,
+                                componentIdxBlocked: this.upstreamComponentIdx,
                                 typeBlocked: "stateVariable",
                                 stateVariableBlocked: varName,
                             });
@@ -2946,12 +2943,11 @@ class Dependency {
                                 this.dependencyType === "determineDependencies"
                             ) {
                                 await this.dependencyHandler.addBlocker({
-                                    blockerComponentName:
-                                        downstreamComponentName,
+                                    blockerComponentIdx: downstreamComponentIdx,
                                     blockerType: "stateVariable",
                                     blockerStateVariable: downVar,
-                                    componentNameBlocked:
-                                        this.upstreamComponentName,
+                                    componentIdxBlocked:
+                                        this.upstreamComponentIdx,
                                     typeBlocked: "determineDependencies",
                                     stateVariableBlocked: varName,
                                     dependencyBlocked: this.dependencyName,
@@ -2971,11 +2967,11 @@ class Dependency {
 
             let downCompUpDeps =
                 this.dependencyHandler.upstreamDependencies[
-                    downstreamComponentName
+                    downstreamComponentIdx
                 ];
             if (!downCompUpDeps) {
                 downCompUpDeps = this.dependencyHandler.upstreamDependencies[
-                    downstreamComponentName
+                    downstreamComponentIdx
                 ] = {};
             }
 
@@ -2988,7 +2984,7 @@ class Dependency {
                 if (varName !== this.downstreamVariableNameIfNoVariables) {
                     for (let upstreamVarName of this.upstreamVariableNames) {
                         this.dependencyHandler.resetCircularCheckPassed(
-                            this.upstreamComponentName,
+                            this.upstreamComponentIdx,
                             upstreamVarName,
                         );
                     }
@@ -2998,14 +2994,14 @@ class Dependency {
 
         for (let upVarName of this.upstreamVariableNames) {
             if (
-                this.dependencyHandler._components[this.upstreamComponentName]
+                this.dependencyHandler._components[this.upstreamComponentIdx]
                     .state[upVarName].initiallyResolved
             ) {
                 await this.dependencyHandler.core.markStateVariableAndUpstreamDependentsStale(
                     {
                         component:
                             this.dependencyHandler.components[
-                                this.upstreamComponentName
+                                this.upstreamComponentIdx
                             ],
                         varName: upVarName,
                     },
@@ -3016,7 +3012,7 @@ class Dependency {
 
     async removeDownstreamComponent({ indexToRemove, recordChange = true }) {
         // console.log(`remove downstream ${indexToRemove}, ${this.downstreamComponentNames[indexToRemove]} dependency: ${this.dependencyName}`)
-        // console.log(this.upstreamComponentName, this.representativeStateVariable);
+        // console.log(this.upstreamComponentIdx, this.representativeStateVariable);
 
         // remove downstream component specified by indexToRemove from this dependency
 
@@ -3083,7 +3079,7 @@ class Dependency {
                     for (let upstreamVarName of this.upstreamVariableNames) {
                         // TODO: check why have to do this when remove a component from a dependency
                         this.dependencyHandler.resetCircularCheckPassed(
-                            this.upstreamComponentName,
+                            this.upstreamComponentIdx,
                             upstreamVarName,
                         );
                     }
@@ -3095,14 +3091,14 @@ class Dependency {
             for (let upVarName of this.upstreamVariableNames) {
                 if (
                     this.dependencyHandler._components[
-                        this.upstreamComponentName
+                        this.upstreamComponentIdx
                     ].state[upVarName].initiallyResolved
                 ) {
                     await this.dependencyHandler.core.markStateVariableAndUpstreamDependentsStale(
                         {
                             component:
                                 this.dependencyHandler.components[
-                                    this.upstreamComponentName
+                                    this.upstreamComponentIdx
                                 ],
                             varName: upVarName,
                         },
@@ -3151,14 +3147,14 @@ class Dependency {
 
         for (let upVarName of this.upstreamVariableNames) {
             if (
-                this.dependencyHandler._components[this.upstreamComponentName]
+                this.dependencyHandler._components[this.upstreamComponentIdx]
                     .state[upVarName].initiallyResolved
             ) {
                 await this.dependencyHandler.core.markStateVariableAndUpstreamDependentsStale(
                     {
                         component:
                             this.dependencyHandler.components[
-                                this.upstreamComponentName
+                                this.upstreamComponentIdx
                             ],
                         varName: upVarName,
                     },
@@ -3169,7 +3165,7 @@ class Dependency {
 
     deleteDependency() {
         // console.log(`deleting dependency: ${this.dependencyName}`)
-        // console.log(this.upstreamComponentName, this.representativeStateVariable);
+        // console.log(this.upstreamComponentIdx, this.representativeStateVariable);
 
         let affectedDownstreamVariableNamesByUpstreamComponent = [];
 
@@ -3241,7 +3237,7 @@ class Dependency {
 
                 for (let upVar of this.upstreamVariableNames) {
                     this.dependencyHandler.deleteFromNeededToResolve({
-                        componentNameBlocked: this.componentIdx,
+                        componentIdxBlocked: this.componentIdx,
                         typeBlocked: "stateVariable",
                         stateVariableBlocked: upVar,
                         blockerType: "stateVariable",
@@ -3253,7 +3249,7 @@ class Dependency {
                     for (let upstreamVarName of this.upstreamVariableNames) {
                         // TODO: check why have to do this when delete a dependency
                         this.dependencyHandler.resetCircularCheckPassed(
-                            this.upstreamComponentName,
+                            this.upstreamComponentIdx,
                             upstreamVarName,
                         );
                     }
@@ -3267,7 +3263,7 @@ class Dependency {
 
         let upCompDownDeps =
             this.dependencyHandler.downstreamDependencies[
-                this.upstreamComponentName
+                this.upstreamComponentIdx
             ];
 
         for (let varName of this.upstreamVariableNames) {
@@ -3471,20 +3467,20 @@ class Dependency {
     checkForCircular() {
         for (let varName of this.upstreamVariableNames) {
             this.dependencyHandler.resetCircularCheckPassed(
-                this.upstreamComponentName,
+                this.upstreamComponentIdx,
                 varName,
             );
         }
         for (let varName of this.upstreamVariableNames) {
             this.dependencyHandler.checkForCircularDependency({
-                componentIdx: this.upstreamComponentName,
+                componentIdx: this.upstreamComponentIdx,
                 varName,
             });
         }
     }
 
     async recalculateDownstreamComponents({ force = false } = {}) {
-        // console.log(`recalc down of ${this.dependencyName} of ${this.representativeStateVariable} of ${this.upstreamComponentName}`)
+        // console.log(`recalc down of ${this.dependencyName} of ${this.representativeStateVariable} of ${this.upstreamComponentIdx}`)
 
         let newDownComponents = await this.determineDownstreamComponents({
             force,
@@ -3528,7 +3524,7 @@ class Dependency {
                     }
                 } else {
                     await this.addDownstreamComponent({
-                        downstreamComponentName: downCompName,
+                        downstreamComponentIdx: downCompName,
                         downstreamComponentType:
                             newDownComponents.downstreamComponentTypes[ind],
                         index: ind,
@@ -3561,7 +3557,7 @@ class Dependency {
                     });
 
                     await this.addDownstreamComponent({
-                        downstreamComponentName: downCompName,
+                        downstreamComponentIdx: downCompName,
                         downstreamComponentType:
                             newDownComponents.downstreamComponentTypes[ind],
                         index: ind,
@@ -3582,12 +3578,12 @@ class StateVariableDependency extends Dependency {
             this.componentIdx = this.definition.componentIdx;
             this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentIdx = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentIdx;
         }
 
         if (this.definition.variableName === undefined) {
             throw Error(
-                `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}: variableName is not defined`,
+                `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}: variableName is not defined`,
             );
         }
         this.originalDownstreamVariableNames = [this.definition.variableName];
@@ -3629,20 +3625,20 @@ class StateVariableDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentIdx,
+                    blockerComponentIdx: this.componentIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -3689,12 +3685,12 @@ class MultipleStateVariablesDependency extends Dependency {
             this.componentIdx = this.definition.componentIdx;
             this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentIdx = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentIdx;
         }
 
         if (!Array.isArray(this.definition.variableNames)) {
             throw Error(
-                `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}: variableNames must be an array`,
+                `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}: variableNames must be an array`,
             );
         }
         this.originalDownstreamVariableNames = this.definition.variableNames;
@@ -3723,20 +3719,20 @@ class MultipleStateVariablesDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentIdx,
+                    blockerComponentIdx: this.componentIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -3941,12 +3937,12 @@ class RecursiveDependencyValuesDependency extends Dependency {
             this.componentIdx = this.definition.componentIdx;
             this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentIdx = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentIdx;
         }
 
         if (this.definition.variableNames === undefined) {
             throw Error(
-                `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}: variableNames is not defined`,
+                `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}: variableNames is not defined`,
             );
         }
 
@@ -3965,7 +3961,7 @@ class RecursiveDependencyValuesDependency extends Dependency {
     }
 
     async determineDownstreamComponents({ force = false } = {}) {
-        // console.log(`determine downstream of ${this.dependencyName}, ${this.representativeStateVariable}, ${this.upstreamComponentName}`)
+        // console.log(`determine downstream of ${this.dependencyName}, ${this.representativeStateVariable}, ${this.upstreamComponentIdx}`)
 
         this.missingComponents = [];
         this.originalDownstreamVariableNamesByComponent = [];
@@ -4063,20 +4059,20 @@ class RecursiveDependencyValuesDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: componentIdx,
+                    blockerComponentIdx: componentIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -4145,11 +4141,11 @@ class RecursiveDependencyValuesDependency extends Dependency {
                         } else {
                             for (let vName of this.upstreamVariableNames) {
                                 await this.dependencyHandler.addBlocker({
-                                    blockerComponentName: componentIdx,
+                                    blockerComponentIdx: componentIdx,
                                     blockerType: "stateVariable",
                                     blockerStateVariable: varName,
-                                    componentNameBlocked:
-                                        this.upstreamComponentName,
+                                    componentIdxBlocked:
+                                        this.upstreamComponentIdx,
                                     typeBlocked:
                                         "recalculateDownstreamComponents",
                                     stateVariableBlocked: vName,
@@ -4157,14 +4153,14 @@ class RecursiveDependencyValuesDependency extends Dependency {
                                 });
 
                                 await this.dependencyHandler.addBlocker({
-                                    blockerComponentName:
-                                        this.upstreamComponentName,
+                                    blockerComponentIdx:
+                                        this.upstreamComponentIdx,
                                     blockerType:
                                         "recalculateDownstreamComponents",
                                     blockerStateVariable: vName,
                                     blockerDependency: this.dependencyName,
-                                    componentNameBlocked:
-                                        this.upstreamComponentName,
+                                    componentIdxBlocked:
+                                        this.upstreamComponentIdx,
                                     typeBlocked: "stateVariable",
                                     stateVariableBlocked: vName,
                                 });
@@ -4306,7 +4302,7 @@ class ComponentIdentityDependency extends Dependency {
             this.componentIdx = this.definition.componentIdx;
             this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentIdx = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentIdx;
         }
 
         this.returnSingleComponent = true;
@@ -4333,20 +4329,20 @@ class ComponentIdentityDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentIdx,
+                    blockerComponentIdx: this.componentIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -4393,13 +4389,13 @@ class AttributeComponentDependency extends Dependency {
             this.parentIdx = this.definition.parentIdx;
             this.specifiedComponentName = this.parentIdx;
         } else {
-            this.parentIdx = this.upstreamComponentName;
+            this.parentIdx = this.upstreamComponentIdx;
         }
 
         if (this.definition.variableNames) {
             if (!Array.isArray(this.definition.variableNames)) {
                 throw Error(
-                    `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}: variableNames must be an array`,
+                    `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}: variableNames must be an array`,
                 );
             }
             this.originalDownstreamVariableNames =
@@ -4438,20 +4434,20 @@ class AttributeComponentDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.parentIdx,
+                    blockerComponentIdx: this.parentIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -4630,13 +4626,13 @@ class ChildDependency extends Dependency {
             this.parentIdx = this.definition.parentIdx;
             this.specifiedComponentName = this.parentIdx;
         } else {
-            this.parentIdx = this.upstreamComponentName;
+            this.parentIdx = this.upstreamComponentIdx;
         }
 
         if (this.definition.variableNames) {
             if (!Array.isArray(this.definition.variableNames)) {
                 throw Error(
-                    `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}: variableNames must be an array`,
+                    `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}: variableNames must be an array`,
                 );
             }
             this.originalDownstreamVariableNames =
@@ -4648,7 +4644,7 @@ class ChildDependency extends Dependency {
         this.childGroups = this.definition.childGroups;
         if (!Array.isArray(this.childGroups)) {
             throw Error(
-                `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}: childGroups must be an array`,
+                `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}: childGroups must be an array`,
             );
         }
 
@@ -4668,7 +4664,7 @@ class ChildDependency extends Dependency {
     }
 
     async determineDownstreamComponents() {
-        // console.log(`determine downstream components of ${this.dependencyName} of ${this.representativeStateVariable} of ${this.upstreamComponentName}`)
+        // console.log(`determine downstream components of ${this.dependencyName} of ${this.representativeStateVariable} of ${this.upstreamComponentIdx}`)
 
         if (this.downstreamPrimitives) {
             this.previousDownstreamPrimitives = [...this.downstreamPrimitives];
@@ -4698,20 +4694,20 @@ class ChildDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.parentIdx,
+                    blockerComponentIdx: this.parentIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -4743,7 +4739,7 @@ class ChildDependency extends Dependency {
         );
         if (activeChildrenIndices === undefined) {
             throw Error(
-                `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}: childGroups ${this.childGroups} does not exist.`,
+                `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}: childGroups ${this.childGroups} does not exist.`,
             );
         }
 
@@ -4803,21 +4799,21 @@ class ChildDependency extends Dependency {
                     // then recalculating the downstream components,
                     for (let varName of this.upstreamVariableNames) {
                         await this.dependencyHandler.addBlocker({
-                            blockerComponentName: this.parentIdx,
+                            blockerComponentIdx: this.parentIdx,
                             blockerType: "childMatches",
                             blockerStateVariable: varName, // add so that can have different blockers of child logic
-                            componentNameBlocked: this.upstreamComponentName,
+                            componentIdxBlocked: this.upstreamComponentIdx,
                             typeBlocked: "recalculateDownstreamComponents",
                             stateVariableBlocked: varName,
                             dependencyBlocked: this.dependencyName,
                         });
 
                         await this.dependencyHandler.addBlocker({
-                            blockerComponentName: this.upstreamComponentName,
+                            blockerComponentIdx: this.upstreamComponentIdx,
                             blockerType: "recalculateDownstreamComponents",
                             blockerStateVariable: varName,
                             blockerDependency: this.dependencyName,
-                            componentNameBlocked: this.upstreamComponentName,
+                            componentIdxBlocked: this.upstreamComponentIdx,
                             typeBlocked: "stateVariable",
                             stateVariableBlocked: varName,
                         });
@@ -4833,21 +4829,21 @@ class ChildDependency extends Dependency {
                 if (haveCompositesNotReady) {
                     for (let varName of this.upstreamVariableNames) {
                         await this.dependencyHandler.addBlocker({
-                            blockerComponentName: this.parentIdx,
+                            blockerComponentIdx: this.parentIdx,
                             blockerType: "childMatches",
                             blockerStateVariable: varName, // add so that can have different blockers of child logic
-                            componentNameBlocked: this.upstreamComponentName,
+                            componentIdxBlocked: this.upstreamComponentIdx,
                             typeBlocked: "recalculateDownstreamComponents",
                             stateVariableBlocked: varName,
                             dependencyBlocked: this.dependencyName,
                         });
 
                         await this.dependencyHandler.addBlocker({
-                            blockerComponentName: this.upstreamComponentName,
+                            blockerComponentIdx: this.upstreamComponentIdx,
                             blockerType: "recalculateDownstreamComponents",
                             blockerStateVariable: varName,
                             blockerDependency: this.dependencyName,
-                            componentNameBlocked: this.upstreamComponentName,
+                            componentIdxBlocked: this.upstreamComponentIdx,
                             typeBlocked: "stateVariable",
                             stateVariableBlocked: varName,
                         });
@@ -4912,12 +4908,11 @@ class ChildDependency extends Dependency {
                     for (let compositeNotReady of compositesToAddBlockers) {
                         for (let varName of this.upstreamVariableNames) {
                             await this.dependencyHandler.addBlocker({
-                                blockerComponentName: compositeNotReady,
+                                blockerComponentIdx: compositeNotReady,
                                 blockerType: "stateVariable",
                                 blockerStateVariable:
                                     "readyToExpandWhenResolved",
-                                componentNameBlocked:
-                                    this.upstreamComponentName,
+                                componentIdxBlocked: this.upstreamComponentIdx,
                                 typeBlocked: "childMatches",
                                 stateVariableBlocked: varName, // add to just block for this variable
                             });
@@ -5193,13 +5188,13 @@ class DescendantDependency extends Dependency {
             this.ancestorIdx = this.definition.ancestorIdx;
             this.specifiedComponentName = this.ancestorIdx;
         } else {
-            this.ancestorIdx = this.upstreamComponentName;
+            this.ancestorIdx = this.upstreamComponentIdx;
         }
 
         if (this.definition.variableNames) {
             if (!Array.isArray(this.definition.variableNames)) {
                 throw Error(
-                    `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}: variableNames must be an array`,
+                    `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}: variableNames must be an array`,
                 );
             }
             this.originalDownstreamVariableNames =
@@ -5239,7 +5234,7 @@ class DescendantDependency extends Dependency {
     }
 
     async determineDownstreamComponents() {
-        // console.log(`deterine downstream components of descendancy dependency ${this.dependencyName} of ${this.representativeStateVariable} of ${this.upstreamComponentName}`)
+        // console.log(`deterine downstream components of descendancy dependency ${this.dependencyName} of ${this.representativeStateVariable} of ${this.upstreamComponentIdx}`)
 
         let ancestor = this.dependencyHandler._components[this.ancestorIdx];
 
@@ -5261,20 +5256,20 @@ class DescendantDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.ancestorIdx,
+                    blockerComponentIdx: this.ancestorIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -5308,21 +5303,21 @@ class DescendantDependency extends Dependency {
         ) {
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
 
                 for (let parentIdx in result.unexpandedCompositesReadyByParentName) {
                     await this.dependencyHandler.addBlocker({
-                        blockerComponentName: parentIdx,
+                        blockerComponentIdx: parentIdx,
                         blockerType: "childMatches",
                         blockerStateVariable: varName,
-                        componentNameBlocked: this.upstreamComponentName,
+                        componentIdxBlocked: this.upstreamComponentIdx,
                         typeBlocked: "recalculateDownstreamComponents",
                         stateVariableBlocked: varName,
                         dependencyBlocked: this.dependencyName,
@@ -5331,10 +5326,10 @@ class DescendantDependency extends Dependency {
 
                 for (let parentIdx in result.unexpandedCompositesNotReadyByParentName) {
                     await this.dependencyHandler.addBlocker({
-                        blockerComponentName: parentIdx,
+                        blockerComponentIdx: parentIdx,
                         blockerType: "childMatches",
                         blockerStateVariable: varName,
-                        componentNameBlocked: this.upstreamComponentName,
+                        componentIdxBlocked: this.upstreamComponentIdx,
                         typeBlocked: "recalculateDownstreamComponents",
                         stateVariableBlocked: varName,
                         dependencyBlocked: this.dependencyName,
@@ -5348,10 +5343,10 @@ class DescendantDependency extends Dependency {
 
                     // for (let compositeNotReady of result.unexpandedCompositesNotReadyByParentName[parentIdx]) {
                     //   this.dependencyHandler.addBlocker({
-                    //     blockerComponentName: compositeNotReady,
+                    //     blockerComponentIdx: compositeNotReady,
                     //     blockerType: "stateVariable",
                     //     blockerStateVariable: "readyToExpandWhenResolved",
-                    //     componentNameBlocked: this.upstreamComponentName,
+                    //     componentIdxBlocked: this.upstreamComponentIdx,
                     //     typeBlocked: "childMatches",
                     //     stateVariableBlocked: varName,
                     //   });
@@ -5563,12 +5558,12 @@ class ParentDependency extends Dependency {
             this.childIdx = this.definition.childIdx;
             this.specifiedComponentName = this.childIdx;
         } else {
-            this.childIdx = this.upstreamComponentName;
+            this.childIdx = this.upstreamComponentIdx;
         }
 
         if (!this.definition.variableName) {
             throw Error(
-                `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}: must have a variableName`,
+                `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}: must have a variableName`,
             );
         } else {
             this.originalDownstreamVariableNames = [
@@ -5607,20 +5602,20 @@ class ParentDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.childIdx,
+                    blockerComponentIdx: this.childIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -5665,20 +5660,20 @@ class ParentDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.parentIdx,
+                    blockerComponentIdx: this.parentIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -5778,7 +5773,7 @@ class ParentIdentityDependency extends Dependency {
             this.childIdx = this.definition.childIdx;
             this.specifiedComponentName = this.childIdx;
         } else {
-            this.childIdx = this.upstreamComponentName;
+            this.childIdx = this.upstreamComponentIdx;
         }
 
         if (this.definition.parentComponentType) {
@@ -5807,20 +5802,20 @@ class ParentIdentityDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.childIdx,
+                    blockerComponentIdx: this.childIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -5865,20 +5860,20 @@ class ParentIdentityDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.parentIdx,
+                    blockerComponentIdx: this.parentIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -5978,13 +5973,13 @@ class AncestorDependency extends Dependency {
             this.descendantIdx = this.definition.descendantIdx;
             this.specifiedComponentName = this.descendantIdx;
         } else {
-            this.descendantIdx = this.upstreamComponentName;
+            this.descendantIdx = this.upstreamComponentIdx;
         }
 
         if (this.definition.variableNames) {
             if (!Array.isArray(this.definition.variableNames)) {
                 throw Error(
-                    `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}: variableNames must be an array`,
+                    `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}: variableNames must be an array`,
                 );
             }
             this.originalDownstreamVariableNames =
@@ -6021,20 +6016,20 @@ class AncestorDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.descendantIdx,
+                    blockerComponentIdx: this.descendantIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -6058,20 +6053,20 @@ class AncestorDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName:
+                    blockerComponentIdx:
                         this.dependencyHandler.core.documentName,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
@@ -6105,20 +6100,20 @@ class AncestorDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: ancestorResults.missingComponentName,
+                    blockerComponentIdx: ancestorResults.missingComponentName,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -6200,7 +6195,7 @@ class AncestorDependency extends Dependency {
 
         if (this.originalDownstreamVariableNames.length === 0) {
             console.warn(
-                `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}: must specify componentType or variableNames to find ancestor`,
+                `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}: must specify componentType or variableNames to find ancestor`,
             );
             return { ancestorsExamined };
         }
@@ -6300,13 +6295,13 @@ class ReplacementDependency extends Dependency {
             this.compositeIdx = this.definition.compositeIdx;
             this.specifiedComponentName = this.compositeIdx;
         } else {
-            this.compositeIdx = this.upstreamComponentName;
+            this.compositeIdx = this.upstreamComponentIdx;
         }
 
         if (this.definition.variableNames) {
             if (!Array.isArray(this.definition.variableNames)) {
                 throw Error(
-                    `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}: variableNames must be an array`,
+                    `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}: variableNames must be an array`,
                 );
             }
             this.originalDownstreamVariableNames =
@@ -6386,20 +6381,20 @@ class ReplacementDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.compositeIdx,
+                    blockerComponentIdx: this.compositeIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -6415,19 +6410,19 @@ class ReplacementDependency extends Dependency {
         if (!composite.isExpanded) {
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.compositeIdx,
+                    blockerComponentIdx: this.compositeIdx,
                     blockerType: "expandComposite",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
@@ -6436,10 +6431,10 @@ class ReplacementDependency extends Dependency {
 
             if (!composite.state.readyToExpandWhenResolved.isResolved) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.compositeIdx,
+                    blockerComponentIdx: this.compositeIdx,
                     blockerType: "stateVariable",
                     blockerStateVariable: "readyToExpandWhenResolved",
-                    componentNameBlocked: this.compositeIdx,
+                    componentIdxBlocked: this.compositeIdx,
                     typeBlocked: "expandComposite",
                 });
             }
@@ -6481,11 +6476,11 @@ class ReplacementDependency extends Dependency {
             ) {
                 for (let varName of this.upstreamVariableNames) {
                     await this.dependencyHandler.addBlocker({
-                        blockerComponentName: this.upstreamComponentName,
+                        blockerComponentIdx: this.upstreamComponentIdx,
                         blockerType: "recalculateDownstreamComponents",
                         blockerStateVariable: varName,
                         blockerDependency: this.dependencyName,
-                        componentNameBlocked: this.upstreamComponentName,
+                        componentIdxBlocked: this.upstreamComponentIdx,
                         typeBlocked: "stateVariable",
                         stateVariableBlocked: varName,
                     });
@@ -6495,9 +6490,9 @@ class ReplacementDependency extends Dependency {
                         ...result.unexpandedCompositesNotReady,
                     ]) {
                         await this.dependencyHandler.addBlocker({
-                            blockerComponentName: compositeIdx,
+                            blockerComponentIdx: compositeIdx,
                             blockerType: "expandComposite",
-                            componentNameBlocked: this.upstreamComponentName,
+                            componentIdxBlocked: this.upstreamComponentIdx,
                             typeBlocked: "recalculateDownstreamComponents",
                             stateVariableBlocked: varName,
                             dependencyBlocked: this.dependencyName,
@@ -6507,10 +6502,10 @@ class ReplacementDependency extends Dependency {
 
                 for (let compositeIdx of result.unexpandedCompositesNotReady) {
                     await this.dependencyHandler.addBlocker({
-                        blockerComponentName: compositeIdx,
+                        blockerComponentIdx: compositeIdx,
                         blockerType: "stateVariable",
                         blockerStateVariable: "readyToExpandWhenResolved",
-                        componentNameBlocked: compositeIdx,
+                        componentIdxBlocked: compositeIdx,
                         typeBlocked: "expandComposite",
                     });
                 }
@@ -6719,12 +6714,12 @@ class SourceCompositeStateVariableDependency extends Dependency {
             this.replacementName = this.definition.replacementName;
             this.specifiedComponentName = this.replacementName;
         } else {
-            this.replacementName = this.upstreamComponentName;
+            this.replacementName = this.upstreamComponentIdx;
         }
 
         if (!this.definition.variableName) {
             throw Error(
-                `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}: must have a variableName`,
+                `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}: must have a variableName`,
             );
         } else {
             this.originalDownstreamVariableNames = [
@@ -6767,20 +6762,20 @@ class SourceCompositeStateVariableDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.replacementName,
+                    blockerComponentIdx: this.replacementName,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -6858,7 +6853,7 @@ class SourceCompositeIdentityDependency extends Dependency {
             this.replacementName = this.definition.replacementName;
             this.specifiedComponentName = this.replacementName;
         } else {
-            this.replacementName = this.upstreamComponentName;
+            this.replacementName = this.upstreamComponentIdx;
         }
 
         this.returnSingleComponent = true;
@@ -6886,20 +6881,20 @@ class SourceCompositeIdentityDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.replacementName,
+                    blockerComponentIdx: this.replacementName,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -6956,13 +6951,13 @@ class ShadowSourceDependency extends Dependency {
             this.componentIdx = this.definition.componentIdx;
             this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentIdx = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentIdx;
         }
 
         if (this.definition.variableNames) {
             if (!Array.isArray(this.definition.variableNames)) {
                 throw Error(
-                    `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}: variableNames must be an array`,
+                    `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}: variableNames must be an array`,
                 );
             }
             this.originalDownstreamVariableNames =
@@ -7000,20 +6995,20 @@ class ShadowSourceDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentIdx,
+                    blockerComponentIdx: this.componentIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -7093,13 +7088,13 @@ class UnlinkedCopySourceDependency extends Dependency {
             this.componentIdx = this.definition.componentIdx;
             this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentIdx = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentIdx;
         }
 
         if (this.definition.variableNames) {
             if (!Array.isArray(this.definition.variableNames)) {
                 throw Error(
-                    `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}: variableNames must be an array`,
+                    `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}: variableNames must be an array`,
                 );
             }
             this.originalDownstreamVariableNames =
@@ -7137,20 +7132,20 @@ class UnlinkedCopySourceDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentIdx,
+                    blockerComponentIdx: this.componentIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -7217,13 +7212,13 @@ class PrimaryShadowDependency extends Dependency {
             this.componentIdx = this.definition.componentIdx;
             this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentIdx = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentIdx;
         }
 
         if (this.definition.variableNames) {
             if (!Array.isArray(this.definition.variableNames)) {
                 throw Error(
-                    `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}: variableNames must be an array`,
+                    `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}: variableNames must be an array`,
                 );
             }
             this.originalDownstreamVariableNames =
@@ -7261,20 +7256,20 @@ class PrimaryShadowDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentIdx,
+                    blockerComponentIdx: this.componentIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -7355,12 +7350,12 @@ class AdapterSourceStateVariableDependency extends Dependency {
             this.componentIdx = this.definition.componentIdx;
             this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentIdx = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentIdx;
         }
 
         if (!this.definition.variableName) {
             throw Error(
-                `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}: must have a variableName`,
+                `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}: must have a variableName`,
             );
         } else {
             this.originalDownstreamVariableNames = [
@@ -7397,20 +7392,20 @@ class AdapterSourceStateVariableDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentIdx,
+                    blockerComponentIdx: this.componentIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -7467,13 +7462,13 @@ class AdapterSourceDependency extends Dependency {
             this.componentIdx = this.definition.componentIdx;
             this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentIdx = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentIdx;
         }
 
         if (this.definition.variableNames) {
             if (!Array.isArray(this.definition.variableNames)) {
                 throw Error(
-                    `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}: variableNames must be an array`,
+                    `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}: variableNames must be an array`,
                 );
             }
             this.originalDownstreamVariableNames =
@@ -7511,20 +7506,20 @@ class AdapterSourceDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentIdx,
+                    blockerComponentIdx: this.componentIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -7581,7 +7576,7 @@ class CountAmongSiblingsDependency extends Dependency {
             this.componentIdx = this.definition.componentIdx;
             this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentIdx = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentIdx;
         }
         if (this.definition.componentType) {
             this.componentType = this.definition.componentType;
@@ -7615,20 +7610,20 @@ class CountAmongSiblingsDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentIdx,
+                    blockerComponentIdx: this.componentIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -7643,7 +7638,7 @@ class CountAmongSiblingsDependency extends Dependency {
 
         if (!component.parentIdx) {
             console.warn(
-                `component ${this.componentIdx} does not have a parent for state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}.`,
+                `component ${this.componentIdx} does not have a parent for state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}.`,
             );
             return {
                 success: true,
@@ -7675,20 +7670,20 @@ class CountAmongSiblingsDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.parentIdx,
+                    blockerComponentIdx: this.parentIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -7731,21 +7726,21 @@ class CountAmongSiblingsDependency extends Dependency {
                     // then recalculating the downstream components
                     for (let varName of this.upstreamVariableNames) {
                         await this.dependencyHandler.addBlocker({
-                            blockerComponentName: this.parentIdx,
+                            blockerComponentIdx: this.parentIdx,
                             blockerType: "childMatches",
                             blockerStateVariable: varName, // add so that can have different blockers of child logic
-                            componentNameBlocked: this.upstreamComponentName,
+                            componentIdxBlocked: this.upstreamComponentIdx,
                             typeBlocked: "recalculateDownstreamComponents",
                             stateVariableBlocked: varName,
                             dependencyBlocked: this.dependencyName,
                         });
 
                         await this.dependencyHandler.addBlocker({
-                            blockerComponentName: this.upstreamComponentName,
+                            blockerComponentIdx: this.upstreamComponentIdx,
                             blockerType: "recalculateDownstreamComponents",
                             blockerStateVariable: varName,
                             blockerDependency: this.dependencyName,
-                            componentNameBlocked: this.upstreamComponentName,
+                            componentIdxBlocked: this.upstreamComponentIdx,
                             typeBlocked: "stateVariable",
                             stateVariableBlocked: varName,
                         });
@@ -7761,21 +7756,21 @@ class CountAmongSiblingsDependency extends Dependency {
                 if (haveCompositesNotReady) {
                     for (let varName of this.upstreamVariableNames) {
                         await this.dependencyHandler.addBlocker({
-                            blockerComponentName: this.parentIdx,
+                            blockerComponentIdx: this.parentIdx,
                             blockerType: "childMatches",
                             blockerStateVariable: varName, // add so that can have different blockers of child logic
-                            componentNameBlocked: this.upstreamComponentName,
+                            componentIdxBlocked: this.upstreamComponentIdx,
                             typeBlocked: "recalculateDownstreamComponents",
                             stateVariableBlocked: varName,
                             dependencyBlocked: this.dependencyName,
                         });
 
                         await this.dependencyHandler.addBlocker({
-                            blockerComponentName: this.upstreamComponentName,
+                            blockerComponentIdx: this.upstreamComponentIdx,
                             blockerType: "recalculateDownstreamComponents",
                             blockerStateVariable: varName,
                             blockerDependency: this.dependencyName,
-                            componentNameBlocked: this.upstreamComponentName,
+                            componentIdxBlocked: this.upstreamComponentIdx,
                             typeBlocked: "stateVariable",
                             stateVariableBlocked: varName,
                         });
@@ -7787,12 +7782,11 @@ class CountAmongSiblingsDependency extends Dependency {
                     for (let compositeNotReady of parent.unexpandedCompositesNotReady) {
                         for (let varName of this.upstreamVariableNames) {
                             await this.dependencyHandler.addBlocker({
-                                blockerComponentName: compositeNotReady,
+                                blockerComponentIdx: compositeNotReady,
                                 blockerType: "stateVariable",
                                 blockerStateVariable:
                                     "readyToExpandWhenResolved",
-                                componentNameBlocked:
-                                    this.upstreamComponentName,
+                                componentIdxBlocked: this.upstreamComponentIdx,
                                 typeBlocked: "childMatches",
                                 stateVariableBlocked: varName, // add to just block for this variable
                             });
@@ -7863,7 +7857,7 @@ class CountAmongSiblingsDependency extends Dependency {
             childComponentType = this.componentType;
         } else if (this.sameType) {
             childComponentType =
-                this.dependencyHandler.components[this.upstreamComponentName]
+                this.dependencyHandler.components[this.upstreamComponentIdx]
                     .componentType;
         }
 
@@ -7890,7 +7884,7 @@ class CountAmongSiblingsDependency extends Dependency {
         let value =
             children
                 .map((x) => x.componentIdx)
-                .indexOf(this.upstreamComponentName) + 1;
+                .indexOf(this.upstreamComponentIdx) + 1;
 
         // if `initializeCounters` was passed into core with a key that matches the component type
         // then increment `value` so that the first instance would yield that initial counter.
@@ -7941,7 +7935,7 @@ class AttributeTargetComponentNamesDependency extends StateVariableDependency {
             this.componentIdx = this.definition.parentIdx;
             this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentIdx = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentIdx;
         }
     }
 
@@ -7982,7 +7976,7 @@ class TargetComponentDependency extends Dependency {
 
     setUpParameters() {
         let component =
-            this.dependencyHandler._components[this.upstreamComponentName];
+            this.dependencyHandler._components[this.upstreamComponentIdx];
 
         this.target = component.doenetAttributes.target;
 
@@ -7994,7 +7988,7 @@ class TargetComponentDependency extends Dependency {
         if (this.definition.variableNames) {
             if (!Array.isArray(this.definition.variableNames)) {
                 throw Error(
-                    `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}: variableNames must be an array`,
+                    `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}: variableNames must be an array`,
                 );
             }
             this.originalDownstreamVariableNames =
@@ -8035,20 +8029,20 @@ class TargetComponentDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.targetComponentName,
+                    blockerComponentIdx: this.targetComponentName,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -8123,7 +8117,7 @@ class DoenetAttributeDependency extends StateVariableDependency {
             this.componentIdx = this.definition.componentIdx;
             this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentIdx = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentIdx;
         }
     }
 
@@ -8165,7 +8159,7 @@ class AttributePrimitiveDependency extends StateVariableDependency {
             this.componentIdx = this.definition.parentIdx;
             this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentIdx = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentIdx;
         }
     }
 
@@ -8209,7 +8203,7 @@ class SerializedChildrenDependency extends Dependency {
             this.parentIdx = this.definition.parentIdx;
             this.specifiedComponentName = this.parentIdx;
         } else {
-            this.parentIdx = this.upstreamComponentName;
+            this.parentIdx = this.upstreamComponentIdx;
         }
     }
 
@@ -8234,20 +8228,20 @@ class SerializedChildrenDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.parentIdx,
+                    blockerComponentIdx: this.parentIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -8303,7 +8297,7 @@ class DoenetMLDependency extends Dependency {
             this.componentIdx = this.definition.componentIdx;
             this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentIdx = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentIdx;
         }
 
         this.displayOnlyChildren = this.definition.displayOnlyChildren;
@@ -8330,20 +8324,20 @@ class DoenetMLDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentIdx,
+                    blockerComponentIdx: this.componentIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -8402,7 +8396,7 @@ class DoenetMLRangeDependency extends Dependency {
             this.componentIdx = this.definition.componentIdx;
             this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentIdx = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentIdx;
         }
     }
 
@@ -8427,20 +8421,20 @@ class DoenetMLRangeDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentIdx,
+                    blockerComponentIdx: this.componentIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -8512,7 +8506,7 @@ class VariantsDependency extends Dependency {
             this.componentIdx = this.definition.componentIdx;
             this.specifiedComponentName = this.componentIdx;
         } else {
-            this.componentIdx = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentIdx;
         }
     }
 
@@ -8537,20 +8531,20 @@ class VariantsDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentIdx,
+                    blockerComponentIdx: this.componentIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -8604,7 +8598,7 @@ class CounterDependency extends Dependency {
     setUpParameters() {
         this.counterName = this.definition.counterName;
 
-        this.componentIdx = this.upstreamComponentName;
+        this.componentIdx = this.upstreamComponentIdx;
     }
 
     async determineDownstreamComponents() {
@@ -8657,12 +8651,12 @@ class DetermineDependenciesDependency extends Dependency {
         if (this.definition.componentIdx) {
             this.componentIdx = this.definition.componentIdx;
         } else {
-            this.componentIdx = this.upstreamComponentName;
+            this.componentIdx = this.upstreamComponentIdx;
         }
 
         if (this.definition.variableNames === undefined) {
             throw Error(
-                `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentName}, dependency ${this.dependencyName}: variableNames is not defined`,
+                `Invalid state variable ${this.representativeStateVariable} of ${this.upstreamComponentIdx}, dependency ${this.dependencyName}: variableNames is not defined`,
             );
         }
         this.originalDownstreamVariableNames = this.definition.variableNames;
@@ -8671,7 +8665,7 @@ class DetermineDependenciesDependency extends Dependency {
     }
 
     async determineDownstreamComponents() {
-        // console.log(`deterine downstream components of determine deps dependency ${this.dependencyName} of ${this.representativeStateVariable} of ${this.upstreamComponentName}`)
+        // console.log(`deterine downstream components of determine deps dependency ${this.dependencyName} of ${this.representativeStateVariable} of ${this.upstreamComponentIdx}`)
 
         let component = this.dependencyHandler._components[this.componentIdx];
 
@@ -8693,20 +8687,20 @@ class DetermineDependenciesDependency extends Dependency {
 
             for (let varName of this.upstreamVariableNames) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.componentIdx,
+                    blockerComponentIdx: this.componentIdx,
                     blockerType: "componentIdentity",
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "recalculateDownstreamComponents",
                     stateVariableBlocked: varName,
                     dependencyBlocked: this.dependencyName,
                 });
 
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "recalculateDownstreamComponents",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -8721,11 +8715,11 @@ class DetermineDependenciesDependency extends Dependency {
 
         for (let varName of this.upstreamVariableNames) {
             await this.dependencyHandler.addBlocker({
-                blockerComponentName: this.upstreamComponentName,
+                blockerComponentIdx: this.upstreamComponentIdx,
                 blockerType: "determineDependencies",
                 blockerStateVariable: varName,
                 blockerDependency: this.dependencyName,
-                componentNameBlocked: this.upstreamComponentName,
+                componentIdxBlocked: this.upstreamComponentIdx,
                 typeBlocked: "stateVariable",
                 stateVariableBlocked: varName,
             });
@@ -8756,7 +8750,7 @@ class DetermineDependenciesDependency extends Dependency {
 
     async markStale() {
         let component =
-            this.dependencyHandler._components[this.upstreamComponentName];
+            this.dependencyHandler._components[this.upstreamComponentIdx];
 
         for (let varName of this.upstreamVariableNames) {
             if (
@@ -8767,11 +8761,11 @@ class DetermineDependenciesDependency extends Dependency {
                 )
             ) {
                 await this.dependencyHandler.addBlocker({
-                    blockerComponentName: this.upstreamComponentName,
+                    blockerComponentIdx: this.upstreamComponentIdx,
                     blockerType: "determineDependencies",
                     blockerStateVariable: varName,
                     blockerDependency: this.dependencyName,
-                    componentNameBlocked: this.upstreamComponentName,
+                    componentIdxBlocked: this.upstreamComponentIdx,
                     typeBlocked: "stateVariable",
                     stateVariableBlocked: varName,
                 });
@@ -8779,20 +8773,20 @@ class DetermineDependenciesDependency extends Dependency {
                 // add a blocker to recalculating the downstream dependencies of all
                 // the dependencies of varName
                 for (let depName in this.dependencyHandler
-                    .downstreamDependencies[this.upstreamComponentName][
+                    .downstreamDependencies[this.upstreamComponentIdx][
                     varName
                 ]) {
                     let dep =
                         this.dependencyHandler.downstreamDependencies[
-                            this.upstreamComponentName
+                            this.upstreamComponentIdx
                         ][varName][depName];
                     if (dep.dependencyType !== "determineDependencies") {
                         await this.dependencyHandler.addBlocker({
-                            blockerComponentName: this.upstreamComponentName,
+                            blockerComponentIdx: this.upstreamComponentIdx,
                             blockerType: "determineDependencies",
                             blockerStateVariable: varName,
                             blockerDependency: this.dependencyName,
-                            componentNameBlocked: this.upstreamComponentName,
+                            componentIdxBlocked: this.upstreamComponentIdx,
                             typeBlocked: "recalculateDownstreamComponents",
                             stateVariableBlocked: varName,
                             dependencyBlocked: depName,

--- a/packages/doenetml-worker-javascript/src/components/Angle.js
+++ b/packages/doenetml-worker-javascript/src/components/Angle.js
@@ -100,7 +100,7 @@ export default class Angle extends GraphicalComponent {
 
                 if (dependencyValues.betweenLines !== null) {
                     betweenLinesName =
-                        dependencyValues.betweenLines.componentName;
+                        dependencyValues.betweenLines.componentIdx;
                 }
                 return { setValue: { betweenLinesName } };
             },
@@ -217,7 +217,7 @@ export default class Angle extends GraphicalComponent {
                 if (stateValues.betweenLinesName !== null) {
                     globalDependencies.lineChildren = {
                         dependencyType: "child",
-                        parentName: stateValues.betweenLinesName,
+                        parentIdx: stateValues.betweenLinesName,
                         childGroups: ["lines"],
                         variableNames: [
                             "points",

--- a/packages/doenetml-worker-javascript/src/components/AnimateFromSequence.js
+++ b/packages/doenetml-worker-javascript/src/components/AnimateFromSequence.js
@@ -428,8 +428,8 @@ export default class AnimateFromSequence extends BaseComponent {
 
                         dependencies.targets = {
                             dependencyType: "replacement",
-                            compositeName:
-                                stateValues.targetComponent.componentName,
+                            compositeIdx:
+                                stateValues.targetComponent.componentIdx,
                             recursive: true,
                             componentIndex: stateValues.componentIndex,
                             targetSubnames: stateValues.targetSubnames,
@@ -515,7 +515,7 @@ export default class AnimateFromSequence extends BaseComponent {
                             }
                             thisTarget = {
                                 dependencyType: "stateVariable",
-                                componentName: target.componentName,
+                                componentIdx: target.componentIdx,
                                 variableName: stateValues.propName,
                                 returnAsComponentObject: true,
                                 variablesOptional: true,
@@ -527,7 +527,7 @@ export default class AnimateFromSequence extends BaseComponent {
                         } else {
                             thisTarget = {
                                 dependencyType: "stateVariable",
-                                componentName: target.componentName,
+                                componentIdx: target.componentIdx,
                                 variableName: "value",
                                 returnAsComponentObject: true,
                                 variablesOptional: true,
@@ -630,7 +630,7 @@ export default class AnimateFromSequence extends BaseComponent {
                             newDirection = "decrease";
                             updateInstructions.push({
                                 updateType: "updateValue",
-                                componentName: this.componentName,
+                                componentIdx: this.componentIdx,
                                 stateVariable: "currentAnimationDirection",
                                 value: newDirection,
                             });
@@ -649,7 +649,7 @@ export default class AnimateFromSequence extends BaseComponent {
                             newDirection = "increase";
                             updateInstructions.push({
                                 updateType: "updateValue",
-                                componentName: this.componentName,
+                                componentIdx: this.componentIdx,
                                 stateVariable: "currentAnimationDirection",
                                 value: newDirection,
                             });
@@ -660,7 +660,7 @@ export default class AnimateFromSequence extends BaseComponent {
                 if (startIndex !== selectedIndex) {
                     updateInstructions.push({
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "selectedIndex",
                         value: startIndex,
                     });
@@ -682,7 +682,7 @@ export default class AnimateFromSequence extends BaseComponent {
                     event: {
                         verb: "played",
                         object: {
-                            componentName: this.componentName,
+                            componentIdx: this.componentIdx,
                             componentType: this.componentType,
                         },
                         context: {
@@ -694,7 +694,7 @@ export default class AnimateFromSequence extends BaseComponent {
                 });
 
                 await this.coreFunctions.triggerChainedActions({
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     actionId,
                     sourceInformation,
                     skipRendererUpdate,
@@ -704,7 +704,7 @@ export default class AnimateFromSequence extends BaseComponent {
                 await this.coreFunctions.requestAnimationFrame({
                     action: {
                         actionName: "advanceAnimation",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                     },
                     delay: await this.stateValues.animationInterval,
                     animationId: this.animationId,
@@ -717,7 +717,7 @@ export default class AnimateFromSequence extends BaseComponent {
                 await this.coreFunctions.cancelAnimationFrame(this.animationId);
                 this.canceledAnimationId = this.animationId;
                 await this.coreFunctions.triggerChainedActions({
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     actionId,
                     sourceInformation,
                     skipRendererUpdate,
@@ -726,7 +726,7 @@ export default class AnimateFromSequence extends BaseComponent {
                 this.coreFunctions.requestRecordEvent({
                     verb: "paused",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     context: {
@@ -868,7 +868,7 @@ export default class AnimateFromSequence extends BaseComponent {
         let updateInstructions = [
             {
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "selectedIndex",
                 value: newSelectedIndex,
             },
@@ -888,7 +888,7 @@ export default class AnimateFromSequence extends BaseComponent {
         if (!continueAnimation) {
             updateInstructions.push({
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "animationOn",
                 value: false,
             });
@@ -896,7 +896,7 @@ export default class AnimateFromSequence extends BaseComponent {
         if (newDirection) {
             updateInstructions.push({
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "currentAnimationDirection",
                 value: newDirection,
             });
@@ -914,7 +914,7 @@ export default class AnimateFromSequence extends BaseComponent {
             await this.coreFunctions.requestAnimationFrame({
                 action: {
                     actionName: "advanceAnimation",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                 },
                 delay: await this.stateValues.animationInterval,
                 animationId: this.animationId,
@@ -932,7 +932,7 @@ export default class AnimateFromSequence extends BaseComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "animationOn",
                     value: true,
                 },
@@ -952,7 +952,7 @@ export default class AnimateFromSequence extends BaseComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "animationOn",
                     value: false,
                 },
@@ -972,7 +972,7 @@ export default class AnimateFromSequence extends BaseComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "animationOn",
                     value: !(await this.stateValues.animationOn),
                 },
@@ -999,7 +999,7 @@ export default class AnimateFromSequence extends BaseComponent {
 
             updateInstructions.push({
                 updateType: "updateValue",
-                componentName: target.componentName,
+                componentIdx: target.componentIdx,
                 stateVariable,
                 value,
             });

--- a/packages/doenetml-worker-javascript/src/components/Answer.js
+++ b/packages/doenetml-worker-javascript/src/components/Answer.js
@@ -762,9 +762,9 @@ export default class Answer extends InlineComponent {
                 if (stateValues.allInputChildrenIncludingSugared.length > 0) {
                     dependencies.firstInputFromSugar = {
                         dependencyType: "doenetAttribute",
-                        componentName:
+                        componentIdx:
                             stateValues.allInputChildrenIncludingSugared[0]
-                                .componentName,
+                                .componentIdx,
                         attributeName: "createdFromSugar",
                     };
                 }
@@ -910,7 +910,7 @@ export default class Answer extends InlineComponent {
                     ) {
                         dependencies["child" + ind] = {
                             dependencyType: "descendant",
-                            ancestorName: child.componentName,
+                            ancestorIdx: child.componentIdx,
                             componentTypes: ["_base"],
                             variableNames: ["isResponse", "numValues"],
                             variablesOptional: true,
@@ -926,7 +926,7 @@ export default class Answer extends InlineComponent {
                     ) {
                         dependencies["childNValues" + ind] = {
                             dependencyType: "stateVariable",
-                            componentName: child.componentName,
+                            componentIdx: child.componentIdx,
                             variableName: "numValues",
                             variablesOptional: true,
                         };
@@ -934,7 +934,7 @@ export default class Answer extends InlineComponent {
                         // considerAsResponses
                         dependencies["child" + ind] = {
                             dependencyType: "stateVariable",
-                            componentName: child.componentName,
+                            componentIdx: child.componentIdx,
                             variableName: "childrenWithNValues",
                         };
                     }
@@ -1056,7 +1056,7 @@ export default class Answer extends InlineComponent {
                     ) {
                         globalDependencies["child" + ind] = {
                             dependencyType: "descendant",
-                            ancestorName: child.componentName,
+                            ancestorIdx: child.componentIdx,
                             componentTypes: ["_base"],
                             variableNames: [
                                 "isResponse",
@@ -1079,19 +1079,19 @@ export default class Answer extends InlineComponent {
                     ) {
                         globalDependencies["childValue" + ind] = {
                             dependencyType: "stateVariable",
-                            componentName: child.componentName,
+                            componentIdx: child.componentIdx,
                             variableName: "value",
                             variablesOptional: true,
                         };
                         globalDependencies["childValues" + ind] = {
                             dependencyType: "stateVariable",
-                            componentName: child.componentName,
+                            componentIdx: child.componentIdx,
                             variableName: "values",
                             variablesOptional: true,
                         };
                         globalDependencies["childComponentType" + ind] = {
                             dependencyType: "stateVariable",
-                            componentName: child.componentName,
+                            componentIdx: child.componentIdx,
                             variableName: "componentType",
                             variablesOptional: true,
                         };
@@ -1099,7 +1099,7 @@ export default class Answer extends InlineComponent {
                         // considerAsResponses
                         globalDependencies["child" + ind] = {
                             dependencyType: "stateVariable",
-                            componentName: child.componentName,
+                            componentIdx: child.componentIdx,
                             variableName: "childrenAsResponses",
                         };
                     }
@@ -1520,7 +1520,7 @@ export default class Answer extends InlineComponent {
                         if (inputCredit >= 0) {
                             creditAchieved = inputCredit;
                             inputUsed =
-                                dependencyValues.inputChildren[0].componentName;
+                                dependencyValues.inputChildren[0].componentIdx;
                         }
                     }
                 } else {
@@ -1542,7 +1542,7 @@ export default class Answer extends InlineComponent {
                                 child.stateValues.fractionSatisfiedIfSubmit > 0
                             ) {
                                 if (awardsUsed[0] === null) {
-                                    awardsUsed[0] = child.componentName;
+                                    awardsUsed[0] = child.componentIdx;
                                     awardCredits[0] = creditFromChild;
                                     minimumFromAwardCredits = Math.min(
                                         ...awardCredits,
@@ -1559,7 +1559,7 @@ export default class Answer extends InlineComponent {
                                             awardsUsed.splice(
                                                 ind,
                                                 0,
-                                                child.componentName,
+                                                child.componentIdx,
                                             );
                                             awardsUsed = awardsUsed.slice(0, n);
                                             awardCredits.splice(
@@ -1702,7 +1702,7 @@ export default class Answer extends InlineComponent {
                     includeOnlyEssentialValues: true,
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 // Use stringify from json-stringify-deterministic
                 // so that the string will be the same
                 // even if the object was built in a different order
@@ -1712,7 +1712,7 @@ export default class Answer extends InlineComponent {
 
                 let selfDependencies =
                     dependencyValues.currentCreditAchievedDependencies.find(
-                        (x) => x.componentName === componentName,
+                        (x) => x.componentIdx === componentIdx,
                     );
 
                 if (selfDependencies) {
@@ -1800,7 +1800,7 @@ export default class Answer extends InlineComponent {
             definition: function ({
                 dependencyValues,
                 justUpdatedForNewComponent,
-                componentName,
+                componentIdx,
             }) {
                 if (
                     dependencyValues.disableAfterCorrect &&
@@ -1826,7 +1826,7 @@ export default class Answer extends InlineComponent {
                     };
                 }
             },
-            inverseDefinition({ desiredStateVariableValues, componentName }) {
+            inverseDefinition({ desiredStateVariableValues, componentIdx }) {
                 return {
                     success: true,
                     instructions: [
@@ -2070,12 +2070,12 @@ export default class Answer extends InlineComponent {
                     variableNames: ["componentNumberByAnswerName"],
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 return {
                     setValue: {
                         inComponentNumber:
                             dependencyValues.documentAncestor.stateValues
-                                .componentNumberByAnswerName[componentName],
+                                .componentNumberByAnswerName[componentIdx],
                     },
                 };
             },
@@ -2110,13 +2110,13 @@ export default class Answer extends InlineComponent {
         let instructions = [
             {
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "creditAchieved",
                 value: creditAchieved,
             },
             {
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "responseHasBeenSubmitted",
                 value: true,
             },
@@ -2132,13 +2132,13 @@ export default class Answer extends InlineComponent {
             let inputChild = inputChildrenWithValues[0];
 
             if (
-                inputUsed === inputChild.componentName &&
+                inputUsed === inputChild.componentIdx &&
                 "valueToRecordOnSubmit" in inputChild.stateValues &&
                 "valueRecordedAtSubmit" in inputChild.stateValues
             ) {
                 instructions.push({
                     updateType: "updateValue",
-                    componentName: inputChild.componentName,
+                    componentIdx: inputChild.componentIdx,
                     stateVariable: "valueRecordedAtSubmit",
                     value: inputChild.stateValues.valueToRecordOnSubmit,
                 });
@@ -2151,14 +2151,14 @@ export default class Answer extends InlineComponent {
 
         instructions.push({
             updateType: "updateValue",
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             stateVariable: "submittedResponses",
             value: currentResponses,
         });
 
         instructions.push({
             updateType: "updateValue",
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             stateVariable: "submittedResponsesComponentType",
             value: this.state.currentResponses.shadowingInstructions
                 .createComponentOfType,
@@ -2166,42 +2166,42 @@ export default class Answer extends InlineComponent {
 
         instructions.push({
             updateType: "updateValue",
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             stateVariable: "justSubmitted",
             value: true,
         });
 
         instructions.push({
             updateType: "updateValue",
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             stateVariable: "creditAchievedDependenciesAtSubmit",
             value: await this.stateValues.creditAchievedDependencies,
         });
 
         instructions.push({
             updateType: "updateValue",
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             stateVariable: "numSubmissions",
             value: (await this.stateValues.numSubmissions) + 1,
         });
 
         for (let child of await this.stateValues.awardChildren) {
-            let awarded = awardsUsed.includes(child.componentName);
+            let awarded = awardsUsed.includes(child.componentIdx);
             instructions.push({
                 updateType: "updateValue",
-                componentName: child.componentName,
+                componentIdx: child.componentIdx,
                 stateVariable: "awarded",
                 value: awarded,
             });
             instructions.push({
                 updateType: "updateValue",
-                componentName: child.componentName,
+                componentIdx: child.componentIdx,
                 stateVariable: "creditAchieved",
                 value: child.stateValues.creditAchievedIfSubmit,
             });
             instructions.push({
                 updateType: "updateValue",
-                componentName: child.componentName,
+                componentIdx: child.componentIdx,
                 stateVariable: "fractionSatisfied",
                 value: child.stateValues.fractionSatisfiedIfSubmit,
             });
@@ -2223,7 +2223,7 @@ export default class Answer extends InlineComponent {
         instructions.push({
             updateType: "recordItemSubmission",
             componentNumber: await this.stateValues.inComponentNumber,
-            submittedComponent: this.componentName,
+            submittedComponent: this.componentIdx,
             response: currentResponses,
             responseText,
             creditAchieved,
@@ -2240,7 +2240,7 @@ export default class Answer extends InlineComponent {
             event: {
                 verb: "submitted",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                     answerNumber: this.answerNumber,
                 },
@@ -2256,7 +2256,7 @@ export default class Answer extends InlineComponent {
         });
 
         return await this.coreFunctions.triggerChainedActions({
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             actionId,
             sourceInformation,
             skipRendererUpdate,

--- a/packages/doenetml-worker-javascript/src/components/AttractToAngles.js
+++ b/packages/doenetml-worker-javascript/src/components/AttractToAngles.js
@@ -25,7 +25,7 @@ export default class AttractToAngles extends ConstraintComponent {
             for (let child of activeChildrenMatched) {
                 anglesChildren.push({
                     createdComponent: true,
-                    componentName: child.componentName,
+                    componentIdx: child.componentIdx,
                 });
             }
             return {
@@ -109,7 +109,7 @@ export default class AttractToAngles extends ConstraintComponent {
         }
 
         let trackChanges = this.currentTracker.trackChanges;
-        let childrenChanged = trackChanges.childrenChanged(this.componentName);
+        let childrenChanged = trackChanges.childrenChanged(this.componentIdx);
 
         if (childrenChanged) {
             let anglesInd = this.childLogic.returnMatches("AtMostOneAngles");

--- a/packages/doenetml-worker-javascript/src/components/Award.js
+++ b/packages/doenetml-worker-javascript/src/components/Award.js
@@ -158,7 +158,7 @@ export default class Award extends BaseComponent {
     static preprocessSerializedChildren({
         serializedChildren,
         attributes,
-        componentName,
+        componentIdx,
     }) {
         if (attributes.sourcesAreResponses) {
             let targetNames = attributes.sourcesAreResponses.primitive
@@ -166,9 +166,9 @@ export default class Award extends BaseComponent {
                 .filter((s) => s);
             let nameSpace;
             if (attributes.newNamespace?.primitive) {
-                nameSpace = componentName + "/";
+                nameSpace = componentIdx + "/";
             } else {
-                nameSpace = getNamespaceFromName(componentName);
+                nameSpace = getNamespaceFromName(componentIdx);
             }
             for (let target of targetNames) {
                 let absoluteTarget;

--- a/packages/doenetml-worker-javascript/src/components/BezierControls.js
+++ b/packages/doenetml-worker-javascript/src/components/BezierControls.js
@@ -190,9 +190,9 @@ export default class BezierControls extends InlineComponent {
                 desiredStateVariableValues,
                 dependencyNamesByKey,
                 dependencyValuesByKey,
-                // componentName
+                // componentIdx
             }) {
-                // console.log(`inverse definition of directions for beziercontrols of ${componentName}`)
+                // console.log(`inverse definition of directions for beziercontrols of ${componentIdx}`)
                 // console.log(JSON.parse(JSON.stringify(desiredStateVariableValues)));
                 // console.log(JSON.parse(JSON.stringify(dependencyNamesByKey)));
                 // console.log(JSON.parse(JSON.stringify(dependencyValuesByKey)));
@@ -292,9 +292,9 @@ export default class BezierControls extends InlineComponent {
                 desiredStateVariableValues,
                 dependencyNamesByKey,
                 dependencyValuesByKey,
-                // componentName
+                // componentIdx
             }) {
-                // console.log(`inverse definition of hiddenControls for beziercontrols of ${componentName}`)
+                // console.log(`inverse definition of hiddenControls for beziercontrols of ${componentIdx}`)
                 // console.log(JSON.parse(JSON.stringify(desiredStateVariableValues)));
                 // console.log(JSON.parse(JSON.stringify(dependencyNamesByKey)));
                 // console.log(JSON.parse(JSON.stringify(dependencyValuesByKey)));
@@ -527,9 +527,9 @@ export default class BezierControls extends InlineComponent {
             arrayDefinitionByKey({
                 dependencyValuesByKey,
                 arrayKeys,
-                componentName,
+                componentIdx,
             }) {
-                // console.log(`definition of controls for beziercontrols of ${componentName}`)
+                // console.log(`definition of controls for beziercontrols of ${componentIdx}`)
                 // console.log(JSON.parse(JSON.stringify(dependencyValuesByKey)));
                 // console.log(JSON.parse(JSON.stringify(arrayKeys)))
 

--- a/packages/doenetml-worker-javascript/src/components/BlockQuote.js
+++ b/packages/doenetml-worker-javascript/src/components/BlockQuote.js
@@ -25,7 +25,7 @@ export default class BlockQuote extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/BooleanInput.js
+++ b/packages/doenetml-worker-javascript/src/components/BooleanInput.js
@@ -28,7 +28,7 @@ export default class BooleanInput extends Input {
                 let answerAncestor = await this.stateValues.answerAncestor;
                 if (answerAncestor !== null) {
                     return {
-                        componentName: answerAncestor.componentName,
+                        componentIdx: answerAncestor.componentIdx,
                         actionName: "submitAnswer",
                     };
                 } else {
@@ -268,7 +268,7 @@ export default class BooleanInput extends Input {
             let updateInstructions = [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "value",
                     value: boolean,
                 },
@@ -277,7 +277,7 @@ export default class BooleanInput extends Input {
             let event = {
                 verb: "selected",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
                 result: {
@@ -289,7 +289,7 @@ export default class BooleanInput extends Input {
             let answerAncestor = await this.stateValues.answerAncestor;
             if (answerAncestor) {
                 event.context = {
-                    answerAncestor: answerAncestor.componentName,
+                    answerAncestor: answerAncestor.componentIdx,
                 };
             }
 
@@ -302,7 +302,7 @@ export default class BooleanInput extends Input {
             });
 
             return await this.coreFunctions.triggerChainedActions({
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,
@@ -327,7 +327,7 @@ export default class BooleanInput extends Input {
             actionId,
             sourceInformation,
             skipRendererUpdate,
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             componentType: this.componentType,
             coreFunctions: this.coreFunctions,
         });

--- a/packages/doenetml-worker-javascript/src/components/BooleanList.js
+++ b/packages/doenetml-worker-javascript/src/components/BooleanList.js
@@ -131,7 +131,7 @@ export default class BooleanList extends CompositeComponent {
 
                 if (dependencyValues.booleanChildren.length > 0) {
                     childNameByComponent = dependencyValues.booleanChildren.map(
-                        (x) => x.componentName,
+                        (x) => x.componentIdx,
                     );
                     numComponents = dependencyValues.booleanChildren.length;
                 } else if (dependencyValues.booleansShadow !== null) {
@@ -338,20 +338,20 @@ export default class BooleanList extends CompositeComponent {
 
         let numComponents = await component.stateValues.numComponents;
         for (let i = 0; i < numComponents; i++) {
-            let childName = childNameByComponent[i];
-            let replacementSource = components[childName];
+            let childIdx = childNameByComponent[i];
+            let replacementSource = components[childIdx];
 
             if (replacementSource) {
-                componentsCopied.push(replacementSource.componentName);
+                componentsCopied.push(replacementSource.componentIdx);
             }
             replacements.push({
                 componentType: "boolean",
                 attributes: JSON.parse(JSON.stringify(attributesFromComposite)),
                 downstreamDependencies: {
-                    [component.componentName]: [
+                    [component.componentIdx]: [
                         {
                             dependencyType: "referenceShadow",
-                            compositeName: component.componentName,
+                            compositeIdx: component.componentIdx,
                             propVariable: `boolean${i + 1}`,
                         },
                     ],
@@ -362,7 +362,7 @@ export default class BooleanList extends CompositeComponent {
         workspace.uniqueIdentifiersUsed = [];
         replacements = postProcessCopy({
             serializedComponents: replacements,
-            componentName: component.componentName,
+            componentIdx: component.componentIdx,
             uniqueIdentifiersUsed: workspace.uniqueIdentifiersUsed,
             addShadowDependencies: true,
             markAsPrimaryShadow: true,
@@ -371,7 +371,7 @@ export default class BooleanList extends CompositeComponent {
         let processResult = processAssignNames({
             assignNames: component.doenetAttributes.assignNames,
             serializedComponents: replacements,
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             parentCreatesNewNamespace: newNamespace,
             componentInfoObjects,
         });
@@ -406,11 +406,11 @@ export default class BooleanList extends CompositeComponent {
             let childNameByComponent =
                 await component.stateValues.childNameByComponent;
 
-            for (let childName of childNameByComponent) {
-                let replacementSource = components[childName];
+            for (let childIdx of childNameByComponent) {
+                let replacementSource = components[childIdx];
 
                 if (replacementSource) {
-                    componentsToCopy.push(replacementSource.componentName);
+                    componentsToCopy.push(replacementSource.componentIdx);
                 }
             }
 

--- a/packages/doenetml-worker-javascript/src/components/CallAction.js
+++ b/packages/doenetml-worker-javascript/src/components/CallAction.js
@@ -171,7 +171,7 @@ export default class CallAction extends InlineComponent {
             definition({ dependencyValues }) {
                 let targetName = null;
                 if (dependencyValues.targetComponent) {
-                    targetName = dependencyValues.targetComponent.componentName;
+                    targetName = dependencyValues.targetComponent.componentIdx;
                 }
                 return { setValue: { targetName } };
             },
@@ -206,13 +206,13 @@ export default class CallAction extends InlineComponent {
             }
 
             await this.coreFunctions.performAction({
-                componentName: targetName,
+                componentIdx: targetName,
                 actionName,
                 args,
                 event: {
                     verb: "selected",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                 },
@@ -220,7 +220,7 @@ export default class CallAction extends InlineComponent {
             });
 
             await this.coreFunctions.triggerChainedActions({
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,
@@ -261,7 +261,7 @@ export default class CallAction extends InlineComponent {
             actionId,
             sourceInformation,
             skipRendererUpdate,
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             componentType: this.componentType,
             coreFunctions: this.coreFunctions,
         });

--- a/packages/doenetml-worker-javascript/src/components/Caption.js
+++ b/packages/doenetml-worker-javascript/src/components/Caption.js
@@ -60,7 +60,7 @@ export default class Caption extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/Choice.js
+++ b/packages/doenetml-worker-javascript/src/components/Choice.js
@@ -132,7 +132,7 @@ export default class Choice extends InlineComponent {
                     variableNames: ["selected"],
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 let selected;
                 if (dependencyValues.childIndicesSelected) {
                     selected = dependencyValues.childIndicesSelected.includes(

--- a/packages/doenetml-worker-javascript/src/components/ChoiceInput.js
+++ b/packages/doenetml-worker-javascript/src/components/ChoiceInput.js
@@ -24,7 +24,7 @@ export default class Choiceinput extends Input {
                 let answerAncestor = await this.stateValues.answerAncestor;
                 if (answerAncestor !== null) {
                     return {
-                        componentName: answerAncestor.componentName,
+                        componentIdx: answerAncestor.componentIdx,
                         actionName: "submitAnswer",
                     };
                 } else {
@@ -314,10 +314,10 @@ export default class Choiceinput extends Input {
                     ignoreReplacementsOfEncounteredComposites: true,
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 let generatedVariantInfo = {
                     seed: dependencyValues.variantSeed,
-                    meta: { createdBy: componentName },
+                    meta: { createdBy: componentIdx },
                 };
 
                 if (dependencyValues.shuffleOrder) {
@@ -1426,7 +1426,7 @@ export default class Choiceinput extends Input {
         //     } else {
         //       return {
         //         setValue: {
-        //           childrenToRender: dependencyValues.choiceChildrenOrdered.map(x => x.componentName)
+        //           childrenToRender: dependencyValues.choiceChildrenOrdered.map(x => x.componentIdx)
         //         }
         //       }
         //     }
@@ -1452,7 +1452,7 @@ export default class Choiceinput extends Input {
             let updateInstructions = [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "allSelectedIndices",
                     value: effectiveSelectedIndices,
                 },
@@ -1462,7 +1462,7 @@ export default class Choiceinput extends Input {
             let event = {
                 verb: "selected",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
                 result: {
@@ -1476,7 +1476,7 @@ export default class Choiceinput extends Input {
             let answerAncestor = await this.stateValues.answerAncestor;
             if (answerAncestor) {
                 event.context = {
-                    answerAncestor: answerAncestor.componentName,
+                    answerAncestor: answerAncestor.componentIdx,
                 };
             }
 
@@ -1489,7 +1489,7 @@ export default class Choiceinput extends Input {
             });
 
             return await this.coreFunctions.triggerChainedActions({
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,

--- a/packages/doenetml-worker-javascript/src/components/Circle.js
+++ b/packages/doenetml-worker-javascript/src/components/Circle.js
@@ -2949,7 +2949,7 @@ export default class Circle extends Curve {
         if (numThroughPoints <= 1 || numericalPrescribedCenter.length > 0) {
             instructions.push({
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "numericalCenter",
                 value: center,
             });
@@ -2983,7 +2983,7 @@ export default class Circle extends Curve {
 
             instructions.push({
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "numericalThroughPoints",
                 value: numericalThroughPoints,
             });
@@ -3008,7 +3008,7 @@ export default class Circle extends Curve {
                 event: {
                     verb: "interacted",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: {
@@ -3054,7 +3054,7 @@ export default class Circle extends Curve {
                 let newInstructions = [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "numericalThroughPoints",
                         value: newNumericalThroughPoints,
                     },
@@ -3078,7 +3078,7 @@ export default class Circle extends Curve {
                 let newInstructions = [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "numericalCenter",
                         value: newCenter,
                     },
@@ -3171,7 +3171,7 @@ export default class Circle extends Curve {
                     let newInstructions = [
                         {
                             updateType: "updateValue",
-                            componentName: this.componentName,
+                            componentIdx: this.componentIdx,
                             stateVariable: "numericalThroughPoints",
                             value: newNumericalThroughPoints,
                         },
@@ -3205,7 +3205,7 @@ export default class Circle extends Curve {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "click",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,
@@ -3222,7 +3222,7 @@ export default class Circle extends Curve {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "focus",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,

--- a/packages/doenetml-worker-javascript/src/components/CodeEditor.js
+++ b/packages/doenetml-worker-javascript/src/components/CodeEditor.js
@@ -412,13 +412,13 @@ export default class CodeEditor extends BlockComponent {
             let updateInstructions = [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "immediateValue",
                     value: text,
                 },
                 {
                     updateType: "setComponentNeedingUpdateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                 },
             ];
 
@@ -444,7 +444,7 @@ export default class CodeEditor extends BlockComponent {
                 let updateInstructions = [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "value",
                         value: immediateValue,
                     },
@@ -458,7 +458,7 @@ export default class CodeEditor extends BlockComponent {
                     },
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "immediateValue",
                         valueOfStateVariable: "value",
                     },
@@ -470,7 +470,7 @@ export default class CodeEditor extends BlockComponent {
                 let event = {
                     verb: "answered",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: {
@@ -482,7 +482,7 @@ export default class CodeEditor extends BlockComponent {
                 let answerAncestor = await this.stateValues.answerAncestor;
                 if (answerAncestor) {
                     event.context = {
-                        answerAncestor: answerAncestor.componentName,
+                        answerAncestor: answerAncestor.componentIdx,
                     };
                 }
 
@@ -494,7 +494,7 @@ export default class CodeEditor extends BlockComponent {
                     event,
                 });
                 await this.coreFunctions.triggerChainedActions({
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     actionId,
                     sourceInformation,
                     skipRendererUpdate,
@@ -507,7 +507,7 @@ export default class CodeEditor extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/CodeViewer.js
+++ b/packages/doenetml-worker-javascript/src/components/CodeViewer.js
@@ -217,7 +217,7 @@ export default class CodeViewer extends BlockComponent {
                     return {
                         setValue: {
                             codeSource:
-                                dependencyValues.codeEditorParent.componentName,
+                                dependencyValues.codeEditorParent.componentIdx,
                         },
                     };
                 } else {
@@ -231,7 +231,7 @@ export default class CodeViewer extends BlockComponent {
             returnDependencies: ({ stateValues }) => ({
                 doenetML: {
                     dependencyType: "stateVariable",
-                    componentName: stateValues.codeSource,
+                    componentIdx: stateValues.codeSource,
                     variableName: "text",
                     variablesOptional: true,
                 },
@@ -347,13 +347,13 @@ export default class CodeViewer extends BlockComponent {
         let updateInstructions = [
             {
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "doenetML",
                 value: await this.stateValues.doenetMLFromSource,
             },
             {
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "codeChanged",
                 value: false,
             },
@@ -376,7 +376,7 @@ export default class CodeViewer extends BlockComponent {
         let updateInstructions = [
             {
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "errorsAndWarnings",
                 value: errorsAndWarnings,
             },
@@ -394,7 +394,7 @@ export default class CodeViewer extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/Collect.js
+++ b/packages/doenetml-worker-javascript/src/components/Collect.js
@@ -108,8 +108,8 @@ export default class Collect extends CompositeComponent {
                     return {
                         targetIsInactiveCompositeReplacement: {
                             dependencyType: "stateVariable",
-                            componentName:
-                                stateValues.targetComponent.componentName,
+                            componentIdx:
+                                stateValues.targetComponent.componentIdx,
                             variableName: "isInactiveCompositeReplacement",
                         },
                     };
@@ -149,7 +149,7 @@ export default class Collect extends CompositeComponent {
                 return {
                     setValue: {
                         targetName:
-                            dependencyValues.targetComponent.componentName,
+                            dependencyValues.targetComponent.componentIdx,
                     },
                 };
             },
@@ -239,7 +239,7 @@ export default class Collect extends CompositeComponent {
 
                 let descendants = {
                     dependencyType: "descendant",
-                    ancestorName: stateValues.targetName,
+                    ancestorIdx: stateValues.targetName,
                     componentTypes: stateValues.componentTypesToCollect,
                     useReplacementsForComposites: true,
                     includeNonActiveChildren: true,
@@ -276,7 +276,7 @@ export default class Collect extends CompositeComponent {
                 };
             },
             definition: function ({ dependencyValues }) {
-                // console.log(`definition of collectedComponents for ${componentName}`)
+                // console.log(`definition of collectedComponents for ${componentIdx}`)
                 // console.log(dependencyValues)
 
                 let collectedComponents = dependencyValues.descendants;
@@ -366,7 +366,7 @@ export default class Collect extends CompositeComponent {
         numComponentsForSource,
         publicCaseInsensitiveAliasSubstitutions,
     }) {
-        // console.log(`create serialized replacements for ${component.componentName}`)
+        // console.log(`create serialized replacements for ${component.componentIdx}`)
         // console.log(await component.stateValues.collectedComponents)
 
         let errors = [];
@@ -424,7 +424,7 @@ export default class Collect extends CompositeComponent {
                 numReplacementsSoFar += collectedReplacements.length;
                 replacements.push(...collectedReplacements);
                 replacementNamesByCollected[collectedNum] =
-                    collectedReplacements.map((x) => x.componentName);
+                    collectedReplacements.map((x) => x.componentIdx);
             } else {
                 numReplacementsByCollected[collectedNum] = 0;
                 replacementNamesByCollected[collectedNum] = [];
@@ -434,7 +434,7 @@ export default class Collect extends CompositeComponent {
 
         workspace.numReplacementsByCollected = numReplacementsByCollected;
         workspace.collectedNames = collectedComponents.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         workspace.replacementNamesByCollected = replacementNamesByCollected;
         return { replacements, errors, warnings };
@@ -459,7 +459,7 @@ export default class Collect extends CompositeComponent {
         let collectedObj = (await component.stateValues.collectedComponents)[
             collectedNum
         ];
-        let collectedName = collectedObj.componentName;
+        let collectedName = collectedObj.componentIdx;
         let collectedComponent = components[collectedName];
 
         let serializedReplacements = [];
@@ -514,7 +514,7 @@ export default class Collect extends CompositeComponent {
 
             serializedReplacements = postProcessCopy({
                 serializedComponents: serializedCopy,
-                componentName: component.componentName,
+                componentIdx: component.componentIdx,
                 uniqueIdentifiersUsed,
                 identifierPrefix: collectedNum + "|",
             });
@@ -540,7 +540,7 @@ export default class Collect extends CompositeComponent {
         let processResult = processAssignNames({
             assignNames: component.doenetAttributes.assignNames,
             serializedComponents: serializedReplacements,
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             indOffset: numReplacementsSoFar,
             parentCreatesNewNamespace: newNamespace,
             componentInfoObjects,
@@ -567,10 +567,10 @@ export default class Collect extends CompositeComponent {
         numComponentsForSource,
         publicCaseInsensitiveAliasSubstitutions,
     }) {
-        // console.log("Calculating replacement changes for " + component.componentName);
-        // console.log((await component.stateValues.collectedComponents).map(x => x.componentName))
+        // console.log("Calculating replacement changes for " + component.componentIdx);
+        // console.log((await component.stateValues.collectedComponents).map(x => x.componentIdx))
         // console.log(deepClone(workspace));
-        // console.log(component.replacements.map(x => x.componentName))
+        // console.log(component.replacements.map(x => x.componentIdx))
 
         // TODO: don't yet have a way to return errors and warnings!
         let errors = [];
@@ -591,7 +591,7 @@ export default class Collect extends CompositeComponent {
                 if (
                     !component.replacements[numReplacementsFoundSoFar] ||
                     component.replacements[numReplacementsFoundSoFar]
-                        .componentName !== repName
+                        .componentIdx !== repName
                 ) {
                     indsDeleted.push(ind);
                 } else {
@@ -690,7 +690,7 @@ export default class Collect extends CompositeComponent {
             // check if collected has changed
             if (
                 prevCollectedName === undefined ||
-                collected.componentName !== prevCollectedName ||
+                collected.componentIdx !== prevCollectedName ||
                 recreateRemaining
             ) {
                 let prevNumReplacements = 0;
@@ -735,7 +735,7 @@ export default class Collect extends CompositeComponent {
 
                 replacementNamesByCollected[collectedNum] =
                     replacementInstruction.serializedReplacements.map(
-                        (x) => x.componentName,
+                        (x) => x.componentIdx,
                     );
 
                 if (!recreateRemaining) {
@@ -876,12 +876,12 @@ export default class Collect extends CompositeComponent {
                 propVariablesCopiedByReplacement;
 
             replacementNamesByCollected[collectedNum] =
-                newSerializedReplacements.map((x) => x.componentName);
+                newSerializedReplacements.map((x) => x.componentIdx);
         }
 
         workspace.numReplacementsByCollected = numReplacementsByCollected;
         workspace.collectedNames = collectedComponents.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         workspace.propVariablesCopiedByCollected =
             propVariablesCopiedByCollected;

--- a/packages/doenetml-worker-javascript/src/components/ConditionalContent.js
+++ b/packages/doenetml-worker-javascript/src/components/ConditionalContent.js
@@ -238,11 +238,11 @@ export default class ConditionalContent extends CompositeComponent {
                     ignoreReplacementsOfEncounteredComposites: true,
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 let generatedVariantInfo = {
                     seed: dependencyValues.variantSeed,
                     meta: {
-                        createdBy: componentName,
+                        createdBy: componentIdx,
                     },
                 };
 
@@ -288,7 +288,7 @@ export default class ConditionalContent extends CompositeComponent {
         workspace.previousBaseConditionSatisfied =
             await component.stateValues.baseConditionSatisfied;
 
-        // console.log(`replacements for ${component.componentName}`)
+        // console.log(`replacements for ${component.componentIdx}`)
         // console.log(JSON.parse(JSON.stringify(replacements)));
         // console.log(replacements);
 
@@ -318,18 +318,18 @@ export default class ConditionalContent extends CompositeComponent {
                     newNameForSelectedChild;
                 if (selectedIndex < (await component.stateValues.numCases)) {
                     selectedChildName =
-                        caseChildren[selectedIndex].componentName;
+                        caseChildren[selectedIndex].componentIdx;
                     newNameForSelectedChild = createUniqueName(
                         "case",
-                        `${component.componentName}|replacement|${selectedIndex}`,
+                        `${component.componentIdx}|replacement|${selectedIndex}`,
                     );
                     childComponentType = "case";
                 } else {
                     selectedChildName = (await component.stateValues.elseChild)
-                        .componentName;
+                        .componentIdx;
                     newNameForSelectedChild = createUniqueName(
                         "else",
-                        `${component.componentName}|replacement|${selectedIndex}`,
+                        `${component.componentIdx}|replacement|${selectedIndex}`,
                     );
                     childComponentType = "else";
                 }
@@ -383,7 +383,7 @@ export default class ConditionalContent extends CompositeComponent {
         let processResult = processAssignNames({
             assignNames: component.doenetAttributes.assignNames,
             serializedComponents: replacements,
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             parentCreatesNewNamespace: newNamespace,
             componentInfoObjects,
             originalNamesAreConsistent: true,
@@ -404,7 +404,7 @@ export default class ConditionalContent extends CompositeComponent {
         workspace,
         componentInfoObjects,
     }) {
-        // console.log(`calculate replacement changes for selectByCondition ${component.componentName}`)
+        // console.log(`calculate replacement changes for selectByCondition ${component.componentIdx}`)
         // console.log(workspace.previousSelectedIndex);
         // console.log(component.stateValues.selectedIndex);
 

--- a/packages/doenetml-worker-javascript/src/components/ConstrainTo.js
+++ b/packages/doenetml-worker-javascript/src/components/ConstrainTo.js
@@ -76,7 +76,7 @@ export default class ConstrainTo extends ConstraintComponent {
                     variableNames: ["scales"],
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 let scales;
 
                 if (dependencyValues.relativeToGraphScales) {

--- a/packages/doenetml-worker-javascript/src/components/ConstrainToAngles.js
+++ b/packages/doenetml-worker-javascript/src/components/ConstrainToAngles.js
@@ -14,7 +14,7 @@ export default class ConstrainToAngles extends ConstraintComponent {
             for (let child of activeChildrenMatched) {
                 anglesChildren.push({
                     createdComponent: true,
-                    componentName: child.componentName,
+                    componentIdx: child.componentIdx,
                 });
             }
             return {
@@ -98,7 +98,7 @@ export default class ConstrainToAngles extends ConstraintComponent {
         }
 
         let trackChanges = this.currentTracker.trackChanges;
-        let childrenChanged = trackChanges.childrenChanged(this.componentName);
+        let childrenChanged = trackChanges.childrenChanged(this.componentIdx);
 
         if (childrenChanged) {
             let anglesInd = this.childLogic.returnMatches("AtMostOneAngles");

--- a/packages/doenetml-worker-javascript/src/components/ConstrainToInterior.js
+++ b/packages/doenetml-worker-javascript/src/components/ConstrainToInterior.js
@@ -80,7 +80,7 @@ export default class ConstrainToInterior extends ConstraintComponent {
                     variableNames: ["scales"],
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 let scales;
 
                 if (dependencyValues.relativeToGraphScales) {

--- a/packages/doenetml-worker-javascript/src/components/ContentPicker.js
+++ b/packages/doenetml-worker-javascript/src/components/ContentPicker.js
@@ -100,7 +100,7 @@ export default class ContentPicker extends BlockComponent {
                     ] of stateValues.childrenWithTitle.entries()) {
                         dependencies[`childTopics${ind}`] = {
                             dependencyType: "descendant",
-                            ancestorName: child.componentName,
+                            ancestorIdx: child.componentIdx,
                             componentTypes: ["topic"],
                             variableNames: ["value"],
                             includeNonActiveChildren: true,
@@ -119,7 +119,7 @@ export default class ContentPicker extends BlockComponent {
                     child,
                 ] of dependencyValues.childrenWithTitle.entries()) {
                     let childObject = {
-                        componentName: child.componentName,
+                        componentIdx: child.componentIdx,
                         title: child.stateValues.title || "Untitled",
                     };
                     childInfo.push(childObject);
@@ -227,7 +227,7 @@ export default class ContentPicker extends BlockComponent {
             let updateInstructions = [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "selectedIndices",
                     value: selectedIndices,
                 },
@@ -236,7 +236,7 @@ export default class ContentPicker extends BlockComponent {
             let event = {
                 verb: "selected",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
                 result: {
@@ -254,7 +254,7 @@ export default class ContentPicker extends BlockComponent {
             });
 
             return await this.coreFunctions.triggerChainedActions({
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,
@@ -266,7 +266,7 @@ export default class ContentPicker extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/Copy.js
+++ b/packages/doenetml-worker-javascript/src/components/Copy.js
@@ -207,7 +207,7 @@ export default class Copy extends CompositeComponent {
                 return {
                     targetSourcesComponent: {
                         dependencyType: "componentIdentity",
-                        componentName: stateValues.targetSourcesName,
+                        componentIdx: stateValues.targetSourcesName,
                     },
                 };
             },
@@ -271,8 +271,8 @@ export default class Copy extends CompositeComponent {
                     return {
                         targetSourcesChildren: {
                             dependencyType: "stateVariable",
-                            componentName:
-                                stateValues.targetSources.componentName,
+                            componentIdx:
+                                stateValues.targetSources.componentIdx,
                             variableName: "childIdentities",
                         },
                         sourcesChildNumber: {
@@ -315,8 +315,8 @@ export default class Copy extends CompositeComponent {
                     return {
                         targetIsInactiveCompositeReplacement: {
                             dependencyType: "stateVariable",
-                            componentName:
-                                stateValues.targetComponent.componentName,
+                            componentIdx:
+                                stateValues.targetComponent.componentIdx,
                             variableName: "isInactiveCompositeReplacement",
                         },
                     };
@@ -457,7 +457,7 @@ export default class Copy extends CompositeComponent {
                 if (stateValues.targetComponent !== null) {
                     dependencies.targetComponentNewNamespace = {
                         dependencyType: "attributePrimitive",
-                        parentName: stateValues.targetComponent.componentName,
+                        parentIdx: stateValues.targetComponent.componentIdx,
                         attributeName: "newNamespace",
                     };
 
@@ -501,8 +501,8 @@ export default class Copy extends CompositeComponent {
                             // for the case where we have a prop and a composite target
                             dependencies.targets = {
                                 dependencyType: "replacement",
-                                compositeName:
-                                    stateValues.targetComponent.componentName,
+                                compositeIdx:
+                                    stateValues.targetComponent.componentIdx,
                                 recursive: true,
                                 componentIndex: stateValues.componentIndex,
                                 targetSubnames: stateValues.targetSubnames,
@@ -598,7 +598,7 @@ export default class Copy extends CompositeComponent {
                         let source = stateValues.replacementSourceIdentities[0];
                         dependencies[`newNamespaceSource`] = {
                             dependencyType: "attributePrimitive",
-                            parentName: source.componentName,
+                            parentIdx: source.componentIdx,
                             attributeName: "newNamespace",
                         };
                     }
@@ -746,7 +746,7 @@ export default class Copy extends CompositeComponent {
                             }
                             thisTarget = {
                                 dependencyType: "stateVariable",
-                                componentName: source.componentName,
+                                componentIdx: source.componentIdx,
                                 variableName: thisPropName,
                                 returnAsComponentObject: true,
                                 variablesOptional: true,
@@ -758,7 +758,7 @@ export default class Copy extends CompositeComponent {
                         } else {
                             thisTarget = {
                                 dependencyType: "componentIdentity",
-                                componentName: source.componentName,
+                                componentIdx: source.componentIdx,
                             };
                         }
 
@@ -912,8 +912,7 @@ export default class Copy extends CompositeComponent {
                 ) {
                     dependencies.targetReplacements = {
                         dependencyType: "replacement",
-                        compositeName:
-                            stateValues.targetComponent.componentName,
+                        compositeIdx: stateValues.targetComponent.componentIdx,
                         recursive: true,
                         recurseNonStandardComposites: true,
                     };
@@ -977,8 +976,7 @@ export default class Copy extends CompositeComponent {
                 ) {
                     dependencies.targetReadyToExpandWhenResolved = {
                         dependencyType: "stateVariable",
-                        componentName:
-                            stateValues.targetComponent.componentName,
+                        componentIdx: stateValues.targetComponent.componentIdx,
                         variableName: "readyToExpandWhenResolved",
                     };
                 }
@@ -1054,7 +1052,7 @@ export default class Copy extends CompositeComponent {
 
                             dependencies["sourceArraySize" + ind] = {
                                 dependencyType: "stateVariableArraySize",
-                                componentName: source.componentName,
+                                componentIdx: source.componentIdx,
                                 variableName: propName,
                                 variablesOptional: true,
                                 caseInsensitiveVariableMatch: true,
@@ -1062,7 +1060,7 @@ export default class Copy extends CompositeComponent {
 
                             dependencies["sourceComponentType" + ind] = {
                                 dependencyType: "stateVariableComponentType",
-                                componentName: source.componentName,
+                                componentIdx: source.componentIdx,
                                 variableName: propName,
                                 variablesOptional: true,
                                 caseInsensitiveVariableMatch: true,
@@ -1090,8 +1088,7 @@ export default class Copy extends CompositeComponent {
 
                     dependencies.allReplacementIdentities = {
                         dependencyType: "replacement",
-                        compositeName:
-                            stateValues.targetComponent.componentName,
+                        compositeIdx: stateValues.targetComponent.componentIdx,
                         recursive: true,
                         variableNames: ["isInactiveCompositeReplacement"],
                     };
@@ -1155,7 +1152,7 @@ export default class Copy extends CompositeComponent {
         resolveItem,
         publicCaseInsensitiveAliasSubstitutions,
     }) {
-        // console.log(`create serialized replacements of ${component.componentName}`)
+        // console.log(`create serialized replacements of ${component.componentIdx}`)
 
         // console.log(await component.stateValues.targetComponent);
         // console.log(await component.stateValues.effectivePropNameBySource);
@@ -1191,8 +1188,8 @@ export default class Copy extends CompositeComponent {
 
             if (replacements[0].children) {
                 let namespace;
-                if (replacements[0].componentName) {
-                    namespace = replacements[0].componentName + "/";
+                if (replacements[0].componentIdx) {
+                    namespace = replacements[0].componentIdx + "/";
                 } else {
                     namespace = replacements[0].originalName + "/";
                 }
@@ -1281,7 +1278,7 @@ export default class Copy extends CompositeComponent {
                     component.doenetAttributes
                         .assignNamesForCompositeReplacement,
                 serializedComponents: replacements,
-                parentName: component.componentName,
+                parentIdx: component.componentIdx,
                 parentCreatesNewNamespace: newNamespace,
                 componentInfoObjects,
             });
@@ -1355,7 +1352,7 @@ export default class Copy extends CompositeComponent {
                     component.doenetAttributes
                         .assignNamesForCompositeReplacement,
                 serializedComponents: replacements,
-                parentName: component.componentName,
+                parentIdx: component.componentIdx,
                 parentCreatesNewNamespace: newNamespace,
                 componentInfoObjects,
             });
@@ -1450,7 +1447,7 @@ export default class Copy extends CompositeComponent {
                         component.doenetAttributes
                             .assignNamesForCompositeReplacement,
                     serializedComponents: replacements,
-                    parentName: component.componentName,
+                    parentIdx: component.componentIdx,
                     componentInfoObjects,
                     originalNamesAreConsistent: true,
                 });
@@ -1491,7 +1488,7 @@ export default class Copy extends CompositeComponent {
         // and resolve recalculateDownstreamComponents of its target dependencies
         // so any array entry prop is created
         let resolveResult = await resolveItem({
-            componentName: component.componentName,
+            componentIdx: component.componentIdx,
             type: "determineDependencies",
             stateVariable: "replacementSources",
             dependency: "__determine_dependencies",
@@ -1500,7 +1497,7 @@ export default class Copy extends CompositeComponent {
 
         if (!resolveResult.success) {
             throw Error(
-                `Couldn't resolve determineDependencies of replacementSources of ${component.componentName}`,
+                `Couldn't resolve determineDependencies of replacementSources of ${component.componentIdx}`,
             );
         }
 
@@ -1511,7 +1508,7 @@ export default class Copy extends CompositeComponent {
 
             if (thisPropName) {
                 resolveResult = await resolveItem({
-                    componentName: component.componentName,
+                    componentIdx: component.componentIdx,
                     type: "recalculateDownstreamComponents",
                     stateVariable: "replacementSources",
                     dependency: "target" + ind,
@@ -1520,7 +1517,7 @@ export default class Copy extends CompositeComponent {
 
                 if (!resolveResult.success) {
                     throw Error(
-                        `Couldn't resolve recalculateDownstreamComponents for target${ind} of replacementSources of ${component.componentName}`,
+                        `Couldn't resolve recalculateDownstreamComponents for target${ind} of replacementSources of ${component.componentIdx}`,
                     );
                 }
             }
@@ -1529,7 +1526,7 @@ export default class Copy extends CompositeComponent {
         if (!component.doenetAttributes.sourceIsProp) {
             let targetComponent =
                 components[
-                    (await component.stateValues.targetComponent).componentName
+                    (await component.stateValues.targetComponent).componentIdx
                 ];
             let componentIndex = await component.stateValues.componentIndex;
             let targetSubnames = await component.stateValues.targetSubnames;
@@ -1587,7 +1584,7 @@ export default class Copy extends CompositeComponent {
                         component.doenetAttributes
                             .assignNamesForCompositeReplacement,
                     serializedComponents: substituteSerializedReplacements,
-                    parentName: component.componentName,
+                    parentIdx: component.componentIdx,
                     componentInfoObjects,
                 });
 
@@ -1663,7 +1660,7 @@ export default class Copy extends CompositeComponent {
         workspace.numNonStringReplacementsBySource =
             numNonStringReplacementsBySource;
         workspace.sourceNames = replacementSourceIdentities.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
 
         let verificationResult = await verifyReplacementsMatchSpecifiedType({
@@ -1680,7 +1677,7 @@ export default class Copy extends CompositeComponent {
         errors.push(...verificationResult.errors);
         warnings.push(...verificationResult.warnings);
 
-        // console.log(`serialized replacements for ${component.componentName}`);
+        // console.log(`serialized replacements for ${component.componentIdx}`);
         // console.log(JSON.parse(JSON.stringify(verificationResult.replacements)));
 
         return {
@@ -1728,7 +1725,7 @@ export default class Copy extends CompositeComponent {
             }
         }
         let replacementSourceComponent =
-            components[replacementSource.componentName];
+            components[replacementSource.componentIdx];
 
         // if not linking or removing empty array entries,
         // then replacementSources is resolved,
@@ -1772,7 +1769,7 @@ export default class Copy extends CompositeComponent {
                     component.doenetAttributes
                         .assignNamesForCompositeReplacement,
                 serializedComponents: results.serializedReplacements,
-                parentName: component.componentName,
+                parentIdx: component.componentIdx,
                 parentCreatesNewNamespace: newNamespace,
                 indOffset: numNonStringReplacementsSoFar,
                 componentInfoObjects,
@@ -1835,7 +1832,7 @@ export default class Copy extends CompositeComponent {
                     primitiveSourceAttributesToIgnore: sourceAttributesToIgnore,
                     copyPrimaryEssential,
                     copyEssentialState,
-                    errorIfEncounterComponent: [component.componentName],
+                    errorIfEncounterComponent: [component.componentIdx],
                 }),
             ];
         } catch (e) {
@@ -1862,12 +1859,12 @@ export default class Copy extends CompositeComponent {
             delete serializedReplacements[0].state.fixed;
         }
 
-        // console.log(`serializedReplacements for ${component.componentName}`);
+        // console.log(`serializedReplacements for ${component.componentIdx}`);
         // console.log(JSON.parse(JSON.stringify(serializedReplacements)));
 
         serializedReplacements = postProcessCopy({
             serializedComponents: serializedReplacements,
-            componentName: component.componentName,
+            componentIdx: component.componentIdx,
             uniqueIdentifiersUsed,
             addShadowDependencies: link,
             unlinkExternalCopies: !link,
@@ -1917,15 +1914,15 @@ export default class Copy extends CompositeComponent {
             serializedReplacements[0].doenetAttributes.haveNewNamespaceOnlyFromShadow = true;
         }
 
-        let parentName = component.componentName;
+        let parentIdx = component.componentIdx;
 
         if (component.doenetAttributes.parentNameForAssignNames) {
-            parentName = component.doenetAttributes.parentNameForAssignNames;
+            parentIdx = component.doenetAttributes.parentNameForAssignNames;
         }
 
         let compositesParentNameForAssignNames;
         if (await component.stateValues.addLevelToAssignNames) {
-            compositesParentNameForAssignNames = parentName;
+            compositesParentNameForAssignNames = parentIdx;
         }
 
         let processResult = processAssignNames({
@@ -1935,7 +1932,7 @@ export default class Copy extends CompositeComponent {
             assignNamesForCompositeReplacement:
                 component.doenetAttributes.assignNamesForCompositeReplacement,
             serializedComponents: serializedReplacements,
-            parentName,
+            parentIdx,
             parentCreatesNewNamespace: newNamespace,
             indOffset: numNonStringReplacementsSoFar,
             componentInfoObjects,
@@ -1964,7 +1961,7 @@ export default class Copy extends CompositeComponent {
             warnings.push(...res.warnings);
         }
 
-        // console.log(`ending serializedReplacements for ${component.componentName}`);
+        // console.log(`ending serializedReplacements for ${component.componentIdx}`);
         // console.log(JSON.parse(JSON.stringify(serializedReplacements)));
 
         return { serializedReplacements, errors, warnings };
@@ -2011,7 +2008,7 @@ export default class Copy extends CompositeComponent {
 
         let processResult = processAssignNames({
             serializedComponents: newChildren,
-            parentName: replacements[0].componentName,
+            parentIdx: replacements[0].componentIdx,
             parentCreatesNewNamespace: assignNewNamespaces,
             componentInfoObjects,
             originalNamesAreConsistent: true,
@@ -2052,7 +2049,7 @@ export default class Copy extends CompositeComponent {
         publicCaseInsensitiveAliasSubstitutions,
     }) {
         // console.log(
-        //   "Calculating replacement changes for " + component.componentName,
+        //   "Calculating replacement changes for " + component.componentIdx,
         // );
 
         // TODO: don't yet have a way to return errors and warnings!
@@ -2178,7 +2175,7 @@ export default class Copy extends CompositeComponent {
         // and resolve recalculateDownstreamComponents of its target dependencies
         // so any array entry prop is created
         let resolveResult = await resolveItem({
-            componentName: component.componentName,
+            componentIdx: component.componentIdx,
             type: "determineDependencies",
             stateVariable: "replacementSources",
             dependency: "__determine_dependencies",
@@ -2187,7 +2184,7 @@ export default class Copy extends CompositeComponent {
 
         if (!resolveResult.success) {
             throw Error(
-                `Couldn't resolve determineDependencies of replacementSources of ${component.componentName}`,
+                `Couldn't resolve determineDependencies of replacementSources of ${component.componentIdx}`,
             );
         }
 
@@ -2199,7 +2196,7 @@ export default class Copy extends CompositeComponent {
 
             if (thisPropName) {
                 resolveResult = await resolveItem({
-                    componentName: component.componentName,
+                    componentIdx: component.componentIdx,
                     type: "recalculateDownstreamComponents",
                     stateVariable: "replacementSources",
                     dependency: "target" + ind,
@@ -2208,7 +2205,7 @@ export default class Copy extends CompositeComponent {
 
                 if (!resolveResult.success) {
                     throw Error(
-                        `Couldn't resolve recalculateDownstreamComponents for target${ind} of replacementSources of ${component.componentName}`,
+                        `Couldn't resolve recalculateDownstreamComponents for target${ind} of replacementSources of ${component.componentIdx}`,
                     );
                 }
             }
@@ -2217,7 +2214,7 @@ export default class Copy extends CompositeComponent {
         if (!component.doenetAttributes.sourceIsProp) {
             let targetComponent =
                 components[
-                    (await component.stateValues.targetComponent).componentName
+                    (await component.stateValues.targetComponent).componentIdx
                 ];
             let componentIndex = await component.stateValues.componentIndex;
             let targetSubnames = await component.stateValues.targetSubnames;
@@ -2335,7 +2332,7 @@ export default class Copy extends CompositeComponent {
             // check if replacementSource has changed
             let needToRecreate =
                 prevSourceName === undefined ||
-                replacementSource.componentName !== prevSourceName ||
+                replacementSource.componentIdx !== prevSourceName ||
                 recreateRemaining;
 
             if (!needToRecreate) {
@@ -2352,8 +2349,8 @@ export default class Copy extends CompositeComponent {
                         break;
                     } else if (
                         !effectivePropNameBySource[sourceNum] &&
-                        currentReplacement.shadows?.componentName !==
-                            replacementSourceIdentities[sourceNum].componentName
+                        currentReplacement.shadows?.componentIdx !==
+                            replacementSourceIdentities[sourceNum].componentIdx
                     ) {
                         needToRecreate = true;
                         break;
@@ -2616,7 +2613,7 @@ export default class Copy extends CompositeComponent {
         workspace.numNonStringReplacementsBySource =
             numNonStringReplacementsBySource;
         workspace.sourceNames = replacementSourceIdentities.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         workspace.propVariablesCopiedBySource = propVariablesCopiedBySource;
 
@@ -2734,7 +2731,7 @@ export async function replacementFromProp({
     numComponentsForSource,
     publicCaseInsensitiveAliasSubstitutions,
 }) {
-    // console.log(`replacement from prop for ${component.componentName}`)
+    // console.log(`replacement from prop for ${component.componentIdx}`)
     // console.log(replacementSource)
 
     let errors = [];
@@ -2750,7 +2747,7 @@ export async function replacementFromProp({
 
     let replacementInd = -1; //numReplacementsSoFar - 1;
 
-    let target = components[replacementSource.componentName];
+    let target = components[replacementSource.componentIdx];
 
     let varName = publicCaseInsensitiveAliasSubstitutions({
         stateVariables: [propName],
@@ -2922,7 +2919,7 @@ export async function replacementFromProp({
                     propVariablesCopied.push(propVariable);
 
                     let uniqueIdentifierBase =
-                        replacementSource.componentName +
+                        replacementSource.componentIdx +
                         "|shadow|" +
                         propVariable;
                     let uniqueIdentifier = getUniqueIdentifierFromBase(
@@ -3020,10 +3017,10 @@ export async function replacementFromProp({
                                     let shadowComponent = {
                                         componentType: attributeComponentType,
                                         downstreamDependencies: {
-                                            [target.componentName]: [
+                                            [target.componentIdx]: [
                                                 {
-                                                    compositeName:
-                                                        component.componentName,
+                                                    compositeIdx:
+                                                        component.componentIdx,
                                                     dependencyType:
                                                         "referenceShadow",
                                                     propVariable:
@@ -3049,10 +3046,10 @@ export async function replacementFromProp({
                             componentType: createComponentOfType,
                             attributes: attributesForReplacement,
                             downstreamDependencies: {
-                                [replacementSource.componentName]: [
+                                [replacementSource.componentIdx]: [
                                     {
                                         dependencyType: "referenceShadow",
-                                        compositeName: component.componentName,
+                                        compositeIdx: component.componentIdx,
                                         propVariable,
                                         additionalStateVariableShadowing:
                                             stateVariablesShadowingStateVariables,
@@ -3235,7 +3232,7 @@ export async function replacementFromProp({
                         let propVariablesCopiedForThisPiece = [propVariable];
 
                         let uniqueIdentifierBase =
-                            replacementSource.componentName +
+                            replacementSource.componentIdx +
                             "|shadow|" +
                             propVariable;
                         let uniqueIdentifier = getUniqueIdentifierFromBase(
@@ -3347,10 +3344,10 @@ export async function replacementFromProp({
                                             componentType:
                                                 attributeComponentType,
                                             downstreamDependencies: {
-                                                [target.componentName]: [
+                                                [target.componentIdx]: [
                                                     {
-                                                        compositeName:
-                                                            component.componentName,
+                                                        compositeIdx:
+                                                            component.componentIdx,
                                                         dependencyType:
                                                             "referenceShadow",
                                                         propVariable:
@@ -3371,11 +3368,11 @@ export async function replacementFromProp({
                                 componentType: createComponentOfType,
                                 attributes: attributesForReplacement,
                                 downstreamDependencies: {
-                                    [replacementSource.componentName]: [
+                                    [replacementSource.componentIdx]: [
                                         {
                                             dependencyType: "referenceShadow",
-                                            compositeName:
-                                                component.componentName,
+                                            compositeIdx:
+                                                component.componentIdx,
                                             propVariable,
                                             additionalStateVariableShadowing:
                                                 stateVariablesShadowingStateVariables,
@@ -3629,10 +3626,10 @@ export async function replacementFromProp({
                                             componentType:
                                                 attributeComponentType,
                                             downstreamDependencies: {
-                                                [target.componentName]: [
+                                                [target.componentIdx]: [
                                                     {
-                                                        compositeName:
-                                                            component.componentName,
+                                                        compositeIdx:
+                                                            component.componentIdx,
                                                         dependencyType:
                                                             "referenceShadow",
                                                         propVariable:
@@ -3727,10 +3724,10 @@ export async function replacementFromProp({
 
                 if (link) {
                     replacement.downstreamDependencies = {
-                        [replacementSource.componentName]: [
+                        [replacementSource.componentIdx]: [
                             {
                                 dependencyType: "referenceShadow",
-                                compositeName: component.componentName,
+                                compositeIdx: component.componentIdx,
                                 propVariable: varName,
                                 ignorePrimaryStateVariable: true,
                             },
@@ -3810,7 +3807,7 @@ export async function replacementFromProp({
                 }
             } else if (newReplacements > numReplacementsForSource) {
                 throw Error(
-                    `Something went wrong when creating replacements for ${component.componentName} as we ended up with too many replacements`,
+                    `Something went wrong when creating replacements for ${component.componentIdx} as we ended up with too many replacements`,
                 );
             }
         }
@@ -3839,7 +3836,7 @@ export async function replacementFromProp({
 
         propVariablesCopied.push(varName);
 
-        let uniqueIdentifierBase = target.componentName + "|shadow|" + varName;
+        let uniqueIdentifierBase = target.componentIdx + "|shadow|" + varName;
         let uniqueIdentifier = getUniqueIdentifierFromBase(
             uniqueIdentifierBase,
             uniqueIdentifiersUsed,
@@ -3888,10 +3885,10 @@ export async function replacementFromProp({
                             let shadowComponent = {
                                 componentType: attributeComponentType,
                                 downstreamDependencies: {
-                                    [target.componentName]: [
+                                    [target.componentIdx]: [
                                         {
-                                            compositeName:
-                                                component.componentName,
+                                            compositeIdx:
+                                                component.componentIdx,
                                             dependencyType: "referenceShadow",
                                             propVariable: stateVariableToShadow,
                                         },
@@ -3916,10 +3913,10 @@ export async function replacementFromProp({
                         stateVarObj.shadowingInstructions.createComponentOfType,
                     attributes: attributesForReplacement,
                     downstreamDependencies: {
-                        [target.componentName]: [
+                        [target.componentIdx]: [
                             {
                                 dependencyType: "referenceShadow",
-                                compositeName: component.componentName,
+                                compositeIdx: component.componentIdx,
                                 propVariable: varName,
                                 additionalStateVariableShadowing:
                                     stateVarObj.shadowingInstructions
@@ -4048,15 +4045,15 @@ export async function replacementFromProp({
                 repl.doenetAttributes = {};
             }
             repl.doenetAttributes.fromImplicitProp = true;
-            if (repl.downstreamDependencies?.[target.componentName]?.[0]) {
+            if (repl.downstreamDependencies?.[target.componentIdx]?.[0]) {
                 repl.downstreamDependencies[
-                    target.componentName
+                    target.componentIdx
                 ][0].fromImplicitProp = true;
             }
         }
     }
 
-    // console.log(`serializedReplacements for ${component.componentName}`)
+    // console.log(`serializedReplacements for ${component.componentIdx}`)
     // console.log(JSON.parse(JSON.stringify(serializedReplacements)))
     // console.log(serializedReplacements)
 

--- a/packages/doenetml-worker-javascript/src/components/Curve.js
+++ b/packages/doenetml-worker-javascript/src/components/Curve.js
@@ -3866,7 +3866,7 @@ export default class Curve extends GraphicalComponent {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "controlVectors",
                         value: desiredVector,
                         sourceDetails: {
@@ -3884,7 +3884,7 @@ export default class Curve extends GraphicalComponent {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "controlVectors",
                         value: desiredVector,
                         sourceDetails: {
@@ -3898,7 +3898,7 @@ export default class Curve extends GraphicalComponent {
                 event: {
                     verb: "interacted",
                     object: {
-                        componentId: this.componentName,
+                        componentId: this.componentIdx,
                     },
                     result: {
                         ["controlVector" + controlVectorInds.join("_")]:
@@ -3927,7 +3927,7 @@ export default class Curve extends GraphicalComponent {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "throughPoints",
                         value: desiredPoint,
                         sourceDetails: { throughPointMoved: throughPointInd },
@@ -3943,7 +3943,7 @@ export default class Curve extends GraphicalComponent {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "throughPoints",
                         value: desiredPoint,
                         sourceDetails: { throughPointMoved: throughPointInd },
@@ -3955,7 +3955,7 @@ export default class Curve extends GraphicalComponent {
                 event: {
                     verb: "interacted",
                     object: {
-                        componentId: this.componentName,
+                        componentId: this.componentIdx,
                     },
                     result: {
                         ["throughPoint" + throughPointInd]: throughPoint,
@@ -3976,7 +3976,7 @@ export default class Curve extends GraphicalComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "vectorControlDirections",
                     value: { [throughPointInd]: direction },
                 },
@@ -3998,7 +3998,7 @@ export default class Curve extends GraphicalComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "click",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,
@@ -4015,7 +4015,7 @@ export default class Curve extends GraphicalComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "focus",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,

--- a/packages/doenetml-worker-javascript/src/components/CustomAttribute.js
+++ b/packages/doenetml-worker-javascript/src/components/CustomAttribute.js
@@ -38,7 +38,7 @@ export default class CustomAttribute extends CompositeComponent {
                     variableName: "componentNameForAttributes",
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 let componentNameForAttributes =
                     dependencyValues.parentVariableContainingName;
                 return { setValue: { componentNameForAttributes } };
@@ -66,7 +66,7 @@ export default class CustomAttribute extends CompositeComponent {
             returnDependencies: ({ stateValues }) => ({
                 componentIdentity: {
                     dependencyType: "componentIdentity",
-                    componentName: stateValues.componentNameForAttributes,
+                    componentIdx: stateValues.componentNameForAttributes,
                 },
             }),
             definition() {
@@ -202,7 +202,7 @@ export default class CustomAttribute extends CompositeComponent {
         let processResult = processAssignNames({
             assignNames: component.doenetAttributes.assignNames,
             serializedComponents: [serializedComponent],
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             parentCreatesNewNamespace: newNamespace,
             componentInfoObjects,
         });

--- a/packages/doenetml-worker-javascript/src/components/DataFrame.js
+++ b/packages/doenetml-worker-javascript/src/components/DataFrame.js
@@ -113,7 +113,7 @@ export default class DataFrame extends BaseComponent {
                     variableName: "columnTypesPrelim",
                 },
             }),
-            definition: function ({ dependencyValues, componentName }) {
+            definition: function ({ dependencyValues, componentIdx }) {
                 let columnTypes = [],
                     columnNames = [];
 
@@ -139,7 +139,7 @@ export default class DataFrame extends BaseComponent {
 
                 if (foundInconsistentRow) {
                     let warning = {
-                        message: `Data has invalid shape.  Rows has inconsistent lengths. Found in componentName :${componentName}`,
+                        message: `Data has invalid shape.  Rows has inconsistent lengths. Found in componentIdx :${componentIdx}`,
                         level: 1,
                     };
                     return {
@@ -182,7 +182,7 @@ export default class DataFrame extends BaseComponent {
                     dataFrame.columnNames
                 ) {
                     let warning = {
-                        message: `Data has duplicate column names.  Found in componentName :${componentName}`,
+                        message: `Data has duplicate column names.  Found in componentIdx :${componentIdx}`,
                         level: 1,
                     };
                     return {
@@ -199,7 +199,7 @@ export default class DataFrame extends BaseComponent {
 
                 if (dataFrame.columnNames.includes("")) {
                     let warning = {
-                        message: `Data is missing a column name.  Found in componentName :${componentName}`,
+                        message: `Data is missing a column name.  Found in componentIdx :${componentIdx}`,
                         level: 1,
                     };
                     return {

--- a/packages/doenetml-worker-javascript/src/components/DiscreteSimulationResultList.js
+++ b/packages/doenetml-worker-javascript/src/components/DiscreteSimulationResultList.js
@@ -320,7 +320,7 @@ export default class DiscreteSimulationResultList extends BlockComponent {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "cells",
                         value: cellChanges,
                     },
@@ -331,7 +331,7 @@ export default class DiscreteSimulationResultList extends BlockComponent {
                 event: {
                     verb: "interacted",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: cellChanges,
@@ -344,7 +344,7 @@ export default class DiscreteSimulationResultList extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/DiscreteSimulationResultPolyline.js
+++ b/packages/doenetml-worker-javascript/src/components/DiscreteSimulationResultPolyline.js
@@ -555,7 +555,7 @@ export default class DiscreteSimulationResultPolyline extends GraphicalComponent
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "vertices",
                         value: vertexComponents,
                         sourceDetails,
@@ -571,7 +571,7 @@ export default class DiscreteSimulationResultPolyline extends GraphicalComponent
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "vertices",
                         value: vertexComponents,
                         sourceDetails,
@@ -583,7 +583,7 @@ export default class DiscreteSimulationResultPolyline extends GraphicalComponent
                 event: {
                     verb: "interacted",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: {
@@ -621,7 +621,7 @@ export default class DiscreteSimulationResultPolyline extends GraphicalComponent
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "click",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,
@@ -638,7 +638,7 @@ export default class DiscreteSimulationResultPolyline extends GraphicalComponent
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "focus",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,

--- a/packages/doenetml-worker-javascript/src/components/Divisions.js
+++ b/packages/doenetml-worker-javascript/src/components/Divisions.js
@@ -30,7 +30,7 @@ export class Div extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/Document.js
+++ b/packages/doenetml-worker-javascript/src/components/Document.js
@@ -129,7 +129,7 @@ export default class Document extends BaseComponent {
                 let titleChildName = null;
                 if (dependencyValues.titleChild.length > 0) {
                     titleChildName =
-                        dependencyValues.titleChild[0].componentName;
+                        dependencyValues.titleChild[0].componentIdx;
                 }
                 return {
                     setValue: { titleChildName },
@@ -324,7 +324,7 @@ export default class Document extends BaseComponent {
                         dependenciesByKey[arrayKey] = {
                             creditAchieved: {
                                 dependencyType: "stateVariable",
-                                componentName: descendant.componentName,
+                                componentIdx: descendant.componentIdx,
                                 variableName: "creditAchieved",
                             },
                         };
@@ -358,7 +358,7 @@ export default class Document extends BaseComponent {
                     let descendant = stateValues.scoredDescendants[ind];
                     dependencies[`descendantsOf${ind}`] = {
                         dependencyType: "descendant",
-                        ancestorName: descendant.componentName,
+                        ancestorIdx: descendant.componentIdx,
                         componentTypes: ["answer"],
                         recurseToMatchedChildren: false,
                     };
@@ -378,7 +378,7 @@ export default class Document extends BaseComponent {
                         `descendantsOf${ind}`
                     ]) {
                         componentNumberByAnswerName[
-                            answerDescendant.componentName
+                            answerDescendant.componentIdx
                         ] = componentNumber;
                     }
                     if (
@@ -387,7 +387,7 @@ export default class Document extends BaseComponent {
                             baseComponentType: "answer",
                         })
                     ) {
-                        componentNumberByAnswerName[component.componentName] =
+                        componentNumberByAnswerName[component.componentIdx] =
                             componentNumber;
                     }
                 }
@@ -416,7 +416,7 @@ export default class Document extends BaseComponent {
                         dependenciesByKey[arrayKey] = {
                             generatedVariantInfo: {
                                 dependencyType: "stateVariable",
-                                componentName: descendant.componentName,
+                                componentIdx: descendant.componentIdx,
                                 variableName: "generatedVariantInfo",
                                 variablesOptional: true,
                             },
@@ -586,7 +586,7 @@ export default class Document extends BaseComponent {
                 ] of stateValues.scoredDescendants.entries()) {
                     dependencies["creditAchievedIfSubmit" + ind] = {
                         dependencyType: "stateVariable",
-                        componentName: descendant.componentName,
+                        componentIdx: descendant.componentIdx,
                         variableName: "creditAchievedIfSubmit",
                     };
                 }
@@ -642,12 +642,12 @@ export default class Document extends BaseComponent {
                     ignoreReplacementsOfEncounteredComposites: true,
                 },
             }),
-            definition({ dependencyValues, componentName, previousValues }) {
+            definition({ dependencyValues, componentIdx, previousValues }) {
                 let generatedVariantInfo = {
                     index: dependencyValues.variantIndex,
                     name: dependencyValues.variantName,
                     meta: {
-                        createdBy: componentName,
+                        createdBy: componentIdx,
                     },
                 };
 
@@ -703,7 +703,7 @@ export default class Document extends BaseComponent {
                     variableName: "documentWideCheckWork",
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 let createSubmitAllButton = false;
                 let suppressAnswerSubmitButtons = false;
 
@@ -755,7 +755,7 @@ export default class Document extends BaseComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "submitted",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
         });
@@ -772,7 +772,7 @@ export default class Document extends BaseComponent {
 
         for (let [ind, answer] of answersToSubmit.entries()) {
             await this.coreFunctions.performAction({
-                componentName: answer.componentName,
+                componentIdx: answer.componentIdx,
                 actionName: "submitAnswer",
                 args: {
                     actionId,
@@ -788,7 +788,7 @@ export default class Document extends BaseComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/Embed.js
+++ b/packages/doenetml-worker-javascript/src/components/Embed.js
@@ -57,7 +57,7 @@ export default class Embed extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/Endpoint.js
+++ b/packages/doenetml-worker-javascript/src/components/Endpoint.js
@@ -36,7 +36,7 @@ export default class Endpoint extends Point {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "open",
                         value: !(await this.stateValues.open),
                     },
@@ -47,7 +47,7 @@ export default class Endpoint extends Point {
                 event: {
                     verb: "interacted",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: {

--- a/packages/doenetml-worker-javascript/src/components/Extract.js
+++ b/packages/doenetml-worker-javascript/src/components/Extract.js
@@ -261,7 +261,7 @@ export default class Extract extends CompositeComponent {
         flags,
         publicCaseInsensitiveAliasSubstitutions,
     }) {
-        // console.log(`calculating replacements for ${component.componentName}`);
+        // console.log(`calculating replacements for ${component.componentIdx}`);
 
         let errors = [];
         let warnings = [];
@@ -316,7 +316,7 @@ export default class Extract extends CompositeComponent {
         workspace.numNonStringReplacementsBySource = [
             ...numReplacementsBySource,
         ];
-        workspace.sourceNames = sourceComponents.map((x) => x.componentName);
+        workspace.sourceNames = sourceComponents.map((x) => x.componentIdx);
 
         let verificationResult = await verifyReplacementsMatchSpecifiedType({
             component,
@@ -332,7 +332,7 @@ export default class Extract extends CompositeComponent {
         errors.push(...verificationResult.errors);
         warnings.push(...verificationResult.warnings);
 
-        // console.log(`serialized replacements for ${component.componentName}`)
+        // console.log(`serialized replacements for ${component.componentIdx}`)
         // console.log(JSON.parse(JSON.stringify(verificationResult.replacements)))
 
         return {
@@ -352,7 +352,7 @@ export default class Extract extends CompositeComponent {
         compositeAttributesObj,
         publicCaseInsensitiveAliasSubstitutions,
     }) {
-        // console.log(`create replacement for source ${sourceNum}, ${numReplacementsSoFar} of ${component.componentName}`)
+        // console.log(`create replacement for source ${sourceNum}, ${numReplacementsSoFar} of ${component.componentIdx}`)
 
         let errors = [];
         let warnings = [];
@@ -388,7 +388,7 @@ export default class Extract extends CompositeComponent {
         let processResult = processAssignNames({
             assignNames,
             serializedComponents: serializedReplacements,
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             indOffset: numReplacementsSoFar,
             parentCreatesNewNamespace: newNamespace,
             componentInfoObjects,
@@ -414,7 +414,7 @@ export default class Extract extends CompositeComponent {
         flags,
         publicCaseInsensitiveAliasSubstitutions,
     }) {
-        // console.log(`calculating replacement changes for ${component.componentName}`);
+        // console.log(`calculating replacement changes for ${component.componentIdx}`);
         // console.log(workspace.numReplacementsBySource);
         // console.log(component.replacements);
 
@@ -492,7 +492,7 @@ export default class Extract extends CompositeComponent {
             // check if source has changed
             let needToRecreate =
                 prevSourceName === undefined ||
-                source.componentName !== prevSourceName ||
+                source.componentIdx !== prevSourceName ||
                 recreateRemaining;
 
             if (!needToRecreate) {
@@ -677,7 +677,7 @@ export default class Extract extends CompositeComponent {
         workspace.numNonStringReplacementsBySource = [
             ...numReplacementsBySource,
         ];
-        workspace.sourceNames = sourceComponents.map((x) => x.componentName);
+        workspace.sourceNames = sourceComponents.map((x) => x.componentIdx);
         workspace.propVariablesCopiedBySource = propVariablesCopiedBySource;
 
         let verificationResult = await verifyReplacementsMatchSpecifiedType({

--- a/packages/doenetml-worker-javascript/src/components/Feedback.js
+++ b/packages/doenetml-worker-javascript/src/components/Feedback.js
@@ -177,7 +177,7 @@ export default class Feedback extends BlockComponent {
         let updateInstructions = [
             {
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "hide",
                 value: await this.stateValues.hideWhenUpdated,
             },
@@ -195,7 +195,7 @@ export default class Feedback extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/Figure.js
+++ b/packages/doenetml-worker-javascript/src/components/Figure.js
@@ -109,7 +109,7 @@ export default class Figure extends BlockComponent {
                 let captionChildName = null;
                 if (dependencyValues.captionChild.length > 0) {
                     captionChildName =
-                        dependencyValues.captionChild[0].componentName;
+                        dependencyValues.captionChild[0].componentIdx;
                 }
                 return {
                     setValue: { captionChildName },
@@ -147,7 +147,7 @@ export default class Figure extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/Function.js
+++ b/packages/doenetml-worker-javascript/src/components/Function.js
@@ -447,7 +447,7 @@ export default class Function extends InlineComponent {
                     },
                 },
             }),
-            arrayDefinitionByKey({ globalDependencyValues, componentName }) {
+            arrayDefinitionByKey({ globalDependencyValues, componentIdx }) {
                 if (globalDependencyValues.domainAttr !== null) {
                     let numInputs = globalDependencyValues.numInputs;
                     let specifiedDomain =
@@ -871,7 +871,7 @@ export default class Function extends InlineComponent {
                     return {
                         setValue: {
                             mathChildName:
-                                dependencyValues.mathChild[0].componentName,
+                                dependencyValues.mathChild[0].componentIdx,
                         },
                     };
                 } else {
@@ -887,7 +887,7 @@ export default class Function extends InlineComponent {
                     return {
                         mathChildCreatedBySugar: {
                             dependencyType: "doenetAttribute",
-                            componentName: stateValues.mathChildName,
+                            componentIdx: stateValues.mathChildName,
                             attributeName: "createdFromSugar",
                         },
                     };
@@ -922,12 +922,12 @@ export default class Function extends InlineComponent {
                         if (stateValues.mathChildCreatedBySugar) {
                             dependencies.mathChildExpressionWithCodes = {
                                 dependencyType: "stateVariable",
-                                componentName: stateValues.mathChildName,
+                                componentIdx: stateValues.mathChildName,
                                 variableName: "expressionWithCodes",
                             };
                             dependencies.mathChildMathChildren = {
                                 dependencyType: "child",
-                                parentName: stateValues.mathChildName,
+                                parentIdx: stateValues.mathChildName,
                                 childGroups: ["maths"],
                                 variableNames: [
                                     "value",
@@ -938,7 +938,7 @@ export default class Function extends InlineComponent {
                             };
                             dependencies.mathChildCodePre = {
                                 dependencyType: "stateVariable",
-                                componentName: stateValues.mathChildName,
+                                componentIdx: stateValues.mathChildName,
                                 variableName: "codePre",
                             };
                         } else {
@@ -1422,12 +1422,12 @@ export default class Function extends InlineComponent {
                         if (stateValues.mathChildCreatedBySugar) {
                             globalDependencies.mathChildExpressionWithCodes = {
                                 dependencyType: "stateVariable",
-                                componentName: stateValues.mathChildName,
+                                componentIdx: stateValues.mathChildName,
                                 variableName: "expressionWithCodes",
                             };
                             globalDependencies.mathChildMathChildren = {
                                 dependencyType: "child",
-                                parentName: stateValues.mathChildName,
+                                parentIdx: stateValues.mathChildName,
                                 childGroups: ["maths"],
                                 variableNames: [
                                     "value",
@@ -1438,7 +1438,7 @@ export default class Function extends InlineComponent {
                             };
                             globalDependencies.mathChildCodePre = {
                                 dependencyType: "stateVariable",
-                                componentName: stateValues.mathChildName,
+                                componentIdx: stateValues.mathChildName,
                                 variableName: "codePre",
                             };
                         } else {
@@ -1855,12 +1855,12 @@ export default class Function extends InlineComponent {
                         if (stateValues.mathChildCreatedBySugar) {
                             globalDependencies.mathChildExpressionWithCodes = {
                                 dependencyType: "stateVariable",
-                                componentName: stateValues.mathChildName,
+                                componentIdx: stateValues.mathChildName,
                                 variableName: "expressionWithCodes",
                             };
                             globalDependencies.mathChildMathChildren = {
                                 dependencyType: "child",
-                                parentName: stateValues.mathChildName,
+                                parentIdx: stateValues.mathChildName,
                                 childGroups: ["maths"],
                                 variableNames: [
                                     "value",
@@ -1871,7 +1871,7 @@ export default class Function extends InlineComponent {
                             };
                             globalDependencies.mathChildCodePre = {
                                 dependencyType: "stateVariable",
-                                componentName: stateValues.mathChildName,
+                                componentIdx: stateValues.mathChildName,
                                 variableName: "codePre",
                             };
                         } else {
@@ -2283,12 +2283,12 @@ export default class Function extends InlineComponent {
                         if (stateValues.mathChildCreatedBySugar) {
                             globalDependencies.mathChildExpressionWithCodes = {
                                 dependencyType: "stateVariable",
-                                componentName: stateValues.mathChildName,
+                                componentIdx: stateValues.mathChildName,
                                 variableName: "expressionWithCodes",
                             };
                             globalDependencies.mathChildMathChildren = {
                                 dependencyType: "child",
-                                parentName: stateValues.mathChildName,
+                                parentIdx: stateValues.mathChildName,
                                 childGroups: ["maths"],
                                 variableNames: [
                                     "value",
@@ -2299,7 +2299,7 @@ export default class Function extends InlineComponent {
                             };
                             globalDependencies.mathChildCodePre = {
                                 dependencyType: "stateVariable",
-                                componentName: stateValues.mathChildName,
+                                componentIdx: stateValues.mathChildName,
                                 variableName: "codePre",
                             };
                         } else {

--- a/packages/doenetml-worker-javascript/src/components/Graph.js
+++ b/packages/doenetml-worker-javascript/src/components/Graph.js
@@ -442,14 +442,14 @@ export default class Graph extends BlockComponent {
 
                 let graphicalChildNames =
                     dependencyValues.graphicalOrGraphChildren.map(
-                        (x) => x.componentName,
+                        (x) => x.componentIdx,
                     );
 
                 for (let [
                     ind,
                     child,
                 ] of dependencyValues.allChildren.entries()) {
-                    if (graphicalChildNames.includes(child.componentName)) {
+                    if (graphicalChildNames.includes(child.componentIdx)) {
                         childIndicesToRender.push(ind);
                     }
                 }
@@ -1380,7 +1380,7 @@ export default class Graph extends BlockComponent {
                     return {
                         setValue: {
                             gridAttrCompName:
-                                dependencyValues.gridAttr.componentName,
+                                dependencyValues.gridAttr.componentIdx,
                         },
                     };
                 } else {
@@ -1396,7 +1396,7 @@ export default class Graph extends BlockComponent {
                     return {
                         gridAttrCompChildren: {
                             dependencyType: "child",
-                            parentName: stateValues.gridAttrCompName,
+                            parentIdx: stateValues.gridAttrCompName,
                             childGroups: ["textLike"],
                             variableNames: ["value"],
                         },
@@ -1448,7 +1448,7 @@ export default class Graph extends BlockComponent {
                     ] of stateValues.gridAttrCompChildren.entries()) {
                         dependencies["childAdapter" + ind] = {
                             dependencyType: "adapterSourceStateVariable",
-                            componentName: child.componentName,
+                            componentIdx: child.componentIdx,
                             variableName: "value",
                         };
                     }
@@ -1625,7 +1625,7 @@ export default class Graph extends BlockComponent {
         if (xmin !== undefined) {
             updateInstructions.push({
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "xmin",
                 value: xmin,
             });
@@ -1633,7 +1633,7 @@ export default class Graph extends BlockComponent {
         if (xmax !== undefined) {
             updateInstructions.push({
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "xmax",
                 value: xmax,
             });
@@ -1641,7 +1641,7 @@ export default class Graph extends BlockComponent {
         if (ymin !== undefined) {
             updateInstructions.push({
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "ymin",
                 value: ymin,
             });
@@ -1649,7 +1649,7 @@ export default class Graph extends BlockComponent {
         if (ymax !== undefined) {
             updateInstructions.push({
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "ymax",
                 value: ymax,
             });
@@ -1663,7 +1663,7 @@ export default class Graph extends BlockComponent {
             event: {
                 verb: "interacted",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
                 result: {
@@ -1685,7 +1685,7 @@ export default class Graph extends BlockComponent {
         if (serializedComponents && serializedComponents.length > 0) {
             let processResult = processAssignNames({
                 serializedComponents,
-                parentName: this.componentName,
+                parentIdx: this.componentIdx,
                 parentCreatesNewNamespace:
                     this.attributes.newNamespace?.primitive,
                 componentInfoObjects: this.componentInfoObjects,
@@ -1698,13 +1698,13 @@ export default class Graph extends BlockComponent {
                         updateType: "addComponents",
                         serializedComponents:
                             processResult.serializedComponents,
-                        parentName: this.componentName,
+                        parentIdx: this.componentIdx,
                         assignNamesOffset:
                             await this.stateValues.numChildrenAdded,
                     },
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "numChildrenAdded",
                         value:
                             (await this.stateValues.numChildrenAdded) +
@@ -1733,7 +1733,7 @@ export default class Graph extends BlockComponent {
             let numChildren = this.definingChildren.length;
             let componentNamesToDelete = this.definingChildren
                 .slice(numChildren - numberToDelete, numChildren)
-                .map((x) => x.componentName);
+                .map((x) => x.componentIdx);
 
             return await this.coreFunctions.performUpdate({
                 updateInstructions: [
@@ -1743,7 +1743,7 @@ export default class Graph extends BlockComponent {
                     },
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "numChildrenAdded",
                         value:
                             (await this.stateValues.numChildrenAdded) -
@@ -1761,7 +1761,7 @@ export default class Graph extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/Group.js
+++ b/packages/doenetml-worker-javascript/src/components/Group.js
@@ -148,11 +148,11 @@ export default class Group extends CompositeComponent {
                     ignoreReplacementsOfEncounteredComposites: true,
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 let generatedVariantInfo = {
                     seed: dependencyValues.variantSeed,
                     meta: {
-                        createdBy: componentName,
+                        createdBy: componentIdx,
                     },
                 };
 
@@ -291,7 +291,7 @@ export default class Group extends CompositeComponent {
             let processResult = processAssignNames({
                 assignNames: component.doenetAttributes.assignNames,
                 serializedComponents: replacements,
-                parentName: component.componentName,
+                parentIdx: component.componentIdx,
                 parentCreatesNewNamespace: newNamespace,
                 componentInfoObjects,
                 originalNamesAreConsistent: true,
@@ -314,7 +314,7 @@ export default class Group extends CompositeComponent {
             errors.push(...verificationResult.errors);
             warnings.push(...verificationResult.warnings);
 
-            // console.log(`serialized replacements for ${component.componentName}`)
+            // console.log(`serialized replacements for ${component.componentIdx}`)
             // console.log(JSON.parse(JSON.stringify(verificationResult.replacements)))
 
             return {

--- a/packages/doenetml-worker-javascript/src/components/Hint.js
+++ b/packages/doenetml-worker-javascript/src/components/Hint.js
@@ -99,7 +99,7 @@ export default class Hint extends BlockComponent {
                     titleChildName =
                         dependencyValues.titleChild[
                             dependencyValues.titleChild.length - 1
-                        ].componentName;
+                        ].componentIdx;
                 }
                 return {
                     setValue: { titleChildName },
@@ -126,7 +126,7 @@ export default class Hint extends BlockComponent {
                 let childIndicesToRender = [];
 
                 let allTitleChildNames = dependencyValues.titleChildren.map(
-                    (x) => x.componentName,
+                    (x) => x.componentIdx,
                 );
 
                 for (let [
@@ -135,8 +135,8 @@ export default class Hint extends BlockComponent {
                 ] of dependencyValues.allChildren.entries()) {
                     if (
                         typeof child !== "object" ||
-                        !allTitleChildNames.includes(child.componentName) ||
-                        child.componentName === dependencyValues.titleChildName
+                        !allTitleChildNames.includes(child.componentIdx) ||
+                        child.componentIdx === dependencyValues.titleChildName
                     ) {
                         childIndicesToRender.push(ind);
                     }
@@ -186,7 +186,7 @@ export default class Hint extends BlockComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "open",
                     value: true,
                 },
@@ -198,7 +198,7 @@ export default class Hint extends BlockComponent {
             event: {
                 verb: "viewed",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
             },
@@ -214,7 +214,7 @@ export default class Hint extends BlockComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "open",
                     value: false,
                 },
@@ -226,7 +226,7 @@ export default class Hint extends BlockComponent {
             event: {
                 verb: "closed",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
             },
@@ -237,7 +237,7 @@ export default class Hint extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/Image.js
+++ b/packages/doenetml-worker-javascript/src/components/Image.js
@@ -479,7 +479,7 @@ export default class Image extends BlockComponent {
             actionId,
             sourceInformation,
             skipRendererUpdate,
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             componentType: this.componentType,
             coreFunctions: this.coreFunctions,
         });
@@ -489,7 +489,7 @@ export default class Image extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },
@@ -505,7 +505,7 @@ export default class Image extends BlockComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "click",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,
@@ -522,7 +522,7 @@ export default class Image extends BlockComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "focus",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,

--- a/packages/doenetml-worker-javascript/src/components/Intersection.js
+++ b/packages/doenetml-worker-javascript/src/components/Intersection.js
@@ -235,7 +235,7 @@ export default class Intersection extends CompositeComponent {
         let processResult = processAssignNames({
             assignNames: component.doenetAttributes.assignNames,
             serializedComponents: serializedReplacements,
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             parentCreatesNewNamespace: newNamespace,
             componentInfoObjects,
         });

--- a/packages/doenetml-worker-javascript/src/components/Label.js
+++ b/packages/doenetml-worker-javascript/src/components/Label.js
@@ -223,7 +223,7 @@ export default class Label extends InlineComponent {
                     variableName: "hasLatex",
                 },
             }),
-            definition: function ({ dependencyValues, componentName }) {
+            definition: function ({ dependencyValues, componentIdx }) {
                 if (
                     dependencyValues.inlineChildren.length === 0 &&
                     dependencyValues.valueShadow !== null
@@ -508,7 +508,7 @@ export default class Label extends InlineComponent {
             actionId,
             sourceInformation,
             skipRendererUpdate,
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             componentType: this.componentType,
             coreFunctions: this.coreFunctions,
         });
@@ -523,7 +523,7 @@ export default class Label extends InlineComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "click",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,
@@ -540,7 +540,7 @@ export default class Label extends InlineComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "focus",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,

--- a/packages/doenetml-worker-javascript/src/components/Legend.js
+++ b/packages/doenetml-worker-javascript/src/components/Legend.js
@@ -52,7 +52,7 @@ export default class Legend extends GraphicalComponent {
                         setValue: {
                             graphicalElementNames:
                                 dependencyValues.graphAncestor.stateValues.graphicalDescendants.map(
-                                    (x) => x.componentName,
+                                    (x) => x.componentIdx,
                                 ),
                         },
                     };
@@ -93,7 +93,7 @@ export default class Legend extends GraphicalComponent {
                     ] of stateValues.graphicalElementNames.entries()) {
                         dependencies[`graphicalElement${ind}`] = {
                             dependencyType: "multipleStateVariables",
-                            componentName: cName,
+                            componentIdx: cName,
                             variableNames: [
                                 "selectedStyle",
                                 "styleNumber",
@@ -103,11 +103,11 @@ export default class Legend extends GraphicalComponent {
                         };
                         dependencies[`graphicalElement${ind}AdapterSource`] = {
                             dependencyType: "adapterSource",
-                            componentName: cName,
+                            componentIdx: cName,
                         };
                         dependencies[`graphicalElement${ind}ShadowSource`] = {
                             dependencyType: "shadowSource",
-                            componentName: cName,
+                            componentIdx: cName,
                         };
                     }
                 }
@@ -135,31 +135,31 @@ export default class Legend extends GraphicalComponent {
                                 `graphicalElement${ind}AdapterSource`
                             ];
                         if (adapter) {
-                            // if have adapter, use that componentName instead,
+                            // if have adapter, use that componentIdx instead,
                             // since that would be the name used in forObjectComponentName
                             graphicalElement = { ...graphicalElement };
-                            graphicalElement.componentName =
-                                adapter.componentName;
+                            graphicalElement.componentIdx =
+                                adapter.componentIdx;
                         }
                         if (
-                            graphicalElement.componentName.slice(0, 3) === "/__"
+                            graphicalElement.componentIdx.slice(0, 3) === "/__"
                         ) {
                             let shadowSource =
                                 dependencyValues[
                                     `graphicalElement${ind}ShadowSource`
                                 ];
                             if (shadowSource) {
-                                // if have shadow source, use that componentName instead,
+                                // if have shadow source, use that componentIdx instead,
                                 graphicalElement = { ...graphicalElement };
-                                graphicalElement.componentName =
-                                    shadowSource.componentName;
+                                graphicalElement.componentIdx =
+                                    shadowSource.componentIdx;
                             }
                         }
                         graphicalDescendantsLeft.push(graphicalElement);
                     }
 
                     let graphicalDescendantComponentNamesLeft =
-                        graphicalDescendantsLeft.map((x) => x.componentName);
+                        graphicalDescendantsLeft.map((x) => x.componentIdx);
 
                     let labelsInOrder = [];
                     let labelsByComponentName = {};
@@ -245,7 +245,7 @@ export default class Legend extends GraphicalComponent {
                                 let comp = graphicalDescendantsLeft[ind];
                                 if (
                                     !(
-                                        comp.componentName in
+                                        comp.componentIdx in
                                         labelsByComponentName
                                     )
                                 ) {

--- a/packages/doenetml-worker-javascript/src/components/Line.js
+++ b/packages/doenetml-worker-javascript/src/components/Line.js
@@ -199,7 +199,7 @@ export default class Line extends GraphicalComponent {
                 }
             },
             definition: function ({ dependencyValues, changes }) {
-                // console.log(`definition of numDimensions of ${componentName}`)
+                // console.log(`definition of numDimensions of ${componentIdx}`)
                 // console.log(dependencyValues)
                 // console.log(changes)
 
@@ -453,7 +453,7 @@ export default class Line extends GraphicalComponent {
                 },
             }),
             definition: function ({ dependencyValues }) {
-                // console.log(`definition of equation child for ${componentName}`)
+                // console.log(`definition of equation child for ${componentIdx}`)
                 // console.log(dependencyValues);
 
                 if (dependencyValues.equation !== null) {
@@ -812,7 +812,7 @@ export default class Line extends GraphicalComponent {
                 arrayKeys,
                 arraySize,
             }) {
-                // console.log(`array definition of points for ${componentName}`)
+                // console.log(`array definition of points for ${componentIdx}`)
                 // console.log(globalDependencyValues)
                 // console.log(dependencyValuesByKey)
                 // console.log(arrayKeys)
@@ -1408,7 +1408,7 @@ export default class Line extends GraphicalComponent {
                 return dependencies;
             },
             definition: function ({ dependencyValues }) {
-                // console.log(`definition of equation for ${componentName}`)
+                // console.log(`definition of equation for ${componentIdx}`)
                 // console.log(dependencyValues);
 
                 let variables = dependencyValues.variables;
@@ -1744,7 +1744,7 @@ export default class Line extends GraphicalComponent {
                 dependencyValuesByKey,
                 arrayKeys,
             }) {
-                // console.log(`array definition by key of numericalPoints of ${componentName}`)
+                // console.log(`array definition by key of numericalPoints of ${componentIdx}`)
 
                 // console.log(globalDependencyValues)
                 // console.log(dependencyValuesByKey)
@@ -2158,7 +2158,7 @@ export default class Line extends GraphicalComponent {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "points",
                         value: desiredPoints,
                     },
@@ -2173,7 +2173,7 @@ export default class Line extends GraphicalComponent {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "points",
                         value: desiredPoints,
                     },
@@ -2184,7 +2184,7 @@ export default class Line extends GraphicalComponent {
                 event: {
                     verb: "interacted",
                     object: {
-                        componentId: this.componentName,
+                        componentId: this.componentIdx,
                     },
                     result: {
                         point1: point1coords,
@@ -2258,7 +2258,7 @@ export default class Line extends GraphicalComponent {
                 let newInstructions = [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "points",
                         value: newPointComponents,
                     },
@@ -2294,7 +2294,7 @@ export default class Line extends GraphicalComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "click",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,
@@ -2311,7 +2311,7 @@ export default class Line extends GraphicalComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "focus",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,

--- a/packages/doenetml-worker-javascript/src/components/LineSegment.js
+++ b/packages/doenetml-worker-javascript/src/components/LineSegment.js
@@ -1197,7 +1197,7 @@ export default class LineSegment extends GraphicalComponent {
             await this.coreFunctions.performUpdate({
                 updateInstructions: [
                     {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         updateType: "updateValue",
                         stateVariable: "endpoints",
                         value: newComponents,
@@ -1213,7 +1213,7 @@ export default class LineSegment extends GraphicalComponent {
             await this.coreFunctions.performUpdate({
                 updateInstructions: [
                     {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         updateType: "updateValue",
                         stateVariable: "endpoints",
                         value: newComponents,
@@ -1226,7 +1226,7 @@ export default class LineSegment extends GraphicalComponent {
                 event: {
                     verb: "interacted",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: {
@@ -1298,7 +1298,7 @@ export default class LineSegment extends GraphicalComponent {
                 let newInstructions = [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "endpoints",
                         value: newPointComponents,
                     },
@@ -1331,7 +1331,7 @@ export default class LineSegment extends GraphicalComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "click",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,
@@ -1348,7 +1348,7 @@ export default class LineSegment extends GraphicalComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "focus",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,

--- a/packages/doenetml-worker-javascript/src/components/Lists.js
+++ b/packages/doenetml-worker-javascript/src/components/Lists.js
@@ -113,7 +113,7 @@ export class Ol extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },
@@ -200,7 +200,7 @@ export class Li extends BaseComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/Lorem.js
+++ b/packages/doenetml-worker-javascript/src/components/Lorem.js
@@ -122,11 +122,11 @@ export default class Lorem extends CompositeComponent {
                     value: sharedParameters.variantSeed,
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 let generatedVariantInfo = {
                     seed: dependencyValues.variantSeed,
                     meta: {
-                        createdBy: componentName,
+                        createdBy: componentIdx,
                     },
                 };
 
@@ -220,7 +220,7 @@ export default class Lorem extends CompositeComponent {
         let processResult = processAssignNames({
             assignNames: component.doenetAttributes.assignNames,
             serializedComponents: replacements,
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             parentCreatesNewNamespace: newNamespace,
             componentInfoObjects,
         });

--- a/packages/doenetml-worker-javascript/src/components/MMeMen.js
+++ b/packages/doenetml-worker-javascript/src/components/MMeMen.js
@@ -223,7 +223,7 @@ export class M extends InlineComponent {
             actionId,
             sourceInformation,
             skipRendererUpdate,
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             componentType: this.componentType,
             coreFunctions: this.coreFunctions,
         });
@@ -238,7 +238,7 @@ export class M extends InlineComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "click",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,
@@ -255,7 +255,7 @@ export class M extends InlineComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "focus",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,

--- a/packages/doenetml-worker-javascript/src/components/Map.js
+++ b/packages/doenetml-worker-javascript/src/components/Map.js
@@ -82,7 +82,7 @@ export default class Map extends CompositeComponent {
                     setValue: {
                         numSources: dependencyValues.sourcesChildren.length,
                         sourcesNames: dependencyValues.sourcesChildren.map(
-                            (x) => x.componentName,
+                            (x) => x.componentIdx,
                         ),
                         sourceAliases: dependencyValues.sourcesChildren.map(
                             (x) => x.stateValues.alias,
@@ -151,7 +151,7 @@ export default class Map extends CompositeComponent {
                     componentType: "template",
                     state: { rendered: true },
                     children: childrenOfTemplate,
-                    originalName: templateChild.componentName,
+                    originalName: templateChild.componentIdx,
                     attributes: {},
                 };
                 if (templateChild.stateValues.newNamespace) {
@@ -258,11 +258,11 @@ export default class Map extends CompositeComponent {
                     ignoreReplacementsOfEncounteredComposites: true,
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 let generatedVariantInfo = {
                     seed: dependencyValues.variantSeed,
                     meta: {
-                        createdBy: componentName,
+                        createdBy: componentIdx,
                     },
                 };
 
@@ -297,7 +297,7 @@ export default class Map extends CompositeComponent {
         workspace,
         componentInfoObjects,
     }) {
-        // console.log(`create serialized replacements for ${component.componentName}`);
+        // console.log(`create serialized replacements for ${component.componentIdx}`);
 
         let errors = [];
         let warnings = [];
@@ -402,7 +402,7 @@ export default class Map extends CompositeComponent {
         let processResult = processAssignNames({
             assignNames: component.doenetAttributes.assignNames,
             serializedComponents: replacements,
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             parentCreatesNewNamespace: newNamespace,
             componentInfoObjects,
             indOffset: iter,
@@ -493,7 +493,7 @@ export default class Map extends CompositeComponent {
                 let processResult = processAssignNames({
                     assignNames: component.doenetAttributes.assignNames,
                     serializedComponents,
-                    parentName: component.componentName,
+                    parentIdx: component.componentIdx,
                     parentCreatesNewNamespace: newNamespace,
                     componentInfoObjects,
                     indOffset: iterateNumber,
@@ -544,7 +544,7 @@ export default class Map extends CompositeComponent {
         workspace,
         componentInfoObjects,
     }) {
-        // console.log(`calculate replacement changes for ${component.componentName}`)
+        // console.log(`calculate replacement changes for ${component.componentIdx}`)
 
         // TODO: don't yet have a way to return errors and warnings!
         let errors = [];

--- a/packages/doenetml-worker-javascript/src/components/Math.js
+++ b/packages/doenetml-worker-javascript/src/components/Math.js
@@ -1108,7 +1108,7 @@ export default class MathComponent extends InlineComponent {
             actionId,
             sourceInformation,
             skipRendererUpdate,
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             componentType: this.componentType,
             coreFunctions: this.coreFunctions,
         });
@@ -1123,7 +1123,7 @@ export default class MathComponent extends InlineComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "click",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,
@@ -1140,7 +1140,7 @@ export default class MathComponent extends InlineComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "focus",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,

--- a/packages/doenetml-worker-javascript/src/components/MathInput.js
+++ b/packages/doenetml-worker-javascript/src/components/MathInput.js
@@ -37,7 +37,7 @@ export default class MathInput extends Input {
                 let answerAncestor = await this.stateValues.answerAncestor;
                 if (answerAncestor !== null) {
                     return {
-                        componentName: answerAncestor.componentName,
+                        componentIdx: answerAncestor.componentIdx,
                         actionName: "submitAnswer",
                     };
                 } else {
@@ -595,7 +595,7 @@ export default class MathInput extends Input {
                 justUpdatedForNewComponent,
                 usedDefault,
             }) {
-                // console.log(`definition of raw value for ${componentName}`)
+                // console.log(`definition of raw value for ${componentIdx}`)
                 // console.log(JSON.parse(JSON.stringify(dependencyValues)), JSON.parse(JSON.stringify(essentialValues)), JSON.parse(JSON.stringify(usedDefault)))
 
                 // use deepCompare of trees rather than equalsViaSyntax
@@ -660,9 +660,9 @@ export default class MathInput extends Input {
                 stateValues,
                 essentialValues,
                 dependencyValues,
-                componentName,
+                componentIdx,
             }) {
-                // console.log(`inverse definition of rawRenderer value for ${componentName}`, desiredStateVariableValues, JSON.parse(JSON.stringify(essentialValues)))
+                // console.log(`inverse definition of rawRenderer value for ${componentIdx}`, desiredStateVariableValues, JSON.parse(JSON.stringify(essentialValues)))
 
                 let instructions = [];
 
@@ -818,13 +818,13 @@ export default class MathInput extends Input {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "rawRendererValue",
                         value: rawRendererValue,
                     },
                     {
                         updateType: "setComponentNeedingUpdateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                     },
                 ],
                 transient: true,
@@ -852,13 +852,13 @@ export default class MathInput extends Input {
                 let updateInstructions = [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "dontUpdateRawValueInDefinition",
                         value: true,
                     },
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "value",
                         value: immediateValue,
                     },
@@ -870,13 +870,13 @@ export default class MathInput extends Input {
                     },
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "dontUpdateRawValueInDefinition",
                         value: false,
                     },
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "immediateValue",
                         valueOfStateVariable: "value",
                     },
@@ -887,7 +887,7 @@ export default class MathInput extends Input {
 
                 updateInstructions.push({
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "rawRendererValue",
                     valueOfStateVariable: "valueForDisplay",
                 });
@@ -895,7 +895,7 @@ export default class MathInput extends Input {
                 let event = {
                     verb: "answered",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: {
@@ -907,7 +907,7 @@ export default class MathInput extends Input {
                 let answerAncestor = await this.stateValues.answerAncestor;
                 if (answerAncestor) {
                     event.context = {
-                        answerAncestor: answerAncestor.componentName,
+                        answerAncestor: answerAncestor.componentIdx,
                     };
                 }
 
@@ -925,7 +925,7 @@ export default class MathInput extends Input {
                 });
 
                 return await this.coreFunctions.triggerChainedActions({
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     actionId,
                     sourceInformation,
                     skipRendererUpdate,

--- a/packages/doenetml-worker-javascript/src/components/MathList.js
+++ b/packages/doenetml-worker-javascript/src/components/MathList.js
@@ -236,14 +236,14 @@ export default class MathList extends CompositeComponent {
                                         childInd,
                                         component: i,
                                         nComponents,
-                                        childName: child.componentName,
+                                        childIdx: child.componentIdx,
                                     };
                                 }
                                 numComponents += nComponents;
                             } else {
                                 childInfoByComponent[numComponents] = {
                                     childInd,
-                                    childName: child.componentName,
+                                    childIdx: child.componentIdx,
                                 };
                                 numComponents += 1;
                             }
@@ -253,7 +253,7 @@ export default class MathList extends CompositeComponent {
                         childInfoByComponent =
                             dependencyValues.mathChildren.map((child, i) => ({
                                 childInd: i,
-                                childName: child.componentName,
+                                childIdx: child.componentIdx,
                             }));
                     }
                 } else if (dependencyValues.mathsShadow !== null) {
@@ -595,26 +595,26 @@ export default class MathList extends CompositeComponent {
         for (let i = 0; i < numComponents; i++) {
             let childInfo = childInfoByComponent[i];
             if (childInfo) {
-                let replacementSource = components[childInfo.childName];
+                let replacementSource = components[childInfo.childIdx];
 
                 if (childInfo.nComponents !== undefined) {
                     componentsCopied.push(
-                        replacementSource.componentName +
+                        replacementSource.componentIdx +
                             ":" +
                             childInfo.component,
                     );
                 } else {
-                    componentsCopied.push(replacementSource.componentName);
+                    componentsCopied.push(replacementSource.componentIdx);
                 }
             }
             replacements.push({
                 componentType: "math",
                 attributes: JSON.parse(JSON.stringify(attributesFromComposite)),
                 downstreamDependencies: {
-                    [component.componentName]: [
+                    [component.componentIdx]: [
                         {
                             dependencyType: "referenceShadow",
-                            compositeName: component.componentName,
+                            compositeIdx: component.componentIdx,
                             propVariable: `math${i + 1}`,
                         },
                     ],
@@ -625,7 +625,7 @@ export default class MathList extends CompositeComponent {
         workspace.uniqueIdentifiersUsed = [];
         replacements = postProcessCopy({
             serializedComponents: replacements,
-            componentName: component.componentName,
+            componentIdx: component.componentIdx,
             uniqueIdentifiersUsed: workspace.uniqueIdentifiersUsed,
             addShadowDependencies: true,
             markAsPrimaryShadow: true,
@@ -634,7 +634,7 @@ export default class MathList extends CompositeComponent {
         let processResult = processAssignNames({
             assignNames: component.doenetAttributes.assignNames,
             serializedComponents: replacements,
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             parentCreatesNewNamespace: newNamespace,
             componentInfoObjects,
         });
@@ -670,16 +670,16 @@ export default class MathList extends CompositeComponent {
                 await component.stateValues.childInfoByComponent;
 
             for (let childInfo of childInfoByComponent) {
-                let replacementSource = components[childInfo.childName];
+                let replacementSource = components[childInfo.childIdx];
 
                 if (childInfo.nComponents !== undefined) {
                     componentsToCopy.push(
-                        replacementSource.componentName +
+                        replacementSource.componentIdx +
                             ":" +
                             childInfo.component,
                     );
                 } else {
-                    componentsToCopy.push(replacementSource.componentName);
+                    componentsToCopy.push(replacementSource.componentIdx);
                 }
             }
 

--- a/packages/doenetml-worker-javascript/src/components/MatrixInput.js
+++ b/packages/doenetml-worker-javascript/src/components/MatrixInput.js
@@ -40,7 +40,7 @@ export class MatrixInput extends Input {
                 let answerAncestor = await this.stateValues.answerAncestor;
                 if (answerAncestor !== null) {
                     return {
-                        componentName: answerAncestor.componentName,
+                        componentIdx: answerAncestor.componentIdx,
                         actionName: "submitAnswer",
                     };
                 } else {
@@ -2842,7 +2842,7 @@ export class MatrixInput extends Input {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "numRows",
                         value: numRows,
                     },
@@ -2865,7 +2865,7 @@ export class MatrixInput extends Input {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "numColumns",
                         value: numColumns,
                     },
@@ -3620,7 +3620,7 @@ export default class MatrixComponentInput extends BaseComponent {
                 },
             }),
             definition({ dependencyValues, essentialValues }) {
-                // console.log(`definition of raw value for ${componentName}`)
+                // console.log(`definition of raw value for ${componentIdx}`)
                 // console.log(dependencyValues, essentialValues)
 
                 // use deepCompare of trees rather than equalsViaSyntax
@@ -3664,7 +3664,7 @@ export default class MatrixComponentInput extends BaseComponent {
                 stateValues,
                 essentialValues,
             }) {
-                // console.log(`inverse definition of rawRenderer value for ${componentName}`, desiredStateVariableValues, essentialValues)
+                // console.log(`inverse definition of rawRenderer value for ${componentIdx}`, desiredStateVariableValues, essentialValues)
 
                 const calculateMathExpressionFromLatex = async (text) => {
                     let expression;
@@ -3787,13 +3787,13 @@ export default class MatrixComponentInput extends BaseComponent {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "rawRendererValue",
                         value: rawRendererValue,
                     },
                     {
                         updateType: "setComponentNeedingUpdateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                     },
                 ],
                 actionId,
@@ -3820,7 +3820,7 @@ export default class MatrixComponentInput extends BaseComponent {
                 let updateInstructions = [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "value",
                         value: immediateValue,
                     },
@@ -3832,7 +3832,7 @@ export default class MatrixComponentInput extends BaseComponent {
                     },
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "immediateValue",
                         valueOfStateVariable: "value",
                     },
@@ -3844,7 +3844,7 @@ export default class MatrixComponentInput extends BaseComponent {
                 if (immediateValue.tree !== "\uff3f") {
                     updateInstructions.push({
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "rawRendererValue",
                         valueOfStateVariable: "valueForDisplay",
                     });
@@ -3853,7 +3853,7 @@ export default class MatrixComponentInput extends BaseComponent {
                 let event = {
                     verb: "answered",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: {
@@ -3865,7 +3865,7 @@ export default class MatrixComponentInput extends BaseComponent {
                 let answerAncestor = await this.stateValues.answerAncestor;
                 if (answerAncestor) {
                     event.context = {
-                        answerAncestor: answerAncestor.componentName,
+                        answerAncestor: answerAncestor.componentIdx,
                     };
                 }
 
@@ -3878,7 +3878,7 @@ export default class MatrixComponentInput extends BaseComponent {
                 });
 
                 return await this.coreFunctions.triggerChainedActions({
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     actionId,
                     sourceInformation,
                     skipRendererUpdate,
@@ -3891,7 +3891,7 @@ export default class MatrixComponentInput extends BaseComponent {
                     updateInstructions: [
                         {
                             updateType: "updateValue",
-                            componentName: this.componentName,
+                            componentIdx: this.componentIdx,
                             stateVariable: "rawRendererValue",
                             valueOfStateVariable: "rawRendererValue",
                         },

--- a/packages/doenetml-worker-javascript/src/components/MdMdnMrow.js
+++ b/packages/doenetml-worker-javascript/src/components/MdMdnMrow.js
@@ -86,7 +86,7 @@ export class Md extends InlineComponent {
             definition: ({ dependencyValues }) => ({
                 setValue: {
                     mrowChildNames: dependencyValues.mrowChildren.map(
-                        (x) => x.componentName,
+                        (x) => x.componentIdx,
                     ),
                 },
             }),
@@ -205,7 +205,7 @@ export class Md extends InlineComponent {
             actionId,
             sourceInformation,
             skipRendererUpdate,
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             componentType: this.componentType,
             coreFunctions: this.coreFunctions,
         });
@@ -220,7 +220,7 @@ export class Md extends InlineComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "click",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,
@@ -237,7 +237,7 @@ export class Md extends InlineComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "focus",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,

--- a/packages/doenetml-worker-javascript/src/components/Number.js
+++ b/packages/doenetml-worker-javascript/src/components/Number.js
@@ -1081,7 +1081,7 @@ export default class NumberComponent extends InlineComponent {
             actionId,
             sourceInformation,
             skipRendererUpdate,
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             componentType: this.componentType,
             coreFunctions: this.coreFunctions,
         });
@@ -1096,7 +1096,7 @@ export default class NumberComponent extends InlineComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "click",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,
@@ -1113,7 +1113,7 @@ export default class NumberComponent extends InlineComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "focus",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,

--- a/packages/doenetml-worker-javascript/src/components/NumberList.js
+++ b/packages/doenetml-worker-javascript/src/components/NumberList.js
@@ -205,14 +205,14 @@ export default class NumberList extends CompositeComponent {
                                         childInd,
                                         component: i,
                                         nComponents,
-                                        childName: child.componentName,
+                                        childIdx: child.componentIdx,
                                     };
                                 }
                                 numComponents += nComponents;
                             } else {
                                 childInfoByComponent[numComponents] = {
                                     childInd,
-                                    childName: child.componentName,
+                                    childIdx: child.componentIdx,
                                 };
                                 numComponents += 1;
                             }
@@ -224,7 +224,7 @@ export default class NumberList extends CompositeComponent {
                             dependencyValues.numberMathChildren.map(
                                 (child, i) => ({
                                     childInd: i,
-                                    childName: child.componentName,
+                                    childIdx: child.componentIdx,
                                 }),
                             );
                     }
@@ -602,26 +602,26 @@ export default class NumberList extends CompositeComponent {
         for (let i = 0; i < numComponents; i++) {
             let childInfo = childInfoByComponent[i];
             if (childInfo) {
-                let replacementSource = components[childInfo.childName];
+                let replacementSource = components[childInfo.childIdx];
 
                 if (childInfo.nComponents !== undefined) {
                     componentsCopied.push(
-                        replacementSource.componentName +
+                        replacementSource.componentIdx +
                             ":" +
                             childInfo.component,
                     );
                 } else {
-                    componentsCopied.push(replacementSource.componentName);
+                    componentsCopied.push(replacementSource.componentIdx);
                 }
             }
             replacements.push({
                 componentType: "number",
                 attributes: JSON.parse(JSON.stringify(attributesFromComposite)),
                 downstreamDependencies: {
-                    [component.componentName]: [
+                    [component.componentIdx]: [
                         {
                             dependencyType: "referenceShadow",
-                            compositeName: component.componentName,
+                            compositeIdx: component.componentIdx,
                             propVariable: `number${i + 1}`,
                         },
                     ],
@@ -632,7 +632,7 @@ export default class NumberList extends CompositeComponent {
         workspace.uniqueIdentifiersUsed = [];
         replacements = postProcessCopy({
             serializedComponents: replacements,
-            componentName: component.componentName,
+            componentIdx: component.componentIdx,
             uniqueIdentifiersUsed: workspace.uniqueIdentifiersUsed,
             addShadowDependencies: true,
             markAsPrimaryShadow: true,
@@ -641,7 +641,7 @@ export default class NumberList extends CompositeComponent {
         let processResult = processAssignNames({
             assignNames: component.doenetAttributes.assignNames,
             serializedComponents: replacements,
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             parentCreatesNewNamespace: newNamespace,
             componentInfoObjects,
         });
@@ -677,16 +677,16 @@ export default class NumberList extends CompositeComponent {
                 await component.stateValues.childInfoByComponent;
 
             for (let childInfo of childInfoByComponent) {
-                let replacementSource = components[childInfo.childName];
+                let replacementSource = components[childInfo.childIdx];
 
                 if (childInfo.nComponents !== undefined) {
                     componentsToCopy.push(
-                        replacementSource.componentName +
+                        replacementSource.componentIdx +
                             ":" +
                             childInfo.component,
                     );
                 } else {
-                    componentsToCopy.push(replacementSource.componentName);
+                    componentsToCopy.push(replacementSource.componentIdx);
                 }
             }
 

--- a/packages/doenetml-worker-javascript/src/components/P.js
+++ b/packages/doenetml-worker-javascript/src/components/P.js
@@ -59,7 +59,7 @@ export default class P extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/Paginator.js
+++ b/packages/doenetml-worker-javascript/src/components/Paginator.js
@@ -168,7 +168,7 @@ export class Paginator extends BlockComponent {
         let updateInstructions = [
             {
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "currentPage",
                 value: pageNumber,
                 sourceDetails: { fromSetPage: true },
@@ -184,7 +184,7 @@ export class Paginator extends BlockComponent {
             event: {
                 verb: "selected",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
                 result: {
@@ -199,7 +199,7 @@ export class Paginator extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },
@@ -221,7 +221,7 @@ export class PaginatorControls extends BlockComponent {
                     await this.stateValues.paginatorComponentName;
                 if (paginatorComponentName) {
                     return {
-                        componentName: paginatorComponentName,
+                        componentIdx: paginatorComponentName,
                         actionName: "setPage",
                     };
                 } else {
@@ -298,7 +298,7 @@ export class PaginatorControls extends BlockComponent {
                     return {
                         paginatorPage: {
                             dependencyType: "stateVariable",
-                            componentName: stateValues.paginatorComponentName,
+                            componentIdx: stateValues.paginatorComponentName,
                             variableName: "currentPage",
                         },
                     };
@@ -327,7 +327,7 @@ export class PaginatorControls extends BlockComponent {
                     return {
                         paginatorNPages: {
                             dependencyType: "stateVariable",
-                            componentName: stateValues.paginatorComponentName,
+                            componentIdx: stateValues.paginatorComponentName,
                             variableName: "numPages",
                         },
                     };

--- a/packages/doenetml-worker-javascript/src/components/Parabola.js
+++ b/packages/doenetml-worker-javascript/src/components/Parabola.js
@@ -580,8 +580,8 @@ export default class Parabola extends Curve {
                     variableName: "aShadow",
                 },
             }),
-            definition: function ({ dependencyValues, componentName }) {
-                // console.log(`definition of a, b, c, realValued of parabola ${componentName}`)
+            definition: function ({ dependencyValues, componentIdx }) {
+                // console.log(`definition of a, b, c, realValued of parabola ${componentIdx}`)
                 // console.log(dependencyValues)
 
                 if (!dependencyValues.pointsAreNumerical) {
@@ -1576,7 +1576,7 @@ export default class Parabola extends Curve {
                     variableName: "c",
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 let skip = !(
                     Number.isFinite(dependencyValues.a) &&
                     Number.isFinite(dependencyValues.b) &&

--- a/packages/doenetml-worker-javascript/src/components/Point.js
+++ b/packages/doenetml-worker-javascript/src/components/Point.js
@@ -613,7 +613,7 @@ export default class Point extends GraphicalComponent {
                 dependencyValuesByKey,
                 arrayKeys,
             }) {
-                // console.log(`unconstrained xs definition by key for ${componentName}`)
+                // console.log(`unconstrained xs definition by key for ${componentIdx}`)
                 // console.log(deepClone(globalDependencyValues))
                 // console.log(deepClone(dependencyValuesByKey))
                 // console.log(deepClone(arrayKeys));
@@ -711,7 +711,7 @@ export default class Point extends GraphicalComponent {
                 dependencyNamesByKey,
                 arraySize,
             }) {
-                // console.log(`invertUnconstrainedXs, ${componentName}`);
+                // console.log(`invertUnconstrainedXs, ${componentIdx}`);
                 // console.log(desiredStateVariableValues)
                 // console.log(globalDependencyValues);
                 // console.log(dependencyValuesByKey);
@@ -1288,7 +1288,7 @@ export default class Point extends GraphicalComponent {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "xs",
                         value: components,
                     },
@@ -1303,7 +1303,7 @@ export default class Point extends GraphicalComponent {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "xs",
                         value: components,
                     },
@@ -1314,7 +1314,7 @@ export default class Point extends GraphicalComponent {
                 event: {
                     verb: "interacted",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: {
@@ -1338,7 +1338,7 @@ export default class Point extends GraphicalComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "click",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,
@@ -1355,7 +1355,7 @@ export default class Point extends GraphicalComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "focus",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,

--- a/packages/doenetml-worker-javascript/src/components/Polyline.js
+++ b/packages/doenetml-worker-javascript/src/components/Polyline.js
@@ -1998,7 +1998,7 @@ export default class Polyline extends GraphicalComponent {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "vertices",
                         value: vertexComponents,
                         sourceDetails,
@@ -2014,7 +2014,7 @@ export default class Polyline extends GraphicalComponent {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "vertices",
                         value: vertexComponents,
                         sourceDetails,
@@ -2026,7 +2026,7 @@ export default class Polyline extends GraphicalComponent {
                 event: {
                     verb: "interacted",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: {
@@ -2135,7 +2135,7 @@ export default class Polyline extends GraphicalComponent {
                     let newInstructions = [
                         {
                             updateType: "updateValue",
-                            componentName: this.componentName,
+                            componentIdx: this.componentIdx,
                             stateVariable: "unconstrainedVertices",
                             value: newVertexComponents,
                         },
@@ -2187,7 +2187,7 @@ export default class Polyline extends GraphicalComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "click",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,
@@ -2204,7 +2204,7 @@ export default class Polyline extends GraphicalComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "focus",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,

--- a/packages/doenetml-worker-javascript/src/components/RandomizedTextList.js
+++ b/packages/doenetml-worker-javascript/src/components/RandomizedTextList.js
@@ -44,7 +44,7 @@ export default class TextList extends InlineComponent {
             return {
                 success: true,
                 newChildren: newChildren,
-                toDelete: [stringChild.componentName],
+                toDelete: [stringChild.componentIdx],
             };
         };
 
@@ -110,10 +110,10 @@ export default class TextList extends InlineComponent {
                 let texts = [];
 
                 let childNames = dependencyValues.textAndTextListChildren.map(
-                    (x) => x.componentName,
+                    (x) => x.componentIdx,
                 );
-                for (let childName of dependencyValues.childrenToRender) {
-                    let index = childNames.indexOf(childName);
+                for (let childIdx of dependencyValues.childrenToRender) {
+                    let index = childNames.indexOf(childIdx);
                     let child = dependencyValues.textAndTextListChildren[index];
                     if (child.stateValues.texts) {
                         texts.push(...child.stateValues.texts);
@@ -187,7 +187,7 @@ export default class TextList extends InlineComponent {
                             ...child.stateValues.childrenToRender,
                         );
                     } else {
-                        childrenToRender.push(child.componentName);
+                        childrenToRender.push(child.componentIdx);
                     }
                 }
 
@@ -226,7 +226,7 @@ export default class TextList extends InlineComponent {
     initializeRenderer() {
         if (this.renderer === undefined) {
             this.renderer = new this.availableRenderers.aslist({
-                key: this.componentName,
+                key: this.componentIdx,
             });
         }
     }

--- a/packages/doenetml-worker-javascript/src/components/Ray.js
+++ b/packages/doenetml-worker-javascript/src/components/Ray.js
@@ -814,7 +814,7 @@ export default class Ray extends GraphicalComponent {
                 dependencyValuesByKey,
                 arrayKeys,
             }) {
-                // console.log('array definition of vector direction', componentName)
+                // console.log('array definition of vector direction', componentIdx)
                 // console.log(globalDependencyValues, dependencyValuesByKey, arrayKeys)
 
                 let direction = {};
@@ -1695,7 +1695,7 @@ export default class Ray extends GraphicalComponent {
 
                 updateInstructions.push({
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "direction",
                     value: direction.map((x) => me.fromAst(x)),
                 });
@@ -1703,7 +1703,7 @@ export default class Ray extends GraphicalComponent {
                 // set endpoint directly
                 updateInstructions.push({
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "endpoint",
                     value: endpointcoords.map((x) => me.fromAst(x)),
                 });
@@ -1721,7 +1721,7 @@ export default class Ray extends GraphicalComponent {
                     );
                     updateInstructions.push({
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "direction",
                         value: direction.map((x) => me.fromAst(x)),
                     });
@@ -1734,7 +1734,7 @@ export default class Ray extends GraphicalComponent {
             if (await this.stateValues.basedOnThrough) {
                 updateInstructions.push({
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "through",
                     value: throughcoords.map((x) => me.fromAst(x)),
                 });
@@ -1750,7 +1750,7 @@ export default class Ray extends GraphicalComponent {
                 );
                 updateInstructions.push({
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "direction",
                     value: direction.map((x) => me.fromAst(x)),
                 });
@@ -1771,7 +1771,7 @@ export default class Ray extends GraphicalComponent {
                     );
                     updateInstructions.push({
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "direction",
                         value: direction.map((x) => me.fromAst(x)),
                     });
@@ -1799,7 +1799,7 @@ export default class Ray extends GraphicalComponent {
                 event: {
                     verb: "interacted",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: {
@@ -1867,13 +1867,13 @@ export default class Ray extends GraphicalComponent {
                 let newInstructions = [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "endpoint",
                         value: newNumericalPoints[0].map((x) => me.fromAst(x)),
                     },
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "through",
                         value: newNumericalPoints[1].map((x) => me.fromAst(x)),
                     },
@@ -1907,7 +1907,7 @@ export default class Ray extends GraphicalComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "click",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,
@@ -1924,7 +1924,7 @@ export default class Ray extends GraphicalComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "focus",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,

--- a/packages/doenetml-worker-javascript/src/components/Rectangle.js
+++ b/packages/doenetml-worker-javascript/src/components/Rectangle.js
@@ -1429,7 +1429,7 @@ export default class Rectangle extends Polygon {
         }
         updateInstructions.push({
             updateType: "updateValue",
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             stateVariable: "vertices",
             value: vertexComponents,
             sourceDetails,
@@ -1465,7 +1465,7 @@ export default class Rectangle extends Polygon {
                     if (centerX !== undefined) {
                         updateInstructions.push({
                             updateType: "updateValue",
-                            componentName: this.componentName,
+                            componentIdx: this.componentIdx,
                             stateVariable: "specifiedCenter",
                             value: { 0: centerX.simplify() },
                         });
@@ -1473,7 +1473,7 @@ export default class Rectangle extends Polygon {
                     if (centerY !== undefined) {
                         updateInstructions.push({
                             updateType: "updateValue",
-                            componentName: this.componentName,
+                            componentIdx: this.componentIdx,
                             stateVariable: "specifiedCenter",
                             value: { 1: centerY.simplify() },
                         });
@@ -1494,7 +1494,7 @@ export default class Rectangle extends Polygon {
                     if (width !== undefined) {
                         updateInstructions.push({
                             updateType: "updateValue",
-                            componentName: this.componentName,
+                            componentIdx: this.componentIdx,
                             stateVariable: "specifiedWidth",
                             value: width.simplify(),
                         });
@@ -1502,7 +1502,7 @@ export default class Rectangle extends Polygon {
                     if (height !== undefined) {
                         updateInstructions.push({
                             updateType: "updateValue",
-                            componentName: this.componentName,
+                            componentIdx: this.componentIdx,
                             stateVariable: "specifiedHeight",
                             value: height.simplify(),
                         });
@@ -1530,7 +1530,7 @@ export default class Rectangle extends Polygon {
                 event: {
                     verb: "interacted",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: {
@@ -1644,7 +1644,7 @@ export default class Rectangle extends Polygon {
                     let newInstructions = [
                         {
                             updateType: "updateValue",
-                            componentName: this.componentName,
+                            componentIdx: this.componentIdx,
                             stateVariable: "vertices",
                             value: newVertexComponents,
                         },

--- a/packages/doenetml-worker-javascript/src/components/Ref.js
+++ b/packages/doenetml-worker-javascript/src/components/Ref.js
@@ -71,8 +71,8 @@ export default class Ref extends InlineComponent {
                     return {
                         targetIsInactiveCompositeReplacement: {
                             dependencyType: "stateVariable",
-                            componentName:
-                                stateValues.targetComponent.componentName,
+                            componentIdx:
+                                stateValues.targetComponent.componentIdx,
                             variableName: "isInactiveCompositeReplacement",
                         },
                     };
@@ -131,7 +131,7 @@ export default class Ref extends InlineComponent {
                     return {
                         setValue: {
                             targetName:
-                                dependencyValues.targetComponent.componentName,
+                                dependencyValues.targetComponent.componentIdx,
                         },
                     };
                 }
@@ -292,13 +292,13 @@ export default class Ref extends InlineComponent {
                 if (stateValues.targetName) {
                     dependencies.equationTag = {
                         dependencyType: "stateVariable",
-                        componentName: stateValues.targetName,
+                        componentIdx: stateValues.targetName,
                         variableName: "equationTag",
                         variablesOptional: true,
                     };
                     dependencies.title = {
                         dependencyType: "stateVariable",
-                        componentName: stateValues.targetName,
+                        componentIdx: stateValues.targetName,
                         variableName: "title",
                         variablesOptional: true,
                     };
@@ -367,7 +367,7 @@ export default class Ref extends InlineComponent {
             uri,
             targetName,
             actionId,
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             effectiveName,
         });
     }

--- a/packages/doenetml-worker-javascript/src/components/RegularPolygon.js
+++ b/packages/doenetml-worker-javascript/src/components/RegularPolygon.js
@@ -2041,7 +2041,7 @@ export default class RegularPolygon extends Polygon {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "vertices",
                         value: vertexComponents,
                         sourceDetails,
@@ -2057,7 +2057,7 @@ export default class RegularPolygon extends Polygon {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "vertices",
                         value: vertexComponents,
                         sourceDetails,
@@ -2069,7 +2069,7 @@ export default class RegularPolygon extends Polygon {
                 event: {
                     verb: "interacted",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: {
@@ -2131,14 +2131,14 @@ export default class RegularPolygon extends Polygon {
                             let newInstructions = [
                                 {
                                     updateType: "updateValue",
-                                    componentName: this.componentName,
+                                    componentIdx: this.componentIdx,
                                     stateVariable:
                                         "unconstrainedCenterComponents",
                                     value: resultingCenter,
                                 },
                                 {
                                     updateType: "updateValue",
-                                    componentName: this.componentName,
+                                    componentIdx: this.componentIdx,
                                     stateVariable:
                                         "unconstrainedDirectionWithRadius",
                                     value: desiredUnconstrainedDirectionWithRadius,
@@ -2167,13 +2167,13 @@ export default class RegularPolygon extends Polygon {
                         let newInstructions = [
                             {
                                 updateType: "updateValue",
-                                componentName: this.componentName,
+                                componentIdx: this.componentIdx,
                                 stateVariable: "unconstrainedCenterComponents",
                                 value: newCenter,
                             },
                             {
                                 updateType: "updateValue",
-                                componentName: this.componentName,
+                                componentIdx: this.componentIdx,
                                 stateVariable:
                                     "unconstrainedDirectionWithRadius",
                                 value: desiredUnconstrainedDirectionWithRadius,
@@ -2244,13 +2244,13 @@ export default class RegularPolygon extends Polygon {
                         let newInstructions = [
                             {
                                 updateType: "updateValue",
-                                componentName: this.componentName,
+                                componentIdx: this.componentIdx,
                                 stateVariable: "unconstrainedCenterComponents",
                                 value: newCenter,
                             },
                             {
                                 updateType: "updateValue",
-                                componentName: this.componentName,
+                                componentIdx: this.componentIdx,
                                 stateVariable:
                                     "unconstrainedDirectionWithRadius",
                                 value: desiredUnconstrainedDirectionWithRadius,
@@ -2277,13 +2277,13 @@ export default class RegularPolygon extends Polygon {
                     let newInstructions = [
                         {
                             updateType: "updateValue",
-                            componentName: this.componentName,
+                            componentIdx: this.componentIdx,
                             stateVariable: "unconstrainedCenterComponents",
                             value: newCenter,
                         },
                         {
                             updateType: "updateValue",
-                            componentName: this.componentName,
+                            componentIdx: this.componentIdx,
                             stateVariable: "unconstrainedDirectionWithRadius",
                             value: desiredUnconstrainedDirectionWithRadius,
                         },

--- a/packages/doenetml-worker-javascript/src/components/SamplePrimeNumbers.js
+++ b/packages/doenetml-worker-javascript/src/components/SamplePrimeNumbers.js
@@ -206,11 +206,11 @@ export default class SamplePrimeNumbers extends CompositeComponent {
                     value: sharedParameters.variantSeed,
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 let generatedVariantInfo = {
                     seed: dependencyValues.variantSeed,
                     meta: {
-                        createdBy: componentName,
+                        createdBy: componentIdx,
                     },
                 };
 
@@ -249,7 +249,7 @@ export default class SamplePrimeNumbers extends CompositeComponent {
         let processResult = processAssignNames({
             assignNames: component.doenetAttributes.assignNames,
             serializedComponents: replacements,
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             parentCreatesNewNamespace: newNamespace,
             indOffset: startNum,
             componentInfoObjects,
@@ -391,7 +391,7 @@ export default class SamplePrimeNumbers extends CompositeComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "sampledValues",
                     value: sampledValues,
                 },

--- a/packages/doenetml-worker-javascript/src/components/SampleRandomNumbers.js
+++ b/packages/doenetml-worker-javascript/src/components/SampleRandomNumbers.js
@@ -603,11 +603,11 @@ export default class SampleRandomNumbers extends CompositeComponent {
                     value: sharedParameters.variantSeed,
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 let generatedVariantInfo = {
                     seed: dependencyValues.variantSeed,
                     meta: {
-                        createdBy: componentName,
+                        createdBy: componentIdx,
                     },
                 };
 
@@ -665,7 +665,7 @@ export default class SampleRandomNumbers extends CompositeComponent {
         let processResult = processAssignNames({
             assignNames: component.doenetAttributes.assignNames,
             serializedComponents: replacements,
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             parentCreatesNewNamespace: newNamespace,
             indOffset: startNum,
             componentInfoObjects,
@@ -813,7 +813,7 @@ export default class SampleRandomNumbers extends CompositeComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "sampledValues",
                     value: sampledValues,
                 },

--- a/packages/doenetml-worker-javascript/src/components/Select.js
+++ b/packages/doenetml-worker-javascript/src/components/Select.js
@@ -577,10 +577,10 @@ export default class Select extends CompositeComponent {
                     ignoreReplacementsOfEncounteredComposites: true,
                 },
             }),
-            definition({ dependencyValues, componentName, previousValues }) {
+            definition({ dependencyValues, componentIdx, previousValues }) {
                 let generatedVariantInfo = {
                     indices: dependencyValues.selectedIndices,
-                    meta: { createdBy: componentName },
+                    meta: { createdBy: componentIdx },
                 };
 
                 let subvariants = (generatedVariantInfo.subvariants = []);
@@ -643,7 +643,7 @@ export default class Select extends CompositeComponent {
         components,
         componentInfoObjects,
     }) {
-        // console.log(`create serialized replacements for ${component.componentName}`);
+        // console.log(`create serialized replacements for ${component.componentIdx}`);
 
         let errors = [];
         let warnings = [];
@@ -671,7 +671,7 @@ export default class Select extends CompositeComponent {
 
         for (let selectedIndex of await component.stateValues.selectedIndices) {
             let selectedChildName =
-                optionChildren[selectedIndex - 1].componentName;
+                optionChildren[selectedIndex - 1].componentIdx;
 
             let selectedChild = components[selectedChildName];
 
@@ -747,7 +747,7 @@ export default class Select extends CompositeComponent {
             let processResult = processAssignNames({
                 assignNames,
                 serializedComponents: [rep],
-                parentName: component.componentName,
+                parentIdx: component.componentIdx,
                 parentCreatesNewNamespace: newNamespace,
                 componentInfoObjects,
                 indOffset: ind,

--- a/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
@@ -202,10 +202,10 @@ export default class SelectFromSequence extends Sequence {
                     variableName: "selectedIndices",
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 let generatedVariantInfo = {
                     indices: dependencyValues.selectedIndices,
-                    meta: { createdBy: componentName },
+                    meta: { createdBy: componentIdx },
                 };
 
                 return { setValue: { generatedVariantInfo } };
@@ -298,7 +298,7 @@ export default class SelectFromSequence extends Sequence {
         let processResult = processAssignNames({
             assignNames: component.doenetAttributes.assignNames,
             serializedComponents: replacements,
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             parentCreatesNewNamespace: newNamespace,
             componentInfoObjects,
         });

--- a/packages/doenetml-worker-javascript/src/components/SelectPrimeNumbers.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectPrimeNumbers.js
@@ -219,10 +219,10 @@ export default class SelectPrimeNumbers extends CompositeComponent {
                     variableName: "selectedValues",
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 let generatedVariantInfo = {
                     values: dependencyValues.selectedValues,
-                    meta: { createdBy: componentName },
+                    meta: { createdBy: componentIdx },
                 };
 
                 return { setValue: { generatedVariantInfo } };
@@ -282,7 +282,7 @@ export default class SelectPrimeNumbers extends CompositeComponent {
         let processResult = processAssignNames({
             assignNames: component.doenetAttributes.assignNames,
             serializedComponents: replacements,
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             parentCreatesNewNamespace: newNamespace,
             componentInfoObjects,
         });

--- a/packages/doenetml-worker-javascript/src/components/SelectRandomNumbers.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectRandomNumbers.js
@@ -160,10 +160,10 @@ export default class SelectRandomNumbers extends SampleRandomNumbers {
                     variableName: "selectedValues",
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 let generatedVariantInfo = {
                     values: dependencyValues.selectedValues,
-                    meta: { createdBy: componentName },
+                    meta: { createdBy: componentIdx },
                 };
 
                 return { setValue: { generatedVariantInfo } };
@@ -225,7 +225,7 @@ export default class SelectRandomNumbers extends SampleRandomNumbers {
         let processResult = processAssignNames({
             assignNames: component.doenetAttributes.assignNames,
             serializedComponents: replacements,
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             parentCreatesNewNamespace: newNamespace,
             componentInfoObjects,
         });

--- a/packages/doenetml-worker-javascript/src/components/Sequence.js
+++ b/packages/doenetml-worker-javascript/src/components/Sequence.js
@@ -93,7 +93,7 @@ export default class Sequence extends CompositeComponent {
         workspace,
         componentInfoObjects,
     }) {
-        // console.log(`create serialized replacements for ${component.componentName}`)
+        // console.log(`create serialized replacements for ${component.componentIdx}`)
 
         let errors = [];
         let warnings = [];
@@ -178,13 +178,13 @@ export default class Sequence extends CompositeComponent {
             replacements.push(serializedComponent);
         }
 
-        // console.log(`replacements for ${component.componentName}`)
+        // console.log(`replacements for ${component.componentIdx}`)
         // console.log(replacements)
 
         let processResult = processAssignNames({
             assignNames: component.doenetAttributes.assignNames,
             serializedComponents: replacements,
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             parentCreatesNewNamespace: newNamespace,
             componentInfoObjects,
         });
@@ -203,7 +203,7 @@ export default class Sequence extends CompositeComponent {
         workspace,
         componentInfoObjects,
     }) {
-        // console.log(`calculate replacement changes for ${component.componentName}`);
+        // console.log(`calculate replacement changes for ${component.componentIdx}`);
 
         // TODO: don't yet have a way to return errors and warnings!
         let errors = [];
@@ -427,7 +427,7 @@ export default class Sequence extends CompositeComponent {
                 let processResult = processAssignNames({
                     assignNames: component.doenetAttributes.assignNames,
                     serializedComponents: newSerializedReplacements,
-                    parentName: component.componentName,
+                    parentIdx: component.componentIdx,
                     parentCreatesNewNamespace: newNamespace,
                     componentInfoObjects,
                     indOffset: prevlength,

--- a/packages/doenetml-worker-javascript/src/components/Setup.js
+++ b/packages/doenetml-worker-javascript/src/components/Setup.js
@@ -37,7 +37,7 @@ export default class Setup extends CompositeComponent {
                 let componentNameForAttributes = null;
                 if (dependencyValues.sourceCompositeIdentity) {
                     componentNameForAttributes =
-                        dependencyValues.sourceCompositeIdentity.componentName;
+                        dependencyValues.sourceCompositeIdentity.componentIdx;
                 }
                 return { setValue: { componentNameForAttributes } };
             },

--- a/packages/doenetml-worker-javascript/src/components/Shuffle.js
+++ b/packages/doenetml-worker-javascript/src/components/Shuffle.js
@@ -135,7 +135,7 @@ export default class Shuffle extends CompositeComponent {
                             ...child.stateValues.componentNamesInList,
                         );
                     } else {
-                        originalComponentNames.push(child.componentName);
+                        originalComponentNames.push(child.componentIdx);
                     }
                 }
 
@@ -282,10 +282,10 @@ export default class Shuffle extends CompositeComponent {
                     ignoreReplacementsOfEncounteredComposites: true,
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 let generatedVariantInfo = {
                     seed: dependencyValues.variantSeed,
-                    meta: { createdBy: componentName },
+                    meta: { createdBy: componentIdx },
                     indices: dependencyValues.componentOrder,
                 };
 
@@ -347,7 +347,7 @@ export default class Shuffle extends CompositeComponent {
             let replacementSource = components[originalComponentNames[ind - 1]];
 
             if (replacementSource) {
-                componentsCopied.push(replacementSource.componentName);
+                componentsCopied.push(replacementSource.componentIdx);
 
                 replacements.push(
                     await replacementSource.serialize({
@@ -360,7 +360,7 @@ export default class Shuffle extends CompositeComponent {
         workspace.uniqueIdentifiersUsed = [];
         replacements = postProcessCopy({
             serializedComponents: replacements,
-            componentName: component.componentName,
+            componentIdx: component.componentIdx,
             uniqueIdentifiersUsed: workspace.uniqueIdentifiersUsed,
             addShadowDependencies: true,
             markAsPrimaryShadow: true,
@@ -369,7 +369,7 @@ export default class Shuffle extends CompositeComponent {
         let processResult = processAssignNames({
             assignNames: component.doenetAttributes.assignNames,
             serializedComponents: replacements,
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             parentCreatesNewNamespace: await component.stateValues.newNamespace,
             componentInfoObjects,
         });
@@ -404,7 +404,7 @@ export default class Shuffle extends CompositeComponent {
             let replacementSource = components[originalComponentNames[ind - 1]];
 
             if (replacementSource) {
-                componentsToCopy.push(replacementSource.componentName);
+                componentsToCopy.push(replacementSource.componentIdx);
             }
         }
 

--- a/packages/doenetml-worker-javascript/src/components/SideBySide.js
+++ b/packages/doenetml-worker-javascript/src/components/SideBySide.js
@@ -1166,7 +1166,7 @@ export class SideBySide extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },
@@ -2240,7 +2240,7 @@ export class SbsGroup extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },
@@ -2276,7 +2276,7 @@ export class Stack extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/Slider.js
+++ b/packages/doenetml-worker-javascript/src/components/Slider.js
@@ -673,7 +673,7 @@ export default class Slider extends BaseComponent {
                     updateInstructions: [
                         {
                             updateType: "updateValue",
-                            componentName: this.componentName,
+                            componentIdx: this.componentIdx,
                             stateVariable: "value",
                             value,
                         },
@@ -688,7 +688,7 @@ export default class Slider extends BaseComponent {
                     updateInstructions: [
                         {
                             updateType: "updateValue",
-                            componentName: this.componentName,
+                            componentIdx: this.componentIdx,
                             stateVariable: "value",
                             value,
                         },
@@ -699,7 +699,7 @@ export default class Slider extends BaseComponent {
                     event: {
                         verb: "selected",
                         object: {
-                            componentName: this.componentName,
+                            componentIdx: this.componentIdx,
                             componentType: this.componentType,
                         },
                         result: {

--- a/packages/doenetml-worker-javascript/src/components/Solution.js
+++ b/packages/doenetml-worker-javascript/src/components/Solution.js
@@ -269,7 +269,7 @@ export class Solution extends BlockComponent {
         // is not received, the solution will stay closed.
         if (displayMode === "buttonRequirePermission") {
             const requestResult = await this.coreFunctions.requestSolutionView(
-                this.componentName,
+                this.componentIdx,
             );
             allowView = requestResult.allowView;
         }
@@ -277,7 +277,7 @@ export class Solution extends BlockComponent {
         let updateInstructions = [
             {
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "open",
                 value: allowView,
             },
@@ -289,7 +289,7 @@ export class Solution extends BlockComponent {
             event = {
                 verb: "viewed",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
             };
@@ -307,7 +307,7 @@ export class Solution extends BlockComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "rendered",
                     value: allowView,
                 },
@@ -328,7 +328,7 @@ export class Solution extends BlockComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "open",
                     value: false,
                 },
@@ -340,7 +340,7 @@ export class Solution extends BlockComponent {
             event: {
                 verb: "closed",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
             },
@@ -351,7 +351,7 @@ export class Solution extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/Sort.js
+++ b/packages/doenetml-worker-javascript/src/components/Sort.js
@@ -162,7 +162,7 @@ export default class Sort extends CompositeComponent {
                             ...child.stateValues.componentNamesInList,
                         );
                     } else {
-                        componentNamesForValues.push(child.componentName);
+                        componentNamesForValues.push(child.componentIdx);
                     }
                 }
 
@@ -198,7 +198,7 @@ export default class Sort extends CompositeComponent {
                     ] of stateValues.componentNamesForValues.entries()) {
                         dependencies[`component${ind}`] = {
                             dependencyType: "stateVariable",
-                            componentName: cName,
+                            componentIdx: cName,
                             variableName: stateValues.propName,
                             variablesOptional: true,
                             caseInsensitiveVariableMatch: true,
@@ -213,7 +213,7 @@ export default class Sort extends CompositeComponent {
                     ] of stateValues.componentNamesForValues.entries()) {
                         dependencies[`component${ind}`] = {
                             dependencyType: "multipleStateVariables",
-                            componentName: cName,
+                            componentIdx: cName,
                             variableNames: [
                                 "value",
                                 `x${stateValues.sortByComponent}`,
@@ -236,7 +236,7 @@ export default class Sort extends CompositeComponent {
                     if (dependencyValues.propName) {
                         let value = Object.values(component.stateValues)[0];
                         allValues.push({
-                            componentName: component.componentName,
+                            componentIdx: component.componentIdx,
                             numericalValue: Number(value),
                             textValue: String(value),
                         });
@@ -250,7 +250,7 @@ export default class Sort extends CompositeComponent {
                         })
                     ) {
                         allValues.push({
-                            componentName: component.componentName,
+                            componentIdx: component.componentIdx,
                             numericalValue: component.stateValues.value,
                             textValue: String(component.stateValues.value),
                         });
@@ -263,7 +263,7 @@ export default class Sort extends CompositeComponent {
                         let numericalValue = NaN;
                         let textValue = component.stateValues.value;
                         allValues.push({
-                            componentName: component.componentName,
+                            componentIdx: component.componentIdx,
                             numericalValue,
                             textValue,
                         });
@@ -280,7 +280,7 @@ export default class Sort extends CompositeComponent {
                             allAreNumeric = false;
                         }
                         allValues.push({
-                            componentName: component.componentName,
+                            componentIdx: component.componentIdx,
                             numericalValue,
                             textValue: component.stateValues.value.toString(),
                         });
@@ -304,7 +304,7 @@ export default class Sort extends CompositeComponent {
                             textValue = compValue.toString();
                         }
                         allValues.push({
-                            componentName: component.componentName,
+                            componentIdx: component.componentIdx,
                             numericalValue,
                             textValue,
                         });
@@ -339,7 +339,7 @@ export default class Sort extends CompositeComponent {
                             textValue = compValue.toString();
                         }
                         allValues.push({
-                            componentName: component.componentName,
+                            componentIdx: component.componentIdx,
                             numericalValue,
                             textValue,
                         });
@@ -401,15 +401,15 @@ export default class Sort extends CompositeComponent {
             let replacementSource;
 
             if (valueObj.listInd === undefined) {
-                replacementSource = components[valueObj.componentName];
+                replacementSource = components[valueObj.componentIdx];
             } else {
-                let listComponent = components[valueObj.componentName];
+                let listComponent = components[valueObj.componentIdx];
                 replacementSource =
                     listComponent.activeChildren[valueObj.listInd];
             }
 
             if (replacementSource) {
-                componentsCopied.push(replacementSource.componentName);
+                componentsCopied.push(replacementSource.componentIdx);
 
                 replacements.push(
                     await replacementSource.serialize({
@@ -422,7 +422,7 @@ export default class Sort extends CompositeComponent {
         workspace.uniqueIdentifiersUsed = [];
         replacements = postProcessCopy({
             serializedComponents: replacements,
-            componentName: component.componentName,
+            componentIdx: component.componentIdx,
             uniqueIdentifiersUsed: workspace.uniqueIdentifiersUsed,
             addShadowDependencies: true,
             markAsPrimaryShadow: true,
@@ -431,7 +431,7 @@ export default class Sort extends CompositeComponent {
         let processResult = processAssignNames({
             assignNames: component.doenetAttributes.assignNames,
             serializedComponents: replacements,
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             parentCreatesNewNamespace: await component.stateValues.newNamespace,
             componentInfoObjects,
         });
@@ -463,15 +463,15 @@ export default class Sort extends CompositeComponent {
             let replacementSource;
 
             if (valueObj.listInd === undefined) {
-                replacementSource = components[valueObj.componentName];
+                replacementSource = components[valueObj.componentIdx];
             } else {
-                let listComponent = components[valueObj.componentName];
+                let listComponent = components[valueObj.componentIdx];
                 replacementSource =
                     listComponent.activeChildren[valueObj.listInd];
             }
 
             if (replacementSource) {
-                componentsToCopy.push(replacementSource.componentName);
+                componentsToCopy.push(replacementSource.componentIdx);
             }
         }
 

--- a/packages/doenetml-worker-javascript/src/components/Sources.js
+++ b/packages/doenetml-worker-javascript/src/components/Sources.js
@@ -97,7 +97,7 @@ export default class Sources extends BaseComponent {
             definition: function ({ dependencyValues }) {
                 let numChildren = dependencyValues.children.length;
                 let childComponentNames = dependencyValues.children.map(
-                    (x) => x.componentName,
+                    (x) => x.componentIdx,
                 );
                 return {
                     setValue: {

--- a/packages/doenetml-worker-javascript/src/components/Split.js
+++ b/packages/doenetml-worker-javascript/src/components/Split.js
@@ -194,10 +194,10 @@ export default class Split extends CompositeComponent {
             componentType: "textList",
             state: { textsShadow: await component.stateValues.splitValues },
             downstreamDependencies: {
-                [component.componentName]: [
+                [component.componentIdx]: [
                     {
                         dependencyType: "referenceShadow",
-                        compositeName: component.componentName,
+                        compositeIdx: component.componentIdx,
                         propVariable: "splitValues",
                     },
                 ],
@@ -207,7 +207,7 @@ export default class Split extends CompositeComponent {
         let processResult = processAssignNames({
             assignNames: component.doenetAttributes.assignNames,
             serializedComponents: [serializedReplacement],
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             parentCreatesNewNamespace: newNamespace,
             componentInfoObjects,
         });

--- a/packages/doenetml-worker-javascript/src/components/Spreadsheet.js
+++ b/packages/doenetml-worker-javascript/src/components/Spreadsheet.js
@@ -603,7 +603,7 @@ export default class Spreadsheet extends BlockComponent {
                         dependenciesByKey[arrayKey] = {
                             cellText: {
                                 dependencyType: "stateVariable",
-                                componentName: cnbrc[rowInd][colInd],
+                                componentIdx: cnbrc[rowInd][colInd],
                                 variableName: "text",
                                 variablesOptional: true,
                             },
@@ -1450,7 +1450,7 @@ export default class Spreadsheet extends BlockComponent {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "cells",
                         value: cellChanges,
                     },
@@ -1461,7 +1461,7 @@ export default class Spreadsheet extends BlockComponent {
                 event: {
                     verb: "interacted",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: cellChanges,
@@ -1474,7 +1474,7 @@ export default class Spreadsheet extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },
@@ -1663,7 +1663,7 @@ function addCellToMapping({
     cellNameToRowCol,
     cellNamesByRowCol,
 }) {
-    cellNameToRowCol[cell.componentName] = [rowIndex, colIndex];
+    cellNameToRowCol[cell.componentIdx] = [rowIndex, colIndex];
     if (cellNamesByRowCol[rowIndex] === undefined) {
         cellNamesByRowCol[rowIndex] = [];
     }
@@ -1676,5 +1676,5 @@ function addCellToMapping({
         let previousComponentName = cellNamesByRowCol[rowIndex][colIndex];
         cellNameToRowCol[previousComponentName] = null;
     }
-    cellNamesByRowCol[rowIndex][colIndex] = cell.componentName;
+    cellNamesByRowCol[rowIndex][colIndex] = cell.componentIdx;
 }

--- a/packages/doenetml-worker-javascript/src/components/SubsetOfRealsInput.js
+++ b/packages/doenetml-worker-javascript/src/components/SubsetOfRealsInput.js
@@ -375,7 +375,7 @@ export default class SubsetOfRealsInput extends BlockComponent {
                     return await this.coreFunctions.performUpdate({
                         updateInstructions: [
                             {
-                                componentName: this.componentName,
+                                componentIdx: this.componentIdx,
                                 updateType: "updateValue",
                                 stateVariable: "additionalPoints",
                                 value: additionalPoints,
@@ -387,7 +387,7 @@ export default class SubsetOfRealsInput extends BlockComponent {
                         event: {
                             verb: "interacted",
                             object: {
-                                componentName: this.componentName,
+                                componentIdx: this.componentIdx,
                                 componentType: this.componentType,
                             },
                             result: {
@@ -421,7 +421,7 @@ export default class SubsetOfRealsInput extends BlockComponent {
                         event: {
                             verb: "interacted",
                             object: {
-                                componentName: this.componentName,
+                                componentIdx: this.componentIdx,
                                 componentType: this.componentType,
                             },
                             result: {
@@ -455,7 +455,7 @@ export default class SubsetOfRealsInput extends BlockComponent {
             return await this.coreFunctions.performUpdate({
                 updateInstructions: [
                     {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         updateType: "updateValue",
                         stateVariable: "additionalPoints",
                         value: additionalPoints,
@@ -467,7 +467,7 @@ export default class SubsetOfRealsInput extends BlockComponent {
                 event: {
                     verb: "interacted",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: {
@@ -616,7 +616,7 @@ export default class SubsetOfRealsInput extends BlockComponent {
                 event: {
                     verb: "interacted",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: {
@@ -666,7 +666,7 @@ export default class SubsetOfRealsInput extends BlockComponent {
 
         let updateInstructions = [
             {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 updateType: "updateValue",
                 stateVariable: "subsetValue",
                 value: newSubset,
@@ -675,7 +675,7 @@ export default class SubsetOfRealsInput extends BlockComponent {
 
         if (modifiedAdditionalPoints) {
             updateInstructions.push({
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 updateType: "updateValue",
                 stateVariable: "additionalPoints",
                 value: additionalPoints.map(roundValue),
@@ -727,7 +727,7 @@ export default class SubsetOfRealsInput extends BlockComponent {
                 return await this.coreFunctions.performUpdate({
                     updateInstructions: [
                         {
-                            componentName: this.componentName,
+                            componentIdx: this.componentIdx,
                             updateType: "updateValue",
                             stateVariable: "additionalPoints",
                             value: additionalPoints,
@@ -742,7 +742,7 @@ export default class SubsetOfRealsInput extends BlockComponent {
                 return await this.coreFunctions.performUpdate({
                     updateInstructions: [
                         {
-                            componentName: this.componentName,
+                            componentIdx: this.componentIdx,
                             updateType: "updateValue",
                             stateVariable: "additionalPoints",
                             value: additionalPoints,
@@ -754,7 +754,7 @@ export default class SubsetOfRealsInput extends BlockComponent {
                     event: {
                         verb: "interacted",
                         object: {
-                            componentName: this.componentName,
+                            componentIdx: this.componentIdx,
                             componentType: this.componentType,
                         },
                         result: {
@@ -818,7 +818,7 @@ export default class SubsetOfRealsInput extends BlockComponent {
                     event: {
                         verb: "interacted",
                         object: {
-                            componentName: this.componentName,
+                            componentIdx: this.componentIdx,
                             componentType: this.componentType,
                         },
                         result: {
@@ -954,7 +954,7 @@ export default class SubsetOfRealsInput extends BlockComponent {
             event: {
                 verb: "interacted",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
                 result: {
@@ -1338,7 +1338,7 @@ export default class SubsetOfRealsInput extends BlockComponent {
             event: {
                 verb: "interacted",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
                 result: {
@@ -1371,7 +1371,7 @@ export default class SubsetOfRealsInput extends BlockComponent {
             event: {
                 verb: "interacted",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
                 result: {
@@ -1404,7 +1404,7 @@ export default class SubsetOfRealsInput extends BlockComponent {
             event: {
                 verb: "interacted",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
                 result: {
@@ -1421,7 +1421,7 @@ export default class SubsetOfRealsInput extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/Substitute.js
+++ b/packages/doenetml-worker-javascript/src/components/Substitute.js
@@ -456,10 +456,10 @@ export default class Substitute extends CompositeComponent {
             componentType: type,
             state: { value: await component.stateValues.value },
             downstreamDependencies: {
-                [component.componentName]: [
+                [component.componentIdx]: [
                     {
                         dependencyType: "referenceShadow",
-                        compositeName: component.componentName,
+                        compositeIdx: component.componentIdx,
                         propVariable: "value",
                     },
                 ],
@@ -485,9 +485,9 @@ export default class Substitute extends CompositeComponent {
                 let shadowComponent = {
                     componentType: attributesComponentTypes[attr],
                     downstreamDependencies: {
-                        [component.componentName]: [
+                        [component.componentIdx]: [
                             {
-                                compositeName: component.componentName,
+                                compositeIdx: component.componentIdx,
                                 dependencyType: "referenceShadow",
                                 propVariable: attr,
                             },
@@ -506,7 +506,7 @@ export default class Substitute extends CompositeComponent {
         let processResult = processAssignNames({
             assignNames: component.doenetAttributes.assignNames,
             serializedComponents: [serializedReplacement],
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             parentCreatesNewNamespace: newNamespace,
             componentInfoObjects,
         });

--- a/packages/doenetml-worker-javascript/src/components/SummaryStatistics.js
+++ b/packages/doenetml-worker-javascript/src/components/SummaryStatistics.js
@@ -151,7 +151,7 @@ export default class SummaryStatistics extends BlockComponent {
                 return {
                     dataFrame: {
                         dependencyType: "stateVariable",
-                        componentName: stateValues.sourceName,
+                        componentIdx: stateValues.sourceName,
                         variableName: "dataFrame",
                         variableOptional: true,
                     },
@@ -651,7 +651,7 @@ export default class SummaryStatistics extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/Table.js
+++ b/packages/doenetml-worker-javascript/src/components/Table.js
@@ -104,7 +104,7 @@ export default class Table extends BlockComponent {
                 let titleChildName = null;
                 if (dependencyValues.titleChild.length > 0) {
                     titleChildName =
-                        dependencyValues.titleChild[0].componentName;
+                        dependencyValues.titleChild[0].componentIdx;
                 }
                 return {
                     setValue: { titleChildName },
@@ -141,7 +141,7 @@ export default class Table extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/Tabular.js
+++ b/packages/doenetml-worker-javascript/src/components/Tabular.js
@@ -374,7 +374,7 @@ export default class Tabular extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/Text.js
+++ b/packages/doenetml-worker-javascript/src/components/Text.js
@@ -374,7 +374,7 @@ export default class Text extends InlineComponent {
             actionId,
             sourceInformation,
             skipRendererUpdate,
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             componentType: this.componentType,
             coreFunctions: this.coreFunctions,
         });
@@ -389,7 +389,7 @@ export default class Text extends InlineComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "click",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,
@@ -406,7 +406,7 @@ export default class Text extends InlineComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "focus",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,

--- a/packages/doenetml-worker-javascript/src/components/TextInput.js
+++ b/packages/doenetml-worker-javascript/src/components/TextInput.js
@@ -30,7 +30,7 @@ export default class Textinput extends Input {
                 let answerAncestor = await this.stateValues.answerAncestor;
                 if (answerAncestor !== null) {
                     return {
-                        componentName: answerAncestor.componentName,
+                        componentIdx: answerAncestor.componentIdx,
                         actionName: "submitAnswer",
                     };
                 } else {
@@ -468,13 +468,13 @@ export default class Textinput extends Input {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "immediateValue",
                         value: text,
                     },
                     {
                         updateType: "setComponentNeedingUpdateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                     },
                 ],
                 transient: true,
@@ -497,7 +497,7 @@ export default class Textinput extends Input {
                 let updateInstructions = [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "value",
                         value: immediateValue,
                     },
@@ -511,7 +511,7 @@ export default class Textinput extends Input {
                     },
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "immediateValue",
                         valueOfStateVariable: "value",
                     },
@@ -523,7 +523,7 @@ export default class Textinput extends Input {
                 let event = {
                     verb: "answered",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: {
@@ -535,7 +535,7 @@ export default class Textinput extends Input {
                 let answerAncestor = await this.stateValues.answerAncestor;
                 if (answerAncestor) {
                     event.context = {
-                        answerAncestor: answerAncestor.componentName,
+                        answerAncestor: answerAncestor.componentIdx,
                     };
                 }
 
@@ -548,7 +548,7 @@ export default class Textinput extends Input {
                 });
 
                 return await this.coreFunctions.triggerChainedActions({
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     actionId,
                     sourceInformation,
                     skipRendererUpdate,
@@ -574,7 +574,7 @@ export default class Textinput extends Input {
             actionId,
             sourceInformation,
             skipRendererUpdate,
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             componentType: this.componentType,
             coreFunctions: this.coreFunctions,
         });

--- a/packages/doenetml-worker-javascript/src/components/TextList.js
+++ b/packages/doenetml-worker-javascript/src/components/TextList.js
@@ -134,7 +134,7 @@ export default class TextList extends CompositeComponent {
 
                 if (dependencyValues.textChildren.length > 0) {
                     childNameByComponent = dependencyValues.textChildren.map(
-                        (x) => x.componentName,
+                        (x) => x.componentIdx,
                     );
                     numComponents = dependencyValues.textChildren.length;
                 } else if (dependencyValues.textsShadow !== null) {
@@ -339,20 +339,20 @@ export default class TextList extends CompositeComponent {
 
         let numComponents = await component.stateValues.numComponents;
         for (let i = 0; i < numComponents; i++) {
-            let childName = childNameByComponent[i];
-            let replacementSource = components[childName];
+            let childIdx = childNameByComponent[i];
+            let replacementSource = components[childIdx];
 
             if (replacementSource) {
-                componentsCopied.push(replacementSource.componentName);
+                componentsCopied.push(replacementSource.componentIdx);
             }
             replacements.push({
                 componentType: "text",
                 attributes: JSON.parse(JSON.stringify(attributesFromComposite)),
                 downstreamDependencies: {
-                    [component.componentName]: [
+                    [component.componentIdx]: [
                         {
                             dependencyType: "referenceShadow",
-                            compositeName: component.componentName,
+                            compositeIdx: component.componentIdx,
                             propVariable: `text${i + 1}`,
                         },
                     ],
@@ -363,7 +363,7 @@ export default class TextList extends CompositeComponent {
         workspace.uniqueIdentifiersUsed = [];
         replacements = postProcessCopy({
             serializedComponents: replacements,
-            componentName: component.componentName,
+            componentIdx: component.componentIdx,
             uniqueIdentifiersUsed: workspace.uniqueIdentifiersUsed,
             addShadowDependencies: true,
             markAsPrimaryShadow: true,
@@ -372,7 +372,7 @@ export default class TextList extends CompositeComponent {
         let processResult = processAssignNames({
             assignNames: component.doenetAttributes.assignNames,
             serializedComponents: replacements,
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             parentCreatesNewNamespace: newNamespace,
             componentInfoObjects,
         });
@@ -407,11 +407,11 @@ export default class TextList extends CompositeComponent {
             let childNameByComponent =
                 await component.stateValues.childNameByComponent;
 
-            for (let childName of childNameByComponent) {
-                let replacementSource = components[childName];
+            for (let childIdx of childNameByComponent) {
+                let replacementSource = components[childIdx];
 
                 if (replacementSource) {
-                    componentsToCopy.push(replacementSource.componentName);
+                    componentsToCopy.push(replacementSource.componentIdx);
                 }
             }
 

--- a/packages/doenetml-worker-javascript/src/components/TriggerSet.js
+++ b/packages/doenetml-worker-javascript/src/components/TriggerSet.js
@@ -126,7 +126,7 @@ export default class triggerSet extends InlineComponent {
                 })
             ) {
                 await this.coreFunctions.performAction({
-                    componentName: child.componentName,
+                    componentIdx: child.componentIdx,
                     actionName: "updateValue",
                     args: {
                         actionId,
@@ -141,7 +141,7 @@ export default class triggerSet extends InlineComponent {
                 })
             ) {
                 await this.coreFunctions.performAction({
-                    componentName: child.componentName,
+                    componentIdx: child.componentIdx,
                     actionName: "callAction",
                     args: {
                         actionId,
@@ -153,7 +153,7 @@ export default class triggerSet extends InlineComponent {
         }
 
         return await this.coreFunctions.triggerChainedActions({
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             actionId,
             sourceInformation,
             skipRendererUpdate,
@@ -192,7 +192,7 @@ export default class triggerSet extends InlineComponent {
             actionId,
             sourceInformation,
             skipRendererUpdate,
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             componentType: this.componentType,
             coreFunctions: this.coreFunctions,
         });

--- a/packages/doenetml-worker-javascript/src/components/UpdateValue.js
+++ b/packages/doenetml-worker-javascript/src/components/UpdateValue.js
@@ -232,8 +232,8 @@ export default class UpdateValue extends InlineComponent {
 
                         dependencies.targets = {
                             dependencyType: "replacement",
-                            compositeName:
-                                stateValues.targetComponent.componentName,
+                            compositeIdx:
+                                stateValues.targetComponent.componentIdx,
                             recursive: true,
                             componentIndex: stateValues.componentIndex,
                             targetSubnames: stateValues.targetSubnames,
@@ -318,7 +318,7 @@ export default class UpdateValue extends InlineComponent {
                             }
                             thisTarget = {
                                 dependencyType: "stateVariable",
-                                componentName: target.componentName,
+                                componentIdx: target.componentIdx,
                                 variableName: stateValues.propName,
                                 returnAsComponentObject: true,
                                 variablesOptional: true,
@@ -330,7 +330,7 @@ export default class UpdateValue extends InlineComponent {
                         } else {
                             thisTarget = {
                                 dependencyType: "stateVariable",
-                                componentName: target.componentName,
+                                componentIdx: target.componentIdx,
                                 variableName: "value",
                                 returnAsComponentObject: true,
                                 variablesOptional: true,
@@ -443,7 +443,7 @@ export default class UpdateValue extends InlineComponent {
 
             updateInstructions.push({
                 updateType: "updateValue",
-                componentName: target.componentName,
+                componentIdx: target.componentIdx,
                 stateVariable,
                 value: newValue,
             });
@@ -457,7 +457,7 @@ export default class UpdateValue extends InlineComponent {
             event: {
                 verb: "selected",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
                 result: {
@@ -468,7 +468,7 @@ export default class UpdateValue extends InlineComponent {
         });
 
         return await this.coreFunctions.triggerChainedActions({
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             actionId,
             sourceInformation,
             skipRendererUpdate,
@@ -511,7 +511,7 @@ export default class UpdateValue extends InlineComponent {
             actionId,
             sourceInformation,
             skipRendererUpdate,
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             componentType: this.componentType,
             coreFunctions: this.coreFunctions,
         });

--- a/packages/doenetml-worker-javascript/src/components/Vector.js
+++ b/packages/doenetml-worker-javascript/src/components/Vector.js
@@ -1240,7 +1240,7 @@ export default class Vector extends GraphicalComponent {
                 dependencyValuesByKey,
                 arrayKeys,
             }) {
-                // console.log('array definition of vector displacement', componentName)
+                // console.log('array definition of vector displacement', componentIdx)
                 // console.log(globalDependencyValues, dependencyValuesByKey, arrayKeys)
 
                 let displacement = {};
@@ -2448,7 +2448,7 @@ export default class Vector extends GraphicalComponent {
 
                 updateInstructions.push({
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "displacement",
                     value: displacement.map((x) => me.fromAst(x)),
                     sourceDetails,
@@ -2457,7 +2457,7 @@ export default class Vector extends GraphicalComponent {
                 // set tail directly
                 updateInstructions.push({
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "tail",
                     value: tailcoords.map((x) => me.fromAst(x)),
                     sourceDetails,
@@ -2476,7 +2476,7 @@ export default class Vector extends GraphicalComponent {
                     );
                     updateInstructions.push({
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "displacement",
                         value: displacement.map((x) => me.fromAst(x)),
                         sourceDetails,
@@ -2490,7 +2490,7 @@ export default class Vector extends GraphicalComponent {
             if (await this.stateValues.basedOnHead) {
                 updateInstructions.push({
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "head",
                     value: headcoords.map((x) => me.fromAst(x)),
                     sourceDetails,
@@ -2505,7 +2505,7 @@ export default class Vector extends GraphicalComponent {
                 let displacement = tailcoords.map((x, i) => headcoords[i] - x);
                 updateInstructions.push({
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "displacement",
                     value: displacement.map((x) => me.fromAst(x)),
                     sourceDetails,
@@ -2527,7 +2527,7 @@ export default class Vector extends GraphicalComponent {
                     );
                     updateInstructions.push({
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "displacement",
                         value: displacement.map((x) => me.fromAst(x)),
                         sourceDetails,
@@ -2556,7 +2556,7 @@ export default class Vector extends GraphicalComponent {
                 event: {
                     verb: "interacted",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: {
@@ -2619,13 +2619,13 @@ export default class Vector extends GraphicalComponent {
                 let newInstructions = [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "tail",
                         value: newNumericalPoints[0].map((x) => me.fromAst(x)),
                     },
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "head",
                         value: newNumericalPoints[1].map((x) => me.fromAst(x)),
                     },
@@ -2659,7 +2659,7 @@ export default class Vector extends GraphicalComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "click",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,
@@ -2676,7 +2676,7 @@ export default class Vector extends GraphicalComponent {
         if (!(await this.stateValues.fixed)) {
             await this.coreFunctions.triggerChainedActions({
                 triggeringAction: "focus",
-                componentName: name, // use name rather than this.componentName to get original name if adapted
+                componentIdx: name, // use name rather than this.componentIdx to get original name if adapted
                 actionId,
                 sourceInformation,
                 skipRendererUpdate,

--- a/packages/doenetml-worker-javascript/src/components/Verbatim.js
+++ b/packages/doenetml-worker-javascript/src/components/Verbatim.js
@@ -60,7 +60,7 @@ export class Pre extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },
@@ -148,7 +148,7 @@ export class DisplayDoenetML extends InlineComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/Video.js
+++ b/packages/doenetml-worker-javascript/src/components/Video.js
@@ -382,7 +382,7 @@ export default class Video extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "played",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
                 duration: duration,
             },
@@ -395,7 +395,7 @@ export default class Video extends BlockComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "state",
                     value: "playing",
                 },
@@ -419,7 +419,7 @@ export default class Video extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "watched",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
                 duration: duration,
             },
@@ -472,7 +472,7 @@ export default class Video extends BlockComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "segmentsWatched",
                     value: segmentsWatched,
                 },
@@ -484,7 +484,7 @@ export default class Video extends BlockComponent {
         });
 
         return await this.coreFunctions.triggerChainedActions({
-            componentName: this.componentName,
+            componentIdx: this.componentIdx,
             actionId,
             sourceInformation,
             skipRendererUpdate,
@@ -501,7 +501,7 @@ export default class Video extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "paused",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
                 duration: duration,
             },
@@ -513,7 +513,7 @@ export default class Video extends BlockComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "state",
                     value: "stopped",
                 },
@@ -529,7 +529,7 @@ export default class Video extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "skipped",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
                 duration: duration,
             },
@@ -549,7 +549,7 @@ export default class Video extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "completed",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
                 duration: duration,
             },
@@ -558,7 +558,7 @@ export default class Video extends BlockComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "state",
                     value: "stopped",
                 },
@@ -574,7 +574,7 @@ export default class Video extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },
@@ -591,13 +591,13 @@ export default class Video extends BlockComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "state",
                     value: "stopped",
                 },
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "duration",
                     value: duration,
                 },
@@ -619,7 +619,7 @@ export default class Video extends BlockComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "state",
                     value: "playing",
                 },
@@ -640,7 +640,7 @@ export default class Video extends BlockComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "state",
                     value: "stopped",
                 },
@@ -662,7 +662,7 @@ export default class Video extends BlockComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "time",
                     value: time,
                 },

--- a/packages/doenetml-worker-javascript/src/components/abstract/AngleListComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/AngleListComponent.js
@@ -80,7 +80,7 @@ export default class AngleListComponent extends BaseComponent {
         }
 
         let trackChanges = this.currentTracker.trackChanges;
-        let childrenChanged = trackChanges.childrenChanged(this.componentName);
+        let childrenChanged = trackChanges.childrenChanged(this.componentIdx);
 
         if (childrenChanged) {
             delete this.unresolvedState.angles;
@@ -98,13 +98,13 @@ export default class AngleListComponent extends BaseComponent {
     initializeRenderer() {
         if (this.renderer === undefined) {
             this.renderer = new this.availableRenderers.container({
-                key: this.componentName,
+                key: this.componentIdx,
             });
         }
     }
 
     updateChildrenWhoRender() {
-        this.childrenWhoRender = this.state.angles.map((x) => x.componentName);
+        this.childrenWhoRender = this.state.angles.map((x) => x.componentIdx);
     }
 
     // allowDownstreamUpdates() {
@@ -118,7 +118,7 @@ export default class AngleListComponent extends BaseComponent {
     // calculateDownstreamChanges({ stateVariablesToUpdate, stateVariableChangesToSave,
     //   dependenciesToUpdate, dryRun }) {
 
-    //   let angleNames = this.state.angles.map(x => x.componentName);
+    //   let angleNames = this.state.angles.map(x => x.componentIdx);
 
     //   let newAngle = stateVariablesToUpdate.angles;
 

--- a/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
@@ -9,7 +9,7 @@ import {
 
 export default class BaseComponent {
     constructor({
-        componentName,
+        componentIdx,
         ancestors,
         serializedComponent,
         definingChildren,
@@ -28,7 +28,7 @@ export default class BaseComponent {
         this.parentSharedParameters = parentSharedParameters;
         this.sharedParameters = sharedParameters;
 
-        this.componentName = componentName;
+        this.componentIdx = componentIdx;
         this.ancestors = ancestors;
         this.counters = {};
 
@@ -105,7 +105,7 @@ export default class BaseComponent {
         if (this.adaptedFrom) {
             return this.adaptedFrom.componentOrAdaptedName;
         } else {
-            return this.componentName;
+            return this.componentIdx;
         }
     }
 
@@ -184,8 +184,8 @@ export default class BaseComponent {
         }
 
         // recurse to all children
-        for (let childName in this.allChildren) {
-            let child = this.allChildren[childName].component;
+        for (let childIdx in this.allChildren) {
+            let child = this.allChildren[childIdx].component;
             if (typeof child !== "object") {
                 continue;
             } else {
@@ -1125,11 +1125,11 @@ export default class BaseComponent {
         return { stateVariableDescriptions, arrayEntryPrefixes, aliases };
     }
 
-    get parentName() {
+    get parentIdx() {
         if (this.ancestors === undefined || this.ancestors.length === 0) {
             return;
         }
-        return this.ancestors[0].componentName;
+        return this.ancestors[0].componentIdx;
     }
 
     // TODO: if resurrect this, it would just be componentNames
@@ -1177,10 +1177,8 @@ export default class BaseComponent {
 
         // TODO: not serializing attribute children (as don't need them with forLink)
 
-        if (
-            parameters.errorIfEncounterComponent?.includes(this.componentName)
-        ) {
-            throw Error("Encountered " + this.componentName);
+        if (parameters.errorIfEncounterComponent?.includes(this.componentIdx)) {
+            throw Error("Encountered " + this.componentIdx);
         }
 
         let includeDefiningChildren = true;
@@ -1364,7 +1362,7 @@ export default class BaseComponent {
             }
         }
 
-        serializedComponent.originalName = this.componentName;
+        serializedComponent.originalName = this.componentIdx;
         serializedComponent.originalDoenetAttributes = deepClone(
             this.doenetAttributes,
         );
@@ -1395,7 +1393,7 @@ export default class BaseComponent {
 
         let serializedCopy = {
             componentType: serializedComponent.componentType,
-            originalName: serializedComponent.componentName,
+            originalName: serializedComponent.componentIdx,
             originalNameFromSerializedComponent: true,
             children: serializedChildren,
             state: {},
@@ -1488,12 +1486,12 @@ export default class BaseComponent {
         return {
             componentType: adapterComponentType,
             downstreamDependencies: {
-                [this.componentName]: [
+                [this.componentIdx]: [
                     {
                         dependencyType: "adapter",
                         adapterVariable: adapterStateVariable,
                         adapterTargetIdentity: {
-                            componentName: this.componentName,
+                            componentIdx: this.componentIdx,
                             componentType: this.componentType,
                         },
                         substituteForPrimaryStateVariable,

--- a/packages/doenetml-worker-javascript/src/components/abstract/ComponentWithSelectableType.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/ComponentWithSelectableType.js
@@ -343,9 +343,9 @@ export class ComponentListWithSelectableType extends ComponentWithSelectableType
                 globalDependencyValues,
                 dependencyValuesByKey,
                 arrayKeys,
-                componentName,
+                componentIdx,
             }) {
-                // console.log(`array definition for value of component list with selectable type, ${componentName}`)
+                // console.log(`array definition for value of component list with selectable type, ${componentIdx}`)
                 // console.log(globalDependencyValues)
                 // console.log(dependencyValuesByKey);
                 // console.log(arrayKeys)

--- a/packages/doenetml-worker-javascript/src/components/abstract/CompositeComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/CompositeComponent.js
@@ -118,8 +118,8 @@ export default class CompositeComponent extends BaseComponent {
 
         // we still recurse to all children, even though was skipped at base component
         // due to not having a rendererType
-        for (let childName in this.allChildren) {
-            let child = this.allChildren[childName].component;
+        for (let childIdx in this.allChildren) {
+            let child = this.allChildren[childIdx].component;
             for (let rendererType of child.allPotentialRendererTypes) {
                 if (!allPotentialRendererTypes.includes(rendererType)) {
                     allPotentialRendererTypes.push(rendererType);

--- a/packages/doenetml-worker-javascript/src/components/abstract/LineListComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/LineListComponent.js
@@ -107,7 +107,7 @@ export default class LineListComponent extends BaseComponent {
                     let lineChild =
                         dependencyValuesByKey[arrayKey].lineChild[0];
                     if (lineChild) {
-                        lineNames[arrayKey] = lineChild.componentName;
+                        lineNames[arrayKey] = lineChild.componentIdx;
                     }
                 }
 

--- a/packages/doenetml-worker-javascript/src/components/abstract/MathBaseOperatorOneInput.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/MathBaseOperatorOneInput.js
@@ -55,7 +55,7 @@ export default class MathOperatorOneInput extends MathComponent {
             inverseDefinition: function ({
                 desiredStateVariableValues,
                 dependencyValues,
-                componentName,
+                componentIdx,
             }) {
                 if (dependencyValues.inverseMathOperator) {
                     let newValue = dependencyValues.inverseMathOperator(

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -318,7 +318,7 @@ export class SectioningComponent extends BlockComponent {
                     titleChildName =
                         dependencyValues.titleChild[
                             dependencyValues.titleChild.length - 1
-                        ].componentName;
+                        ].componentIdx;
                 }
                 return {
                     setValue: { titleChildName },
@@ -354,7 +354,7 @@ export class SectioningComponent extends BlockComponent {
                 let childIndicesToRender = [];
 
                 let allTitleChildNames = dependencyValues.titleChildren.map(
-                    (x) => x.componentName,
+                    (x) => x.componentIdx,
                 );
 
                 for (let [
@@ -364,7 +364,7 @@ export class SectioningComponent extends BlockComponent {
                     if (dependencyValues.asList) {
                         // if asList, then only include titleChild and sections
                         if (
-                            child.componentName ===
+                            child.componentIdx ===
                                 dependencyValues.titleChildName ||
                             componentInfoObjects.isInheritedComponentType({
                                 inheritedComponentType: child.componentType,
@@ -375,8 +375,8 @@ export class SectioningComponent extends BlockComponent {
                         }
                     } else if (
                         typeof child !== "object" ||
-                        !allTitleChildNames.includes(child.componentName) ||
-                        child.componentName === dependencyValues.titleChildName
+                        !allTitleChildNames.includes(child.componentIdx) ||
+                        child.componentIdx === dependencyValues.titleChildName
                     ) {
                         childIndicesToRender.push(ind);
                     }
@@ -673,7 +673,7 @@ export class SectioningComponent extends BlockComponent {
                     ] of stateValues.scoredDescendants.entries()) {
                         dependencies["creditAchieved" + ind] = {
                             dependencyType: "stateVariable",
-                            componentName: descendant.componentName,
+                            componentIdx: descendant.componentIdx,
                             variableName: "creditAchieved",
                         };
                     }
@@ -740,7 +740,7 @@ export class SectioningComponent extends BlockComponent {
                     ] of stateValues.scoredDescendants.entries()) {
                         dependencies["creditAchievedIfSubmit" + ind] = {
                             dependencyType: "stateVariable",
-                            componentName: descendant.componentName,
+                            componentIdx: descendant.componentIdx,
                             variableName: "creditAchievedIfSubmit",
                         };
                     }
@@ -809,7 +809,7 @@ export class SectioningComponent extends BlockComponent {
                     ignoreReplacementsOfEncounteredComposites: true,
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 let generatedVariantInfo = {};
 
                 if (dependencyValues.variantName) {
@@ -820,7 +820,7 @@ export class SectioningComponent extends BlockComponent {
                 }
 
                 generatedVariantInfo.meta = {
-                    createdBy: componentName,
+                    createdBy: componentIdx,
                 };
 
                 let subvariants = (generatedVariantInfo.subvariants = []);
@@ -936,7 +936,7 @@ export class SectioningComponent extends BlockComponent {
                     variableNames: ["suppressAnswerSubmitButtons"],
                 },
             }),
-            definition({ dependencyValues, componentName }) {
+            definition({ dependencyValues, componentIdx }) {
                 let warnings = [];
 
                 let createSubmitAllButton = false;
@@ -1000,7 +1000,7 @@ export class SectioningComponent extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "submitted",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: {
@@ -1014,7 +1014,7 @@ export class SectioningComponent extends BlockComponent {
         ] of await this.stateValues.answerDescendants.entries()) {
             if (!(await answer.stateValues.justSubmitted)) {
                 await this.coreFunctions.performAction({
-                    componentName: answer.componentName,
+                    componentIdx: answer.componentIdx,
                     actionName: "submitAnswer",
                     args: {
                         actionId,
@@ -1036,7 +1036,7 @@ export class SectioningComponent extends BlockComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "open",
                     value: true,
                 },
@@ -1047,7 +1047,7 @@ export class SectioningComponent extends BlockComponent {
             event: {
                 verb: "viewed",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
             },
@@ -1057,7 +1057,7 @@ export class SectioningComponent extends BlockComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "rendered",
                     value: true,
                 },
@@ -1078,7 +1078,7 @@ export class SectioningComponent extends BlockComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "open",
                     value: false,
                 },
@@ -1090,7 +1090,7 @@ export class SectioningComponent extends BlockComponent {
             event: {
                 verb: "closed",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
             },
@@ -1101,7 +1101,7 @@ export class SectioningComponent extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/abstract/VectorListComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/VectorListComponent.js
@@ -223,9 +223,9 @@ export default class VectorListComponent extends BaseComponent {
             inverseArrayDefinitionByKey({
                 desiredStateVariableValues,
                 dependencyNamesByKey,
-                // componentName
+                // componentIdx
             }) {
-                // console.log(`array inverse definition of vectors of vectorlist of ${componentName}`)
+                // console.log(`array inverse definition of vectors of vectorlist of ${componentIdx}`)
                 // console.log(desiredStateVariableValues)
                 // console.log(arrayKeys);
 

--- a/packages/doenetml-worker-javascript/src/components/chemistry/OrbitalDiagram.js
+++ b/packages/doenetml-worker-javascript/src/components/chemistry/OrbitalDiagram.js
@@ -174,7 +174,7 @@ export default class OrbitalDiagram extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/chemistry/OrbitalDiagramInput.js
+++ b/packages/doenetml-worker-javascript/src/components/chemistry/OrbitalDiagramInput.js
@@ -269,7 +269,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
         let updateInstructions = [
             {
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "rows",
                 value: newRows,
             },
@@ -280,7 +280,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
         if (selectedRowIndex0 !== -1) {
             updateInstructions.push({
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "selectedRowIndex",
                 value: 0,
             });
@@ -291,7 +291,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
         if (selectedBoxIndex0 !== -1) {
             updateInstructions.push({
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "selectedBoxIndex",
                 value: 0,
             });
@@ -305,7 +305,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
             event: {
                 verb: "interacted",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
                 result: {
@@ -336,19 +336,19 @@ export default class OrbitalDiagramInput extends BlockComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "rows",
                     value: newRows,
                 },
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "selectedRowIndex",
                     value: 0,
                 },
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "selectedBoxIndex",
                     value: 0,
                 },
@@ -359,7 +359,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
             event: {
                 verb: "interacted",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
                 result: {
@@ -391,7 +391,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
         let updateInstructions = [
             {
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "rows",
                 value: newRows,
             },
@@ -404,7 +404,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
             let newIndex = 0;
             updateInstructions.push({
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "selectedBoxIndex",
                 value: newIndex,
             });
@@ -418,7 +418,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
             event: {
                 verb: "interacted",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
                 result: {
@@ -452,7 +452,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
         let updateInstructions = [
             {
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "rows",
                 value: newRows,
             },
@@ -462,7 +462,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
         if (selectedBoxIndex0 !== -1) {
             updateInstructions.push({
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "selectedBoxIndex",
                 value: 0,
             });
@@ -476,7 +476,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
             event: {
                 verb: "interacted",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
                 result: {
@@ -515,7 +515,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
         let updateInstructions = [
             {
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "rows",
                 value: newRows,
             },
@@ -529,7 +529,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
             event: {
                 verb: "interacted",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
                 result: {
@@ -568,7 +568,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
         let updateInstructions = [
             {
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "rows",
                 value: newRows,
             },
@@ -582,7 +582,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
             event: {
                 verb: "interacted",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
                 result: {
@@ -622,7 +622,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
         let updateInstructions = [
             {
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "rows",
                 value: newRows,
             },
@@ -636,7 +636,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
             event: {
                 verb: "interacted",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
                 result: {
@@ -666,7 +666,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
         let updateInstructions = [
             {
                 updateType: "updateValue",
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 stateVariable: "rows",
                 value: newRows,
             },
@@ -680,7 +680,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
             event: {
                 verb: "interacted",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
                 result: {
@@ -700,7 +700,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "selectedRowIndex",
                     value: index,
                 },
@@ -711,7 +711,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
             event: {
                 verb: "interacted",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
                 result: {
@@ -731,7 +731,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     stateVariable: "selectedBoxIndex",
                     value: index,
                 },
@@ -742,7 +742,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
             event: {
                 verb: "interacted",
                 object: {
-                    componentName: this.componentName,
+                    componentIdx: this.componentIdx,
                     componentType: this.componentType,
                 },
                 result: {
@@ -756,7 +756,7 @@ export default class OrbitalDiagramInput extends BlockComponent {
         this.coreFunctions.requestRecordEvent({
             verb: "visibilityChanged",
             object: {
-                componentName: this.componentName,
+                componentIdx: this.componentIdx,
                 componentType: this.componentType,
             },
             result: { isVisible },

--- a/packages/doenetml-worker-javascript/src/components/commonsugar/breakstrings.js
+++ b/packages/doenetml-worker-javascript/src/components/commonsugar/breakstrings.js
@@ -553,7 +553,7 @@ export function breakIntoVectorComponents(compList) {
 //         if (comp.createdComponent === true) {
 //           // broke up an original string
 //           // need to make original string as to be deleted
-//           toDelete.push(comp.componentName);
+//           toDelete.push(comp.componentIdx);
 //         }
 //       }
 //     }

--- a/packages/doenetml-worker-javascript/src/components/dynamicalSystems/EquilibriumCurve.js
+++ b/packages/doenetml-worker-javascript/src/components/dynamicalSystems/EquilibriumCurve.js
@@ -69,7 +69,7 @@ export default class EquilibriumCurve extends Curve {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "stable",
                         value: !this.stateValues.stable,
                     },
@@ -80,7 +80,7 @@ export default class EquilibriumCurve extends Curve {
                 event: {
                     verb: "interacted",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: {

--- a/packages/doenetml-worker-javascript/src/components/dynamicalSystems/EquilibriumLine.js
+++ b/packages/doenetml-worker-javascript/src/components/dynamicalSystems/EquilibriumLine.js
@@ -67,7 +67,7 @@ export default class EquilibriumLine extends Line {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "stable",
                         value: !this.stateValues.stable,
                     },
@@ -78,7 +78,7 @@ export default class EquilibriumLine extends Line {
                 event: {
                     verb: "interacted",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: {

--- a/packages/doenetml-worker-javascript/src/components/dynamicalSystems/EquilibriumPoint.js
+++ b/packages/doenetml-worker-javascript/src/components/dynamicalSystems/EquilibriumPoint.js
@@ -67,7 +67,7 @@ export default class EquilibriumPoint extends Point {
                 updateInstructions: [
                     {
                         updateType: "updateValue",
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         stateVariable: "stable",
                         value: !this.stateValues.stable,
                     },
@@ -78,7 +78,7 @@ export default class EquilibriumPoint extends Point {
                 event: {
                     verb: "interacted",
                     object: {
-                        componentName: this.componentName,
+                        componentIdx: this.componentIdx,
                         componentType: this.componentType,
                     },
                     result: {

--- a/packages/doenetml-worker-javascript/src/components/dynamicalSystems/ODESystem.js
+++ b/packages/doenetml-worker-javascript/src/components/dynamicalSystems/ODESystem.js
@@ -751,7 +751,7 @@ export default class ODESystem extends InlineComponent {
             arrayDefinitionByKey({
                 globalDependencyValues,
                 workspace,
-                componentName,
+                componentIdx,
             }) {
                 let numericalSolutions = {};
 
@@ -839,8 +839,8 @@ export default class ODESystem extends InlineComponent {
                                         " and tolerance " +
                                         tolerance +
                                         ", odesystem";
-                                    if (componentName !== undefined) {
-                                        message += " (" + componentName + ")";
+                                    if (componentIdx !== undefined) {
+                                        message += " (" + componentIdx + ")";
                                     }
                                     message +=
                                         " hit maxiterations (" +

--- a/packages/doenetml-worker-javascript/src/test/answerValidation/errorInNumbers.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/answerValidation/errorInNumbers.test.ts
@@ -17,7 +17,7 @@ async function run_single_response_tests({
     const core = await createTestCore({ doenetML });
     const stateVariables = await core.returnAllStateVariables(false, true);
     const mathInputName =
-        stateVariables["/ans"].stateValues.inputChildren[0].componentName;
+        stateVariables["/ans"].stateValues.inputChildren[0].componentIdx;
 
     for (let response in responseCredits) {
         await submit_check({

--- a/packages/doenetml-worker-javascript/src/test/assignNames/basicCopy.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/assignNames/basicCopy.test.ts
@@ -352,16 +352,12 @@ describe("Basic copy assign name tests", async () => {
                 false,
                 true,
             );
-            let point1 = stateVariables["/pts"].replacements![0].componentName;
-            let point2 = stateVariables["/pts"].replacements![1].componentName;
-            let point1a =
-                stateVariables["/ptsb"].replacements![0].componentName;
-            let point2a =
-                stateVariables["/ptsb"].replacements![1].componentName;
-            let point1b =
-                stateVariables["/ptsc"].replacements![0].componentName;
-            let point2b =
-                stateVariables["/ptsc"].replacements![1].componentName;
+            let point1 = stateVariables["/pts"].replacements![0].componentIdx;
+            let point2 = stateVariables["/pts"].replacements![1].componentIdx;
+            let point1a = stateVariables["/ptsb"].replacements![0].componentIdx;
+            let point2a = stateVariables["/ptsb"].replacements![1].componentIdx;
+            let point1b = stateVariables["/ptsc"].replacements![0].componentIdx;
+            let point2b = stateVariables["/ptsc"].replacements![1].componentIdx;
 
             expect(
                 stateVariables[point1].stateValues.xs.map((v) => v.tree),
@@ -485,17 +481,17 @@ describe("Basic copy assign name tests", async () => {
                 true,
             );
             let point1 =
-                stateVariables["/hello/pts"].replacements![0].componentName;
+                stateVariables["/hello/pts"].replacements![0].componentIdx;
             let point2 =
-                stateVariables["/hello/pts"].replacements![1].componentName;
+                stateVariables["/hello/pts"].replacements![1].componentIdx;
             let point1a =
-                stateVariables["/hello/ptsb"].replacements![0].componentName;
+                stateVariables["/hello/ptsb"].replacements![0].componentIdx;
             let point2a =
-                stateVariables["/hello/ptsb"].replacements![1].componentName;
+                stateVariables["/hello/ptsb"].replacements![1].componentIdx;
             let point1b =
-                stateVariables["/hello/ptsc"].replacements![0].componentName;
+                stateVariables["/hello/ptsc"].replacements![0].componentIdx;
             let point2b =
-                stateVariables["/hello/ptsc"].replacements![1].componentName;
+                stateVariables["/hello/ptsc"].replacements![1].componentIdx;
 
             expect(
                 stateVariables[point1].stateValues.xs.map((v) => v.tree),

--- a/packages/doenetml-worker-javascript/src/test/assignNames/selects.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/assignNames/selects.test.ts
@@ -54,9 +54,8 @@ describe("selects assign name tests", async () => {
             let optionReplacement =
                 stateVariables[
                     stateVariables[
-                        stateVariables["/select1"].replacements![j]
-                            .componentName
-                    ].replacements![1].componentName
+                        stateVariables["/select1"].replacements![j].componentIdx
+                    ].replacements![1].componentIdx
                 ];
 
             expect(comp.componentType).eq(cType);

--- a/packages/doenetml-worker-javascript/src/test/baseComponent/doenetMLtext.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/baseComponent/doenetMLtext.test.ts
@@ -38,7 +38,7 @@ describe("DoenetML text tests", async () => {
         expect(stateVariables["/theP"].stateValues.doenetML).eqls(thePDoenetML);
 
         let preChild =
-            stateVariables["/theDoenetML"].activeChildren[0].componentName;
+            stateVariables["/theDoenetML"].activeChildren[0].componentIdx;
         expect(stateVariables[preChild].stateValues.value).eqls(thePDoenetML);
     });
 

--- a/packages/doenetml-worker-javascript/src/test/chemistry/ion.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/chemistry/ion.test.ts
@@ -598,19 +598,19 @@ describe("Ion tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let mathinputClName =
-            stateVariables["/ansCl"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ansCl"].stateValues.inputChildren[0].componentIdx;
 
         let mathinputHName =
-            stateVariables["/ansH"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ansH"].stateValues.inputChildren[0].componentIdx;
 
         let mathinputMgName =
-            stateVariables["/ansMg"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ansMg"].stateValues.inputChildren[0].componentIdx;
 
         let mathinputPName =
-            stateVariables["/ansP"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ansP"].stateValues.inputChildren[0].componentIdx;
 
         let mathinputSName =
-            stateVariables["/ansS"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ansS"].stateValues.inputChildren[0].componentIdx;
 
         await updateMathInputValue({
             name: mathinputClName,

--- a/packages/doenetml-worker-javascript/src/test/chemistry/ionicCompound.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/chemistry/ionicCompound.test.ts
@@ -48,7 +48,7 @@ describe("Ionic Compounds tests", async () => {
             );
             let mi =
                 stateVariables[`/ans${name}`].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
 
             expect(stateVariables[`/${name}`].stateValues.latex).eq(latex);
             expect(stateVariables[`/${name}`].stateValues.text).eq(text);

--- a/packages/doenetml-worker-javascript/src/test/copying/unlinked.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/copying/unlinked.test.ts
@@ -309,8 +309,8 @@ describe("Unlinked Copying Tests", async () => {
                 // Unlinked copied content does not exist yet
                 expect(graph2Children.length).eqls(0);
             } else {
-                let P2 = graph2Children[0].componentName;
-                let Q2 = graph2Children[1].componentName;
+                let P2 = graph2Children[0].componentIdx;
+                let Q2 = graph2Children[1].componentIdx;
                 expect(
                     stateVariables[P2].stateValues.xs.map((v) => v.tree),
                 ).eqls(p2);

--- a/packages/doenetml-worker-javascript/src/test/dynamicalsystem/cobwebpolyline.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/dynamicalsystem/cobwebpolyline.test.ts
@@ -109,8 +109,8 @@ describe("CobwebPolyline Tag Tests", async () => {
             let mdChildren = stateVariables["/md1"].activeChildren;
             expect(mdChildren.length).eqls(latexResults.length);
             for (let i = 0; i < latexResults.length; i++) {
-                let childName = mdChildren[i].componentName;
-                expect(stateVariables[childName].stateValues.latex).eqls(
+                let childIdx = mdChildren[i].componentIdx;
+                expect(stateVariables[childIdx].stateValues.latex).eqls(
                     latexResults[i],
                 );
             }

--- a/packages/doenetml-worker-javascript/src/test/dynamicalsystem/equilibriumcurve.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/dynamicalsystem/equilibriumcurve.test.ts
@@ -114,7 +114,7 @@ describe("Equilibriumcurve Tag Tests", async () => {
         // switch A via first action
         As = !As;
         await core.requestAction({
-            componentName: "/g/A",
+            componentIdx: "/g/A",
             actionName: "switchCurve",
             args: {},
         });
@@ -123,7 +123,7 @@ describe("Equilibriumcurve Tag Tests", async () => {
         // switch A via second action
         As = !As;
         await core.requestAction({
-            componentName: "/g2/A",
+            componentIdx: "/g2/A",
             actionName: "switchCurve",
             args: {},
         });
@@ -131,7 +131,7 @@ describe("Equilibriumcurve Tag Tests", async () => {
 
         // cannot switch B via action
         await core.requestAction({
-            componentName: "/g/B",
+            componentIdx: "/g/B",
             actionName: "switchCurve",
             args: {},
         });
@@ -139,7 +139,7 @@ describe("Equilibriumcurve Tag Tests", async () => {
 
         // cannot switch C via second action
         await core.requestAction({
-            componentName: "/g2/C",
+            componentIdx: "/g2/C",
             actionName: "switchCurve",
             args: {},
         });
@@ -148,7 +148,7 @@ describe("Equilibriumcurve Tag Tests", async () => {
         // switch D via second action
         Ds = !Ds;
         await core.requestAction({
-            componentName: "/g2/D",
+            componentIdx: "/g2/D",
             actionName: "switchCurve",
             args: {},
         });

--- a/packages/doenetml-worker-javascript/src/test/dynamicalsystem/equilibriumline.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/dynamicalsystem/equilibriumline.test.ts
@@ -96,7 +96,7 @@ describe("Equilibriumline Tag Tests", async () => {
         // switch A via first action
         As = !As;
         await core.requestAction({
-            componentName: "/g/A",
+            componentIdx: "/g/A",
             actionName: "switchLine",
             args: {},
         });
@@ -105,7 +105,7 @@ describe("Equilibriumline Tag Tests", async () => {
         // switch A via second action
         As = !As;
         await core.requestAction({
-            componentName: "/g2/A",
+            componentIdx: "/g2/A",
             actionName: "switchLine",
             args: {},
         });
@@ -113,7 +113,7 @@ describe("Equilibriumline Tag Tests", async () => {
 
         // cannot switch B via action
         await core.requestAction({
-            componentName: "/g/B",
+            componentIdx: "/g/B",
             actionName: "switchLine",
             args: {},
         });
@@ -121,7 +121,7 @@ describe("Equilibriumline Tag Tests", async () => {
 
         // cannot switch C via second action
         await core.requestAction({
-            componentName: "/g2/C",
+            componentIdx: "/g2/C",
             actionName: "switchLine",
             args: {},
         });
@@ -130,7 +130,7 @@ describe("Equilibriumline Tag Tests", async () => {
         // switch D via second action
         Ds = !Ds;
         await core.requestAction({
-            componentName: "/g2/D",
+            componentIdx: "/g2/D",
             actionName: "switchLine",
             args: {},
         });

--- a/packages/doenetml-worker-javascript/src/test/dynamicalsystem/equilibriumpoint.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/dynamicalsystem/equilibriumpoint.test.ts
@@ -96,7 +96,7 @@ describe("Equilibriumpoint Tag Tests", async () => {
         // switch A via first action
         As = !As;
         await core.requestAction({
-            componentName: "/g/A",
+            componentIdx: "/g/A",
             actionName: "switchPoint",
             args: {},
         });
@@ -105,7 +105,7 @@ describe("Equilibriumpoint Tag Tests", async () => {
         // switch A via second action
         As = !As;
         await core.requestAction({
-            componentName: "/g2/A",
+            componentIdx: "/g2/A",
             actionName: "switchPoint",
             args: {},
         });
@@ -113,7 +113,7 @@ describe("Equilibriumpoint Tag Tests", async () => {
 
         // cannot switch B via action
         await core.requestAction({
-            componentName: "/g/B",
+            componentIdx: "/g/B",
             actionName: "switchPoint",
             args: {},
         });
@@ -121,7 +121,7 @@ describe("Equilibriumpoint Tag Tests", async () => {
 
         // cannot switch C via second action
         await core.requestAction({
-            componentName: "/g2/C",
+            componentIdx: "/g2/C",
             actionName: "switchPoint",
             args: {},
         });
@@ -130,7 +130,7 @@ describe("Equilibriumpoint Tag Tests", async () => {
         // switch D via second action
         Ds = !Ds;
         await core.requestAction({
-            componentName: "/g2/D",
+            componentIdx: "/g2/D",
             actionName: "switchPoint",
             args: {},
         });

--- a/packages/doenetml-worker-javascript/src/test/dynamicalsystem/odesystem.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/dynamicalsystem/odesystem.test.ts
@@ -62,11 +62,11 @@ $tol.value{assignNames="tol2"}
             let solutionsFromCore = stateVariables["/map1"]
                 .replacements!.map(
                     (child) =>
-                        stateVariables[child.componentName].replacements![0],
+                        stateVariables[child.componentIdx].replacements![0],
                 )
                 .map(
                     (grandChild) =>
-                        stateVariables[grandChild.componentName].stateValues
+                        stateVariables[grandChild.componentIdx].stateValues
                             .value,
                 )
                 .map((v) => v.tree);
@@ -277,8 +277,8 @@ $tol.value{assignNames="tol2"}
             let solutionsFromCore = stateVariables["/map1"].replacements!.map(
                 (x) =>
                     stateVariables[
-                        stateVariables[x.componentName].replacements![0]
-                            .componentName
+                        stateVariables[x.componentIdx].replacements![0]
+                            .componentIdx
                     ].stateValues.value.tree,
             );
 
@@ -552,22 +552,22 @@ $tol.value{assignNames="tol2"}
             let solutionsFromCoreX = stateVariables["/map1"]
                 .replacements!.map(
                     (child) =>
-                        stateVariables[child.componentName].replacements![0],
+                        stateVariables[child.componentIdx].replacements![0],
                 )
                 .map(
                     (grandChild) =>
-                        stateVariables[grandChild.componentName].stateValues
+                        stateVariables[grandChild.componentIdx].stateValues
                             .value,
                 )
                 .map((v) => v.tree);
             let solutionsFromCoreY = stateVariables["/map1"]
                 .replacements!.map(
                     (child) =>
-                        stateVariables[child.componentName].replacements![1],
+                        stateVariables[child.componentIdx].replacements![1],
                 )
                 .map(
                     (grandChild) =>
-                        stateVariables[grandChild.componentName].stateValues
+                        stateVariables[grandChild.componentIdx].stateValues
                             .value,
                 )
                 .map((v) => v.tree);
@@ -731,7 +731,7 @@ $tol.value{assignNames="tol2"}
         ) {
             expect(
                 stateVariables[
-                    stateVariables[origName].replacements![repNum].componentName
+                    stateVariables[origName].replacements![repNum].componentIdx
                 ].stateValues.value.tree,
             ).eqls(desiredValue);
         }

--- a/packages/doenetml-worker-javascript/src/test/graphical/graphreferences.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/graphical/graphreferences.test.ts
@@ -52,73 +52,73 @@ describe("Graph Reference Test", async () => {
         let pointsA = [
             "/pointA",
             "/pointC",
-            graphB.activeChildren[0].componentName,
-            graphB.activeChildren[4].componentName,
-            graphC.activeChildren[0].componentName,
-            graphC.activeChildren[4].componentName,
-            graphD.activeChildren[0].componentName,
-            graphD.activeChildren[4].componentName,
-            graphE.activeChildren[0].componentName,
-            graphE.activeChildren[4].componentName,
-            graphF.activeChildren[0].componentName,
-            graphF.activeChildren[4].componentName,
+            graphB.activeChildren[0].componentIdx,
+            graphB.activeChildren[4].componentIdx,
+            graphC.activeChildren[0].componentIdx,
+            graphC.activeChildren[4].componentIdx,
+            graphD.activeChildren[0].componentIdx,
+            graphD.activeChildren[4].componentIdx,
+            graphE.activeChildren[0].componentIdx,
+            graphE.activeChildren[4].componentIdx,
+            graphF.activeChildren[0].componentIdx,
+            graphF.activeChildren[4].componentIdx,
         ];
 
         let pointsB = [
             "/pointB",
-            graphB.activeChildren[1].componentName,
-            graphC.activeChildren[1].componentName,
-            graphD.activeChildren[1].componentName,
-            graphE.activeChildren[1].componentName,
-            graphF.activeChildren[1].componentName,
+            graphB.activeChildren[1].componentIdx,
+            graphC.activeChildren[1].componentIdx,
+            graphD.activeChildren[1].componentIdx,
+            graphE.activeChildren[1].componentIdx,
+            graphF.activeChildren[1].componentIdx,
         ];
 
         let pointsD = [
             "/pointD",
-            graphB.activeChildren[5].componentName,
-            graphC.activeChildren[5].componentName,
-            graphD.activeChildren[5].componentName,
-            graphE.activeChildren[5].componentName,
-            graphF.activeChildren[5].componentName,
+            graphB.activeChildren[5].componentIdx,
+            graphC.activeChildren[5].componentIdx,
+            graphD.activeChildren[5].componentIdx,
+            graphE.activeChildren[5].componentIdx,
+            graphF.activeChildren[5].componentIdx,
         ];
 
         let pointsE = [
-            stateVariables["/pointE"].replacements![0].componentName,
-            graphB.activeChildren[8].componentName,
-            graphC.activeChildren[8].componentName,
-            graphD.activeChildren[8].componentName,
-            graphE.activeChildren[8].componentName,
-            graphF.activeChildren[8].componentName,
+            stateVariables["/pointE"].replacements![0].componentIdx,
+            graphB.activeChildren[8].componentIdx,
+            graphC.activeChildren[8].componentIdx,
+            graphD.activeChildren[8].componentIdx,
+            graphE.activeChildren[8].componentIdx,
+            graphF.activeChildren[8].componentIdx,
         ];
 
         let linesA = [
             "/lineA",
             "/lineC",
-            graphB.activeChildren[2].componentName,
-            graphB.activeChildren[6].componentName,
-            graphC.activeChildren[2].componentName,
-            graphC.activeChildren[6].componentName,
-            graphD.activeChildren[2].componentName,
-            graphD.activeChildren[6].componentName,
-            graphE.activeChildren[2].componentName,
-            graphE.activeChildren[6].componentName,
-            graphF.activeChildren[2].componentName,
-            graphF.activeChildren[6].componentName,
+            graphB.activeChildren[2].componentIdx,
+            graphB.activeChildren[6].componentIdx,
+            graphC.activeChildren[2].componentIdx,
+            graphC.activeChildren[6].componentIdx,
+            graphD.activeChildren[2].componentIdx,
+            graphD.activeChildren[6].componentIdx,
+            graphE.activeChildren[2].componentIdx,
+            graphE.activeChildren[6].componentIdx,
+            graphF.activeChildren[2].componentIdx,
+            graphF.activeChildren[6].componentIdx,
         ];
 
         let linesB = [
             "/lineB",
             "/lineD",
-            graphB.activeChildren[3].componentName,
-            graphB.activeChildren[7].componentName,
-            graphC.activeChildren[3].componentName,
-            graphC.activeChildren[7].componentName,
-            graphD.activeChildren[3].componentName,
-            graphD.activeChildren[7].componentName,
-            graphE.activeChildren[3].componentName,
-            graphE.activeChildren[7].componentName,
-            graphF.activeChildren[3].componentName,
-            graphF.activeChildren[7].componentName,
+            graphB.activeChildren[3].componentIdx,
+            graphB.activeChildren[7].componentIdx,
+            graphC.activeChildren[3].componentIdx,
+            graphC.activeChildren[7].componentIdx,
+            graphD.activeChildren[3].componentIdx,
+            graphD.activeChildren[7].componentIdx,
+            graphE.activeChildren[3].componentIdx,
+            graphE.activeChildren[7].componentIdx,
+            graphF.activeChildren[3].componentIdx,
+            graphF.activeChildren[7].componentIdx,
         ];
 
         async function check_items({
@@ -683,176 +683,176 @@ describe("Graph Reference Test", async () => {
         let graph1A =
             stateVariables[
                 stateVariables[
-                    stateVariables["/sbsgroup2"].activeChildren[0].componentName
-                ].activeChildren[0].componentName
+                    stateVariables["/sbsgroup2"].activeChildren[0].componentIdx
+                ].activeChildren[0].componentIdx
             ];
         let graph2A =
             stateVariables[
                 stateVariables[
-                    stateVariables["/sbsgroup2"].activeChildren[0].componentName
-                ].activeChildren[1].componentName
+                    stateVariables["/sbsgroup2"].activeChildren[0].componentIdx
+                ].activeChildren[1].componentIdx
             ];
         let graph3A =
             stateVariables[
                 stateVariables[
-                    stateVariables["/sbsgroup2"].activeChildren[0].componentName
-                ].activeChildren[2].componentName
+                    stateVariables["/sbsgroup2"].activeChildren[0].componentIdx
+                ].activeChildren[2].componentIdx
             ];
         let graph4A =
             stateVariables[
                 stateVariables[
-                    stateVariables["/sbsgroup2"].activeChildren[0].componentName
-                ].activeChildren[3].componentName
+                    stateVariables["/sbsgroup2"].activeChildren[0].componentIdx
+                ].activeChildren[3].componentIdx
             ];
         let graph5A =
             stateVariables[
                 stateVariables[
-                    stateVariables["/sbsgroup2"].activeChildren[1].componentName
-                ].activeChildren[0].componentName
+                    stateVariables["/sbsgroup2"].activeChildren[1].componentIdx
+                ].activeChildren[0].componentIdx
             ];
         let graph6A =
             stateVariables[
                 stateVariables[
-                    stateVariables["/sbsgroup2"].activeChildren[1].componentName
-                ].activeChildren[1].componentName
+                    stateVariables["/sbsgroup2"].activeChildren[1].componentIdx
+                ].activeChildren[1].componentIdx
             ];
         let graph7A =
             stateVariables[
                 stateVariables[
-                    stateVariables["/sbsgroup2"].activeChildren[1].componentName
-                ].activeChildren[2].componentName
+                    stateVariables["/sbsgroup2"].activeChildren[1].componentIdx
+                ].activeChildren[2].componentIdx
             ];
         let graph8A =
             stateVariables[
                 stateVariables[
-                    stateVariables["/sbsgroup2"].activeChildren[1].componentName
-                ].activeChildren[3].componentName
+                    stateVariables["/sbsgroup2"].activeChildren[1].componentIdx
+                ].activeChildren[3].componentIdx
             ];
         let graph9A =
             stateVariables[
                 stateVariables[
-                    stateVariables["/sbsgroup2"].activeChildren[2].componentName
-                ].activeChildren[0].componentName
+                    stateVariables["/sbsgroup2"].activeChildren[2].componentIdx
+                ].activeChildren[0].componentIdx
             ];
         let graph10A =
             stateVariables[
                 stateVariables[
-                    stateVariables["/sbsgroup2"].activeChildren[2].componentName
-                ].activeChildren[1].componentName
+                    stateVariables["/sbsgroup2"].activeChildren[2].componentIdx
+                ].activeChildren[1].componentIdx
             ];
         let graph11A =
             stateVariables[
                 stateVariables[
-                    stateVariables["/sbsgroup2"].activeChildren[2].componentName
-                ].activeChildren[2].componentName
+                    stateVariables["/sbsgroup2"].activeChildren[2].componentIdx
+                ].activeChildren[2].componentIdx
             ];
         let graph12A =
             stateVariables[
                 stateVariables[
-                    stateVariables["/sbsgroup2"].activeChildren[2].componentName
-                ].activeChildren[3].componentName
+                    stateVariables["/sbsgroup2"].activeChildren[2].componentIdx
+                ].activeChildren[3].componentIdx
             ];
 
         let vectors = [
-            graph1.activeChildren[0].componentName,
-            graph2.activeChildren[3].componentName,
-            graph4.activeChildren[3].componentName,
-            graph5.activeChildren[0].componentName,
-            graph6.activeChildren[3].componentName,
-            graph8.activeChildren[3].componentName,
-            graph9.activeChildren[0].componentName,
-            graph10.activeChildren[3].componentName,
-            graph12.activeChildren[3].componentName,
-            graph1A.activeChildren[0].componentName,
-            graph2A.activeChildren[3].componentName,
-            graph4A.activeChildren[3].componentName,
-            graph5A.activeChildren[0].componentName,
-            graph6A.activeChildren[3].componentName,
-            graph8A.activeChildren[3].componentName,
-            graph9A.activeChildren[0].componentName,
-            graph10A.activeChildren[3].componentName,
-            graph12A.activeChildren[3].componentName,
+            graph1.activeChildren[0].componentIdx,
+            graph2.activeChildren[3].componentIdx,
+            graph4.activeChildren[3].componentIdx,
+            graph5.activeChildren[0].componentIdx,
+            graph6.activeChildren[3].componentIdx,
+            graph8.activeChildren[3].componentIdx,
+            graph9.activeChildren[0].componentIdx,
+            graph10.activeChildren[3].componentIdx,
+            graph12.activeChildren[3].componentIdx,
+            graph1A.activeChildren[0].componentIdx,
+            graph2A.activeChildren[3].componentIdx,
+            graph4A.activeChildren[3].componentIdx,
+            graph5A.activeChildren[0].componentIdx,
+            graph6A.activeChildren[3].componentIdx,
+            graph8A.activeChildren[3].componentIdx,
+            graph9A.activeChildren[0].componentIdx,
+            graph10A.activeChildren[3].componentIdx,
+            graph12A.activeChildren[3].componentIdx,
         ];
 
         let displacementsA = [
-            graph2.activeChildren[2].componentName,
-            graph3.activeChildren[3].componentName,
-            graph6.activeChildren[2].componentName,
-            graph7.activeChildren[3].componentName,
-            graph10.activeChildren[2].componentName,
-            graph11.activeChildren[3].componentName,
-            graph2A.activeChildren[2].componentName,
-            graph3A.activeChildren[3].componentName,
-            graph6A.activeChildren[2].componentName,
-            graph7A.activeChildren[3].componentName,
-            graph10A.activeChildren[2].componentName,
-            graph11A.activeChildren[3].componentName,
+            graph2.activeChildren[2].componentIdx,
+            graph3.activeChildren[3].componentIdx,
+            graph6.activeChildren[2].componentIdx,
+            graph7.activeChildren[3].componentIdx,
+            graph10.activeChildren[2].componentIdx,
+            graph11.activeChildren[3].componentIdx,
+            graph2A.activeChildren[2].componentIdx,
+            graph3A.activeChildren[3].componentIdx,
+            graph6A.activeChildren[2].componentIdx,
+            graph7A.activeChildren[3].componentIdx,
+            graph10A.activeChildren[2].componentIdx,
+            graph11A.activeChildren[3].componentIdx,
         ];
 
         let displacementsB = [
-            graph3.activeChildren[2].componentName,
-            graph7.activeChildren[2].componentName,
-            graph11.activeChildren[2].componentName,
-            graph3A.activeChildren[2].componentName,
-            graph7A.activeChildren[2].componentName,
-            graph11A.activeChildren[2].componentName,
+            graph3.activeChildren[2].componentIdx,
+            graph7.activeChildren[2].componentIdx,
+            graph11.activeChildren[2].componentIdx,
+            graph3A.activeChildren[2].componentIdx,
+            graph7A.activeChildren[2].componentIdx,
+            graph11A.activeChildren[2].componentIdx,
         ];
 
         let displacementsC = [
-            graph4.activeChildren[2].componentName,
-            graph8.activeChildren[2].componentName,
-            graph12.activeChildren[2].componentName,
-            graph4A.activeChildren[2].componentName,
-            graph8A.activeChildren[2].componentName,
-            graph12A.activeChildren[2].componentName,
+            graph4.activeChildren[2].componentIdx,
+            graph8.activeChildren[2].componentIdx,
+            graph12.activeChildren[2].componentIdx,
+            graph4A.activeChildren[2].componentIdx,
+            graph8A.activeChildren[2].componentIdx,
+            graph12A.activeChildren[2].componentIdx,
         ];
 
         let tails = [
-            graph2.activeChildren[0].componentName,
-            graph4.activeChildren[0].componentName,
-            graph6.activeChildren[0].componentName,
-            graph8.activeChildren[0].componentName,
-            graph10.activeChildren[0].componentName,
-            graph12.activeChildren[0].componentName,
-            graph2A.activeChildren[0].componentName,
-            graph4A.activeChildren[0].componentName,
-            graph6A.activeChildren[0].componentName,
-            graph8A.activeChildren[0].componentName,
-            graph10A.activeChildren[0].componentName,
-            graph12A.activeChildren[0].componentName,
+            graph2.activeChildren[0].componentIdx,
+            graph4.activeChildren[0].componentIdx,
+            graph6.activeChildren[0].componentIdx,
+            graph8.activeChildren[0].componentIdx,
+            graph10.activeChildren[0].componentIdx,
+            graph12.activeChildren[0].componentIdx,
+            graph2A.activeChildren[0].componentIdx,
+            graph4A.activeChildren[0].componentIdx,
+            graph6A.activeChildren[0].componentIdx,
+            graph8A.activeChildren[0].componentIdx,
+            graph10A.activeChildren[0].componentIdx,
+            graph12A.activeChildren[0].componentIdx,
         ];
 
         let heads = [
-            graph2.activeChildren[1].componentName,
-            graph4.activeChildren[1].componentName,
-            graph6.activeChildren[1].componentName,
-            graph8.activeChildren[1].componentName,
-            graph10.activeChildren[1].componentName,
-            graph12.activeChildren[1].componentName,
-            graph2A.activeChildren[1].componentName,
-            graph4A.activeChildren[1].componentName,
-            graph6A.activeChildren[1].componentName,
-            graph8A.activeChildren[1].componentName,
-            graph10A.activeChildren[1].componentName,
-            graph12A.activeChildren[1].componentName,
+            graph2.activeChildren[1].componentIdx,
+            graph4.activeChildren[1].componentIdx,
+            graph6.activeChildren[1].componentIdx,
+            graph8.activeChildren[1].componentIdx,
+            graph10.activeChildren[1].componentIdx,
+            graph12.activeChildren[1].componentIdx,
+            graph2A.activeChildren[1].componentIdx,
+            graph4A.activeChildren[1].componentIdx,
+            graph6A.activeChildren[1].componentIdx,
+            graph8A.activeChildren[1].componentIdx,
+            graph10A.activeChildren[1].componentIdx,
+            graph12A.activeChildren[1].componentIdx,
         ];
 
         let displacementTails = [
-            graph3.activeChildren[0].componentName,
-            graph7.activeChildren[0].componentName,
-            graph11.activeChildren[0].componentName,
-            graph3A.activeChildren[0].componentName,
-            graph7A.activeChildren[0].componentName,
-            graph11A.activeChildren[0].componentName,
+            graph3.activeChildren[0].componentIdx,
+            graph7.activeChildren[0].componentIdx,
+            graph11.activeChildren[0].componentIdx,
+            graph3A.activeChildren[0].componentIdx,
+            graph7A.activeChildren[0].componentIdx,
+            graph11A.activeChildren[0].componentIdx,
         ];
 
         let displacementHeads = [
-            graph3.activeChildren[1].componentName,
-            graph7.activeChildren[1].componentName,
-            graph11.activeChildren[1].componentName,
-            graph3A.activeChildren[1].componentName,
-            graph7A.activeChildren[1].componentName,
-            graph11A.activeChildren[1].componentName,
+            graph3.activeChildren[1].componentIdx,
+            graph7.activeChildren[1].componentIdx,
+            graph11.activeChildren[1].componentIdx,
+            graph3A.activeChildren[1].componentIdx,
+            graph7A.activeChildren[1].componentIdx,
+            graph11A.activeChildren[1].componentIdx,
         ];
 
         async function check_items({

--- a/packages/doenetml-worker-javascript/src/test/graphical/labels.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/graphical/labels.test.ts
@@ -35,30 +35,30 @@ describe("Label tests", async () => {
         expect(stateVariables["/g7Qlabel"].stateValues.value).eq("Q");
         expect(stateVariables["/g7Slabel"].stateValues.value).eq("S");
 
-        let P2Name = stateVariables["/g2"].activeChildren[0].componentName;
-        let Q2Name = stateVariables["/g2"].activeChildren[1].componentName;
-        let R2Name = stateVariables["/g2"].activeChildren[2].componentName;
-        let S2Name = stateVariables["/g2"].activeChildren[3].componentName;
-        let P3Name = stateVariables["/g3"].activeChildren[0].componentName;
-        let Q3Name = stateVariables["/g3"].activeChildren[1].componentName;
-        let R3Name = stateVariables["/g3"].activeChildren[2].componentName;
-        let S3Name = stateVariables["/g3"].activeChildren[3].componentName;
-        let P4Name = stateVariables["/g4"].activeChildren[0].componentName;
-        let Q4Name = stateVariables["/g4"].activeChildren[1].componentName;
-        let R4Name = stateVariables["/g4"].activeChildren[2].componentName;
-        let S4Name = stateVariables["/g4"].activeChildren[3].componentName;
-        let P5Name = stateVariables["/g5"].activeChildren[0].componentName;
-        let Q5Name = stateVariables["/g5"].activeChildren[1].componentName;
-        let R5Name = stateVariables["/g5"].activeChildren[2].componentName;
-        let S5Name = stateVariables["/g5"].activeChildren[3].componentName;
-        let P6Name = stateVariables["/g6"].activeChildren[0].componentName;
-        let Q6Name = stateVariables["/g6"].activeChildren[1].componentName;
-        let R6Name = stateVariables["/g6"].activeChildren[2].componentName;
-        let S6Name = stateVariables["/g6"].activeChildren[3].componentName;
-        let P7Name = stateVariables["/g7"].activeChildren[0].componentName;
-        let Q7Name = stateVariables["/g7"].activeChildren[1].componentName;
-        let R7Name = stateVariables["/g7"].activeChildren[2].componentName;
-        let S7Name = stateVariables["/g7"].activeChildren[3].componentName;
+        let P2Name = stateVariables["/g2"].activeChildren[0].componentIdx;
+        let Q2Name = stateVariables["/g2"].activeChildren[1].componentIdx;
+        let R2Name = stateVariables["/g2"].activeChildren[2].componentIdx;
+        let S2Name = stateVariables["/g2"].activeChildren[3].componentIdx;
+        let P3Name = stateVariables["/g3"].activeChildren[0].componentIdx;
+        let Q3Name = stateVariables["/g3"].activeChildren[1].componentIdx;
+        let R3Name = stateVariables["/g3"].activeChildren[2].componentIdx;
+        let S3Name = stateVariables["/g3"].activeChildren[3].componentIdx;
+        let P4Name = stateVariables["/g4"].activeChildren[0].componentIdx;
+        let Q4Name = stateVariables["/g4"].activeChildren[1].componentIdx;
+        let R4Name = stateVariables["/g4"].activeChildren[2].componentIdx;
+        let S4Name = stateVariables["/g4"].activeChildren[3].componentIdx;
+        let P5Name = stateVariables["/g5"].activeChildren[0].componentIdx;
+        let Q5Name = stateVariables["/g5"].activeChildren[1].componentIdx;
+        let R5Name = stateVariables["/g5"].activeChildren[2].componentIdx;
+        let S5Name = stateVariables["/g5"].activeChildren[3].componentIdx;
+        let P6Name = stateVariables["/g6"].activeChildren[0].componentIdx;
+        let Q6Name = stateVariables["/g6"].activeChildren[1].componentIdx;
+        let R6Name = stateVariables["/g6"].activeChildren[2].componentIdx;
+        let S6Name = stateVariables["/g6"].activeChildren[3].componentIdx;
+        let P7Name = stateVariables["/g7"].activeChildren[0].componentIdx;
+        let Q7Name = stateVariables["/g7"].activeChildren[1].componentIdx;
+        let R7Name = stateVariables["/g7"].activeChildren[2].componentIdx;
+        let S7Name = stateVariables["/g7"].activeChildren[3].componentIdx;
 
         expect(stateVariables["/P"].stateValues.label).eq("P");
         expect(stateVariables["/P"].stateValues.labelForGraph).eq("P");
@@ -298,40 +298,40 @@ describe("Label tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let g1ChildNames = stateVariables["/g1"].activeChildren.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         let g2ChildNames = stateVariables["/g2"].activeChildren.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         let g3ChildNames = stateVariables["/g3"].activeChildren.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         let g4ChildNames = stateVariables["/g4"].activeChildren.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         let g5ChildNames = stateVariables["/g5"].activeChildren.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         let g6ChildNames = stateVariables["/g6"].activeChildren.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         let g7ChildNames = stateVariables["/g7"].activeChildren.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         let g8ChildNames = stateVariables["/g8"].activeChildren.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         let g9ChildNames = stateVariables["/g9"].activeChildren.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         let g10ChildNames = stateVariables["/g10"].activeChildren.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         let g11ChildNames = stateVariables["/g11"].activeChildren.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         let g12ChildNames = stateVariables["/g12"].activeChildren.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
 
         let g1ChildLabels = Array(5).fill("");
@@ -502,10 +502,8 @@ describe("Label tests", async () => {
                 false,
                 true,
             );
-            const p6Name =
-                stateVariables["/g6"].activeChildren[0].componentName;
-            const p7Name =
-                stateVariables["/g7"].activeChildren[0].componentName;
+            const p6Name = stateVariables["/g6"].activeChildren[0].componentIdx;
+            const p7Name = stateVariables["/g7"].activeChildren[0].componentIdx;
 
             expect(stateVariables["/lA"].stateValues.value).eq(lA);
             expect(stateVariables["/lB"].stateValues.value).eq(lA);
@@ -605,10 +603,8 @@ describe("Label tests", async () => {
                 false,
                 true,
             );
-            const p4Name =
-                stateVariables["/g4"].activeChildren[0].componentName;
-            const p5Name =
-                stateVariables["/g5"].activeChildren[0].componentName;
+            const p4Name = stateVariables["/g4"].activeChildren[0].componentIdx;
+            const p5Name = stateVariables["/g5"].activeChildren[0].componentIdx;
 
             expect(stateVariables["/lA"].stateValues.value).eq(lA);
             expect(stateVariables["/lB"].stateValues.value).eq(lB);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/answer.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/answer.test.ts
@@ -51,7 +51,7 @@ async function test_math_answer({
     let stateVariables = await core.returnAllStateVariables(false, true);
     mathInputName =
         mathInputName ||
-        stateVariables[answerName].stateValues.inputChildren[0].componentName;
+        stateVariables[answerName].stateValues.inputChildren[0].componentIdx;
 
     if (!mathInputName) {
         throw Error("Don't have mathInput name");
@@ -197,7 +197,7 @@ async function test_text_answer({
     let stateVariables = await core.returnAllStateVariables(false, true);
     textInputName =
         textInputName ||
-        stateVariables[answerName].stateValues.inputChildren[0].componentName;
+        stateVariables[answerName].stateValues.inputChildren[0].componentIdx;
 
     if (!textInputName) {
         throw Error("Don't have textInput name");
@@ -292,7 +292,7 @@ async function test_boolean_answer({
     let stateVariables = await core.returnAllStateVariables(false, true);
     booleanInputName =
         booleanInputName ||
-        stateVariables[answerName].stateValues.inputChildren[0].componentName;
+        stateVariables[answerName].stateValues.inputChildren[0].componentIdx;
 
     if (!booleanInputName) {
         throw Error("Don't have booleanInput name");
@@ -403,7 +403,7 @@ async function test_choice_answer({
     let stateVariables = await core.returnAllStateVariables(false, true);
     choiceInputName =
         choiceInputName ||
-        stateVariables[answerName].stateValues.inputChildren[0].componentName;
+        stateVariables[answerName].stateValues.inputChildren[0].componentIdx;
 
     if (!choiceInputName) {
         throw Error("Don't have choiceInput name");
@@ -593,7 +593,7 @@ async function test_matrix_answer({
     let stateVariables = await core.returnAllStateVariables(false, true);
     matrixInputName =
         matrixInputName ||
-        stateVariables[answerName].stateValues.inputChildren[0].componentName;
+        stateVariables[answerName].stateValues.inputChildren[0].componentIdx;
 
     if (!matrixInputName) {
         throw Error("Don't have matrixInput name");
@@ -783,7 +783,7 @@ async function test_action_answer({
         // do action for answer
 
         await core.requestAction({
-            componentName: response.actionComponentName,
+            componentIdx: response.actionComponentName,
             actionName: response.actionName,
             args: response.actionArgs,
         });
@@ -869,7 +869,7 @@ async function test_answer_multiple_inputs({
         let name =
             input.name ||
             stateVariables[answerName].stateValues.inputChildren[i]
-                .componentName;
+                .componentIdx;
 
         if (!name) {
             throw Error(`Don't have name for input ${i}.`);
@@ -1271,7 +1271,7 @@ describe("Answer tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
         let textInputName =
             stateVariables["/answer1"].stateValues.inputChildren[0]
-                .componentName;
+                .componentIdx;
 
         await updateTextInputValue({
             text: " hello there ",
@@ -1390,7 +1390,7 @@ describe("Answer tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
         let mathInputName =
             stateVariables["/answer1"].stateValues.inputChildren[0]
-                .componentName;
+                .componentIdx;
 
         await updateMathInputValue({
             latex: "x",
@@ -1450,7 +1450,7 @@ describe("Answer tag tests", async () => {
             );
             let mathInputName =
                 stateVariables["/ans"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
 
             // have to submit the correct answer twice before it is marked correct
             await updateMathInputValue({
@@ -3239,7 +3239,7 @@ Enter any letter:
 
             let textInputName =
                 stateVariables["/ans"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
 
             for (let ind2 = 1; ind2 <= 4; ind2++) {
                 await updateTextInputValue({
@@ -4001,7 +4001,7 @@ Enter any letter:
         stateVariables = await core.returnAllStateVariables(false, true);
 
         expect(stateVariables["/cond"].replacements).eqls([
-            { componentName: "/just", componentType: "p" },
+            { componentIdx: "/just", componentType: "p" },
         ]);
         expect(stateVariables["/cond"].replacementsToWithhold).eq(0);
 
@@ -4024,7 +4024,7 @@ Enter any letter:
 
         expect(stateVariables["/cond"].replacementsToWithhold).eq(0);
         expect(stateVariables["/cond"].replacements).eqls([
-            { componentName: "/just", componentType: "p" },
+            { componentIdx: "/just", componentType: "p" },
         ]);
         expect(stateVariables["/just"].stateValues.text).eq(
             "The answer was just submitted.",
@@ -4227,10 +4227,10 @@ Enter any letter:
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let mathInput1Name =
-            stateVariables["/ans1"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans1"].stateValues.inputChildren[0].componentIdx;
 
         let mathInput2Name =
-            stateVariables["/ans2"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans2"].stateValues.inputChildren[0].componentIdx;
 
         expect(stateVariables["/ans1"].stateValues.justSubmitted).eq(false);
         expect(stateVariables["/ans1"].stateValues.creditAchieved).eq(0);
@@ -4377,10 +4377,10 @@ Enter any letter:
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let mathInput1Name =
-            stateVariables["/ans1"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans1"].stateValues.inputChildren[0].componentIdx;
 
         let mathInput2Name =
-            stateVariables["/ans2"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans2"].stateValues.inputChildren[0].componentIdx;
 
         expect(stateVariables["/ans1"].stateValues.justSubmitted).eq(false);
         expect(stateVariables["/ans1"].stateValues.creditAchieved).eq(0);
@@ -4656,7 +4656,7 @@ Enter any letter:
         let components = core.core!.components || {};
 
         let mathInputName =
-            components["/ans"].stateValues.inputChildren[0].componentName;
+            components["/ans"].stateValues.inputChildren[0].componentIdx;
 
         expect(components["/ans"].stateValues.justSubmitted).eq(false);
         expect(components["/ans"].stateValues.creditAchieved).eq(0);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/callAction.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/callAction.test.ts
@@ -126,7 +126,7 @@ describe("callAction tag tests", async () => {
 
         for (let g of gs) {
             let pointNames = g.stateValues.graphicalDescendants.map(
-                (x) => x.componentName,
+                (x) => x.componentIdx,
             );
             expect(pointNames.length).eq(2);
             expect(
@@ -138,7 +138,7 @@ describe("callAction tag tests", async () => {
         }
 
         await movePoint({
-            name: g1.stateValues.graphicalDescendants[1].componentName,
+            name: g1.stateValues.graphicalDescendants[1].componentIdx,
             x: -2,
             y: 5,
             core,
@@ -157,7 +157,7 @@ describe("callAction tag tests", async () => {
 
         for (let g of gs) {
             let pointNames = g.stateValues.graphicalDescendants.map(
-                (x) => x.componentName,
+                (x) => x.componentIdx,
             );
             expect(
                 stateVariables[pointNames[1]].stateValues.xs.map((x) => x.tree),
@@ -177,7 +177,7 @@ describe("callAction tag tests", async () => {
 
         for (let g of gs) {
             let pointNames = g.stateValues.graphicalDescendants.map(
-                (x) => x.componentName,
+                (x) => x.componentIdx,
             );
             expect(pointNames.length).eq(3);
             expect(
@@ -192,7 +192,7 @@ describe("callAction tag tests", async () => {
         }
 
         await movePoint({
-            name: g2.stateValues.graphicalDescendants[2].componentName,
+            name: g2.stateValues.graphicalDescendants[2].componentIdx,
             x: 7,
             y: -9,
             core,
@@ -212,7 +212,7 @@ describe("callAction tag tests", async () => {
 
         for (let g of gs) {
             let pointNames = g.stateValues.graphicalDescendants.map(
-                (x) => x.componentName,
+                (x) => x.componentIdx,
             );
             expect(
                 stateVariables[pointNames[2]].stateValues.xs.map((x) => x.tree),
@@ -232,7 +232,7 @@ describe("callAction tag tests", async () => {
 
         for (let g of gs) {
             let pointNames = g.stateValues.graphicalDescendants.map(
-                (x) => x.componentName,
+                (x) => x.componentIdx,
             );
             expect(pointNames.length).eq(2);
             expect(
@@ -244,7 +244,7 @@ describe("callAction tag tests", async () => {
         }
 
         await movePoint({
-            name: g3.stateValues.graphicalDescendants[1].componentName,
+            name: g3.stateValues.graphicalDescendants[1].componentIdx,
             x: 1,
             y: 0,
             core,
@@ -262,7 +262,7 @@ describe("callAction tag tests", async () => {
 
         for (let g of gs) {
             let pointNames = g.stateValues.graphicalDescendants.map(
-                (x) => x.componentName,
+                (x) => x.componentIdx,
             );
             expect(
                 stateVariables[pointNames[1]].stateValues.xs.map((x) => x.tree),
@@ -282,7 +282,7 @@ describe("callAction tag tests", async () => {
 
         for (let g of gs) {
             let pointNames = g.stateValues.graphicalDescendants.map(
-                (x) => x.componentName,
+                (x) => x.componentIdx,
             );
             expect(pointNames.length).eq(1);
             expect(
@@ -303,7 +303,7 @@ describe("callAction tag tests", async () => {
 
         for (let g of gs) {
             let pointNames = g.stateValues.graphicalDescendants.map(
-                (x) => x.componentName,
+                (x) => x.componentIdx,
             );
             expect(pointNames.length).eq(1);
             expect(
@@ -324,7 +324,7 @@ describe("callAction tag tests", async () => {
 
         for (let g of gs) {
             let pointNames = g.stateValues.graphicalDescendants.map(
-                (x) => x.componentName,
+                (x) => x.componentIdx,
             );
             expect(pointNames.length).eq(2);
             expect(
@@ -361,7 +361,7 @@ describe("callAction tag tests", async () => {
 
         let pointNames = stateVariables[
             "/g"
-        ].stateValues.graphicalDescendants.map((x) => x.componentName);
+        ].stateValues.graphicalDescendants.map((x) => x.componentIdx);
         expect(pointNames.length).eq(2);
         expect(
             stateVariables[pointNames[0]].stateValues.xs.map((x) => x.tree),
@@ -378,7 +378,7 @@ describe("callAction tag tests", async () => {
         );
 
         pointNames = stateVariables["/g"].stateValues.graphicalDescendants.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         expect(
             stateVariables[pointNames[1]].stateValues.xs.map((x) => x.tree),
@@ -508,7 +508,7 @@ describe("callAction tag tests", async () => {
 
             let pointNames = stateVariables[
                 `/set${ind}/g`
-            ].stateValues.graphicalDescendants.map((x) => x.componentName);
+            ].stateValues.graphicalDescendants.map((x) => x.componentIdx);
             expect(pointNames.length).eq(2);
             expect(
                 stateVariables[pointNames[0]].stateValues.xs.map((x) => x.tree),
@@ -527,7 +527,7 @@ describe("callAction tag tests", async () => {
 
             pointNames = stateVariables[
                 `/set${ind}/g`
-            ].stateValues.graphicalDescendants.map((x) => x.componentName);
+            ].stateValues.graphicalDescendants.map((x) => x.componentIdx);
             expect(
                 stateVariables[pointNames[1]].stateValues.xs.map((x) => x.tree),
             ).eqls([-2, 5]);
@@ -599,7 +599,7 @@ describe("callAction tag tests", async () => {
 
         let pointNames = stateVariables[
             "/g"
-        ].stateValues.graphicalDescendants.map((x) => x.componentName);
+        ].stateValues.graphicalDescendants.map((x) => x.componentIdx);
         expect(pointNames.length).eq(2);
         expect(
             stateVariables[pointNames[0]].stateValues.xs.map((x) => x.tree),
@@ -616,7 +616,7 @@ describe("callAction tag tests", async () => {
         );
 
         pointNames = stateVariables["/g"].stateValues.graphicalDescendants.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         expect(
             stateVariables[pointNames[1]].stateValues.xs.map((x) => x.tree),
@@ -642,7 +642,7 @@ describe("callAction tag tests", async () => {
         expect(cleanLatex(stateVariables["/p3"].stateValues.latex)).eq("(3,4)");
 
         pointNames = stateVariables["/g"].stateValues.graphicalDescendants.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         expect(pointNames.length).eq(3);
         expect(
@@ -664,7 +664,7 @@ describe("callAction tag tests", async () => {
         );
 
         pointNames = stateVariables["/g"].stateValues.graphicalDescendants.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         expect(
             stateVariables[pointNames[2]].stateValues.xs.map((x) => x.tree),
@@ -954,17 +954,16 @@ describe("callAction tag tests", async () => {
 
         for (let ind = 0; ind < 2; ind++) {
             let templateName =
-                stateVariables["/_map1"].replacements![ind].componentName;
+                stateVariables["/_map1"].replacements![ind].componentIdx;
 
             let tReps = stateVariables[templateName].replacements;
-            let graphName = tReps![1].componentName;
-            let copyName = tReps![3].componentName;
-            let numsName = tReps![5].componentName;
+            let graphName = tReps![1].componentIdx;
+            let copyName = tReps![3].componentIdx;
+            let numsName = tReps![5].componentIdx;
 
             let PName =
-                stateVariables[graphName].activeChildren[0].componentName;
-            let P2Name =
-                stateVariables[copyName].replacements![0].componentName;
+                stateVariables[graphName].activeChildren[0].componentIdx;
+            let P2Name = stateVariables[copyName].replacements![0].componentIdx;
 
             let numbers = stateVariables[numsName].stateValues.text
                 .split(",")
@@ -1584,7 +1583,7 @@ describe("callAction tag tests", async () => {
 
         let pointNames = stateVariables[
             "/g"
-        ].stateValues.graphicalDescendants.map((x) => x.componentName);
+        ].stateValues.graphicalDescendants.map((x) => x.componentIdx);
         expect(pointNames.length).eq(2);
         expect(
             stateVariables[pointNames[0]].stateValues.xs.map((x) => x.tree),
@@ -1602,7 +1601,7 @@ describe("callAction tag tests", async () => {
         );
 
         pointNames = stateVariables["/g"].stateValues.graphicalDescendants.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         expect(
             stateVariables[pointNames[1]].stateValues.xs.map((x) => x.tree),
@@ -1656,7 +1655,7 @@ describe("callAction tag tests", async () => {
         expect(stateVariables["/sub"].stateValues.hidden).eq(true);
 
         let mathInputName =
-            stateVariables["/ans"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans"].stateValues.inputChildren[0].componentIdx;
 
         await updateMathInputValue({
             latex: "x",
@@ -1689,7 +1688,7 @@ describe("callAction tag tests", async () => {
 
         let pointNames = stateVariables[
             "/g"
-        ].stateValues.graphicalDescendants.map((x) => x.componentName);
+        ].stateValues.graphicalDescendants.map((x) => x.componentIdx);
         expect(pointNames.length).eq(2);
         expect(
             stateVariables[pointNames[0]].stateValues.xs.map((x) => x.tree),
@@ -1707,7 +1706,7 @@ describe("callAction tag tests", async () => {
         );
 
         pointNames = stateVariables["/g"].stateValues.graphicalDescendants.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         expect(
             stateVariables[pointNames[1]].stateValues.xs.map((x) => x.tree),
@@ -1781,7 +1780,7 @@ describe("callAction tag tests", async () => {
 
         let pointNames = stateVariables[
             "/g"
-        ].stateValues.graphicalDescendants.map((x) => x.componentName);
+        ].stateValues.graphicalDescendants.map((x) => x.componentIdx);
         expect(pointNames.length).eq(2);
         expect(
             stateVariables[pointNames[0]].stateValues.xs.map((x) => x.tree),
@@ -1799,7 +1798,7 @@ describe("callAction tag tests", async () => {
         );
 
         pointNames = stateVariables["/g"].stateValues.graphicalDescendants.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         expect(
             stateVariables[pointNames[1]].stateValues.xs.map((x) => x.tree),

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/collect.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/collect.test.ts
@@ -1936,187 +1936,187 @@ describe("Collect tag tests", async () => {
 
         expect(group1Replacements[1].componentType).eq("mathInput");
         expect(
-            stateVariables[group1Replacements[1].componentName].stateValues
-                .value.tree,
+            stateVariables[group1Replacements[1].componentIdx].stateValues.value
+                .tree,
         ).eq("x");
         expect(collect1Replacements[0].componentType).eq("mathInput");
         expect(
-            stateVariables[collect1Replacements[0].componentName].stateValues
+            stateVariables[collect1Replacements[0].componentIdx].stateValues
                 .value.tree,
         ).eq("x");
         expect(collect2Replacements[0].componentType).eq("mathInput");
         expect(
-            stateVariables[collect2Replacements[0].componentName].stateValues
+            stateVariables[collect2Replacements[0].componentIdx].stateValues
                 .value.tree,
         ).eq("x");
         expect(group2Replacements[1].componentType).eq("mathInput");
         expect(
-            stateVariables[group2Replacements[1].componentName].stateValues
-                .value.tree,
+            stateVariables[group2Replacements[1].componentIdx].stateValues.value
+                .tree,
         ).eq("x");
         expect(collect3Replacements[0].componentType).eq("mathInput");
         expect(
-            stateVariables[collect3Replacements[0].componentName].stateValues
+            stateVariables[collect3Replacements[0].componentIdx].stateValues
                 .value.tree,
         ).eq("x");
         expect(group3Replacements[1].componentType).eq("mathInput");
         expect(
-            stateVariables[group3Replacements[1].componentName].stateValues
-                .value.tree,
+            stateVariables[group3Replacements[1].componentIdx].stateValues.value
+                .tree,
         ).eq("x");
 
         expect(group1Replacements[3].componentType).eq("textInput");
         expect(
-            stateVariables[group1Replacements[3].componentName].stateValues
+            stateVariables[group1Replacements[3].componentIdx].stateValues
                 .value,
         ).eq("hello");
         expect(collect1Replacements[1].componentType).eq("textInput");
         expect(
-            stateVariables[collect1Replacements[1].componentName].stateValues
+            stateVariables[collect1Replacements[1].componentIdx].stateValues
                 .value,
         ).eq("hello");
         expect(collect2Replacements[1].componentType).eq("textInput");
         expect(
-            stateVariables[collect2Replacements[1].componentName].stateValues
+            stateVariables[collect2Replacements[1].componentIdx].stateValues
                 .value,
         ).eq("hello");
         expect(group2Replacements[3].componentType).eq("textInput");
         expect(
-            stateVariables[group2Replacements[3].componentName].stateValues
+            stateVariables[group2Replacements[3].componentIdx].stateValues
                 .value,
         ).eq("hello");
         expect(collect3Replacements[1].componentType).eq("textInput");
         expect(
-            stateVariables[collect3Replacements[1].componentName].stateValues
+            stateVariables[collect3Replacements[1].componentIdx].stateValues
                 .value,
         ).eq("hello");
         expect(group3Replacements[3].componentType).eq("textInput");
         expect(
-            stateVariables[group3Replacements[3].componentName].stateValues
+            stateVariables[group3Replacements[3].componentIdx].stateValues
                 .value,
         ).eq("hello");
 
         expect(group1Replacements[5].componentType).eq("booleanInput");
         expect(
-            stateVariables[group1Replacements[5].componentName].stateValues
+            stateVariables[group1Replacements[5].componentIdx].stateValues
                 .value,
         ).eq(false);
         expect(collect1Replacements[2].componentType).eq("booleanInput");
         expect(
-            stateVariables[collect1Replacements[2].componentName].stateValues
+            stateVariables[collect1Replacements[2].componentIdx].stateValues
                 .value,
         ).eq(false);
         expect(collect2Replacements[2].componentType).eq("booleanInput");
         expect(
-            stateVariables[collect2Replacements[2].componentName].stateValues
+            stateVariables[collect2Replacements[2].componentIdx].stateValues
                 .value,
         ).eq(false);
         expect(group2Replacements[5].componentType).eq("booleanInput");
         expect(
-            stateVariables[group2Replacements[5].componentName].stateValues
+            stateVariables[group2Replacements[5].componentIdx].stateValues
                 .value,
         ).eq(false);
         expect(collect3Replacements[2].componentType).eq("booleanInput");
         expect(
-            stateVariables[collect3Replacements[2].componentName].stateValues
+            stateVariables[collect3Replacements[2].componentIdx].stateValues
                 .value,
         ).eq(false);
         expect(group3Replacements[5].componentType).eq("booleanInput");
         expect(
-            stateVariables[group3Replacements[5].componentName].stateValues
+            stateVariables[group3Replacements[5].componentIdx].stateValues
                 .value,
         ).eq(false);
 
         expect(group1Replacements[7].componentType).eq("math");
         expect(
-            stateVariables[group1Replacements[7].componentName].stateValues
-                .value.tree,
+            stateVariables[group1Replacements[7].componentIdx].stateValues.value
+                .tree,
         ).eqls(["*", 2, "x"]);
         expect(collect1Replacements[3].componentType).eq("math");
         expect(
-            stateVariables[collect1Replacements[3].componentName].stateValues
+            stateVariables[collect1Replacements[3].componentIdx].stateValues
                 .value.tree,
         ).eqls(["*", 2, "x"]);
         expect(collect2Replacements[3].componentType).eq("math");
         expect(
-            stateVariables[collect2Replacements[3].componentName].stateValues
+            stateVariables[collect2Replacements[3].componentIdx].stateValues
                 .value.tree,
         ).eqls(["*", 2, "x"]);
         expect(group2Replacements[7].componentType).eq("math");
         expect(
-            stateVariables[group2Replacements[7].componentName].stateValues
-                .value.tree,
+            stateVariables[group2Replacements[7].componentIdx].stateValues.value
+                .tree,
         ).eqls(["*", 2, "x"]);
         expect(collect3Replacements[3].componentType).eq("math");
         expect(
-            stateVariables[collect3Replacements[3].componentName].stateValues
+            stateVariables[collect3Replacements[3].componentIdx].stateValues
                 .value.tree,
         ).eqls(["*", 2, "x"]);
         expect(group3Replacements[7].componentType).eq("math");
         expect(
-            stateVariables[group3Replacements[7].componentName].stateValues
-                .value.tree,
+            stateVariables[group3Replacements[7].componentIdx].stateValues.value
+                .tree,
         ).eqls(["*", 2, "x"]);
 
         expect(group1Replacements[9].componentType).eq("text");
         expect(
-            stateVariables[group1Replacements[9].componentName].stateValues
+            stateVariables[group1Replacements[9].componentIdx].stateValues
                 .value,
         ).eq("hello there");
         expect(collect1Replacements[4].componentType).eq("text");
         expect(
-            stateVariables[collect1Replacements[4].componentName].stateValues
+            stateVariables[collect1Replacements[4].componentIdx].stateValues
                 .value,
         ).eq("hello there");
         expect(collect2Replacements[4].componentType).eq("text");
         expect(
-            stateVariables[collect2Replacements[4].componentName].stateValues
+            stateVariables[collect2Replacements[4].componentIdx].stateValues
                 .value,
         ).eq("hello there");
         expect(group2Replacements[9].componentType).eq("text");
         expect(
-            stateVariables[group2Replacements[9].componentName].stateValues
+            stateVariables[group2Replacements[9].componentIdx].stateValues
                 .value,
         ).eq("hello there");
         expect(collect3Replacements[4].componentType).eq("text");
         expect(
-            stateVariables[collect3Replacements[4].componentName].stateValues
+            stateVariables[collect3Replacements[4].componentIdx].stateValues
                 .value,
         ).eq("hello there");
         expect(group3Replacements[9].componentType).eq("text");
         expect(
-            stateVariables[group3Replacements[9].componentName].stateValues
+            stateVariables[group3Replacements[9].componentIdx].stateValues
                 .value,
         ).eq("hello there");
 
         expect(group1Replacements[11].componentType).eq("boolean");
         expect(
-            stateVariables[group1Replacements[11].componentName].stateValues
+            stateVariables[group1Replacements[11].componentIdx].stateValues
                 .value,
         ).eq(true);
         expect(collect1Replacements[5].componentType).eq("boolean");
         expect(
-            stateVariables[collect1Replacements[5].componentName].stateValues
+            stateVariables[collect1Replacements[5].componentIdx].stateValues
                 .value,
         ).eq(true);
         expect(collect2Replacements[5].componentType).eq("boolean");
         expect(
-            stateVariables[collect2Replacements[5].componentName].stateValues
+            stateVariables[collect2Replacements[5].componentIdx].stateValues
                 .value,
         ).eq(true);
         expect(group2Replacements[11].componentType).eq("boolean");
         expect(
-            stateVariables[group2Replacements[11].componentName].stateValues
+            stateVariables[group2Replacements[11].componentIdx].stateValues
                 .value,
         ).eq(true);
         expect(collect3Replacements[5].componentType).eq("boolean");
         expect(
-            stateVariables[collect3Replacements[5].componentName].stateValues
+            stateVariables[collect3Replacements[5].componentIdx].stateValues
                 .value,
         ).eq(true);
         expect(group3Replacements[11].componentType).eq("boolean");
         expect(
-            stateVariables[group3Replacements[11].componentName].stateValues
+            stateVariables[group3Replacements[11].componentIdx].stateValues
                 .value,
         ).eq(true);
     });
@@ -2411,7 +2411,7 @@ describe("Collect tag tests", async () => {
 
             let p1AllChildren: string[] = [];
             p1AllChildren.push("/A");
-            p1AllChildren.push(components["/A"].adapterUsed.componentName);
+            p1AllChildren.push(components["/A"].adapterUsed.componentIdx);
             p1AllChildren.push("/map1");
 
             let map = stateVariables["/map1"];
@@ -2422,13 +2422,13 @@ describe("Collect tag tests", async () => {
                     stateVariables["/map1"].replacementsToWithhold || 0;
             }
             for (let template of map.replacements!.slice(0, nActiveReps)) {
-                p1AllChildren.push(template.componentName);
-                let point = components[template.componentName].replacements[0];
-                p1AllChildren.push(point.componentName);
-                p1AllChildren.push(point.adapterUsed.componentName);
+                p1AllChildren.push(template.componentIdx);
+                let point = components[template.componentIdx].replacements[0];
+                p1AllChildren.push(point.componentIdx);
+                p1AllChildren.push(point.adapterUsed.componentIdx);
             }
             p1AllChildren.push("/B");
-            p1AllChildren.push(components["/B"].adapterUsed.componentName);
+            p1AllChildren.push(components["/B"].adapterUsed.componentIdx);
 
             expect(components["/p1"].allChildrenOrdered).eqls(p1AllChildren);
 
@@ -2441,8 +2441,8 @@ describe("Collect tag tests", async () => {
                     stateVariables["/collect1"].replacementsToWithhold || 0;
             }
             for (let rep of collect.replacements!.slice(0, nActiveReps)) {
-                p2AllChildren.push(rep.componentName);
-                p2AllChildren.push(rep.adapterUsed.componentName);
+                p2AllChildren.push(rep.componentIdx);
+                p2AllChildren.push(rep.adapterUsed.componentIdx);
             }
 
             expect(components["/p2"].allChildrenOrdered).eqls(p2AllChildren);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/conditionalcontent.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/conditionalcontent.test.ts
@@ -137,7 +137,7 @@ describe("Conditional content tag tests", async () => {
 
             let p =
                 stateVariables[`/section${index}`].activeChildren[1]
-                    .componentName;
+                    .componentIdx;
 
             expect(
                 stateVariables[p].stateValues.text.replace(/\s+/g, " ").trim(),
@@ -655,7 +655,7 @@ describe("Conditional content tag tests", async () => {
                 let names1 = stateVariables[
                     calcFromContainers[0]
                 ].activeChildren
-                    .map((x) => x.componentName)
+                    .map((x) => x.componentIdx)
                     .filter((x) => x);
 
                 expect(stateVariables[names1[0]].stateValues.text).eq(animal);
@@ -667,7 +667,7 @@ describe("Conditional content tag tests", async () => {
                 let names2 = stateVariables[
                     calcFromContainers[1]
                 ].activeChildren
-                    .map((x) => x.componentName)
+                    .map((x) => x.componentIdx)
                     .filter((x) => x);
 
                 expect(stateVariables[names2[0]].stateValues.text).eq(animal);
@@ -1426,7 +1426,7 @@ describe("Conditional content tag tests", async () => {
 
         expect(stateVariables["/s"].activeChildren).eqls([
             "\n  ",
-            { componentName: "/n", componentType: "mathInput" },
+            { componentIdx: "/n", componentType: "mathInput" },
             "\n  before\n  ",
             "nothing: ",
             "\n  after\n",

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/copy.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/copy.test.ts
@@ -2609,24 +2609,21 @@ describe("Copy tag tests", async () => {
 
         expect(
             stateVariables["/section1"].activeChildren.map(
-                (x) => x.componentName,
+                (x) => x.componentIdx,
             ),
         ).eqls(["/p2"]);
         expect(
             stateVariables["/s1a"].activeChildren.map((x) => x.componentType),
         ).eqls(["p"]);
         expect(
-            stateVariables["/s1b"].activeChildren.map((x) => x.componentName),
+            stateVariables["/s1b"].activeChildren.map((x) => x.componentIdx),
         ).eqls(["/s1b/p2"]);
 
-        let c2p = stateVariables["/_document1"].activeChildren[5].componentName;
-        let c4p = stateVariables["/_document1"].activeChildren[9].componentName;
-        let c6p =
-            stateVariables["/_document1"].activeChildren[13].componentName;
-        let c7s =
-            stateVariables["/_document1"].activeChildren[15].componentName;
-        let c9s =
-            stateVariables["/_document1"].activeChildren[19].componentName;
+        let c2p = stateVariables["/_document1"].activeChildren[5].componentIdx;
+        let c4p = stateVariables["/_document1"].activeChildren[9].componentIdx;
+        let c6p = stateVariables["/_document1"].activeChildren[13].componentIdx;
+        let c7s = stateVariables["/_document1"].activeChildren[15].componentIdx;
+        let c9s = stateVariables["/_document1"].activeChildren[19].componentIdx;
 
         expect(stateVariables[c2p].stateValues.text).eq("values: 1 2 3");
         expect(stateVariables[c4p].stateValues.text).eq("values: 1 2 3");
@@ -2642,8 +2639,8 @@ describe("Copy tag tests", async () => {
 
         // c2p's children should have gotten unique names (so begin with two underscores)
         let c2pChildNames = stateVariables[c2p].activeChildren
-            .filter((x) => x.componentName)
-            .map((x) => x.componentName);
+            .filter((x) => x.componentIdx)
+            .map((x) => x.componentIdx);
         expect(c2pChildNames[0].slice(0, 3)).eq("/__");
         expect(c2pChildNames[1].slice(0, 3)).eq("/__");
         expect(c2pChildNames[2].slice(0, 3)).eq("/__");
@@ -2653,8 +2650,8 @@ describe("Copy tag tests", async () => {
 
         // c4p's children should have gotten unique names (so begin with two underscores)
         let c4pChildNames = stateVariables[c4p].activeChildren
-            .filter((x) => x.componentName)
-            .map((x) => x.componentName);
+            .filter((x) => x.componentIdx)
+            .map((x) => x.componentIdx);
         expect(c4pChildNames[0].slice(0, 3)).eq("/__");
         expect(c4pChildNames[1].slice(0, 3)).eq("/__");
         expect(c4pChildNames[2].slice(0, 3)).eq("/__");
@@ -2664,8 +2661,8 @@ describe("Copy tag tests", async () => {
 
         // c6p's children should have gotten unique names (so begin with two underscores)
         let c6pChildNames = stateVariables[c6p].activeChildren
-            .filter((x) => x.componentName)
-            .map((x) => x.componentName);
+            .filter((x) => x.componentIdx)
+            .map((x) => x.componentIdx);
         expect(c6pChildNames[0].slice(0, 3)).eq("/__");
         expect(c6pChildNames[1].slice(0, 3)).eq("/__");
         expect(c6pChildNames[2].slice(0, 3)).eq("/__");
@@ -2675,11 +2672,11 @@ describe("Copy tag tests", async () => {
 
         // c7s's grandchildren should have gotten unique names (so begin with two underscores)
         let c7sChildName = stateVariables[c7s].activeChildren.filter(
-            (x) => x.componentName,
-        )[0].componentName;
+            (x) => x.componentIdx,
+        )[0].componentIdx;
         let c7sGrandChildNames = stateVariables[c7sChildName].activeChildren
-            .filter((x) => x.componentName)
-            .map((x) => x.componentName);
+            .filter((x) => x.componentIdx)
+            .map((x) => x.componentIdx);
 
         expect(c7sGrandChildNames[0].slice(0, 3)).eq("/__");
         expect(c7sGrandChildNames[1].slice(0, 3)).eq("/__");
@@ -2690,11 +2687,11 @@ describe("Copy tag tests", async () => {
 
         // s1a's grandchildren should have gotten unique names (so begin with two underscores)
         let s1aChildName = stateVariables["/s1a"].activeChildren.filter(
-            (x) => x.componentName,
-        )[0].componentName;
+            (x) => x.componentIdx,
+        )[0].componentIdx;
         let s1aGrandChildNames = stateVariables[s1aChildName].activeChildren
-            .filter((x) => x.componentName)
-            .map((x) => x.componentName);
+            .filter((x) => x.componentIdx)
+            .map((x) => x.componentIdx);
 
         expect(s1aGrandChildNames[0].slice(0, 3)).eq("/__");
         expect(s1aGrandChildNames[1].slice(0, 3)).eq("/__");
@@ -2705,11 +2702,11 @@ describe("Copy tag tests", async () => {
 
         // c9s's grandchildren should have gotten unique names (so begin with two underscores)
         let c9sChildName = stateVariables[c9s].activeChildren.filter(
-            (x) => x.componentName,
-        )[0].componentName;
+            (x) => x.componentIdx,
+        )[0].componentIdx;
         let c9sGrandChildNames = stateVariables[c9sChildName].activeChildren
-            .filter((x) => x.componentName)
-            .map((x) => x.componentName);
+            .filter((x) => x.componentIdx)
+            .map((x) => x.componentIdx);
 
         expect(c9sGrandChildNames[0].slice(0, 3)).eq("/__");
         expect(c9sGrandChildNames[1].slice(0, 3)).eq("/__");
@@ -2720,11 +2717,11 @@ describe("Copy tag tests", async () => {
 
         // s1b's grandchildren should have retained their original names
         let s1bChildName = stateVariables["/s1b"].activeChildren.filter(
-            (x) => x.componentName,
-        )[0].componentName;
+            (x) => x.componentIdx,
+        )[0].componentIdx;
         let s1bGrandChildNames = stateVariables[s1bChildName].activeChildren
-            .filter((x) => x.componentName)
-            .map((x) => x.componentName);
+            .filter((x) => x.componentIdx)
+            .map((x) => x.componentIdx);
 
         expect(s1bGrandChildNames[0]).eq(`/s1b/p2${name_prefix}/n1`);
         expect(s1bGrandChildNames[1]).eq(`/s1b/p2${name_prefix}/n2`);
@@ -2959,12 +2956,12 @@ describe("Copy tag tests", async () => {
 
             expect(
                 stateVariables[`${name_prefix}/section1`].activeChildren.map(
-                    (x) => x.componentName,
+                    (x) => x.componentIdx,
                 ),
             ).eqls([`${name_prefix}/p2`]);
             expect(
                 stateVariables[`${name_prefix}/s1b`].activeChildren.map(
-                    (x) => x.componentName,
+                    (x) => x.componentIdx,
                 ),
             ).eqls([`${name_prefix}/s1b/p2`]);
         }
@@ -3557,12 +3554,12 @@ describe("Copy tag tests", async () => {
         let P2 = [3, 4];
 
         let stateVariables = await core.returnAllStateVariables(false, true);
-        let g5PName = stateVariables["/g5"].activeChildren[0].componentName;
-        let g7PName = stateVariables["/g7"].activeChildren[0].componentName;
-        let g13PName = stateVariables["/g13"].activeChildren[0].componentName;
-        let g15PName = stateVariables["/g15"].activeChildren[0].componentName;
-        let g21PName = stateVariables["/g21"].activeChildren[0].componentName;
-        let g23PName = stateVariables["/g23"].activeChildren[0].componentName;
+        let g5PName = stateVariables["/g5"].activeChildren[0].componentIdx;
+        let g7PName = stateVariables["/g7"].activeChildren[0].componentIdx;
+        let g13PName = stateVariables["/g13"].activeChildren[0].componentIdx;
+        let g15PName = stateVariables["/g15"].activeChildren[0].componentIdx;
+        let g21PName = stateVariables["/g21"].activeChildren[0].componentIdx;
+        let g23PName = stateVariables["/g23"].activeChildren[0].componentIdx;
 
         expect(stateVariables["/P"].stateValues.xs.map((x) => x.tree)).eqls(P1);
         expect(stateVariables["/g2/P"].stateValues.xs.map((x) => x.tree)).eqls(
@@ -4074,12 +4071,12 @@ describe("Copy tag tests", async () => {
         let P2 = [3, 4];
 
         let stateVariables = await core.returnAllStateVariables(false, true);
-        let g5PName = stateVariables["/g5"].activeChildren[0].componentName;
-        let g7PName = stateVariables["/g7"].activeChildren[0].componentName;
-        let g13PName = stateVariables["/g13"].activeChildren[0].componentName;
-        let g15PName = stateVariables["/g15"].activeChildren[0].componentName;
-        let g21PName = stateVariables["/g21"].activeChildren[0].componentName;
-        let g23PName = stateVariables["/g23"].activeChildren[0].componentName;
+        let g5PName = stateVariables["/g5"].activeChildren[0].componentIdx;
+        let g7PName = stateVariables["/g7"].activeChildren[0].componentIdx;
+        let g13PName = stateVariables["/g13"].activeChildren[0].componentIdx;
+        let g15PName = stateVariables["/g15"].activeChildren[0].componentIdx;
+        let g21PName = stateVariables["/g21"].activeChildren[0].componentIdx;
+        let g23PName = stateVariables["/g23"].activeChildren[0].componentIdx;
 
         expect(stateVariables["/P"].stateValues.xs.map((x) => x.tree)).eqls(P1);
         expect(stateVariables["/g2/P"].stateValues.xs.map((x) => x.tree)).eqls(
@@ -4547,23 +4544,23 @@ describe("Copy tag tests", async () => {
 
         let mathinputoutsideName =
             stateVariables["/answer1"].stateValues.inputChildren[0]
-                .componentName;
+                .componentIdx;
 
         let mathinputp1Name =
             stateVariables["/answer2"].stateValues.inputChildren[0]
-                .componentName;
+                .componentIdx;
 
         let mathinputp2Name =
             stateVariables["/p2/answer1"].stateValues.inputChildren[0]
-                .componentName;
+                .componentIdx;
 
         let mathinputp3Name =
             stateVariables["/p3/answer2"].stateValues.inputChildren[0]
-                .componentName;
+                .componentIdx;
 
         let mathinputp4Name =
             stateVariables["/p4/answer1"].stateValues.inputChildren[0]
-                .componentName;
+                .componentIdx;
 
         expect(stateVariables["/ca"].stateValues.value).eq(0);
         expect(stateVariables["/p2/cao"].stateValues.value).eq(0);
@@ -5159,13 +5156,13 @@ describe("Copy tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables["/g"].activeChildren.length).eq(1);
-        expect(stateVariables["/g"].activeChildren[0].componentName).eq("/P");
+        expect(stateVariables["/g"].activeChildren[0].componentIdx).eq("/P");
         expect(stateVariables["/P"].stateValues.xs.map((x) => x.tree)).eqls([
             0, 0,
         ]);
 
         expect(stateVariables["/g2"].activeChildren.length).eq(1);
-        expect(stateVariables["/g2"].activeChildren[0].componentName).eq(
+        expect(stateVariables["/g2"].activeChildren[0].componentIdx).eq(
             "/g2/P",
         );
         expect(stateVariables["/g2/P"].stateValues.xs.map((x) => x.tree)).eqls([
@@ -5266,15 +5263,13 @@ describe("Copy tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables["/g1"].activeChildren.length).eq(1);
-        expect(stateVariables["/g1"].activeChildren[0].componentName).eq("/P1");
+        expect(stateVariables["/g1"].activeChildren[0].componentIdx).eq("/P1");
         expect(stateVariables["/P1"].stateValues.xs.map((x) => x.tree)).eqls([
             1, 2,
         ]);
         expect(stateVariables["/g1a"].activeChildren.length).eq(2);
-        expect(stateVariables["/g1a"].activeChildren[1].componentName).eq(
-            "/v1",
-        );
-        let P1aName = stateVariables["/g1a"].activeChildren[0].componentName;
+        expect(stateVariables["/g1a"].activeChildren[1].componentIdx).eq("/v1");
+        let P1aName = stateVariables["/g1a"].activeChildren[0].componentIdx;
         expect(stateVariables[P1aName].stateValues.xs.map((x) => x.tree)).eqls([
             1, 2,
         ]);
@@ -5293,15 +5288,15 @@ describe("Copy tag tests", async () => {
         ]);
 
         expect(stateVariables["/g2"].activeChildren.length).eq(1);
-        expect(stateVariables["/g2"].activeChildren[0].componentName).eq("/P2");
+        expect(stateVariables["/g2"].activeChildren[0].componentIdx).eq("/P2");
         expect(stateVariables["/P2"].stateValues.xs.map((x) => x.tree)).eqls([
             1, 2,
         ]);
         expect(stateVariables["/g2a"].activeChildren.length).eq(2);
-        expect(stateVariables["/g2a"].activeChildren[0].componentName).eq(
+        expect(stateVariables["/g2a"].activeChildren[0].componentIdx).eq(
             "/g2a/P2",
         );
-        expect(stateVariables["/g2a"].activeChildren[1].componentName).eq(
+        expect(stateVariables["/g2a"].activeChildren[1].componentIdx).eq(
             "/g2a/v2",
         );
         expect(
@@ -5329,17 +5324,17 @@ describe("Copy tag tests", async () => {
         ]);
 
         expect(stateVariables["/g3"].activeChildren.length).eq(1);
-        expect(stateVariables["/g3"].activeChildren[0].componentName).eq(
+        expect(stateVariables["/g3"].activeChildren[0].componentIdx).eq(
             "/g3/P3",
         );
         expect(stateVariables["/g3/P3"].stateValues.xs.map((x) => x.tree)).eqls(
             [1, 2],
         );
         expect(stateVariables["/g3a"].activeChildren.length).eq(2);
-        expect(stateVariables["/g3a"].activeChildren[0].componentName).eq(
+        expect(stateVariables["/g3a"].activeChildren[0].componentIdx).eq(
             "/g3a/P3",
         );
-        expect(stateVariables["/g3a"].activeChildren[1].componentName).eq(
+        expect(stateVariables["/g3a"].activeChildren[1].componentIdx).eq(
             "/g3a/v3",
         );
         expect(
@@ -5367,19 +5362,17 @@ describe("Copy tag tests", async () => {
         ]);
 
         expect(stateVariables["/g4"].activeChildren.length).eq(1);
-        expect(stateVariables["/g4"].activeChildren[0].componentName).eq(
+        expect(stateVariables["/g4"].activeChildren[0].componentIdx).eq(
             "/g4/P4",
         );
         expect(stateVariables["/g4/P4"].stateValues.xs.map((x) => x.tree)).eqls(
             [1, 2],
         );
         expect(stateVariables["/g4a"].activeChildren.length).eq(2);
-        expect(stateVariables["/g4a"].activeChildren[0].componentName).eq(
+        expect(stateVariables["/g4a"].activeChildren[0].componentIdx).eq(
             "/g4a/P4",
         );
-        expect(stateVariables["/g4a"].activeChildren[1].componentName).eq(
-            "/v4",
-        );
+        expect(stateVariables["/g4a"].activeChildren[1].componentIdx).eq("/v4");
         expect(
             stateVariables["/g4a/P4"].stateValues.xs.map((x) => x.tree),
         ).eqls([1, 2]);
@@ -5729,7 +5722,7 @@ describe("Copy tag tests", async () => {
         expect(stateVariables["/g4/P"].stateValues.xs.map((x) => x.tree)).eqls([
             1, 2,
         ]);
-        let g4vName = stateVariables["/g4"].activeChildren[1].componentName;
+        let g4vName = stateVariables["/g4"].activeChildren[1].componentIdx;
         expect(g4vName.substring(0, 3) === "/__");
         expect(
             stateVariables[g4vName].stateValues.displacement.map((x) => x.tree),
@@ -5760,7 +5753,7 @@ describe("Copy tag tests", async () => {
             stateVariables["/grp2/g4/P"].stateValues.xs.map((x) => x.tree),
         ).eqls([1, 2]);
         let grp2g4vName =
-            stateVariables["/grp2/g4"].activeChildren[1].componentName;
+            stateVariables["/grp2/g4"].activeChildren[1].componentIdx;
         expect(grp2g4vName.substring(0, 3) === "/__");
         expect(
             stateVariables[grp2g4vName].stateValues.displacement.map(
@@ -6312,17 +6305,17 @@ describe("Copy tag tests", async () => {
                 true,
             );
             expect(stateVariables["/g1"].activeChildren.length).eq(1);
-            expect(stateVariables["/g1"].activeChildren[0].componentName).eq(
+            expect(stateVariables["/g1"].activeChildren[0].componentIdx).eq(
                 "/g1/P",
             );
             expect(
                 stateVariables["/g1/P"].stateValues.xs.map((x) => x.tree),
             ).eqls(P);
             expect(stateVariables["/g2"].activeChildren.length).eq(2);
-            expect(stateVariables["/g2"].activeChildren[0].componentName).eq(
+            expect(stateVariables["/g2"].activeChildren[0].componentIdx).eq(
                 "/g2/P",
             );
-            expect(stateVariables["/g2"].activeChildren[1].componentName).eq(
+            expect(stateVariables["/g2"].activeChildren[1].componentIdx).eq(
                 "/g2/Q",
             );
             expect(
@@ -7755,17 +7748,17 @@ describe("Copy tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let macrom1Name =
-            stateVariables["/pmacro1"].activeChildren[0].componentName;
+            stateVariables["/pmacro1"].activeChildren[0].componentIdx;
         let macrom2Name =
-            stateVariables["/pmacro2"].activeChildren[0].componentName;
+            stateVariables["/pmacro2"].activeChildren[0].componentIdx;
         let copym1Name =
-            stateVariables["/pcopy1"].activeChildren[0].componentName;
+            stateVariables["/pcopy1"].activeChildren[0].componentIdx;
         let copym2Name =
-            stateVariables["/pcopy2"].activeChildren[0].componentName;
+            stateVariables["/pcopy2"].activeChildren[0].componentIdx;
         let copym3Name =
-            stateVariables["/pcopy3"].activeChildren[0].componentName;
+            stateVariables["/pcopy3"].activeChildren[0].componentIdx;
         let copymi4Name =
-            stateVariables["/pcopy4"].activeChildren[0].componentName;
+            stateVariables["/pcopy4"].activeChildren[0].componentIdx;
 
         expect(stateVariables[macrom1Name].componentType).eq("math");
         expect(stateVariables[macrom2Name].componentType).eq("math");
@@ -7976,20 +7969,20 @@ describe("Copy tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
         let [macromi1Name, macromi2Name] = stateVariables[
             "/pmacro"
-        ].activeChildren.map((x) => x.componentName);
+        ].activeChildren.map((x) => x.componentIdx);
         let [copymi1Name, copymi2Name] = stateVariables[
             "/pcopy"
-        ].activeChildren.map((x) => x.componentName);
+        ].activeChildren.map((x) => x.componentIdx);
         let [macromi1Name2, macromi2Name2] = stateVariables[
             "/pmacro2"
         ].activeChildren
-            .filter((x) => x.componentName)
-            .map((x) => x.componentName);
+            .filter((x) => x.componentIdx)
+            .map((x) => x.componentIdx);
         let [copymi1Name2, copymi2Name2] = stateVariables[
             "/pcopy2"
         ].activeChildren
-            .filter((x) => x.componentName)
-            .map((x) => x.componentName);
+            .filter((x) => x.componentIdx)
+            .map((x) => x.componentIdx);
 
         expect(stateVariables[macromi1Name].componentType).eq("mathInput");
         expect(stateVariables[macromi2Name].componentType).eq("mathInput");
@@ -8032,22 +8025,22 @@ describe("Copy tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
         let [macromi1Name, macromi2Name] = stateVariables[
             "/pmacro"
-        ].activeChildren.map((x) => x.componentName);
+        ].activeChildren.map((x) => x.componentIdx);
         let [copymi1Name, copymi2Name] = stateVariables[
             "/pcopy"
-        ].activeChildren.map((x) => x.componentName);
+        ].activeChildren.map((x) => x.componentIdx);
         let [macroIndmi1Name, macroIndmi2Name] = stateVariables[
             "/pmacroInd"
-        ].activeChildren.map((x) => x.componentName);
+        ].activeChildren.map((x) => x.componentIdx);
         let [copyIndmi1Name, copyIndmi2Name] = stateVariables[
             "/pmacroInd"
-        ].activeChildren.map((x) => x.componentName);
+        ].activeChildren.map((x) => x.componentIdx);
         let [macroSubnamem1Name, macroSubnamem2Name] = stateVariables[
             "/pmacroSubname"
-        ].activeChildren.map((x) => x.componentName);
+        ].activeChildren.map((x) => x.componentIdx);
         let [copySubnamem1Name, copySubnamem2Name] = stateVariables[
             "/pcopySubname"
-        ].activeChildren.map((x) => x.componentName);
+        ].activeChildren.map((x) => x.componentIdx);
 
         expect(stateVariables[macromi1Name].componentType).eq("mathInput");
         expect(stateVariables[macromi2Name].componentType).eq("mathInput");
@@ -8095,9 +8088,9 @@ describe("Copy tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
 
-        let mi3Name = stateVariables["/p2"].activeChildren[0].componentName;
-        let m2Name = stateVariables["/p2"].activeChildren[2].componentName;
-        let m3Name = stateVariables["/p2"].activeChildren[4].componentName;
+        let mi3Name = stateVariables["/p2"].activeChildren[0].componentIdx;
+        let m2Name = stateVariables["/p2"].activeChildren[2].componentIdx;
+        let m3Name = stateVariables["/p2"].activeChildren[4].componentIdx;
 
         expect(stateVariables[m2Name].stateValues.value.tree).eq("\uff3f");
         expect(stateVariables[m3Name].stateValues.value.tree).eq("\uff3f");
@@ -8284,7 +8277,7 @@ describe("Copy tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         const tiName =
-            stateVariables["/ans"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans"].stateValues.inputChildren[0].componentIdx;
 
         expect(stateVariables["/num"].stateValues.value).eqls(NaN);
 

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/curve.bezier.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/curve.bezier.test.ts
@@ -27,7 +27,7 @@ async function changeVectorControlDirection({
     direction: Direction;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "changeVectorControlDirection",
         args: { throughPointInd, direction },
     });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/curve.parametrized.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/curve.parametrized.test.ts
@@ -32,7 +32,7 @@ describe("Parameterized curve tag tests", async () => {
         const stateVariables = await core.returnAllStateVariables(false, true);
 
         const cName = nameFromGraphChild
-            ? stateVariables["/g"].activeChildren[0].componentName
+            ? stateVariables["/g"].activeChildren[0].componentIdx
             : name;
 
         expect(stateVariables[cName].stateValues.curveType).eq(

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/curve.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/curve.test.ts
@@ -328,12 +328,12 @@ describe("Curve tag tests", async () => {
 
         // activate bezier controls and move tangents
         await core.requestAction({
-            componentName: "/c",
+            componentIdx: "/c",
             actionName: "changeVectorControlDirection",
             args: { throughPointInd: 0, direction: "symmetric" },
         });
         await core.requestAction({
-            componentName: "/c",
+            componentIdx: "/c",
             actionName: "changeVectorControlDirection",
             args: { throughPointInd: 3, direction: "symmetric" },
         });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/document.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/document.test.ts
@@ -35,7 +35,7 @@ describe("Document tag tests", async () => {
         expect(stateVariables["/docCa"].stateValues.value).eq(0.5);
 
         let mathInputName =
-            stateVariables["/ans"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans"].stateValues.inputChildren[0].componentIdx;
 
         await updateMathInputValue({
             latex: "x",
@@ -67,7 +67,7 @@ describe("Document tag tests", async () => {
         expect(stateVariables["/docCa"].stateValues.value).eq(0);
 
         let mathInputName =
-            stateVariables["/ans"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans"].stateValues.inputChildren[0].componentIdx;
 
         await updateMathInputValue({
             latex: "x",
@@ -106,15 +106,15 @@ describe("Document tag tests", async () => {
         ).eqls([0, 0, 0, 0, 0]);
 
         let mathInputXName =
-            stateVariables["/x"].stateValues.inputChildren[0].componentName;
+            stateVariables["/x"].stateValues.inputChildren[0].componentIdx;
         let mathInputYName =
-            stateVariables["/y"].stateValues.inputChildren[0].componentName;
+            stateVariables["/y"].stateValues.inputChildren[0].componentIdx;
         let mathInputZName =
-            stateVariables["/z"].stateValues.inputChildren[0].componentName;
+            stateVariables["/z"].stateValues.inputChildren[0].componentIdx;
         let mathInputAName =
-            stateVariables["/a"].stateValues.inputChildren[0].componentName;
+            stateVariables["/a"].stateValues.inputChildren[0].componentIdx;
         let mathInputBName =
-            stateVariables["/b"].stateValues.inputChildren[0].componentName;
+            stateVariables["/b"].stateValues.inputChildren[0].componentIdx;
 
         await updateMathInputValue({
             latex: "x",

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/endpoint.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/endpoint.test.ts
@@ -95,7 +95,7 @@ describe("Endpoint tag tests", async () => {
         // switch A via first action
         await core.requestAction({
             actionName: "switchPoint",
-            componentName: "/g/A",
+            componentIdx: "/g/A",
             args: {},
         });
         AOpen = false;
@@ -104,7 +104,7 @@ describe("Endpoint tag tests", async () => {
         // switch A via second action
         await core.requestAction({
             actionName: "switchPoint",
-            componentName: "/g2/A",
+            componentIdx: "/g2/A",
             args: {},
         });
         AOpen = true;
@@ -113,7 +113,7 @@ describe("Endpoint tag tests", async () => {
         // cannot switch B via action
         await core.requestAction({
             actionName: "switchPoint",
-            componentName: "/g/B",
+            componentIdx: "/g/B",
             args: {},
         });
         await check_items(AOpen, BOpen, COpen, DOpen);
@@ -121,7 +121,7 @@ describe("Endpoint tag tests", async () => {
         // cannot switch C via second action
         await core.requestAction({
             actionName: "switchPoint",
-            componentName: "/g2/C",
+            componentIdx: "/g2/C",
             args: {},
         });
         await check_items(AOpen, BOpen, COpen, DOpen);
@@ -129,7 +129,7 @@ describe("Endpoint tag tests", async () => {
         // switch D via second action
         await core.requestAction({
             actionName: "switchPoint",
-            componentName: "/g2/D",
+            componentIdx: "/g2/D",
             args: {},
         });
         DOpen = false;

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/evaluate.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/evaluate.test.ts
@@ -70,7 +70,7 @@ describe("Evaluate tag tests", async () => {
             0,
         ]);
         let result_symbolic2_name =
-            stateVariables["/result_symbolic2"].activeChildren[0].componentName;
+            stateVariables["/result_symbolic2"].activeChildren[0].componentIdx;
         expect(
             stateVariables[result_symbolic2_name].stateValues.value.tree,
         ).eqls(["apply", "sin", 0]);
@@ -79,7 +79,7 @@ describe("Evaluate tag tests", async () => {
         );
         expect(stateVariables["/result_numeric"].stateValues.value.tree).eq(0);
         let result_numeric2_name =
-            stateVariables["/result_numeric2"].activeChildren[0].componentName;
+            stateVariables["/result_numeric2"].activeChildren[0].componentIdx;
         expect(stateVariables[result_numeric2_name].stateValues.value.tree).eq(
             0,
         );
@@ -1407,7 +1407,7 @@ describe("Evaluate tag tests", async () => {
             ["+", 0, 0],
         ]);
         let result_symbolic2_name =
-            stateVariables["/result_symbolic2"].activeChildren[0].componentName;
+            stateVariables["/result_symbolic2"].activeChildren[0].componentIdx;
         expect(
             stateVariables[result_symbolic2_name].stateValues.value.tree,
         ).eqls(["apply", "sin", ["+", 0, 0]]);
@@ -1416,7 +1416,7 @@ describe("Evaluate tag tests", async () => {
         );
         expect(stateVariables["/result_numeric"].stateValues.value.tree).eq(0);
         let result_numeric2_name =
-            stateVariables["/result_numeric2"].activeChildren[0].componentName;
+            stateVariables["/result_numeric2"].activeChildren[0].componentIdx;
         expect(stateVariables[result_numeric2_name].stateValues.value.tree).eq(
             0,
         );
@@ -1575,7 +1575,7 @@ describe("Evaluate tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables["/result1"].stateValues.value.tree).eqls(0);
         let result2Name =
-            stateVariables["/result2"].activeChildren[0].componentName;
+            stateVariables["/result2"].activeChildren[0].componentIdx;
         expect(stateVariables[result2Name].stateValues.value.tree).eqls(0);
         expect(stateVariables["/result3"].stateValues.value.tree).eqls(0);
 
@@ -1764,7 +1764,7 @@ describe("Evaluate tag tests", async () => {
         ]);
         expect(
             stateVariables[
-                stateVariables["/result1b"].activeChildren[0].componentName
+                stateVariables["/result1b"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["/", 4, 27]);
         expect(stateVariables["/result2a"].stateValues.value.tree).eqls([
@@ -1774,7 +1774,7 @@ describe("Evaluate tag tests", async () => {
         ]);
         expect(
             stateVariables[
-                stateVariables["/result2b"].activeChildren[0].componentName
+                stateVariables["/result2b"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["/", 4, 27]);
         expect(stateVariables["/result3a"].stateValues.value.tree).eqls([
@@ -1784,7 +1784,7 @@ describe("Evaluate tag tests", async () => {
         ]);
         expect(
             stateVariables[
-                stateVariables["/result3b"].activeChildren[0].componentName
+                stateVariables["/result3b"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["/", 4, 27]);
         expect(stateVariables["/result4a"].stateValues.value.tree).eqls([
@@ -1794,12 +1794,12 @@ describe("Evaluate tag tests", async () => {
         ]);
         expect(
             stateVariables[
-                stateVariables["/result4b"].activeChildren[0].componentName
+                stateVariables["/result4b"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["/", 4, 27]);
         expect(
             stateVariables[
-                stateVariables["/result4c"].activeChildren[0].componentName
+                stateVariables["/result4c"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["/", 4, 27]);
         expect(stateVariables["/result5a"].stateValues.value.tree).eqls([
@@ -1809,12 +1809,12 @@ describe("Evaluate tag tests", async () => {
         ]);
         expect(
             stateVariables[
-                stateVariables["/result5b"].activeChildren[0].componentName
+                stateVariables["/result5b"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["/", 4, 27]);
         expect(
             stateVariables[
-                stateVariables["/result5c"].activeChildren[0].componentName
+                stateVariables["/result5c"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["/", 4, 27]);
         expect(stateVariables["/result5d"].stateValues.value.tree).eqls([
@@ -1829,12 +1829,12 @@ describe("Evaluate tag tests", async () => {
         ]);
         expect(
             stateVariables[
-                stateVariables["/result6b"].activeChildren[0].componentName
+                stateVariables["/result6b"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["/", 4, 27]);
         expect(
             stateVariables[
-                stateVariables["/result6c"].activeChildren[0].componentName
+                stateVariables["/result6c"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["/", 4, 27]);
         expect(stateVariables["/result7a"].stateValues.value.tree).eqls([
@@ -1844,12 +1844,12 @@ describe("Evaluate tag tests", async () => {
         ]);
         expect(
             stateVariables[
-                stateVariables["/result7b"].activeChildren[0].componentName
+                stateVariables["/result7b"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["/", 4, 27]);
         expect(
             stateVariables[
-                stateVariables["/result7c"].activeChildren[0].componentName
+                stateVariables["/result7c"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["/", 4, 27]);
         expect(stateVariables["/result7d"].stateValues.value.tree).eqls([
@@ -1891,7 +1891,7 @@ describe("Evaluate tag tests", async () => {
         ]);
         expect(
             stateVariables[
-                stateVariables["/result1b"].activeChildren[0].componentName
+                stateVariables["/result1b"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["/", 9, 125]);
         expect(stateVariables["/result2a"].stateValues.value.tree).eqls([
@@ -1901,7 +1901,7 @@ describe("Evaluate tag tests", async () => {
         ]);
         expect(
             stateVariables[
-                stateVariables["/result2b"].activeChildren[0].componentName
+                stateVariables["/result2b"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["/", 9, 125]);
         expect(stateVariables["/result3a"].stateValues.value.tree).eqls([
@@ -1911,7 +1911,7 @@ describe("Evaluate tag tests", async () => {
         ]);
         expect(
             stateVariables[
-                stateVariables["/result3b"].activeChildren[0].componentName
+                stateVariables["/result3b"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["/", 9, 125]);
         expect(stateVariables["/result4a"].stateValues.value.tree).eqls([
@@ -1921,12 +1921,12 @@ describe("Evaluate tag tests", async () => {
         ]);
         expect(
             stateVariables[
-                stateVariables["/result4b"].activeChildren[0].componentName
+                stateVariables["/result4b"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["/", 9, 125]);
         expect(
             stateVariables[
-                stateVariables["/result4c"].activeChildren[0].componentName
+                stateVariables["/result4c"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["/", 9, 125]);
         expect(stateVariables["/result5a"].stateValues.value.tree).eqls([
@@ -1936,12 +1936,12 @@ describe("Evaluate tag tests", async () => {
         ]);
         expect(
             stateVariables[
-                stateVariables["/result5b"].activeChildren[0].componentName
+                stateVariables["/result5b"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["/", 9, 125]);
         expect(
             stateVariables[
-                stateVariables["/result5c"].activeChildren[0].componentName
+                stateVariables["/result5c"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["/", 9, 125]);
         expect(stateVariables["/result5d"].stateValues.value.tree).eqls([
@@ -2001,7 +2001,7 @@ describe("Evaluate tag tests", async () => {
             ["apply", "cos", 0],
         ]);
         let result_symbolic2_name =
-            stateVariables["/result_symbolic2"].activeChildren[0].componentName;
+            stateVariables["/result_symbolic2"].activeChildren[0].componentIdx;
         expect(
             stateVariables[result_symbolic2_name].stateValues.value.tree,
         ).eqls(["vector", ["apply", "sin", 0], ["apply", "cos", 0]]);
@@ -2014,7 +2014,7 @@ describe("Evaluate tag tests", async () => {
             1,
         ]);
         let result_numeric2_name =
-            stateVariables["/result_numeric2"].activeChildren[0].componentName;
+            stateVariables["/result_numeric2"].activeChildren[0].componentIdx;
         expect(
             stateVariables[result_numeric2_name].stateValues.value.tree,
         ).eqls(["vector", 0, 1]);
@@ -2255,7 +2255,7 @@ describe("Evaluate tag tests", async () => {
             0,
         ]);
         let result2Name =
-            stateVariables["/result2"].activeChildren[0].componentName;
+            stateVariables["/result2"].activeChildren[0].componentIdx;
         expect(stateVariables[result2Name].stateValues.value.tree).eqls([
             "vector",
             0,

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/extract.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/extract.test.ts
@@ -216,12 +216,12 @@ describe("Extract tag tests", async () => {
             ).eqls(componentTypes);
             expect(
                 stateVariables["/p1"].activeChildren.map(
-                    (x) => stateVariables[x.componentName].stateValues.value,
+                    (x) => stateVariables[x.componentIdx].stateValues.value,
                 ),
             ).eqls(vals);
             expect(
                 stateVariables["/p2"].activeChildren.map(
-                    (x) => stateVariables[x.componentName].stateValues.value,
+                    (x) => stateVariables[x.componentIdx].stateValues.value,
                 ),
             ).eqls(vals);
         }
@@ -285,13 +285,13 @@ describe("Extract tag tests", async () => {
             expect(
                 stateVariables["/p1"].activeChildren.map(
                     (x) =>
-                        stateVariables[x.componentName].stateValues.value.tree,
+                        stateVariables[x.componentIdx].stateValues.value.tree,
                 ),
             ).eqls(vals);
             expect(
                 stateVariables["/p2"].activeChildren.map(
                     (x) =>
-                        stateVariables[x.componentName].stateValues.value.tree,
+                        stateVariables[x.componentIdx].stateValues.value.tree,
                 ),
             ).eqls(vals);
         }

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/feedback.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/feedback.test.ts
@@ -64,7 +64,7 @@ describe("Feedback tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let mathInputName =
-            stateVariables["/ans"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans"].stateValues.inputChildren[0].componentIdx;
 
         let hidden1 = true;
         let hidden2 = true;
@@ -822,7 +822,7 @@ describe("Feedback tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let tiName =
-            stateVariables["/ans"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans"].stateValues.inputChildren[0].componentIdx;
 
         await check_items();
 
@@ -1634,7 +1634,7 @@ describe("Feedback tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let mathInputName =
-            stateVariables["/ans"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans"].stateValues.inputChildren[0].componentIdx;
 
         expect(stateVariables["/pSub"].stateValues.hidden).eq(true);
 

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/functionTag.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/functionTag.test.ts
@@ -3615,32 +3615,32 @@ describe("Function tag tests", async () => {
 
         expect(
             stateVariables[
-                stateVariables["/fOfu"].activeChildren[0].componentName
+                stateVariables["/fOfu"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["*", "s", ["^", "u", 3]]);
         expect(
             stateVariables[
-                stateVariables["/f2Ofu"].activeChildren[0].componentName
+                stateVariables["/f2Ofu"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["*", "s", ["^", "u", 3]]);
         expect(
             stateVariables[
-                stateVariables["/f3Ofu"].activeChildren[0].componentName
+                stateVariables["/f3Ofu"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["*", "u", ["^", "t", 3]]);
         expect(
             stateVariables[
-                stateVariables["/f4Ofu"].activeChildren[0].componentName
+                stateVariables["/f4Ofu"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["*", "s", ["^", "u", 3]]);
         expect(
             stateVariables[
-                stateVariables["/f5Ofu"].activeChildren[0].componentName
+                stateVariables["/f5Ofu"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["*", "s", ["^", "u", 3]]);
         expect(
             stateVariables[
-                stateVariables["/f6Ofu"].activeChildren[0].componentName
+                stateVariables["/f6Ofu"].activeChildren[0].componentIdx
             ].stateValues.value.tree,
         ).eqls(["*", "u", ["^", "t", 3]]);
     });
@@ -3709,7 +3709,7 @@ describe("Function tag tests", async () => {
         for (let name of Of0names) {
             expect(
                 stateVariables[
-                    stateVariables[name].activeChildren[0].componentName
+                    stateVariables[name].activeChildren[0].componentIdx
                 ].stateValues.value.tree,
             ).eqls(2);
         }
@@ -3726,7 +3726,7 @@ describe("Function tag tests", async () => {
         for (let name of Of1names) {
             expect(
                 stateVariables[
-                    stateVariables[name].activeChildren[0].componentName
+                    stateVariables[name].activeChildren[0].componentIdx
                 ].stateValues.value.tree,
             ).eqls(3);
         }
@@ -3743,7 +3743,7 @@ describe("Function tag tests", async () => {
         for (let name of Of2names) {
             expect(
                 stateVariables[
-                    stateVariables[name].activeChildren[0].componentName
+                    stateVariables[name].activeChildren[0].componentIdx
                 ].stateValues.value.tree,
             ).eqls(6);
         }

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/functioniterates.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/functioniterates.test.ts
@@ -162,7 +162,7 @@ describe("FunctionIterates tag tests", async () => {
             let x = me.math.matrix([[u1], [u2]]);
 
             let iterNames = stateVariables["/iterates"].replacements!.map(
-                (x) => x.componentName,
+                (x) => x.componentIdx,
             );
 
             for (let i = 0; i < n; i++) {
@@ -270,7 +270,7 @@ describe("FunctionIterates tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let iterNames = stateVariables["/iterates"].replacements!.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
 
         expect(stateVariables["/fis"].stateValues.numDimensions).eq(2);
@@ -293,7 +293,7 @@ describe("FunctionIterates tag tests", async () => {
         stateVariables = await core.returnAllStateVariables(false, true);
 
         iterNames = stateVariables["/iterates"].replacements!.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
 
         expect(stateVariables["/fis"].stateValues.numDimensions).eq(0);
@@ -317,7 +317,7 @@ describe("FunctionIterates tag tests", async () => {
         stateVariables = await core.returnAllStateVariables(false, true);
 
         iterNames = stateVariables["/iterates"].replacements!.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
 
         expect(stateVariables["/fis"].stateValues.numDimensions).eq(3);
@@ -340,7 +340,7 @@ describe("FunctionIterates tag tests", async () => {
         stateVariables = await core.returnAllStateVariables(false, true);
 
         iterNames = stateVariables["/iterates"].replacements!.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
         expect(stateVariables["/fis"].stateValues.numDimensions).eq(3);
         expect(cleanLatex(stateVariables[iterNames[0]].stateValues.latex)).eq(
@@ -371,7 +371,7 @@ describe("FunctionIterates tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let iterNames = stateVariables["/iterates"].replacements!.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
 
         expect(stateVariables["/fis"].stateValues.numDimensions).eq(2);
@@ -394,7 +394,7 @@ describe("FunctionIterates tag tests", async () => {
         stateVariables = await core.returnAllStateVariables(false, true);
 
         iterNames = stateVariables["/iterates"].replacements!.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
 
         expect(stateVariables["/fis"].stateValues.numDimensions).eq(2);
@@ -423,7 +423,7 @@ describe("FunctionIterates tag tests", async () => {
         stateVariables = await core.returnAllStateVariables(false, true);
 
         iterNames = stateVariables["/iterates"].replacements!.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
 
         expect(stateVariables["/fis"].stateValues.numDimensions).eq(0);
@@ -446,7 +446,7 @@ describe("FunctionIterates tag tests", async () => {
         stateVariables = await core.returnAllStateVariables(false, true);
 
         iterNames = stateVariables["/iterates"].replacements!.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
 
         expect(stateVariables["/fis"].stateValues.numDimensions).eq(3);
@@ -469,7 +469,7 @@ describe("FunctionIterates tag tests", async () => {
         stateVariables = await core.returnAllStateVariables(false, true);
 
         iterNames = stateVariables["/iterates"].replacements!.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
 
         expect(stateVariables["/fis"].stateValues.numDimensions).eq(3);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/functionoperators.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/functionoperators.test.ts
@@ -55,23 +55,23 @@ describe("Function Operator tag tests", async () => {
         const stateVariables = await core.returnAllStateVariables(false, true);
         let map1Names: string[] = stateVariables["/map1"].replacements!.map(
             (template) =>
-                stateVariables[template.componentName].replacements![0]
-                    .componentName,
+                stateVariables[template.componentIdx].replacements![0]
+                    .componentIdx,
         );
         let map2Names: string[] = stateVariables["/map2"].replacements!.map(
             (template) =>
-                stateVariables[template.componentName].replacements![0]
-                    .componentName,
+                stateVariables[template.componentIdx].replacements![0]
+                    .componentIdx,
         );
         let map1aNames: string[] = stateVariables["/map1a"].replacements!.map(
             (template) =>
-                stateVariables[template.componentName].replacements![0]
-                    .componentName,
+                stateVariables[template.componentIdx].replacements![0]
+                    .componentIdx,
         );
         let map2aNames: string[] = stateVariables["/map2a"].replacements!.map(
             (template) =>
-                stateVariables[template.componentName].replacements![0]
-                    .componentName,
+                stateVariables[template.componentIdx].replacements![0]
+                    .componentIdx,
         );
 
         let f1d = stateVariables["/f1"].stateValues.numericalfs[0];

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
@@ -27,8 +27,8 @@ describe("Graph tag tests", async () => {
         });
 
         let stateVariables = await core.returnAllStateVariables(false, true);
-        let curve1Name = stateVariables["/g"].activeChildren[0].componentName;
-        let curve2Name = stateVariables["/g"].activeChildren[1].componentName;
+        let curve1Name = stateVariables["/g"].activeChildren[0].componentIdx;
+        let curve2Name = stateVariables["/g"].activeChildren[1].componentIdx;
 
         let f1 = stateVariables[curve1Name].stateValues.fs[0];
         let f2 = stateVariables[curve2Name].stateValues.fs[0];
@@ -633,7 +633,7 @@ describe("Graph tag tests", async () => {
         expect(stateVariables["/graph1"].stateValues.xlabel).eq("\\(\uff3f\\)");
 
         let mathinputName =
-            stateVariables["/x"].stateValues.inputChildren[0].componentName;
+            stateVariables["/x"].stateValues.inputChildren[0].componentIdx;
 
         await updateMathInputValue({
             latex: "x",

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/hint.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/hint.test.ts
@@ -28,7 +28,7 @@ describe("Hint tag tests", async () => {
         expect(stateVariables["/hint2"].stateValues.open).eq(false);
 
         await core.requestAction({
-            componentName: "/hint1",
+            componentIdx: "/hint1",
             actionName: "revealHint",
             args: {},
         });
@@ -37,7 +37,7 @@ describe("Hint tag tests", async () => {
         expect(stateVariables["/hint2"].stateValues.open).eq(false);
 
         await core.requestAction({
-            componentName: "/hint2",
+            componentIdx: "/hint2",
             actionName: "revealHint",
             args: {},
         });
@@ -46,7 +46,7 @@ describe("Hint tag tests", async () => {
         expect(stateVariables["/hint2"].stateValues.open).eq(true);
 
         await core.requestAction({
-            componentName: "/hint1",
+            componentIdx: "/hint1",
             actionName: "closeHint",
             args: {},
         });
@@ -55,7 +55,7 @@ describe("Hint tag tests", async () => {
         expect(stateVariables["/hint2"].stateValues.open).eq(true);
 
         await core.requestAction({
-            componentName: "/hint2",
+            componentIdx: "/hint2",
             actionName: "closeHint",
             args: {},
         });
@@ -92,7 +92,7 @@ describe("Hint tag tests", async () => {
         expect(stateVariables["/revised"].stateValues.open).eq(false);
 
         await core.requestAction({
-            componentName: "/hint1",
+            componentIdx: "/hint1",
             actionName: "revealHint",
             args: {},
         });
@@ -101,7 +101,7 @@ describe("Hint tag tests", async () => {
         expect(stateVariables["/revised"].stateValues.open).eq(false);
 
         await core.requestAction({
-            componentName: "/revised",
+            componentIdx: "/revised",
             actionName: "revealHint",
             args: {},
         });
@@ -110,7 +110,7 @@ describe("Hint tag tests", async () => {
         expect(stateVariables["/revised"].stateValues.open).eq(true);
 
         await core.requestAction({
-            componentName: "/hint1",
+            componentIdx: "/hint1",
             actionName: "closeHint",
             args: {},
         });
@@ -119,7 +119,7 @@ describe("Hint tag tests", async () => {
         expect(stateVariables["/revised"].stateValues.open).eq(true);
 
         await core.requestAction({
-            componentName: "/revised",
+            componentIdx: "/revised",
             actionName: "closeHint",
             args: {},
         });
@@ -148,7 +148,7 @@ describe("Hint tag tests", async () => {
         expect(stateVariables["/ti"].stateValues.disabled).eq(true);
 
         await core.requestAction({
-            componentName: "/hint1",
+            componentIdx: "/hint1",
             actionName: "revealHint",
             args: {},
         });
@@ -156,7 +156,7 @@ describe("Hint tag tests", async () => {
         expect(stateVariables["/hint1"].stateValues.open).eq(true);
 
         await core.requestAction({
-            componentName: "/hint1",
+            componentIdx: "/hint1",
             actionName: "closeHint",
             args: {},
         });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/image.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/image.test.ts
@@ -22,7 +22,7 @@ export async function moveImage({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "moveImage",
         args: { x, y },
     });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/lorem.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/lorem.test.ts
@@ -64,7 +64,7 @@ describe("lorem tag tests", async () => {
         ].replacements!.entries()) {
             expect(
                 stateVariables[`/paragraphs/${names[ind]}`].stateValues.text,
-            ).eq(stateVariables[repl.componentName].activeChildren[0]);
+            ).eq(stateVariables[repl.componentIdx].activeChildren[0]);
         }
 
         for (let [ind, repl] of stateVariables[
@@ -76,7 +76,7 @@ describe("lorem tag tests", async () => {
 
             expect(
                 stateVariables[`/sentences/${names[ind / 2]}`].stateValues.text,
-            ).eq(stateVariables[repl.componentName].activeChildren[0]);
+            ).eq(stateVariables[repl.componentIdx].activeChildren[0]);
         }
 
         for (let [ind, repl] of stateVariables[
@@ -88,7 +88,7 @@ describe("lorem tag tests", async () => {
 
             expect(
                 stateVariables[`/words/${names[ind / 2]}`].stateValues.text,
-            ).eq(stateVariables[repl.componentName].activeChildren[0]);
+            ).eq(stateVariables[repl.componentIdx].activeChildren[0]);
         }
 
         nParagraphs = 6;
@@ -127,7 +127,7 @@ describe("lorem tag tests", async () => {
         ].replacements!.entries()) {
             expect(
                 stateVariables[`/paragraphs/${names[ind]}`].stateValues.text,
-            ).eq(stateVariables[repl.componentName].activeChildren[0]);
+            ).eq(stateVariables[repl.componentIdx].activeChildren[0]);
         }
 
         for (let [ind, repl] of stateVariables[
@@ -139,7 +139,7 @@ describe("lorem tag tests", async () => {
 
             expect(
                 stateVariables[`/sentences/${names[ind / 2]}`].stateValues.text,
-            ).eq(stateVariables[repl.componentName].activeChildren[0]);
+            ).eq(stateVariables[repl.componentIdx].activeChildren[0]);
         }
 
         for (let [ind, repl] of stateVariables[
@@ -151,7 +151,7 @@ describe("lorem tag tests", async () => {
 
             expect(
                 stateVariables[`/words/${names[ind / 2]}`].stateValues.text,
-            ).eq(stateVariables[repl.componentName].activeChildren[0]);
+            ).eq(stateVariables[repl.componentIdx].activeChildren[0]);
         }
     });
 
@@ -172,7 +172,7 @@ describe("lorem tag tests", async () => {
 
         const paragraph1 =
             stateVariables[
-                stateVariables["/lPars"].replacements![0].componentName
+                stateVariables["/lPars"].replacements![0].componentIdx
             ].activeChildren[0];
 
         expect(stateVariables["/a"].stateValues.text).eq(paragraph1);
@@ -192,7 +192,7 @@ describe("lorem tag tests", async () => {
 
         expect(
             stateVariables[
-                stateVariables["/lPars"].replacements![0].componentName
+                stateVariables["/lPars"].replacements![0].componentIdx
             ].activeChildren[0],
         ).eq(paragraph1);
 
@@ -214,7 +214,7 @@ describe("lorem tag tests", async () => {
 
         const paragraph2 =
             stateVariables[
-                stateVariables["/lPars"].replacements![0].componentName
+                stateVariables["/lPars"].replacements![0].componentIdx
             ].activeChildren[0];
         expect(paragraph2).not.eq(paragraph1);
 
@@ -236,7 +236,7 @@ describe("lorem tag tests", async () => {
 
         expect(
             stateVariables[
-                stateVariables["/lPars"].replacements![0].componentName
+                stateVariables["/lPars"].replacements![0].componentIdx
             ].activeChildren[0],
         ).eq(paragraph2);
 

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/map.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/map.test.ts
@@ -29,11 +29,11 @@ describe("Map tag tests", async () => {
 
         let replacements = stateVariables["/map1"].replacements!;
         let mathr1Name =
-            stateVariables[replacements[0].componentName].replacements![0]
-                .componentName;
+            stateVariables[replacements[0].componentIdx].replacements![0]
+                .componentIdx;
         let mathr2Name =
-            stateVariables[replacements[1].componentName].replacements![0]
-                .componentName;
+            stateVariables[replacements[1].componentIdx].replacements![0]
+                .componentIdx;
 
         expect(stateVariables["/p"].stateValues.text).eq(
             "sin(2 x) + 1, sin(2 y) + 2",
@@ -65,11 +65,11 @@ describe("Map tag tests", async () => {
 
         let replacements = stateVariables["/map1"].replacements!;
         let textr1Name =
-            stateVariables[replacements[0].componentName].replacements![0]
-                .componentName;
+            stateVariables[replacements[0].componentIdx].replacements![0]
+                .componentIdx;
         let textr2Name =
-            stateVariables[replacements[1].componentName].replacements![0]
-                .componentName;
+            stateVariables[replacements[1].componentIdx].replacements![0]
+                .componentIdx;
 
         expect(stateVariables["/p"].stateValues.text).eq(
             "You are a squirrel! You are a bat! ",
@@ -97,8 +97,7 @@ describe("Map tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
         let replacements = stateVariables["/map1"].replacements!;
         let mathrNames = replacements.map(
-            (x) =>
-                stateVariables[x.componentName].replacements![0].componentName,
+            (x) => stateVariables[x.componentIdx].replacements![0].componentIdx,
         );
 
         expect(stateVariables["/p"].stateValues.text).eq("1, 4, 9, 16, 25");
@@ -301,8 +300,8 @@ describe("Map tag tests", async () => {
         function checkMap(mapName: string) {
             let graphNames = stateVariables[mapName].replacements!.map(
                 (x) =>
-                    stateVariables[x.componentName].replacements![0]
-                        .componentName,
+                    stateVariables[x.componentIdx].replacements![0]
+                        .componentIdx,
             );
 
             for (let [graphInd, graphName] of graphNames.entries()) {
@@ -311,7 +310,7 @@ describe("Map tag tests", async () => {
 
                 let allPointNames = stateVariables[
                     graphName
-                ].activeChildren.map((x) => x.componentName);
+                ].activeChildren.map((x) => x.componentIdx);
 
                 expect(allPointNames.length).eq(8);
 
@@ -456,8 +455,7 @@ describe("Map tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let graphNames = stateVariables["/map1"].replacements!.map(
-            (x) =>
-                stateVariables[x.componentName].replacements![0].componentName,
+            (x) => stateVariables[x.componentIdx].replacements![0].componentIdx,
         );
 
         for (let [graphInd, graphName] of graphNames.entries()) {
@@ -467,7 +465,7 @@ describe("Map tag tests", async () => {
             ).eq(4);
 
             let pointNames = stateVariables[graphName].activeChildren.map(
-                (x) => x.componentName,
+                (x) => x.componentIdx,
             );
 
             for (let [ind, val] of pointsByGraph[graphInd].entries()) {
@@ -663,8 +661,7 @@ describe("Map tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let replacementNames = stateVariables["/hi/map1"].replacements!.map(
-            (x) =>
-                stateVariables[x.componentName].replacements![0].componentName,
+            (x) => stateVariables[x.componentIdx].replacements![0].componentIdx,
         );
 
         expect(
@@ -1219,7 +1216,7 @@ describe("Map tag tests", async () => {
                 let n = from + i * step;
                 let child =
                     stateVariables[
-                        stateVariables["/math1"].activeChildren[i].componentName
+                        stateVariables["/math1"].activeChildren[i].componentIdx
                     ];
                 // Note: coords is a type of math
                 expect(child.componentType).eq("coords");
@@ -1809,11 +1806,11 @@ describe("Map tag tests", async () => {
         // Note: filter out strings by only including replacements
         // with a component type
         let n1a = stateVariables[
-            stateVariables["/map1"].replacements![0].componentName
-        ].replacements!.filter((s) => s.componentType)[1].componentName;
+            stateVariables["/map1"].replacements![0].componentIdx
+        ].replacements!.filter((s) => s.componentType)[1].componentIdx;
         let n2a = stateVariables[
-            stateVariables["/map1"].replacements![1].componentName
-        ].replacements!.filter((s) => s.componentType)[1].componentName;
+            stateVariables["/map1"].replacements![1].componentIdx
+        ].replacements!.filter((s) => s.componentType)[1].componentIdx;
 
         expect(stateVariables["/n1"].stateValues.value).eq(1);
         expect(stateVariables[n1a].stateValues.value).eq(10);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/matchespattern.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/matchespattern.test.ts
@@ -511,7 +511,7 @@ describe("MatchesPattern tag tests", async () => {
                     if (match1.componentType === "copy") {
                         match1 =
                             stateVariables[
-                                match1.replacements![0].componentName
+                                match1.replacements![0].componentIdx
                             ];
                     }
                     expect(cleanLatex(match1.stateValues.latex)).eq(res[0]);
@@ -519,7 +519,7 @@ describe("MatchesPattern tag tests", async () => {
                     if (match2.componentType === "copy") {
                         match2 =
                             stateVariables[
-                                match2.replacements![0].componentName
+                                match2.replacements![0].componentIdx
                             ];
                     }
                     expect(cleanLatex(match2.stateValues.latex)).eq(res[1]);
@@ -527,7 +527,7 @@ describe("MatchesPattern tag tests", async () => {
                     if (match3.componentType === "copy") {
                         match3 =
                             stateVariables[
-                                match3.replacements![0].componentName
+                                match3.replacements![0].componentIdx
                             ];
                     }
                     expect(cleanLatex(match3.stateValues.latex)).eq(res[2]);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/mathoperators.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/mathoperators.test.ts
@@ -2008,7 +2008,7 @@ describe("Math operator tests", async () => {
         expect(stateVariables["/P3"].stateValues.xs[1].tree).eq(clamp(x));
 
         let g2children = stateVariables["/g2"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect((await g2children[0].stateValues.xs)[0].tree).eq(x);
         expect((await g2children[0].stateValues.xs)[1].tree).eq(y);
@@ -2030,7 +2030,7 @@ describe("Math operator tests", async () => {
         expect(stateVariables["/P3"].stateValues.xs[1].tree).eq(clamp(x));
 
         g2children = stateVariables["/g2"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect((await g2children[0].stateValues.xs)[0].tree).eq(x);
         expect((await g2children[0].stateValues.xs)[1].tree).eq(y);
@@ -2053,7 +2053,7 @@ describe("Math operator tests", async () => {
         expect(stateVariables["/P3"].stateValues.xs[1].tree).eq(clamp(x));
 
         g2children = stateVariables["/g2"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect((await g2children[0].stateValues.xs)[0].tree).eq(clamp(x));
         expect((await g2children[0].stateValues.xs)[1].tree).eq(wrap(y));
@@ -2076,7 +2076,7 @@ describe("Math operator tests", async () => {
         expect(stateVariables["/P3"].stateValues.xs[1].tree).eq(clamp(x));
 
         g2children = stateVariables["/g2"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect((await g2children[0].stateValues.xs)[0].tree).eq(clamp(x));
         expect((await g2children[0].stateValues.xs)[1].tree).eq(wrap(y));
@@ -2090,7 +2090,7 @@ describe("Math operator tests", async () => {
         y = -10;
 
         await movePoint({
-            name: stateVariables["/g2"].activeChildren[0].componentName,
+            name: stateVariables["/g2"].activeChildren[0].componentIdx,
             x,
             y,
             core,
@@ -2105,7 +2105,7 @@ describe("Math operator tests", async () => {
         expect(stateVariables["/P3"].stateValues.xs[1].tree).eq(clamp(x));
 
         g2children = stateVariables["/g2"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect((await g2children[0].stateValues.xs)[0].tree).eq(x);
         expect((await g2children[0].stateValues.xs)[1].tree).eq(y);
@@ -2119,7 +2119,7 @@ describe("Math operator tests", async () => {
         y = -13;
 
         await movePoint({
-            name: stateVariables["/g2"].activeChildren[1].componentName,
+            name: stateVariables["/g2"].activeChildren[1].componentIdx,
             x,
             y,
             core,
@@ -2135,7 +2135,7 @@ describe("Math operator tests", async () => {
         expect(stateVariables["/P3"].stateValues.xs[1].tree).eq(clamp(x));
 
         g2children = stateVariables["/g2"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect((await g2children[0].stateValues.xs)[0].tree).eq(clamp(x));
         expect((await g2children[0].stateValues.xs)[1].tree).eq(wrap(y));
@@ -2149,7 +2149,7 @@ describe("Math operator tests", async () => {
         y = 12;
 
         await movePoint({
-            name: stateVariables["/g2"].activeChildren[2].componentName,
+            name: stateVariables["/g2"].activeChildren[2].componentIdx,
             x: y,
             y: x,
             core,
@@ -2165,7 +2165,7 @@ describe("Math operator tests", async () => {
         expect(stateVariables["/P3"].stateValues.xs[1].tree).eq(clamp(x));
 
         g2children = stateVariables["/g2"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect((await g2children[0].stateValues.xs)[0].tree).eq(clamp(x));
         expect((await g2children[0].stateValues.xs)[1].tree).eq(wrap(y));
@@ -2646,7 +2646,7 @@ describe("Math operator tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let g2ChildrenNames = stateVariables["/g2"].activeChildren.map(
-            (x) => x.componentName,
+            (x) => x.componentIdx,
         );
 
         let checkPoints = async function (x, y) {
@@ -3417,14 +3417,14 @@ describe("Math operator tests", async () => {
         expect(stateVariables["/meanPrimeb"].stateValues.value.tree).eq(4.25);
         expect(
             stateVariables[
-                stateVariables["/pPrimeb"].activeChildren[1].componentName
+                stateVariables["/pPrimeb"].activeChildren[1].componentIdx
             ].stateValues.value.tree,
         ).eq(4.25);
         expect(stateVariables["/mean100"].stateValues.value.tree).eq(50.5);
         expect(stateVariables["/mean100b"].stateValues.value.tree).eq(50.5);
         expect(
             stateVariables[
-                stateVariables["/p100b"].activeChildren[1].componentName
+                stateVariables["/p100b"].activeChildren[1].componentIdx
             ].stateValues.value.tree,
         ).eq(50.5);
     });
@@ -4075,7 +4075,7 @@ describe("Math operator tests", async () => {
         ).closeTo(variancePrimes, 1e-12);
         expect(
             stateVariables[
-                stateVariables["/pPrimeb"].activeChildren[1].componentName
+                stateVariables["/pPrimeb"].activeChildren[1].componentIdx
             ].stateValues.value.tree,
         ).closeTo(variancePrimes, 1e-12);
         expect(stateVariables["/variance100"].stateValues.value.tree).closeTo(
@@ -4088,7 +4088,7 @@ describe("Math operator tests", async () => {
         );
         expect(
             stateVariables[
-                stateVariables["/p100b"].activeChildren[1].componentName
+                stateVariables["/p100b"].activeChildren[1].componentIdx
             ].stateValues.value.tree,
         ).closeTo(variance100, 1e-12);
     });
@@ -4281,7 +4281,7 @@ describe("Math operator tests", async () => {
         ).closeTo(variancePrimes, 1e-12);
         expect(
             stateVariables[
-                stateVariables["/pPrimeb"].activeChildren[1].componentName
+                stateVariables["/pPrimeb"].activeChildren[1].componentIdx
             ].stateValues.value.tree,
         ).closeTo(variancePrimes, 1e-12);
         expect(stateVariables["/variance100"].stateValues.value.tree).closeTo(
@@ -4294,7 +4294,7 @@ describe("Math operator tests", async () => {
         );
         expect(
             stateVariables[
-                stateVariables["/p100b"].activeChildren[1].componentName
+                stateVariables["/p100b"].activeChildren[1].componentIdx
             ].stateValues.value.tree,
         ).closeTo(variance100, 1e-12);
     });
@@ -4626,7 +4626,7 @@ describe("Math operator tests", async () => {
         ).closeTo(stdPrimes, 1e-12);
         expect(
             stateVariables[
-                stateVariables["/pPrimeb"].activeChildren[1].componentName
+                stateVariables["/pPrimeb"].activeChildren[1].componentIdx
             ].stateValues.value.tree,
         ).closeTo(stdPrimes, 1e-12);
         expect(
@@ -4637,7 +4637,7 @@ describe("Math operator tests", async () => {
         ).closeTo(std100, 1e-12);
         expect(
             stateVariables[
-                stateVariables["/p100b"].activeChildren[1].componentName
+                stateVariables["/p100b"].activeChildren[1].componentIdx
             ].stateValues.value.tree,
         ).closeTo(std100, 1e-12);
     });
@@ -4836,7 +4836,7 @@ describe("Math operator tests", async () => {
         ).closeTo(stdPrimes, 1e-12);
         expect(
             stateVariables[
-                stateVariables["/pPrimeb"].activeChildren[1].componentName
+                stateVariables["/pPrimeb"].activeChildren[1].componentIdx
             ].stateValues.value.tree,
         ).closeTo(stdPrimes, 1e-12);
         expect(
@@ -4847,7 +4847,7 @@ describe("Math operator tests", async () => {
         ).closeTo(std100, 1e-12);
         expect(
             stateVariables[
-                stateVariables["/p100b"].activeChildren[1].componentName
+                stateVariables["/p100b"].activeChildren[1].componentIdx
             ].stateValues.value.tree,
         ).closeTo(std100, 1e-12);
     });
@@ -5467,14 +5467,14 @@ describe("Math operator tests", async () => {
         expect(stateVariables["/countPrimeb"].stateValues.value.tree).eq(4);
         expect(
             stateVariables[
-                stateVariables["/pPrimeb"].activeChildren[1].componentName
+                stateVariables["/pPrimeb"].activeChildren[1].componentIdx
             ].stateValues.value.tree,
         ).eq(4);
         expect(stateVariables["/count100"].stateValues.value.tree).eq(100);
         expect(stateVariables["/count100b"].stateValues.value.tree).eq(100);
         expect(
             stateVariables[
-                stateVariables["/p100b"].activeChildren[1].componentName
+                stateVariables["/p100b"].activeChildren[1].componentIdx
             ].stateValues.value.tree,
         ).eq(100);
     });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/matrixinput.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/matrixinput.test.ts
@@ -1546,8 +1546,8 @@ describe("MathInput tag tests", async () => {
         });
 
         let stateVariables = await core.returnAllStateVariables(false, true);
-        let entryName1 = stateVariables["/mi1"].activeChildren[0].componentName;
-        let entryName2 = stateVariables["/mi2"].activeChildren[0].componentName;
+        let entryName1 = stateVariables["/mi1"].activeChildren[0].componentIdx;
+        let entryName2 = stateVariables["/mi2"].activeChildren[0].componentIdx;
 
         expect(stateVariables["/mi1"].stateValues.text).eq("[ [ 5 E + 1 ] ]");
         expect(stateVariables["/m1"].stateValues.text).eq("[ [ 5 E + 1 ] ]");
@@ -1613,9 +1613,9 @@ describe("MathInput tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let entry11OriginalName =
-            stateVariables["/original"].activeChildren[0].componentName;
+            stateVariables["/original"].activeChildren[0].componentIdx;
         let entry11ResultName =
-            stateVariables["/result"].activeChildren[0].componentName;
+            stateVariables["/result"].activeChildren[0].componentIdx;
 
         expect(stateVariables["/mcw"].stateValues.minWidth).eq(50);
         expect(stateVariables[entry11OriginalName].stateValues.minWidth).eq(0);
@@ -1640,17 +1640,17 @@ describe("MathInput tag tests", async () => {
         stateVariables = await core.returnAllStateVariables(false, true);
 
         let entry12OriginalName =
-            stateVariables["/original"].activeChildren[1].componentName;
+            stateVariables["/original"].activeChildren[1].componentIdx;
         let entry21OriginalName =
-            stateVariables["/original"].activeChildren[2].componentName;
+            stateVariables["/original"].activeChildren[2].componentIdx;
         let entry22OriginalName =
-            stateVariables["/original"].activeChildren[3].componentName;
+            stateVariables["/original"].activeChildren[3].componentIdx;
         let entry12ResultName =
-            stateVariables["/result"].activeChildren[1].componentName;
+            stateVariables["/result"].activeChildren[1].componentIdx;
         let entry21ResultName =
-            stateVariables["/result"].activeChildren[2].componentName;
+            stateVariables["/result"].activeChildren[2].componentIdx;
         let entry22ResultName =
-            stateVariables["/result"].activeChildren[3].componentName;
+            stateVariables["/result"].activeChildren[3].componentIdx;
 
         expect(stateVariables[entry11OriginalName].stateValues.minWidth).eq(0);
         expect(stateVariables[entry12OriginalName].stateValues.minWidth).eq(0);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/module.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/module.test.ts
@@ -477,7 +477,7 @@ describe("Module tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
         let errorChild =
             stateVariables[
-                stateVariables["/_document1"].activeChildren[0].componentName
+                stateVariables["/_document1"].activeChildren[0].componentIdx
             ];
         expect(errorChild.componentType).eq("_error");
         expect(errorChild.stateValues.message).eq(

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/number.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/number.test.ts
@@ -282,17 +282,17 @@ describe("Number tag tests", async () => {
         );
         expect(
             stateVariables[
-                stateVariables["/n1am"].activeChildren[0].componentName
+                stateVariables["/n1am"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(234234823.34235235324);
         expect(
             stateVariables[
-                stateVariables["/n1bm"].activeChildren[0].componentName
+                stateVariables["/n1bm"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(234234823.34235235324);
         expect(
             stateVariables[
-                stateVariables["/n1cm"].activeChildren[0].componentName
+                stateVariables["/n1cm"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(234234823.34235235324);
         expect(stateVariables["/n2"].stateValues.value).eq(5.4285023408250342);
@@ -301,17 +301,17 @@ describe("Number tag tests", async () => {
         expect(stateVariables["/n2c"].stateValues.value).eq(5.4285023408250342);
         expect(
             stateVariables[
-                stateVariables["/n2am"].activeChildren[0].componentName
+                stateVariables["/n2am"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(5.4285023408250342);
         expect(
             stateVariables[
-                stateVariables["/n2bm"].activeChildren[0].componentName
+                stateVariables["/n2bm"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(5.4285023408250342);
         expect(
             stateVariables[
-                stateVariables["/n2cm"].activeChildren[0].componentName
+                stateVariables["/n2cm"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(5.4285023408250342);
         expect(stateVariables["/n3"].stateValues.value).eq(
@@ -328,17 +328,17 @@ describe("Number tag tests", async () => {
         );
         expect(
             stateVariables[
-                stateVariables["/n3am"].activeChildren[0].componentName
+                stateVariables["/n3am"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(0.000000000000005023481340324);
         expect(
             stateVariables[
-                stateVariables["/n3bm"].activeChildren[0].componentName
+                stateVariables["/n3bm"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(0.000000000000005023481340324);
         expect(
             stateVariables[
-                stateVariables["/n3cm"].activeChildren[0].componentName
+                stateVariables["/n3cm"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(0.000000000000005023481340324);
 
@@ -350,12 +350,12 @@ describe("Number tag tests", async () => {
         );
         expect(
             stateVariables[
-                stateVariables["/n1aam"].activeChildren[0].componentName
+                stateVariables["/n1aam"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(234234823.34235235324);
         expect(
             stateVariables[
-                stateVariables["/n1abm"].activeChildren[0].componentName
+                stateVariables["/n1abm"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(234234823.34235235324);
         expect(stateVariables["/n2aa"].stateValues.value).eq(
@@ -366,12 +366,12 @@ describe("Number tag tests", async () => {
         );
         expect(
             stateVariables[
-                stateVariables["/n2aam"].activeChildren[0].componentName
+                stateVariables["/n2aam"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(5.4285023408250342);
         expect(
             stateVariables[
-                stateVariables["/n2abm"].activeChildren[0].componentName
+                stateVariables["/n2abm"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(5.4285023408250342);
         expect(stateVariables["/n3aa"].stateValues.value).eq(
@@ -382,12 +382,12 @@ describe("Number tag tests", async () => {
         );
         expect(
             stateVariables[
-                stateVariables["/n3aam"].activeChildren[0].componentName
+                stateVariables["/n3aam"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(0.000000000000005023481340324);
         expect(
             stateVariables[
-                stateVariables["/n3abm"].activeChildren[0].componentName
+                stateVariables["/n3abm"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(0.000000000000005023481340324);
 
@@ -399,12 +399,12 @@ describe("Number tag tests", async () => {
         );
         expect(
             stateVariables[
-                stateVariables["/n1bam"].activeChildren[0].componentName
+                stateVariables["/n1bam"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(234234823.34235235324);
         expect(
             stateVariables[
-                stateVariables["/n1bbm"].activeChildren[0].componentName
+                stateVariables["/n1bbm"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(234234823.34235235324);
         expect(stateVariables["/n2ba"].stateValues.value).eq(
@@ -415,12 +415,12 @@ describe("Number tag tests", async () => {
         );
         expect(
             stateVariables[
-                stateVariables["/n2bam"].activeChildren[0].componentName
+                stateVariables["/n2bam"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(5.4285023408250342);
         expect(
             stateVariables[
-                stateVariables["/n2bbm"].activeChildren[0].componentName
+                stateVariables["/n2bbm"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(5.4285023408250342);
         expect(stateVariables["/n3ba"].stateValues.value).eq(
@@ -431,12 +431,12 @@ describe("Number tag tests", async () => {
         );
         expect(
             stateVariables[
-                stateVariables["/n3bam"].activeChildren[0].componentName
+                stateVariables["/n3bam"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(0.000000000000005023481340324);
         expect(
             stateVariables[
-                stateVariables["/n3bbm"].activeChildren[0].componentName
+                stateVariables["/n3bbm"].activeChildren[0].componentIdx
             ].stateValues.value,
         ).eq(0.000000000000005023481340324);
     });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/paginator.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/paginator.test.ts
@@ -56,16 +56,16 @@ describe("Paginator tag tests", async () => {
 
         let mathinput1Name =
             stateVariables["/answer1"].stateValues.inputChildren[0]
-                .componentName;
+                .componentIdx;
         let mathinput2Name =
             stateVariables["/answer2"].stateValues.inputChildren[0]
-                .componentName;
+                .componentIdx;
         let mathinput3Name =
             stateVariables["/answer3"].stateValues.inputChildren[0]
-                .componentName;
+                .componentIdx;
         let mathinput4Name =
             stateVariables["/answer4"].stateValues.inputChildren[0]
-                .componentName;
+                .componentIdx;
 
         expect(stateVariables["/pgn"].stateValues.numPages).eq(3);
         expect(stateVariables["/pgn"].stateValues.currentPage).eq(1);
@@ -93,7 +93,7 @@ describe("Paginator tag tests", async () => {
 
         // move to page 2
         await core.requestAction({
-            componentName: "/pgn",
+            componentIdx: "/pgn",
             actionName: "setPage",
             args: { number: 2 },
         });
@@ -118,7 +118,7 @@ describe("Paginator tag tests", async () => {
 
         // back to page 1
         await core.requestAction({
-            componentName: "/pgn",
+            componentIdx: "/pgn",
             actionName: "setPage",
             args: { number: 1 },
         });
@@ -148,7 +148,7 @@ describe("Paginator tag tests", async () => {
 
         // on to third page
         await core.requestAction({
-            componentName: "/pgn",
+            componentIdx: "/pgn",
             actionName: "setPage",
             args: { number: 3 },
         });
@@ -224,7 +224,7 @@ describe("Paginator tag tests", async () => {
         expect(stateVariables["/ti2"].stateValues.disabled).eq(true);
 
         await core.requestAction({
-            componentName: "/pgn",
+            componentIdx: "/pgn",
             actionName: "setPage",
             args: { number: 2 },
         });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/point.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/point.test.ts
@@ -2476,16 +2476,16 @@ $g1{name="g2"}
             core.core!.components!["/P"].attributes.xs.component
                 .activeChildren[0];
         let math1 = x1.definingChildren[0];
-        let math1Name = math1.componentName;
+        let math1Name = math1.componentIdx;
         let math2 = x1.definingChildren[2];
-        let math2Name = math2.componentName;
+        let math2Name = math2.componentIdx;
 
-        expect(x1.definingChildren.map((x) => x.componentName)).eqls([
+        expect(x1.definingChildren.map((x) => x.componentIdx)).eqls([
             math1Name,
             "/seq",
             math2Name,
         ]);
-        expect(x1.activeChildren.map((x) => x.componentName)).eqls([
+        expect(x1.activeChildren.map((x) => x.componentIdx)).eqls([
             math1Name,
             math2Name,
         ]);
@@ -2495,13 +2495,13 @@ $g1{name="g2"}
         await updateMathInputValue({ latex: "2", name: "/n", core });
 
         let math3 = core.core!.components!["/seq"].replacements[0].adapterUsed;
-        let math3Name = math3.componentName;
-        expect(x1.definingChildren.map((x) => x.componentName)).eqls([
+        let math3Name = math3.componentIdx;
+        expect(x1.definingChildren.map((x) => x.componentIdx)).eqls([
             math1Name,
             "/seq",
             math2Name,
         ]);
-        expect(x1.activeChildren.map((x) => x.componentName)).eqls([
+        expect(x1.activeChildren.map((x) => x.componentIdx)).eqls([
             math1Name,
             math3Name,
             math2Name,

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/problem.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/problem.test.ts
@@ -25,23 +25,23 @@ describe("Problem tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let mathinput1Name =
-            stateVariables["/ans1"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans1"].stateValues.inputChildren[0].componentIdx;
         let mathinput2Name =
-            stateVariables["/ans2"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans2"].stateValues.inputChildren[0].componentIdx;
         let mathinput3Name =
-            stateVariables["/ans3"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans3"].stateValues.inputChildren[0].componentIdx;
         let mathinput4Name =
-            stateVariables["/ans4"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans4"].stateValues.inputChildren[0].componentIdx;
         let mathinput5Name =
-            stateVariables["/ans5"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans5"].stateValues.inputChildren[0].componentIdx;
         let mathinput6Name =
-            stateVariables["/ans6"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans6"].stateValues.inputChildren[0].componentIdx;
         let mathinput7Name =
-            stateVariables["/ans7"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans7"].stateValues.inputChildren[0].componentIdx;
         let mathinput8Name =
-            stateVariables["/ans8"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans8"].stateValues.inputChildren[0].componentIdx;
         let mathinput9Name =
-            stateVariables["/ans9"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans9"].stateValues.inputChildren[0].componentIdx;
 
         // enter first correct answer
         await updateMathInputValue({ latex: "u", name: mathinput1Name, core });
@@ -382,7 +382,7 @@ describe("Problem tag tests", async () => {
         ).eq(false);
 
         let twoxInputName =
-            stateVariables["/twox"].stateValues.inputChildren[0].componentName;
+            stateVariables["/twox"].stateValues.inputChildren[0].componentIdx;
         await updateMathInputValue({ latex: "2x", name: twoxInputName, core });
         await submitAnswer({ name: "/twox", core });
         stateVariables = await core.returnAllStateVariables(false, true);
@@ -390,7 +390,7 @@ describe("Problem tag tests", async () => {
         expect(stateVariables[sectionName].stateValues.creditAchieved).eq(0.25);
 
         let helloInputName =
-            stateVariables["/hello"].stateValues.inputChildren[0].componentName;
+            stateVariables["/hello"].stateValues.inputChildren[0].componentIdx;
         await updateTextInputValue({
             text: "hello",
             name: helloInputName,
@@ -443,7 +443,7 @@ describe("Problem tag tests", async () => {
         expect(stateVariables[sectionName].stateValues.justSubmitted).eq(false);
 
         await core.requestAction({
-            componentName: sectionName,
+            componentIdx: sectionName,
             actionName: "submitAllAnswers",
             args: {},
         });
@@ -460,7 +460,7 @@ describe("Problem tag tests", async () => {
         expect(stateVariables[sectionName].stateValues.justSubmitted).eq(false);
 
         await core.requestAction({
-            componentName: sectionName,
+            componentIdx: sectionName,
             actionName: "submitAllAnswers",
             args: {},
         });
@@ -615,7 +615,7 @@ describe("Problem tag tests", async () => {
         ).eq(false);
 
         let twoxInputName =
-            stateVariables["/twox"].stateValues.inputChildren[0].componentName;
+            stateVariables["/twox"].stateValues.inputChildren[0].componentIdx;
         await updateMathInputValue({ latex: "2x", name: twoxInputName, core });
         await submitAnswer({ name: "/twox", core });
         stateVariables = await core.returnAllStateVariables(false, true);
@@ -625,7 +625,7 @@ describe("Problem tag tests", async () => {
         );
 
         let helloInputName =
-            stateVariables["/hello"].stateValues.inputChildren[0].componentName;
+            stateVariables["/hello"].stateValues.inputChildren[0].componentIdx;
         await updateTextInputValue({
             text: "hello",
             name: helloInputName,
@@ -654,7 +654,7 @@ describe("Problem tag tests", async () => {
             core,
         });
         await core.requestAction({
-            componentName: "/subProblem",
+            componentIdx: "/subProblem",
             actionName: "submitAllAnswers",
             args: {},
         });
@@ -673,7 +673,7 @@ describe("Problem tag tests", async () => {
         await updateMathInputValue({ latex: "2", name: "/n1", core });
         await updateMathInputValue({ latex: "1", name: "/n2", core });
         await core.requestAction({
-            componentName: "/subProblem",
+            componentIdx: "/subProblem",
             actionName: "submitAllAnswers",
             args: {},
         });
@@ -710,7 +710,7 @@ describe("Problem tag tests", async () => {
         expect(stateVariables[sectionName].stateValues.justSubmitted).eq(false);
 
         await core.requestAction({
-            componentName: sectionName,
+            componentIdx: sectionName,
             actionName: "submitAllAnswers",
             args: {},
         });
@@ -729,7 +729,7 @@ describe("Problem tag tests", async () => {
         expect(stateVariables[sectionName].stateValues.justSubmitted).eq(false);
 
         await core.requestAction({
-            componentName: sectionName,
+            componentIdx: sectionName,
             actionName: "submitAllAnswers",
             args: {},
         });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sampleprimenumbers.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sampleprimenumbers.test.ts
@@ -10,7 +10,7 @@ describe("SamplePrimeNumbers tag tests", async () => {
     async function test_values_separately({
         doenetML,
         componentNames,
-        compositeName,
+        compositeIdx,
         valid_values,
         num_samples,
         must_be_distinct = false,
@@ -18,7 +18,7 @@ describe("SamplePrimeNumbers tag tests", async () => {
     }: {
         doenetML: string;
         componentNames: string[];
-        compositeName?: string;
+        compositeIdx?: string;
         valid_values: any[][];
         num_samples: number;
         must_be_distinct?: boolean;
@@ -33,11 +33,11 @@ describe("SamplePrimeNumbers tag tests", async () => {
                 false,
                 true,
             );
-            const s = stateVariables[compositeName ?? ""];
+            const s = stateVariables[compositeIdx ?? ""];
             for (let [ind, name] of componentNames.entries()) {
                 let value = name
                     ? stateVariables[name].stateValues.value
-                    : stateVariables[s.replacements![ind].componentName]
+                    : stateVariables[s.replacements![ind].componentIdx]
                           .stateValues.value;
                 expect(
                     is_math
@@ -139,7 +139,7 @@ describe("SamplePrimeNumbers tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let samples = stateVariables["/s"].replacements!.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         expect(samples.length).eq(50);
 
@@ -180,7 +180,7 @@ describe("SamplePrimeNumbers tag tests", async () => {
             doenetML,
             valid_values,
             componentNames,
-            compositeName: "/s",
+            compositeIdx: "/s",
             num_samples: 1,
         });
     });
@@ -209,10 +209,10 @@ describe("SamplePrimeNumbers tag tests", async () => {
         expect(sample1replacements.length).eq(50);
         expect(sample2replacements.length).eq(180);
         let sample1numbers = sample1replacements.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let sample2numbers = sample2replacements.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         for (let num of sample1numbers) {
@@ -238,7 +238,7 @@ describe("SamplePrimeNumbers tag tests", async () => {
 
         stateVariables = await core.returnAllStateVariables(false, true);
         let sample1numbersb = stateVariables["/sample1"].replacements!.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let sample2numbersb = stateVariables["/sample2"]
             .replacements!.slice(
@@ -246,7 +246,7 @@ describe("SamplePrimeNumbers tag tests", async () => {
                 stateVariables["/sample2"].replacements!.length -
                     (stateVariables["/sample2"].replacementsToWithhold ?? 0),
             )
-            .map((x) => stateVariables[x.componentName].stateValues.value);
+            .map((x) => stateVariables[x.componentIdx].stateValues.value);
         expect(sample1numbersb.length).eq(70);
         expect(sample2numbersb.length).eq(160);
 
@@ -281,7 +281,7 @@ describe("SamplePrimeNumbers tag tests", async () => {
 
         stateVariables = await core.returnAllStateVariables(false, true);
         let sample1numbersc = stateVariables["/sample1"].replacements!.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let sample2numbersc = stateVariables["/sample2"]
             .replacements!.slice(
@@ -289,7 +289,7 @@ describe("SamplePrimeNumbers tag tests", async () => {
                 stateVariables["/sample2"].replacements!.length -
                     (stateVariables["/sample2"].replacementsToWithhold ?? 0),
             )
-            .map((x) => stateVariables[x.componentName].stateValues.value);
+            .map((x) => stateVariables[x.componentIdx].stateValues.value);
         expect(sample1numbersc.length).eq(70);
         expect(sample2numbersc.length).eq(160);
 
@@ -339,42 +339,42 @@ describe("SamplePrimeNumbers tag tests", async () => {
             expect(
                 stateVariables["/p1"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p2"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p3"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p4"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p5"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p6"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
         }
@@ -488,7 +488,7 @@ describe("SamplePrimeNumbers tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let samples = stateVariables["/p1"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         expect(samples.length).eq(100);
@@ -510,7 +510,7 @@ describe("SamplePrimeNumbers tag tests", async () => {
         stateVariables = await core.returnAllStateVariables(false, true);
 
         let samples2 = stateVariables["/p1"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         expect(samples2).eqls(samples);
@@ -523,7 +523,7 @@ describe("SamplePrimeNumbers tag tests", async () => {
         stateVariables = await core.returnAllStateVariables(false, true);
 
         samples2 = stateVariables["/p1"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         expect(samples2.length).eq(100);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sectioning.test.ts
@@ -19,23 +19,23 @@ describe("Sectioning tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let mathinput1Name =
-            stateVariables["/ans1"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans1"].stateValues.inputChildren[0].componentIdx;
         let mathinput2Name =
-            stateVariables["/ans2"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans2"].stateValues.inputChildren[0].componentIdx;
         let mathinput3Name =
-            stateVariables["/ans3"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans3"].stateValues.inputChildren[0].componentIdx;
         let mathinput4Name =
-            stateVariables["/ans4"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans4"].stateValues.inputChildren[0].componentIdx;
         let mathinput5Name =
-            stateVariables["/ans5"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans5"].stateValues.inputChildren[0].componentIdx;
         let mathinput6Name =
-            stateVariables["/ans6"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans6"].stateValues.inputChildren[0].componentIdx;
         let mathinput7Name =
-            stateVariables["/ans7"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans7"].stateValues.inputChildren[0].componentIdx;
         let mathinput8Name =
-            stateVariables["/ans8"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans8"].stateValues.inputChildren[0].componentIdx;
         let mathinput9Name =
-            stateVariables["/ans9"].stateValues.inputChildren[0].componentName;
+            stateVariables["/ans9"].stateValues.inputChildren[0].componentIdx;
 
         // enter first correct answer
         await updateMathInputValue({ latex: "u", name: mathinput1Name, core });
@@ -510,7 +510,7 @@ describe("Sectioning tag tests", async () => {
         const stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables["/ps"].stateValues.title).eq("Some paragraphs");
         let pNames = stateVariables["/ps"].activeChildren.map(
-            (v) => v.componentName,
+            (v) => v.componentIdx,
         );
 
         expect(stateVariables[pNames[2]].stateValues.text).eq("Paragraph 1");
@@ -922,7 +922,7 @@ describe("Sectioning tag tests", async () => {
 
         await core.requestAction({
             actionName: "revealSection",
-            componentName: "/aside1",
+            componentIdx: "/aside1",
             args: {},
         });
         stateVariables = await core.returnAllStateVariables(false, true);
@@ -930,7 +930,7 @@ describe("Sectioning tag tests", async () => {
 
         await core.requestAction({
             actionName: "closeSection",
-            componentName: "/aside1",
+            componentIdx: "/aside1",
             args: {},
         });
         stateVariables = await core.returnAllStateVariables(false, true);
@@ -952,7 +952,7 @@ describe("Sectioning tag tests", async () => {
 
         await core.requestAction({
             actionName: "revealSection",
-            componentName: "/aside",
+            componentIdx: "/aside",
             args: {},
         });
         stateVariables = await core.returnAllStateVariables(false, true);
@@ -979,7 +979,7 @@ describe("Sectioning tag tests", async () => {
 
         await core.requestAction({
             actionName: "revealSection",
-            componentName: "/aside",
+            componentIdx: "/aside",
             args: {},
         });
         stateVariables = await core.returnAllStateVariables(false, true);
@@ -1004,7 +1004,7 @@ describe("Sectioning tag tests", async () => {
 
         await core.requestAction({
             actionName: "revealSection",
-            componentName: "/proof",
+            componentIdx: "/proof",
             args: {},
         });
         stateVariables = await core.returnAllStateVariables(false, true);
@@ -1031,7 +1031,7 @@ describe("Sectioning tag tests", async () => {
 
         await core.requestAction({
             actionName: "revealSection",
-            componentName: "/proof",
+            componentIdx: "/proof",
             args: {},
         });
         stateVariables = await core.returnAllStateVariables(false, true);
@@ -1076,7 +1076,7 @@ describe("Sectioning tag tests", async () => {
         expect(stateVariables["/pSol"]).be.undefined;
 
         await core.requestAction({
-            componentName: "/hint",
+            componentIdx: "/hint",
             actionName: "revealHint",
             args: {},
         });
@@ -1086,7 +1086,7 @@ describe("Sectioning tag tests", async () => {
         expect(stateVariables["/pSol"]).be.undefined;
 
         await core.requestAction({
-            componentName: "/givenAnswer",
+            componentIdx: "/givenAnswer",
             actionName: "revealSolution",
             args: {},
         });
@@ -1097,7 +1097,7 @@ describe("Sectioning tag tests", async () => {
         expect(stateVariables["/pSol"]).be.undefined;
 
         await core.requestAction({
-            componentName: "/solution",
+            componentIdx: "/solution",
             actionName: "revealSolution",
             args: {},
         });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/select.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/select.test.ts
@@ -42,8 +42,8 @@ describe("Select tag tests", async () => {
                 let value = name
                     ? stateVariables[name].stateValues.value
                     : stateVariables[
-                          stateVariables[s.replacements![ind].componentName]
-                              .replacements![0].componentName
+                          stateVariables[s.replacements![ind].componentIdx]
+                              .replacements![0].componentIdx
                       ].stateValues.value;
                 expect(
                     is_math
@@ -356,54 +356,52 @@ describe("Select tag tests", async () => {
         expect(
             stateVariables[
                 stateVariables[
-                    stateVariables["/noresample1"].replacements![0]
-                        .componentName
-                ].replacements![0].componentName
+                    stateVariables["/noresample1"].replacements![0].componentIdx
+                ].replacements![0].componentIdx
             ].stateValues.value,
         ).eq(num1);
         expect(
             stateVariables[
                 stateVariables[
-                    stateVariables["/noresample2"].replacements![0]
-                        .componentName
-                ].replacements![0].componentName
+                    stateVariables["/noresample2"].replacements![0].componentIdx
+                ].replacements![0].componentIdx
             ].stateValues.value,
         ).eq(num2);
         expect(
             stateVariables[
                 stateVariables[
                     stateVariables["/noreresample1"].replacements![0]
-                        .componentName
-                ].replacements![0].componentName
+                        .componentIdx
+                ].replacements![0].componentIdx
             ].stateValues.value,
         ).eq(num1);
         expect(
             stateVariables[
                 stateVariables[
                     stateVariables["/noreresample2"].replacements![0]
-                        .componentName
-                ].replacements![0].componentName
+                        .componentIdx
+                ].replacements![0].componentIdx
             ].stateValues.value,
         ).eq(num2);
 
         expect(
             stateVariables[
-                stateVariables["/noresamplep"].activeChildren[1].componentName
+                stateVariables["/noresamplep"].activeChildren[1].componentIdx
             ].stateValues.value,
         ).eq(num1);
         expect(
             stateVariables[
-                stateVariables["/noresamplep"].activeChildren[3].componentName
+                stateVariables["/noresamplep"].activeChildren[3].componentIdx
             ].stateValues.value,
         ).eq(num2);
         expect(
             stateVariables[
-                stateVariables["/noreresamplep"].activeChildren[1].componentName
+                stateVariables["/noreresamplep"].activeChildren[1].componentIdx
             ].stateValues.value,
         ).eq(num1);
         expect(
             stateVariables[
-                stateVariables["/noreresamplep"].activeChildren[3].componentName
+                stateVariables["/noreresamplep"].activeChildren[3].componentIdx
             ].stateValues.value,
         ).eq(num2);
     });
@@ -433,9 +431,9 @@ describe("Select tag tests", async () => {
             (x) =>
                 stateVariables[
                     stateVariables[
-                        stateVariables[x.componentName].replacements![0]
-                            .componentName
-                    ].replacements![0].componentName
+                        stateVariables[x.componentIdx].replacements![0]
+                            .componentIdx
+                    ].replacements![0].componentIdx
                 ].stateValues.value.tree,
         );
 
@@ -458,9 +456,9 @@ describe("Select tag tests", async () => {
                 (x) =>
                     stateVariables[
                         stateVariables[
-                            stateVariables[x.componentName].replacements![0]
-                                .componentName
-                        ].replacements![0].componentName
+                            stateVariables[x.componentIdx].replacements![0]
+                                .componentIdx
+                        ].replacements![0].componentIdx
                     ].stateValues.value.tree,
             ),
         ).eqls(sampleMaths);
@@ -495,9 +493,9 @@ describe("Select tag tests", async () => {
             (x) =>
                 stateVariables[
                     stateVariables[
-                        stateVariables[x.componentName].replacements![0]
-                            .componentName
-                    ].replacements![0].componentName
+                        stateVariables[x.componentIdx].replacements![0]
+                            .componentIdx
+                    ].replacements![0].componentIdx
                 ].stateValues.value.tree,
         );
 
@@ -534,42 +532,42 @@ describe("Select tag tests", async () => {
             expect(
                 stateVariables["/p1"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p2"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p3"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p4"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p5"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p6"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
         }
@@ -762,47 +760,47 @@ describe("Select tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let q2 =
-            stateVariables[stateVariables["/q2"].replacements![0].componentName]
+            stateVariables[stateVariables["/q2"].replacements![0].componentIdx]
                 .activeChildren;
         let q2string = q2[0];
         let q2math = me.fromAst(
-            stateVariables[q2[1].componentName].stateValues.value,
+            stateVariables[q2[1].componentIdx].stateValues.value,
         );
         expect(q2math.equals(option[q2string])).eq(true);
 
         let r2 =
-            stateVariables[stateVariables["/r2"].replacements![0].componentName]
+            stateVariables[stateVariables["/r2"].replacements![0].componentIdx]
                 .activeChildren;
         let r2string = r2[0];
         let r2math = me.fromAst(
-            stateVariables[r2[1].componentName].stateValues.value,
+            stateVariables[r2[1].componentIdx].stateValues.value,
         );
         expect(r2math.equals(option[r2string])).eq(true);
 
         let s2 =
-            stateVariables[stateVariables["/s2"].replacements![0].componentName]
+            stateVariables[stateVariables["/s2"].replacements![0].componentIdx]
                 .activeChildren;
         let s2string = s2[0];
         let s2math = me.fromAst(
-            stateVariables[s2[1].componentName].stateValues.value,
+            stateVariables[s2[1].componentIdx].stateValues.value,
         );
         expect(s2math.equals(option[s2string])).eq(true);
 
         let t2 =
-            stateVariables[stateVariables["/t2"].replacements![0].componentName]
+            stateVariables[stateVariables["/t2"].replacements![0].componentIdx]
                 .activeChildren;
         let t2string = t2[0];
         let t2math = me.fromAst(
-            stateVariables[t2[1].componentName].stateValues.value,
+            stateVariables[t2[1].componentIdx].stateValues.value,
         );
         expect(t2math.equals(option[t2string])).eq(true);
 
         let u2 =
-            stateVariables[stateVariables["/u2"].replacements![0].componentName]
+            stateVariables[stateVariables["/u2"].replacements![0].componentIdx]
                 .activeChildren;
         let u2string = u2[0];
         let u2math = me.fromAst(
-            stateVariables[u2[1].componentName].stateValues.value,
+            stateVariables[u2[1].componentIdx].stateValues.value,
         );
         expect(u2math.equals(option[u2string])).eq(true);
     });
@@ -843,47 +841,47 @@ describe("Select tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let q2 =
-            stateVariables[stateVariables["/q2"].replacements![0].componentName]
+            stateVariables[stateVariables["/q2"].replacements![0].componentIdx]
                 .activeChildren;
         let q2string = q2[0];
         let q2math = me.fromAst(
-            stateVariables[q2[1].componentName].stateValues.value,
+            stateVariables[q2[1].componentIdx].stateValues.value,
         );
         expect(q2math.equals(option[q2string])).eq(true);
 
         let r2 =
-            stateVariables[stateVariables["/r2"].replacements![0].componentName]
+            stateVariables[stateVariables["/r2"].replacements![0].componentIdx]
                 .activeChildren;
         let r2string = r2[0];
         let r2math = me.fromAst(
-            stateVariables[r2[1].componentName].stateValues.value,
+            stateVariables[r2[1].componentIdx].stateValues.value,
         );
         expect(r2math.equals(option[r2string])).eq(true);
 
         let s2 =
-            stateVariables[stateVariables["/s2"].replacements![0].componentName]
+            stateVariables[stateVariables["/s2"].replacements![0].componentIdx]
                 .activeChildren;
         let s2string = s2[0];
         let s2math = me.fromAst(
-            stateVariables[s2[1].componentName].stateValues.value,
+            stateVariables[s2[1].componentIdx].stateValues.value,
         );
         expect(s2math.equals(option[s2string])).eq(true);
 
         let t2 =
-            stateVariables[stateVariables["/t2"].replacements![0].componentName]
+            stateVariables[stateVariables["/t2"].replacements![0].componentIdx]
                 .activeChildren;
         let t2string = t2[0];
         let t2math = me.fromAst(
-            stateVariables[t2[1].componentName].stateValues.value,
+            stateVariables[t2[1].componentIdx].stateValues.value,
         );
         expect(t2math.equals(option[t2string])).eq(true);
 
         let u2 =
-            stateVariables[stateVariables["/u2"].replacements![0].componentName]
+            stateVariables[stateVariables["/u2"].replacements![0].componentIdx]
                 .activeChildren;
         let u2string = u2[0];
         let u2math = me.fromAst(
-            stateVariables[u2[1].componentName].stateValues.value,
+            stateVariables[u2[1].componentIdx].stateValues.value,
         );
         expect(u2math.equals(option[u2string])).eq(true);
     });
@@ -932,82 +930,82 @@ describe("Select tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let q2 =
-            stateVariables[stateVariables["/q2"].replacements![0].componentName]
+            stateVariables[stateVariables["/q2"].replacements![0].componentIdx]
                 .activeChildren;
         let q2string = q2[0];
-        let q2math = stateVariables[q2[1].componentName].stateValues.value;
+        let q2math = stateVariables[q2[1].componentIdx].stateValues.value;
         expect(q2math.equals(option[q2string])).eq(true);
         let qx = stateVariables["/qx"].stateValues.value.tree;
         expect(qx).eq(xoption[q2string]);
         let repeatqmath =
             stateVariables[
                 stateVariables[
-                    stateVariables["/repeat"].activeChildren[0].componentName
-                ].activeChildren[1].componentName
+                    stateVariables["/repeat"].activeChildren[0].componentIdx
+                ].activeChildren[1].componentIdx
             ].stateValues.value;
         expect(repeatqmath.equals(option[q2string])).eq(true);
 
         let r2 =
-            stateVariables[stateVariables["/r2"].replacements![0].componentName]
+            stateVariables[stateVariables["/r2"].replacements![0].componentIdx]
                 .activeChildren;
         let r2string = r2[0];
-        let r2math = stateVariables[r2[1].componentName].stateValues.value;
+        let r2math = stateVariables[r2[1].componentIdx].stateValues.value;
         expect(r2math.equals(option[r2string])).eq(true);
         let rx = stateVariables["/rx"].stateValues.value.tree;
         expect(rx).eq(xoption[r2string]);
         let repeatrmath =
             stateVariables[
                 stateVariables[
-                    stateVariables["/repeat"].activeChildren[1].componentName
-                ].activeChildren[1].componentName
+                    stateVariables["/repeat"].activeChildren[1].componentIdx
+                ].activeChildren[1].componentIdx
             ].stateValues.value;
         expect(repeatrmath.equals(option[r2string])).eq(true);
 
         let s2 =
-            stateVariables[stateVariables["/s2"].replacements![0].componentName]
+            stateVariables[stateVariables["/s2"].replacements![0].componentIdx]
                 .activeChildren;
         let s2string = s2[0];
-        let s2math = stateVariables[s2[1].componentName].stateValues.value;
+        let s2math = stateVariables[s2[1].componentIdx].stateValues.value;
         expect(s2math.equals(option[s2string])).eq(true);
         let sx = stateVariables["/sx"].stateValues.value.tree;
         expect(sx).eq(xoption[s2string]);
         let repeatsmath =
             stateVariables[
                 stateVariables[
-                    stateVariables["/repeat"].activeChildren[2].componentName
-                ].activeChildren[1].componentName
+                    stateVariables["/repeat"].activeChildren[2].componentIdx
+                ].activeChildren[1].componentIdx
             ].stateValues.value;
         expect(repeatsmath.equals(option[s2string])).eq(true);
 
         let t2 =
-            stateVariables[stateVariables["/t2"].replacements![0].componentName]
+            stateVariables[stateVariables["/t2"].replacements![0].componentIdx]
                 .activeChildren;
         let t2string = t2[0];
-        let t2math = stateVariables[t2[1].componentName].stateValues.value;
+        let t2math = stateVariables[t2[1].componentIdx].stateValues.value;
         expect(t2math.equals(option[t2string])).eq(true);
         let tx = stateVariables["/tx"].stateValues.value.tree;
         expect(tx).eq(xoption[t2string]);
         let repeattmath =
             stateVariables[
                 stateVariables[
-                    stateVariables["/repeat"].activeChildren[3].componentName
-                ].activeChildren[1].componentName
+                    stateVariables["/repeat"].activeChildren[3].componentIdx
+                ].activeChildren[1].componentIdx
             ].stateValues.value;
         expect(repeattmath.equals(option[t2string])).eq(true);
 
         let u2 =
-            stateVariables[stateVariables["/u2"].replacements![0].componentName]
+            stateVariables[stateVariables["/u2"].replacements![0].componentIdx]
                 .activeChildren;
         let u2string = u2[0];
-        let u2math = stateVariables[u2[1].componentName].stateValues.value;
+        let u2math = stateVariables[u2[1].componentIdx].stateValues.value;
         expect(u2math.equals(option[u2string])).eq(true);
         let ux = stateVariables["/ux"].stateValues.value.tree;
         expect(ux).eq(xoption[u2string]);
         let repeatumath =
             stateVariables[
                 stateVariables[
-                    stateVariables["/repeat"].activeChildren[4].componentName
-                ].activeChildren[1].componentName
+                    stateVariables["/repeat"].activeChildren[4].componentIdx
+                ].activeChildren[1].componentIdx
             ].stateValues.value;
         expect(repeatumath.equals(option[u2string])).eq(true);
     });
@@ -1049,72 +1047,72 @@ describe("Select tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let q2 =
-            stateVariables[stateVariables["/q2"].replacements![0].componentName]
+            stateVariables[stateVariables["/q2"].replacements![0].componentIdx]
                 .activeChildren;
         let q2string = q2[0];
-        let q2math = stateVariables[q2[1].componentName].stateValues.value;
+        let q2math = stateVariables[q2[1].componentIdx].stateValues.value;
         expect(q2math.equals(option[q2string])).eq(true);
         let repeatqmath =
             stateVariables[
                 stateVariables[
-                    stateVariables["/repeat"].activeChildren[0].componentName
-                ].activeChildren[1].componentName
+                    stateVariables["/repeat"].activeChildren[0].componentIdx
+                ].activeChildren[1].componentIdx
             ].stateValues.value;
         expect(repeatqmath.equals(option[q2string])).eq(true);
 
         let r2 =
-            stateVariables[stateVariables["/r2"].replacements![0].componentName]
+            stateVariables[stateVariables["/r2"].replacements![0].componentIdx]
                 .activeChildren;
         let r2string = r2[0];
-        let r2math = stateVariables[r2[1].componentName].stateValues.value;
+        let r2math = stateVariables[r2[1].componentIdx].stateValues.value;
         expect(r2math.equals(option[r2string])).eq(true);
         let repeatrmath =
             stateVariables[
                 stateVariables[
-                    stateVariables["/repeat"].activeChildren[1].componentName
-                ].activeChildren[1].componentName
+                    stateVariables["/repeat"].activeChildren[1].componentIdx
+                ].activeChildren[1].componentIdx
             ].stateValues.value;
         expect(repeatrmath.equals(option[r2string])).eq(true);
 
         let s2 =
-            stateVariables[stateVariables["/s2"].replacements![0].componentName]
+            stateVariables[stateVariables["/s2"].replacements![0].componentIdx]
                 .activeChildren;
         let s2string = s2[0];
-        let s2math = stateVariables[s2[1].componentName].stateValues.value;
+        let s2math = stateVariables[s2[1].componentIdx].stateValues.value;
         expect(s2math.equals(option[s2string])).eq(true);
         let repeatsmath =
             stateVariables[
                 stateVariables[
-                    stateVariables["/repeat"].activeChildren[2].componentName
-                ].activeChildren[1].componentName
+                    stateVariables["/repeat"].activeChildren[2].componentIdx
+                ].activeChildren[1].componentIdx
             ].stateValues.value;
         expect(repeatsmath.equals(option[s2string])).eq(true);
 
         let t2 =
-            stateVariables[stateVariables["/t2"].replacements![0].componentName]
+            stateVariables[stateVariables["/t2"].replacements![0].componentIdx]
                 .activeChildren;
         let t2string = t2[0];
-        let t2math = stateVariables[t2[1].componentName].stateValues.value;
+        let t2math = stateVariables[t2[1].componentIdx].stateValues.value;
         expect(t2math.equals(option[t2string])).eq(true);
         let repeattmath =
             stateVariables[
                 stateVariables[
-                    stateVariables["/repeat"].activeChildren[3].componentName
-                ].activeChildren[1].componentName
+                    stateVariables["/repeat"].activeChildren[3].componentIdx
+                ].activeChildren[1].componentIdx
             ].stateValues.value;
         expect(repeattmath.equals(option[t2string])).eq(true);
 
         let u2 =
-            stateVariables[stateVariables["/u2"].replacements![0].componentName]
+            stateVariables[stateVariables["/u2"].replacements![0].componentIdx]
                 .activeChildren;
         let u2string = u2[0];
-        let u2math = stateVariables[u2[1].componentName].stateValues.value;
+        let u2math = stateVariables[u2[1].componentIdx].stateValues.value;
         expect(u2math.equals(option[u2string])).eq(true);
         let repeatumath =
             stateVariables[
                 stateVariables[
-                    stateVariables["/repeat"].activeChildren[4].componentName
-                ].activeChildren[1].componentName
+                    stateVariables["/repeat"].activeChildren[4].componentIdx
+                ].activeChildren[1].componentIdx
             ].stateValues.value;
         expect(repeatumath.equals(option[u2string])).eq(true);
     });
@@ -1153,8 +1151,8 @@ describe("Select tag tests", async () => {
         let xorig =
             stateVariables[
                 stateVariables[
-                    stateVariables["/s1"].replacements![0].componentName
-                ].replacements![0].componentName
+                    stateVariables["/s1"].replacements![0].componentIdx
+                ].replacements![0].componentIdx
             ].stateValues.value.tree;
         expect(xorig).eq(expectedx);
 
@@ -1164,8 +1162,8 @@ describe("Select tag tests", async () => {
         let x3 =
             stateVariables[
                 stateVariables[
-                    stateVariables["/x3"].replacements![0].componentName
-                ].replacements![0].componentName
+                    stateVariables["/x3"].replacements![0].componentIdx
+                ].replacements![0].componentIdx
             ].stateValues.value.tree;
         expect(x3).eq(expectedx);
     });
@@ -1223,22 +1221,22 @@ describe("Select tag tests", async () => {
         let xorig =
             stateVariables[
                 stateVariables[
-                    stateVariables["/s1"].replacements![0].componentName
-                ].replacements![0].componentName
+                    stateVariables["/s1"].replacements![0].componentIdx
+                ].replacements![0].componentIdx
             ].stateValues.value.tree;
         expect(xorig).eq(x);
         let yorig =
             stateVariables[
                 stateVariables[
-                    stateVariables["/s1"].replacements![1].componentName
-                ].replacements![0].componentName
+                    stateVariables["/s1"].replacements![1].componentIdx
+                ].replacements![0].componentIdx
             ].stateValues.value.tree;
         expect(yorig).eq(y);
         let zorig =
             stateVariables[
                 stateVariables[
-                    stateVariables["/s1"].replacements![2].componentName
-                ].replacements![0].componentName
+                    stateVariables["/s1"].replacements![2].componentIdx
+                ].replacements![0].componentIdx
             ].stateValues.value.tree;
         expect(zorig).eq(z);
 
@@ -1252,22 +1250,22 @@ describe("Select tag tests", async () => {
         let x3 =
             stateVariables[
                 stateVariables[
-                    stateVariables["/s2"].replacements![0].componentName
-                ].replacements![0].componentName
+                    stateVariables["/s2"].replacements![0].componentIdx
+                ].replacements![0].componentIdx
             ].stateValues.value.tree;
         expect(x3).eq(x);
         let y3 =
             stateVariables[
                 stateVariables[
-                    stateVariables["/s2"].replacements![1].componentName
-                ].replacements![0].componentName
+                    stateVariables["/s2"].replacements![1].componentIdx
+                ].replacements![0].componentIdx
             ].stateValues.value.tree;
         expect(y3).eq(y);
         let z3 =
             stateVariables[
                 stateVariables[
-                    stateVariables["/s2"].replacements![2].componentName
-                ].replacements![0].componentName
+                    stateVariables["/s2"].replacements![2].componentIdx
+                ].replacements![0].componentIdx
             ].stateValues.value.tree;
         expect(z3).eq(z);
     });
@@ -1597,10 +1595,10 @@ describe("Select tag tests", async () => {
                         stateVariables[
                             stateVariables[
                                 stateVariables["/_map1"].replacements![ind]
-                                    .componentName
-                            ].replacements![1].componentName
-                        ].replacements![0].componentName
-                    ].replacements![0].componentName
+                                    .componentIdx
+                            ].replacements![1].componentIdx
+                        ].replacements![0].componentIdx
+                    ].replacements![0].componentIdx
                 ];
             let x = theText.stateValues.value;
             if (x === "z") {
@@ -1639,8 +1637,8 @@ describe("Select tag tests", async () => {
         for (let ind = 0; ind < 200; ind++) {
             let x =
                 stateVariables[
-                    stateVariables[selectReplacements[ind].componentName]
-                        .replacements![0].componentName
+                    stateVariables[selectReplacements[ind].componentIdx]
+                        .replacements![0].componentIdx
                 ].stateValues.value;
             if (x === "x") {
                 numX++;
@@ -1687,14 +1685,13 @@ describe("Select tag tests", async () => {
             let theSelect =
                 stateVariables[
                     stateVariables[
-                        stateVariables["/_map1"].replacements![ind]
-                            .componentName
-                    ].replacements![1].componentName
+                        stateVariables["/_map1"].replacements![ind].componentIdx
+                    ].replacements![1].componentIdx
                 ];
             let theText1 =
                 stateVariables[
-                    stateVariables[theSelect.replacements![0].componentName]
-                        .replacements![0].componentName
+                    stateVariables[theSelect.replacements![0].componentIdx]
+                        .replacements![0].componentIdx
                 ];
             let x = theText1.stateValues.value;
 
@@ -1709,8 +1706,8 @@ describe("Select tag tests", async () => {
             }
             let theText2 =
                 stateVariables[
-                    stateVariables[theSelect.replacements![1].componentName]
-                        .replacements![0].componentName
+                    stateVariables[theSelect.replacements![1].componentIdx]
+                        .replacements![0].componentIdx
                 ];
             let y = theText2.stateValues.value;
             if (y === "z") {
@@ -1765,47 +1762,47 @@ describe("Select tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let qs = stateVariables["/q"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let rs = stateVariables["/r"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let ss = stateVariables["/s"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let ts = stateVariables["/t"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let us = stateVariables["/u"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let vs = stateVariables["/v"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let ws = stateVariables["/w"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         let q2s = stateVariables["/q2"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let r2s = stateVariables["/r2"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let s2s = stateVariables["/s2"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let t2s = stateVariables["/t2"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let u2s = stateVariables["/u2"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let v2s = stateVariables["/v2"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let w2s = stateVariables["/w2"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         const getTree = (x) => x.tree ?? x;
@@ -1911,47 +1908,47 @@ describe("Select tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let qs = stateVariables["/q"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let rs = stateVariables["/r"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let ss = stateVariables["/s"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let ts = stateVariables["/t"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let us = stateVariables["/u"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let vs = stateVariables["/v"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let ws = stateVariables["/w"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         let q2s = stateVariables["/q2"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let r2s = stateVariables["/r2"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let s2s = stateVariables["/s2"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let t2s = stateVariables["/t2"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let u2s = stateVariables["/u2"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let v2s = stateVariables["/v2"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let w2s = stateVariables["/w2"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         const getTree = (x) => x.tree ?? x;
@@ -1965,59 +1962,59 @@ describe("Select tag tests", async () => {
         expect(w2s.map(getTree)).eqls(ws.map(getTree));
 
         let q3s = stateVariables["/q3"]
-            .replacements!.map((x) => stateVariables[x.componentName])
+            .replacements!.map((x) => stateVariables[x.componentIdx])
             .map((x) =>
                 x.replacements
-                    ? stateVariables[x.replacements[0].componentName]
-                          .stateValues.value
+                    ? stateVariables[x.replacements[0].componentIdx].stateValues
+                          .value
                     : x.stateValues.value,
             );
         let r3s = stateVariables["/r3"]
-            .replacements!.map((x) => stateVariables[x.componentName])
+            .replacements!.map((x) => stateVariables[x.componentIdx])
             .map((x) =>
                 x.replacements
-                    ? stateVariables[x.replacements[0].componentName]
-                          .stateValues.value
+                    ? stateVariables[x.replacements[0].componentIdx].stateValues
+                          .value
                     : x.stateValues.value,
             );
         let s3s = stateVariables["/s3"]
-            .replacements!.map((x) => stateVariables[x.componentName])
+            .replacements!.map((x) => stateVariables[x.componentIdx])
             .map((x) =>
                 x.replacements
-                    ? stateVariables[x.replacements[0].componentName]
-                          .stateValues.value
+                    ? stateVariables[x.replacements[0].componentIdx].stateValues
+                          .value
                     : x.stateValues.value,
             );
         let t3s = stateVariables["/t3"]
-            .replacements!.map((x) => stateVariables[x.componentName])
+            .replacements!.map((x) => stateVariables[x.componentIdx])
             .map((x) =>
                 x.replacements
-                    ? stateVariables[x.replacements[0].componentName]
-                          .stateValues.value
+                    ? stateVariables[x.replacements[0].componentIdx].stateValues
+                          .value
                     : x.stateValues.value,
             );
         let u3s = stateVariables["/u3"]
-            .replacements!.map((x) => stateVariables[x.componentName])
+            .replacements!.map((x) => stateVariables[x.componentIdx])
             .map((x) =>
                 x.replacements
-                    ? stateVariables[x.replacements[0].componentName]
-                          .stateValues.value
+                    ? stateVariables[x.replacements[0].componentIdx].stateValues
+                          .value
                     : x.stateValues.value,
             );
         let v3s = stateVariables["/v3"]
-            .replacements!.map((x) => stateVariables[x.componentName])
+            .replacements!.map((x) => stateVariables[x.componentIdx])
             .map((x) =>
                 x.replacements
-                    ? stateVariables[x.replacements[0].componentName]
-                          .stateValues.value
+                    ? stateVariables[x.replacements[0].componentIdx].stateValues
+                          .value
                     : x.stateValues.value,
             );
         let w3s = stateVariables["/w3"]
-            .replacements!.map((x) => stateVariables[x.componentName])
+            .replacements!.map((x) => stateVariables[x.componentIdx])
             .map((x) =>
                 x.replacements
-                    ? stateVariables[x.replacements[0].componentName]
-                          .stateValues.value
+                    ? stateVariables[x.replacements[0].componentIdx].stateValues
+                          .value
                     : x.stateValues.value,
             );
 
@@ -2108,84 +2105,84 @@ describe("Select tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let qs = stateVariables["/q"]
-            .replacements!.map((x) => stateVariables[x.componentName])
+            .replacements!.map((x) => stateVariables[x.componentIdx])
             .map((x) =>
                 x.replacements
-                    ? stateVariables[x.replacements[0].componentName]
-                          .stateValues.value
+                    ? stateVariables[x.replacements[0].componentIdx].stateValues
+                          .value
                     : x.stateValues.value,
             );
         let rs = stateVariables["/r"]
-            .replacements!.map((x) => stateVariables[x.componentName])
+            .replacements!.map((x) => stateVariables[x.componentIdx])
             .map((x) =>
                 x.replacements
-                    ? stateVariables[x.replacements[0].componentName]
-                          .stateValues.value
+                    ? stateVariables[x.replacements[0].componentIdx].stateValues
+                          .value
                     : x.stateValues.value,
             );
         let ss = stateVariables["/s"]
-            .replacements!.map((x) => stateVariables[x.componentName])
+            .replacements!.map((x) => stateVariables[x.componentIdx])
             .map((x) =>
                 x.replacements
-                    ? stateVariables[x.replacements[0].componentName]
-                          .stateValues.value
+                    ? stateVariables[x.replacements[0].componentIdx].stateValues
+                          .value
                     : x.stateValues.value,
             );
         let ts = stateVariables["/t"]
-            .replacements!.map((x) => stateVariables[x.componentName])
+            .replacements!.map((x) => stateVariables[x.componentIdx])
             .map((x) =>
                 x.replacements
-                    ? stateVariables[x.replacements[0].componentName]
-                          .stateValues.value
+                    ? stateVariables[x.replacements[0].componentIdx].stateValues
+                          .value
                     : x.stateValues.value,
             );
         let us = stateVariables["/u"]
-            .replacements!.map((x) => stateVariables[x.componentName])
+            .replacements!.map((x) => stateVariables[x.componentIdx])
             .map((x) =>
                 x.replacements
-                    ? stateVariables[x.replacements[0].componentName]
-                          .stateValues.value
+                    ? stateVariables[x.replacements[0].componentIdx].stateValues
+                          .value
                     : x.stateValues.value,
             );
 
         let q2s = stateVariables["/q2"]
-            .replacements!.map((x) => stateVariables[x.componentName])
+            .replacements!.map((x) => stateVariables[x.componentIdx])
             .map((x) =>
                 x.replacements
-                    ? stateVariables[x.replacements[0].componentName]
-                          .stateValues.value
+                    ? stateVariables[x.replacements[0].componentIdx].stateValues
+                          .value
                     : x.stateValues.value,
             );
         let r2s = stateVariables["/r2"]
-            .replacements!.map((x) => stateVariables[x.componentName])
+            .replacements!.map((x) => stateVariables[x.componentIdx])
             .map((x) =>
                 x.replacements
-                    ? stateVariables[x.replacements[0].componentName]
-                          .stateValues.value
+                    ? stateVariables[x.replacements[0].componentIdx].stateValues
+                          .value
                     : x.stateValues.value,
             );
         let s2s = stateVariables["/s2"]
-            .replacements!.map((x) => stateVariables[x.componentName])
+            .replacements!.map((x) => stateVariables[x.componentIdx])
             .map((x) =>
                 x.replacements
-                    ? stateVariables[x.replacements[0].componentName]
-                          .stateValues.value
+                    ? stateVariables[x.replacements[0].componentIdx].stateValues
+                          .value
                     : x.stateValues.value,
             );
         let t2s = stateVariables["/t2"]
-            .replacements!.map((x) => stateVariables[x.componentName])
+            .replacements!.map((x) => stateVariables[x.componentIdx])
             .map((x) =>
                 x.replacements
-                    ? stateVariables[x.replacements[0].componentName]
-                          .stateValues.value
+                    ? stateVariables[x.replacements[0].componentIdx].stateValues
+                          .value
                     : x.stateValues.value,
             );
         let u2s = stateVariables["/u2"]
-            .replacements!.map((x) => stateVariables[x.componentName])
+            .replacements!.map((x) => stateVariables[x.componentIdx])
             .map((x) =>
                 x.replacements
-                    ? stateVariables[x.replacements[0].componentName]
-                          .stateValues.value
+                    ? stateVariables[x.replacements[0].componentIdx].stateValues
+                          .value
                     : x.stateValues.value,
             );
 
@@ -2269,9 +2266,8 @@ describe("Select tag tests", async () => {
             "/q/s/r",
         ].map((x) =>
             stateVariables[x].replacements
-                ? stateVariables[
-                      stateVariables[x].replacements[0].componentName
-                  ].stateValues.value
+                ? stateVariables[stateVariables[x].replacements[0].componentIdx]
+                      .stateValues.value
                 : stateVariables[x].stateValues.value,
         );
         let rs = [
@@ -2283,9 +2279,8 @@ describe("Select tag tests", async () => {
             "/r/s/r",
         ].map((x) =>
             stateVariables[x].replacements
-                ? stateVariables[
-                      stateVariables[x].replacements[0].componentName
-                  ].stateValues.value
+                ? stateVariables[stateVariables[x].replacements[0].componentIdx]
+                      .stateValues.value
                 : stateVariables[x].stateValues.value,
         );
         let ss = [
@@ -2297,9 +2292,8 @@ describe("Select tag tests", async () => {
             "/s/s/r",
         ].map((x) =>
             stateVariables[x].replacements
-                ? stateVariables[
-                      stateVariables[x].replacements[0].componentName
-                  ].stateValues.value
+                ? stateVariables[stateVariables[x].replacements[0].componentIdx]
+                      .stateValues.value
                 : stateVariables[x].stateValues.value,
         );
 
@@ -2378,9 +2372,8 @@ describe("Select tag tests", async () => {
             "/a/q/s/r",
         ].map((x) =>
             stateVariables[x].replacements
-                ? stateVariables[
-                      stateVariables[x].replacements[0].componentName
-                  ].stateValues.value
+                ? stateVariables[stateVariables[x].replacements[0].componentIdx]
+                      .stateValues.value
                 : stateVariables[x].stateValues.value,
         );
         let rs = [
@@ -2392,9 +2385,8 @@ describe("Select tag tests", async () => {
             "/a/r/s/r",
         ].map((x) =>
             stateVariables[x].replacements
-                ? stateVariables[
-                      stateVariables[x].replacements[0].componentName
-                  ].stateValues.value
+                ? stateVariables[stateVariables[x].replacements[0].componentIdx]
+                      .stateValues.value
                 : stateVariables[x].stateValues.value,
         );
         let ss = [
@@ -2406,9 +2398,8 @@ describe("Select tag tests", async () => {
             "/a/s/s/r",
         ].map((x) =>
             stateVariables[x].replacements
-                ? stateVariables[
-                      stateVariables[x].replacements[0].componentName
-                  ].stateValues.value
+                ? stateVariables[stateVariables[x].replacements[0].componentIdx]
+                      .stateValues.value
                 : stateVariables[x].stateValues.value,
         );
 
@@ -2496,12 +2487,12 @@ describe("Select tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let chosenChildren = stateVariables[
-            stateVariables["/_select1"].replacements![0].componentName
+            stateVariables["/_select1"].replacements![0].componentIdx
         ]
             .replacements!.filter((x) => typeof x !== "string")
-            .map((x) => stateVariables[x.componentName])
+            .map((x) => stateVariables[x.componentIdx])
             .map((v, i) =>
-                i < 2 ? v : stateVariables[v.replacements![0].componentName],
+                i < 2 ? v : stateVariables[v.replacements![0].componentIdx],
             );
         let option =
             options[
@@ -2593,17 +2584,17 @@ describe("Select tag tests", async () => {
 
         let theList1 = stateVariables["/list1"].activeChildren.map((x) =>
             me
-                .fromAst(stateVariables[x.componentName].stateValues.value)
+                .fromAst(stateVariables[x.componentIdx].stateValues.value)
                 .toString(),
         );
         let theList2 = stateVariables["/list2"].activeChildren.map((x) =>
             me
-                .fromAst(stateVariables[x.componentName].stateValues.value)
+                .fromAst(stateVariables[x.componentIdx].stateValues.value)
                 .toString(),
         );
         let theList3 = stateVariables["/list3"].activeChildren.map((x) =>
             me
-                .fromAst(stateVariables[x.componentName].stateValues.value)
+                .fromAst(stateVariables[x.componentIdx].stateValues.value)
                 .toString(),
         );
 
@@ -2676,17 +2667,17 @@ describe("Select tag tests", async () => {
 
         let theList1 = stateVariables["/list1"].activeChildren.map((x) =>
             me
-                .fromAst(stateVariables[x.componentName].stateValues.value)
+                .fromAst(stateVariables[x.componentIdx].stateValues.value)
                 .toString(),
         );
         let theList2 = stateVariables["/list2"].activeChildren.map((x) =>
             me
-                .fromAst(stateVariables[x.componentName].stateValues.value)
+                .fromAst(stateVariables[x.componentIdx].stateValues.value)
                 .toString(),
         );
         let theList3 = stateVariables["/list3"].activeChildren.map((x) =>
             me
-                .fromAst(stateVariables[x.componentName].stateValues.value)
+                .fromAst(stateVariables[x.componentIdx].stateValues.value)
                 .toString(),
         );
 
@@ -3010,12 +3001,12 @@ describe("Select tag tests", async () => {
 
         let replacements =
             stateVariables[
-                stateVariables["/select1"].replacements![0].componentName
+                stateVariables["/select1"].replacements![0].componentIdx
             ].replacements!;
 
-        let p1 = replacements[1].componentName;
-        let p2 = replacements[3].componentName;
-        let p3 = replacements[5].componentName;
+        let p1 = replacements[1].componentIdx;
+        let p2 = replacements[3].componentIdx;
+        let p3 = replacements[5].componentIdx;
 
         expect(stateVariables[p1].stateValues.text).eq(`q,r = ab`);
         expect(stateVariables[p2].stateValues.text).eq(`q2 = a`);
@@ -3162,36 +3153,31 @@ describe("Select tag tests", async () => {
         let vars1 = stateVariables["/vars1"].replacements!.map(
             (x) =>
                 stateVariables[
-                    stateVariables[x.componentName].replacements![0]
-                        .componentName
+                    stateVariables[x.componentIdx].replacements![0].componentIdx
                 ].stateValues.value,
         );
         let vars2 = stateVariables["/vars2"].replacements!.map(
             (x) =>
                 stateVariables[
-                    stateVariables[x.componentName].replacements![0]
-                        .componentName
+                    stateVariables[x.componentIdx].replacements![0].componentIdx
                 ].stateValues.value,
         );
         let vars3 = stateVariables["/vars3"].replacements!.map(
             (x) =>
                 stateVariables[
-                    stateVariables[x.componentName].replacements![0]
-                        .componentName
+                    stateVariables[x.componentIdx].replacements![0].componentIdx
                 ].stateValues.value,
         );
         let vars4 = stateVariables["/vars4"].replacements!.map(
             (x) =>
                 stateVariables[
-                    stateVariables[x.componentName].replacements![0]
-                        .componentName
+                    stateVariables[x.componentIdx].replacements![0].componentIdx
                 ].stateValues.value,
         );
         let vars5 = stateVariables["/vars5"].replacements!.map(
             (x) =>
                 stateVariables[
-                    stateVariables[x.componentName].replacements![0]
-                        .componentName
+                    stateVariables[x.componentIdx].replacements![0].componentIdx
                 ].stateValues.value,
         );
 
@@ -3267,15 +3253,14 @@ describe("Select tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let pNames1 = stateVariables["/_select1"].replacements!.map(
-            (x) =>
-                stateVariables[x.componentName].replacements![0].componentName,
+            (x) => stateVariables[x.componentIdx].replacements![0].componentIdx,
         );
         for (let pn of pNames1) {
             expect(stateVariables[pn].stateValues.text).eq("What is this?");
         }
 
         let pNames2 = ["/A", "/B", "/C"].map(
-            (x) => stateVariables[x].replacements![0].componentName,
+            (x) => stateVariables[x].replacements![0].componentIdx,
         );
         for (let pn of pNames2) {
             expect(stateVariables[pn].stateValues.text).eq("What is this?");

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/selectfromsequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/selectfromsequence.test.ts
@@ -521,43 +521,43 @@ describe("SelectFromSequence tag tests", async () => {
         expect(Number.isInteger(num2) && num2 >= 1 && num2 <= 100).eq(true);
         expect(
             stateVariables[
-                stateVariables["/noresample1"].replacements![0].componentName
+                stateVariables["/noresample1"].replacements![0].componentIdx
             ].stateValues.value,
         ).eq(num1);
         expect(
             stateVariables[
-                stateVariables["/noresample2"].replacements![0].componentName
+                stateVariables["/noresample2"].replacements![0].componentIdx
             ].stateValues.value,
         ).eq(num2);
         expect(
             stateVariables[
-                stateVariables["/noreresample1"].replacements![0].componentName
+                stateVariables["/noreresample1"].replacements![0].componentIdx
             ].stateValues.value,
         ).eq(num1);
         expect(
             stateVariables[
-                stateVariables["/noreresample2"].replacements![0].componentName
+                stateVariables["/noreresample2"].replacements![0].componentIdx
             ].stateValues.value,
         ).eq(num2);
 
         expect(
             stateVariables[
-                stateVariables["/noresamplep"].activeChildren[1].componentName
+                stateVariables["/noresamplep"].activeChildren[1].componentIdx
             ].stateValues.value,
         ).eq(num1);
         expect(
             stateVariables[
-                stateVariables["/noresamplep"].activeChildren[3].componentName
+                stateVariables["/noresamplep"].activeChildren[3].componentIdx
             ].stateValues.value,
         ).eq(num2);
         expect(
             stateVariables[
-                stateVariables["/noreresamplep"].activeChildren[1].componentName
+                stateVariables["/noreresamplep"].activeChildren[1].componentIdx
             ].stateValues.value,
         ).eq(num1);
         expect(
             stateVariables[
-                stateVariables["/noreresamplep"].activeChildren[3].componentName
+                stateVariables["/noreresamplep"].activeChildren[3].componentIdx
             ].stateValues.value,
         ).eq(num2);
     });
@@ -586,10 +586,10 @@ describe("SelectFromSequence tag tests", async () => {
         expect(sample1replacements.length).eq(5);
         expect(sample2replacements.length).eq(2);
         let sample1numbers = sample1replacements.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let sample2numbers = sample2replacements.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         for (let num of sample1numbers) {
@@ -627,12 +627,12 @@ describe("SelectFromSequence tag tests", async () => {
 
         expect(
             sample1replacements.map(
-                (x) => stateVariables[x.componentName].stateValues.value,
+                (x) => stateVariables[x.componentIdx].stateValues.value,
             ),
         ).eqls(sample1numbers);
         expect(
             sample2replacements.map(
-                (x) => stateVariables[x.componentName].stateValues.value,
+                (x) => stateVariables[x.componentIdx].stateValues.value,
             ),
         ).eqls(sample2numbers);
     });
@@ -667,42 +667,42 @@ describe("SelectFromSequence tag tests", async () => {
             expect(
                 stateVariables["/p1"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p2"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p3"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p4"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p5"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p6"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
         }
@@ -1016,10 +1016,10 @@ describe("SelectFromSequence tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let originalNumbers = stateVariables["/p1"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let secondNumbers = stateVariables["/p2"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         expect([...originalNumbers].sort((a, b) => a - b)).eqls(
@@ -1040,10 +1040,10 @@ describe("SelectFromSequence tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let originalNumbers = stateVariables["/p1"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let secondNumbers = stateVariables["/p2"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         function compare_letters(a: string, b: string) {
@@ -1287,19 +1287,19 @@ describe("SelectFromSequence tag tests", async () => {
         let n5 = stateVariables["/n5"].stateValues.value;
 
         let nums1 = stateVariables["/nums1"].replacements!.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let nums2 = stateVariables["/nums2"].replacements!.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let nums3 = stateVariables["/nums3"].replacements!.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let nums4 = stateVariables["/nums4"].replacements!.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let nums5 = stateVariables["/nums5"].replacements!.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         expect(nums1.length).eq(n1);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/selectprimenumbers.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/selectprimenumbers.test.ts
@@ -453,7 +453,7 @@ describe("selectPrimeNumbers tag tests", async () => {
         for (let ind = 0; ind < 100; ind++) {
             let num =
                 stateVariables[
-                    stateVariables["/sample"].replacements![ind].componentName
+                    stateVariables["/sample"].replacements![ind].componentIdx
                 ].stateValues.value;
 
             expect(Number.isInteger(num) && num >= 2 && num <= 1000000).eq(
@@ -534,43 +534,43 @@ describe("selectPrimeNumbers tag tests", async () => {
 
         expect(
             stateVariables[
-                stateVariables["/noresample1"].replacements![0].componentName
+                stateVariables["/noresample1"].replacements![0].componentIdx
             ].stateValues.value,
         ).eq(num1);
         expect(
             stateVariables[
-                stateVariables["/noresample2"].replacements![0].componentName
+                stateVariables["/noresample2"].replacements![0].componentIdx
             ].stateValues.value,
         ).eq(num2);
         expect(
             stateVariables[
-                stateVariables["/noreresample1"].replacements![0].componentName
+                stateVariables["/noreresample1"].replacements![0].componentIdx
             ].stateValues.value,
         ).eq(num1);
         expect(
             stateVariables[
-                stateVariables["/noreresample2"].replacements![0].componentName
+                stateVariables["/noreresample2"].replacements![0].componentIdx
             ].stateValues.value,
         ).eq(num2);
 
         expect(
             stateVariables[
-                stateVariables["/noresamplep"].activeChildren[1].componentName
+                stateVariables["/noresamplep"].activeChildren[1].componentIdx
             ].stateValues.value,
         ).eq(num1);
         expect(
             stateVariables[
-                stateVariables["/noresamplep"].activeChildren[3].componentName
+                stateVariables["/noresamplep"].activeChildren[3].componentIdx
             ].stateValues.value,
         ).eq(num2);
         expect(
             stateVariables[
-                stateVariables["/noreresamplep"].activeChildren[1].componentName
+                stateVariables["/noreresamplep"].activeChildren[1].componentIdx
             ].stateValues.value,
         ).eq(num1);
         expect(
             stateVariables[
-                stateVariables["/noreresamplep"].activeChildren[3].componentName
+                stateVariables["/noreresamplep"].activeChildren[3].componentIdx
             ].stateValues.value,
         ).eq(num2);
     });
@@ -599,10 +599,10 @@ describe("selectPrimeNumbers tag tests", async () => {
         expect(sample1replacements.length).eq(5);
         expect(sample2replacements.length).eq(2);
         let sample1numbers = sample1replacements.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let sample2numbers = sample2replacements.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         for (let num of sample1numbers) {
@@ -640,12 +640,12 @@ describe("selectPrimeNumbers tag tests", async () => {
 
         expect(
             sample1replacements.map(
-                (x) => stateVariables[x.componentName].stateValues.value,
+                (x) => stateVariables[x.componentIdx].stateValues.value,
             ),
         ).eqls(sample1numbers);
         expect(
             sample2replacements.map(
-                (x) => stateVariables[x.componentName].stateValues.value,
+                (x) => stateVariables[x.componentIdx].stateValues.value,
             ),
         ).eqls(sample2numbers);
     });
@@ -680,42 +680,42 @@ describe("selectPrimeNumbers tag tests", async () => {
             expect(
                 stateVariables["/p1"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p2"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p3"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p4"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p5"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p6"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
         }
@@ -799,10 +799,10 @@ describe("selectPrimeNumbers tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let originalNumbers = stateVariables["/p1"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let secondNumbers = stateVariables["/p2"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         expect([...originalNumbers].sort((a, b) => a - b)).eqls(
@@ -828,10 +828,10 @@ describe("selectPrimeNumbers tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let originalNumbers = stateVariables["/p1"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let secondNumbers = stateVariables["/p2"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         expect([...originalNumbers].sort((a, b) => a - b)).eqls(
@@ -932,19 +932,19 @@ describe("selectPrimeNumbers tag tests", async () => {
         let n5 = stateVariables["/n5"].stateValues.value;
 
         let nums1 = stateVariables["/nums1"].replacements!.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let nums2 = stateVariables["/nums2"].replacements!.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let nums3 = stateVariables["/nums3"].replacements!.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let nums4 = stateVariables["/nums4"].replacements!.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let nums5 = stateVariables["/nums5"].replacements!.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         expect(nums1.length).eq(n1);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/selectsamplerandomnumbers.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/selectsamplerandomnumbers.test.ts
@@ -57,7 +57,7 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests", async () => {
             );
             samples.push(
                 ...stateVariables[name].replacements!.map(
-                    (x) => stateVariables[x.componentName].stateValues.value,
+                    (x) => stateVariables[x.componentIdx].stateValues.value,
                 ),
             );
 
@@ -665,10 +665,10 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests", async () => {
         expect(sample1replacements.length).eq(20);
         expect(sample2replacements.length).eq(10);
         let sample1numbers = sample1replacements.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let sample2numbers = sample2replacements.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         for (let num of sample1numbers) {
@@ -707,12 +707,12 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests", async () => {
 
         expect(
             sample1replacements.map(
-                (x) => stateVariables[x.componentName].stateValues.value,
+                (x) => stateVariables[x.componentIdx].stateValues.value,
             ),
         ).eqls(sample1numbers);
         expect(
             sample2replacements.map(
-                (x) => stateVariables[x.componentName].stateValues.value,
+                (x) => stateVariables[x.componentIdx].stateValues.value,
             ),
         ).eqls(sample2numbers);
     });
@@ -740,10 +740,10 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests", async () => {
         expect(sample1replacements.length).eq(50);
         expect(sample2replacements.length).eq(180);
         let sample1numbers = sample1replacements.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let sample2numbers = sample2replacements.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         for (let num of sample1numbers) {
@@ -774,7 +774,7 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests", async () => {
 
         stateVariables = await core.returnAllStateVariables(false, true);
         let sample1numbersb = stateVariables["/sample1"].replacements!.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let sample2numbersb = stateVariables["/sample2"]
             .replacements!.slice(
@@ -782,7 +782,7 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests", async () => {
                 stateVariables["/sample2"].replacements!.length -
                     (stateVariables["/sample2"].replacementsToWithhold ?? 0),
             )
-            .map((x) => stateVariables[x.componentName].stateValues.value);
+            .map((x) => stateVariables[x.componentIdx].stateValues.value);
         expect(sample1numbersb.length).eq(70);
         expect(sample2numbersb.length).eq(160);
 
@@ -821,7 +821,7 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests", async () => {
 
         stateVariables = await core.returnAllStateVariables(false, true);
         let sample1numbersc = stateVariables["/sample1"].replacements!.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let sample2numbersc = stateVariables["/sample2"]
             .replacements!.slice(
@@ -829,7 +829,7 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests", async () => {
                 stateVariables["/sample2"].replacements!.length -
                     (stateVariables["/sample2"].replacementsToWithhold ?? 0),
             )
-            .map((x) => stateVariables[x.componentName].stateValues.value);
+            .map((x) => stateVariables[x.componentIdx].stateValues.value);
         expect(sample1numbersc.length).eq(70);
         expect(sample2numbersc.length).eq(160);
 
@@ -867,42 +867,42 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests", async () => {
             expect(
                 stateVariables["/p1"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p2"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p3"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p4"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p5"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
 
             expect(
                 stateVariables["/p6"].activeChildren.map(
                     (child) =>
-                        stateVariables[child.componentName].stateValues.value,
+                        stateVariables[child.componentIdx].stateValues.value,
                 ),
             ).eqls(sampledNumbers);
         }
@@ -1100,7 +1100,7 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests", async () => {
             expect(s.replacements!.length).eq(6);
             for (let ind = 0; ind < 6; ind++) {
                 let num =
-                    stateVariables[s.replacements![ind].componentName]
+                    stateVariables[s.replacements![ind].componentIdx]
                         .stateValues.value;
                 results[ind] = num;
                 expect(num).gte(3);
@@ -1157,7 +1157,7 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests", async () => {
             expect(s.replacements!.length).eq(6);
             for (let ind = 0; ind < 6; ind++) {
                 let num =
-                    stateVariables[s.replacements![ind].componentName]
+                    stateVariables[s.replacements![ind].componentIdx]
                         .stateValues.value;
                 results[ind] = num;
                 expect(num).gte(3);
@@ -1214,19 +1214,19 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests", async () => {
         let n5 = stateVariables["/n5"].stateValues.value;
 
         let nums1 = stateVariables["/nums1"].replacements!.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let nums2 = stateVariables["/nums2"].replacements!.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let nums3 = stateVariables["/nums3"].replacements!.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let nums4 = stateVariables["/nums4"].replacements!.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
         let nums5 = stateVariables["/nums5"].replacements!.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         expect(nums1.length).eq(n1);
@@ -1410,7 +1410,7 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests", async () => {
             }
             let samples = sampleComponent.replacements
                 .slice(0, nReplacements)
-                .map((x) => stateVariables[x.componentName].stateValues.value);
+                .map((x) => stateVariables[x.componentIdx].stateValues.value);
             expect(samples.length).eq(numSamples);
 
             expect(stateVariables["/numSamples"].stateValues.value.tree).eq(
@@ -1788,7 +1788,7 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
 
         let samples = stateVariables["/p1"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         expect(samples.length).eq(100);
@@ -1806,7 +1806,7 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests", async () => {
         stateVariables = await core.returnAllStateVariables(false, true);
 
         let samples2 = stateVariables["/p1"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         expect(samples2).eqls(samples);
@@ -1819,7 +1819,7 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests", async () => {
         stateVariables = await core.returnAllStateVariables(false, true);
 
         samples2 = stateVariables["/p1"].activeChildren.map(
-            (x) => stateVariables[x.componentName].stateValues.value,
+            (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
         expect(samples2.length).eq(100);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sequence.test.ts
@@ -21,7 +21,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(10);
         for (let i = 0; i < 10; i++) {
@@ -38,7 +38,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(10);
         for (let i = 0; i < 10; i++) {
@@ -55,7 +55,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(3);
         for (let i = 0; i < 3; i++) {
@@ -72,7 +72,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(10);
         for (let i = 0; i < 10; i++) {
@@ -89,7 +89,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(5);
         for (let i = 0; i < 5; i++) {
@@ -106,7 +106,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(8);
         for (let i = 0; i < 8; i++) {
@@ -123,7 +123,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(8);
         for (let i = 0; i < 8; i++) {
@@ -140,7 +140,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(8);
         for (let i = 0; i < 8; i++) {
@@ -157,7 +157,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(8);
         for (let i = 0; i < 8; i++) {
@@ -174,7 +174,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(10);
         for (let i = 0; i < 10; i++) {
@@ -191,7 +191,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(3);
         for (let i = 0; i < 3; i++) {
@@ -208,7 +208,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(7);
         for (let i = 0; i < 7; i++) {
@@ -225,7 +225,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(5);
         for (let i = 0; i < 5; i++) {
@@ -244,7 +244,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(5);
         for (let i = 0; i < 5; i++) {
@@ -263,7 +263,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(4);
         for (let i = 0; i < 4; i++) {
@@ -280,7 +280,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(6);
         for (let i = 0; i < 6; i++) {
@@ -297,7 +297,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(4);
         for (let i = 0; i < 4; i++) {
@@ -316,7 +316,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(4);
         for (let i = 0; i < 4; i++) {
@@ -337,7 +337,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(4);
         for (let i = 0; i < 4; i++) {
@@ -356,7 +356,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(6);
         for (let i = 0; i < 6; i++) {
@@ -373,7 +373,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(5);
         for (let i = 0; i < 5; i++) {
@@ -390,7 +390,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(5);
         for (let i = 0; i < 5; i++) {
@@ -407,7 +407,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(5);
         expect(children[0].stateValues.value).eq("c");
@@ -426,7 +426,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(5);
         expect(children[0].stateValues.value).eq("Y");
@@ -445,7 +445,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(4);
         expect(children[0].stateValues.value).eq("az");
@@ -463,7 +463,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(6);
         expect(children[0].stateValues.value).eq("b");
@@ -483,7 +483,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(10);
         expect(children[0].stateValues.value).eq("a");
@@ -507,7 +507,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(4);
         expect(children[0].stateValues.value.tree).eqls(["*", 3, "x"]);
@@ -534,7 +534,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(8);
         let ind = 0;
@@ -555,7 +555,7 @@ describe("Sequence tag tests", async () => {
 
         stateVariables = await core.returnAllStateVariables(false, true);
         children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(7);
         ind = 0;
@@ -576,7 +576,7 @@ describe("Sequence tag tests", async () => {
 
         stateVariables = await core.returnAllStateVariables(false, true);
         children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(8);
         ind = 0;
@@ -597,7 +597,7 @@ describe("Sequence tag tests", async () => {
 
         stateVariables = await core.returnAllStateVariables(false, true);
         children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(8);
         ind = 0;
@@ -618,7 +618,7 @@ describe("Sequence tag tests", async () => {
 
         stateVariables = await core.returnAllStateVariables(false, true);
         children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(7);
         ind = 0;
@@ -639,7 +639,7 @@ describe("Sequence tag tests", async () => {
 
         stateVariables = await core.returnAllStateVariables(false, true);
         children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(8);
         ind = 0;
@@ -663,7 +663,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(5);
         for (let i = 0; i < 5; i++) {
@@ -683,7 +683,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(8);
         let ind = 0;
@@ -701,7 +701,7 @@ describe("Sequence tag tests", async () => {
         await updateTextInputValue({ text: "i", name: "/e", core });
         stateVariables = await core.returnAllStateVariables(false, true);
         children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(7);
         ind = 0;
@@ -720,7 +720,7 @@ describe("Sequence tag tests", async () => {
 
         stateVariables = await core.returnAllStateVariables(false, true);
         children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(8);
         ind = 0;
@@ -739,7 +739,7 @@ describe("Sequence tag tests", async () => {
 
         stateVariables = await core.returnAllStateVariables(false, true);
         children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(8);
         ind = 0;
@@ -758,7 +758,7 @@ describe("Sequence tag tests", async () => {
 
         stateVariables = await core.returnAllStateVariables(false, true);
         children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(7);
         ind = 0;
@@ -777,7 +777,7 @@ describe("Sequence tag tests", async () => {
 
         stateVariables = await core.returnAllStateVariables(false, true);
         children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(8);
         ind = 0;
@@ -802,7 +802,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(8);
         let ind = 0;
@@ -823,7 +823,7 @@ describe("Sequence tag tests", async () => {
 
         stateVariables = await core.returnAllStateVariables(false, true);
         children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(7);
         ind = 0;
@@ -844,7 +844,7 @@ describe("Sequence tag tests", async () => {
 
         stateVariables = await core.returnAllStateVariables(false, true);
         children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(8);
         ind = 0;
@@ -865,7 +865,7 @@ describe("Sequence tag tests", async () => {
 
         stateVariables = await core.returnAllStateVariables(false, true);
         children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(8);
         ind = 0;
@@ -886,7 +886,7 @@ describe("Sequence tag tests", async () => {
 
         stateVariables = await core.returnAllStateVariables(false, true);
         children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(7);
         ind = 0;
@@ -907,7 +907,7 @@ describe("Sequence tag tests", async () => {
 
         stateVariables = await core.returnAllStateVariables(false, true);
         children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(8);
         ind = 0;
@@ -935,7 +935,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(5);
         for (let i = 0; i < 5; i++) {
@@ -956,7 +956,7 @@ describe("Sequence tag tests", async () => {
         // But, don't round internally
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(11);
 
@@ -985,7 +985,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(9);
 
@@ -1006,7 +1006,7 @@ describe("Sequence tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables["/seq"].stateValues.validSequence).eq(false);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(0);
 
@@ -1014,10 +1014,10 @@ describe("Sequence tag tests", async () => {
 
         stateVariables = await core.returnAllStateVariables(false, true);
         children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(1);
-        expect(stateVariables[children[0].componentName].stateValues.value).eq(
+        expect(stateVariables[children[0].componentIdx].stateValues.value).eq(
             2,
         );
         expect(stateVariables["/seq"].stateValues.validSequence).eq(true);
@@ -1447,7 +1447,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(8);
         for (let i = 0; i < 8; i++) {
@@ -1468,7 +1468,7 @@ describe("Sequence tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let children = stateVariables["/p"].activeChildren.map(
-            (x) => stateVariables[x.componentName],
+            (x) => stateVariables[x.componentIdx],
         );
         expect(children.length).eq(nums.length);
         for (let [ind, child] of children.entries()) {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/shuffle.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/shuffle.test.ts
@@ -241,7 +241,7 @@ describe("Shuffle tag tests", async () => {
 
         if (replacements_all_of_type) {
             let replacementTypes = stateVariables["/pList"].activeChildren.map(
-                (child) => stateVariables[child.componentName].componentType,
+                (child) => stateVariables[child.componentIdx].componentType,
             );
 
             expect(replacementTypes).eqls(

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/slider.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/slider.test.ts
@@ -18,7 +18,7 @@ async function changeValue({
 }) {
     await core.requestAction({
         actionName: "changeValue",
-        componentName: name,
+        componentIdx: name,
         args: { value },
     });
 }

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/solution.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/solution.test.ts
@@ -15,7 +15,7 @@ async function revealSolution({
 }) {
     await core.requestAction({
         actionName: "revealSolution",
-        componentName: name,
+        componentIdx: name,
         args: {},
     });
 }
@@ -28,7 +28,7 @@ async function closeSolution({
 }) {
     await core.requestAction({
         actionName: "closeSolution",
-        componentName: name,
+        componentIdx: name,
         args: {},
     });
 }

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sort.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sort.test.ts
@@ -25,7 +25,7 @@ describe("Sort tag tests", async () => {
 
         if (replacements_all_of_type) {
             let replacementTypes = stateVariables[pName].activeChildren.map(
-                (child) => stateVariables[child.componentName].componentType,
+                (child) => stateVariables[child.componentIdx].componentType,
             );
 
             expect(replacementTypes).eqls(

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/spreadsheet.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/spreadsheet.test.ts
@@ -25,7 +25,7 @@ async function changeSpreadsheetText({
 }) {
     await core.requestAction({
         actionName: "onChange",
-        componentName: name,
+        componentIdx: name,
         args: { changes: [[row - 1, column - 1, prevText, text]] },
     });
 }
@@ -1497,12 +1497,12 @@ $s.cellA1{assignNames="c2"}
             );
             expect(
                 stateVariables["/row1"].activeChildren.map(
-                    (v) => v.componentName,
+                    (v) => v.componentIdx,
                 ),
             ).eqls(["/c11", "/c12", "/c13"]);
             expect(
                 stateVariables["/row2"].activeChildren.map(
-                    (v) => v.componentName,
+                    (v) => v.componentIdx,
                 ),
             ).eqls(["/c21", "/c22"]);
             expect(stateVariables["/c1"].stateValues.text).eq(B1);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/updatevalue.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/updatevalue.test.ts
@@ -729,7 +729,7 @@ describe("UpdateValue tag tests", async () => {
         // Note: we expect the macro to trigger the updateValue with triggerWith="uv"
         // because it doesn't have a name.
         let macroName =
-            stateVariables["/pmacro"].activeChildren[0].componentName;
+            stateVariables["/pmacro"].activeChildren[0].componentIdx;
 
         await updateValue({ name: macroName, core });
 
@@ -905,7 +905,7 @@ describe("UpdateValue tag tests", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let PcopyName =
-            stateVariables["/graph1"].activeChildren[0].componentName;
+            stateVariables["/graph1"].activeChildren[0].componentIdx;
 
         expect(cleanLatex(stateVariables["/x"].stateValues.latex)).eq("x");
         expect(stateVariables["/trip"].stateValues.hidden).eq(true);
@@ -1790,7 +1790,7 @@ describe("UpdateValue tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables["/grp2/p"].stateValues.text).eq("true");
         expect(
-            stateVariables["/sec"].activeChildren.filter((x) => x.componentName)
+            stateVariables["/sec"].activeChildren.filter((x) => x.componentIdx)
                 .length,
         ).eq(3);
 
@@ -1799,7 +1799,7 @@ describe("UpdateValue tag tests", async () => {
 
         expect(stateVariables["/grp2/p"].stateValues.text).eq("false");
         expect(
-            stateVariables["/sec"].activeChildren.filter((x) => x.componentName)
+            stateVariables["/sec"].activeChildren.filter((x) => x.componentIdx)
                 .length,
         ).eq(2);
     });

--- a/packages/doenetml-worker-javascript/src/test/utils/actions.ts
+++ b/packages/doenetml-worker-javascript/src/test/utils/actions.ts
@@ -8,7 +8,7 @@ export async function submitAnswer({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "submitAnswer",
         args: {},
     });
@@ -22,7 +22,7 @@ export async function callAction({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "callAction",
         args: {},
     });
@@ -36,7 +36,7 @@ export async function updateValue({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "updateValue",
         args: {},
     });
@@ -50,7 +50,7 @@ export async function triggerActions({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "triggerActions",
         args: {},
     });
@@ -66,12 +66,12 @@ export async function updateTextInputValue({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "updateImmediateValue",
         args: { text },
     });
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "updateValue",
         args: {},
     });
@@ -87,7 +87,7 @@ export async function updateTextInputImmediateValue({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "updateImmediateValue",
         args: { text },
     });
@@ -101,7 +101,7 @@ export async function updateTextInputValueToImmediateValue({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "updateValue",
         args: {},
     });
@@ -117,12 +117,12 @@ export async function updateMathInputValue({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "updateRawValue",
         args: { rawRendererValue: latex },
     });
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "updateValue",
         args: {},
     });
@@ -138,7 +138,7 @@ export async function updateMathInputImmediateValue({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "updateRawValue",
         args: { rawRendererValue: latex },
     });
@@ -152,7 +152,7 @@ export async function updateMathInputValueToImmediateValue({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "updateValue",
         args: {},
     });
@@ -168,7 +168,7 @@ export async function updateBooleanInputValue({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "updateBoolean",
         args: { boolean },
     });
@@ -198,11 +198,11 @@ export async function updateMatrixInputValue({
     let childInd = colInd + numColumns * rowInd;
 
     let matrixInputCellName =
-        matrixInput.activeChildren[childInd]?.componentName;
+        matrixInput.activeChildren[childInd]?.componentIdx;
 
     if (matrixInputCellName) {
         await core.requestAction({
-            componentName: matrixInputCellName,
+            componentIdx: matrixInputCellName,
             actionName: "updateRawValue",
             args: { rawRendererValue: latex },
         });
@@ -210,7 +210,7 @@ export async function updateMatrixInputValue({
         stateVariables = await core.returnAllStateVariables(false, true);
 
         await core.requestAction({
-            componentName: matrixInputCellName,
+            componentIdx: matrixInputCellName,
             actionName: "updateValue",
             args: {},
         });
@@ -243,11 +243,11 @@ export async function updateMatrixInputImmediateValue({
     let childInd = colInd + numColumns * rowInd;
 
     let matrixInputCellName =
-        matrixInput.activeChildren[childInd]?.componentName;
+        matrixInput.activeChildren[childInd]?.componentIdx;
 
     if (matrixInputCellName) {
         await core.requestAction({
-            componentName: matrixInputCellName,
+            componentIdx: matrixInputCellName,
             actionName: "updateRawValue",
             args: { rawRendererValue: latex },
         });
@@ -276,11 +276,11 @@ export async function updateMatrixInputValueToImmediateValue({
     let childInd = colInd + numColumns * rowInd;
 
     let matrixInputCellName =
-        matrixInput.activeChildren[childInd]?.componentName;
+        matrixInput.activeChildren[childInd]?.componentIdx;
 
     if (matrixInputCellName) {
         await core.requestAction({
-            componentName: matrixInputCellName,
+            componentIdx: matrixInputCellName,
             actionName: "updateValue",
             args: {},
         });
@@ -297,7 +297,7 @@ export async function updateMatrixInputNumRows({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "updateNumRows",
         args: { numRows },
     });
@@ -313,7 +313,7 @@ export async function updateMatrixInputNumColumns({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "updateNumColumns",
         args: { numColumns },
     });
@@ -327,7 +327,7 @@ export async function focusPoint({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "pointFocused",
         args: { name },
     });
@@ -341,7 +341,7 @@ export async function clickPoint({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "pointClicked",
         args: { name },
     });
@@ -361,7 +361,7 @@ export async function movePoint({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "movePoint",
         args: { x, y, z },
     });
@@ -379,7 +379,7 @@ export async function moveVector({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "moveVector",
         args: { headcoords, tailcoords },
     });
@@ -397,7 +397,7 @@ export async function moveRay({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "moveRay",
         args: { endpointcoords, throughcoords },
     });
@@ -415,7 +415,7 @@ export async function moveLine({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "moveLine",
         args: { point1coords, point2coords },
     });
@@ -433,7 +433,7 @@ export async function moveLineSegment({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "moveLineSegment",
         args: { point1coords, point2coords },
     });
@@ -449,7 +449,7 @@ export async function movePolyline({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "movePolyline",
         args: { pointCoords },
     });
@@ -465,7 +465,7 @@ export async function movePolygon({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "movePolygon",
         args: { pointCoords },
     });
@@ -483,7 +483,7 @@ export async function moveCircle({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "moveCircle",
         args: { center: [cx, cy] },
     });
@@ -501,7 +501,7 @@ export async function moveControlVector({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "moveControlVector",
         args: { controlVectorInds, controlVector },
     });
@@ -519,7 +519,7 @@ export async function moveThroughPoint({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "moveThroughPoint",
         args: { throughPointInd, throughPoint },
     });
@@ -537,7 +537,7 @@ export async function moveButton({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "moveButton",
         args: { x, y },
     });
@@ -555,7 +555,7 @@ export async function moveInput({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "moveInput",
         args: { x, y },
     });
@@ -573,7 +573,7 @@ export async function moveText({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "moveText",
         args: { x, y },
     });
@@ -591,7 +591,7 @@ export async function moveMath({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "moveMath",
         args: { x, y },
     });
@@ -609,7 +609,7 @@ export async function moveNumber({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "moveNumber",
         args: { x, y },
     });
@@ -627,7 +627,7 @@ export async function moveLabel({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "moveLabel",
         args: { x, y },
     });
@@ -643,7 +643,7 @@ export async function updateSelectedIndices({
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({
-        componentName: name,
+        componentIdx: name,
         actionName: "updateSelectedIndices",
         args: { selectedIndices },
     });

--- a/packages/doenetml-worker-javascript/src/test/utils/test-core.ts
+++ b/packages/doenetml-worker-javascript/src/test/utils/test-core.ts
@@ -45,7 +45,7 @@ export async function createTestCore({
     flags?: DoenetMLFlagsSubset;
     theme?: "dark" | "light";
     initializeCounters?: Record<string, number>;
-    requestSolutionView?: (componentName: string) => Promise<{
+    requestSolutionView?: (componentIdx: string) => Promise<{
         allowView: boolean;
     }>;
 }) {

--- a/packages/doenetml-worker-javascript/src/test/variants/specifySingleVariant.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/variants/specifySingleVariant.test.ts
@@ -353,8 +353,8 @@ describe("Specifying single variant tests", async () => {
             let xorig =
                 stateVariables[
                     stateVariables[
-                        stateVariables["/s1"].replacements![0].componentName
-                    ].replacements![0].componentName
+                        stateVariables["/s1"].replacements![0].componentIdx
+                    ].replacements![0].componentIdx
                 ].stateValues.value.tree;
             expect(xorig).eq(expectedX);
             let x2 = stateVariables["/x2"].stateValues.value.tree;
@@ -362,8 +362,8 @@ describe("Specifying single variant tests", async () => {
             let x3 =
                 stateVariables[
                     stateVariables[
-                        stateVariables["/x3"].replacements![0].componentName
-                    ].replacements![0].componentName
+                        stateVariables["/x3"].replacements![0].componentIdx
+                    ].replacements![0].componentIdx
                 ].stateValues.value.tree;
             expect(x3).eq(expectedX);
 
@@ -491,7 +491,7 @@ describe("Specifying single variant tests", async () => {
             expect(variantInd).not.eq(undefined);
 
             let secondValue =
-                stateVariables[p.activeChildren[1].componentName].stateValues
+                stateVariables[p.activeChildren[1].componentIdx].stateValues
                     .value;
 
             if (variantInd === 0) {
@@ -594,7 +594,7 @@ describe("Specifying single variant tests", async () => {
                     variantInds.push(variantInd);
 
                     let p =
-                        stateVariables[problem.activeChildren[4].componentName];
+                        stateVariables[problem.activeChildren[4].componentIdx];
 
                     if (variantInd === 1) {
                         expect(p.activeChildren[0].trim()).eq("Word:");
@@ -606,9 +606,8 @@ describe("Specifying single variant tests", async () => {
                                 "drab",
                                 "excoriated",
                             ].indexOf(
-                                stateVariables[
-                                    p.activeChildren[1].componentName
-                                ].stateValues.value,
+                                stateVariables[p.activeChildren[1].componentIdx]
+                                    .stateValues.value,
                             ) + 1;
                         expect(problemVariantInd).not.eq(0);
                         if (
@@ -624,7 +623,7 @@ describe("Specifying single variant tests", async () => {
                     } else {
                         expect(p.activeChildren[0].trim()).eq("Number:");
                         let num =
-                            stateVariables[p.activeChildren[1].componentName]
+                            stateVariables[p.activeChildren[1].componentIdx]
                                 .stateValues.value;
                         expect(Number.isInteger(num)).eq(true);
                         expect(num >= 1 && num <= 10).eq(true);
@@ -641,7 +640,7 @@ describe("Specifying single variant tests", async () => {
                     }
 
                     let secondValue =
-                        stateVariables[p.activeChildren[1].componentName]
+                        stateVariables[p.activeChildren[1].componentIdx]
                             .stateValues.value;
                     secondValues.push(secondValue);
                 }
@@ -1029,7 +1028,7 @@ describe("Specifying single variant tests", async () => {
 
             let textinputName =
                 stateVariables["/ans"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
 
             expect(stateVariables["/fruit"].stateValues.value).eq(fruit);
             expect(

--- a/packages/doenetml-worker-javascript/src/test/variants/uniqueVariants.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/variants/uniqueVariants.test.ts
@@ -892,8 +892,8 @@ describe("Unique variant tests", async () => {
             let component =
                 stateVariables[
                     stateVariables["/p"].activeChildren.filter(
-                        (x) => x.componentName,
-                    )[0].componentName
+                        (x) => x.componentIdx,
+                    )[0].componentIdx
                 ];
             let newValue = component.stateValues.value;
             if (category === categories[0]) {
@@ -957,8 +957,8 @@ describe("Unique variant tests", async () => {
             let component =
                 stateVariables[
                     stateVariables["/p"].activeChildren.filter(
-                        (x) => x.componentName,
-                    )[0].componentName
+                        (x) => x.componentIdx,
+                    )[0].componentIdx
                 ];
             let newValue = component.stateValues.value;
             if (newValue.tree !== undefined) {
@@ -1062,7 +1062,7 @@ describe("Unique variant tests", async () => {
 
             let textinputName =
                 stateVariables[`/problem/ans`].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let category = stateVariables["/problem"].stateValues.title;
             expect(categories.includes(category)).eq(true);
 
@@ -1070,9 +1070,9 @@ describe("Unique variant tests", async () => {
                 stateVariables[
                     stateVariables[
                         stateVariables["/problem"].activeChildren.filter(
-                            (x) => x.componentName,
-                        )[1].componentName
-                    ].activeChildren[1].componentName
+                            (x) => x.componentIdx,
+                        )[1].componentIdx
+                    ].activeChildren[1].componentIdx
                 ];
             let newValue = component.stateValues.value;
             if (category === categories[0]) {
@@ -1180,9 +1180,9 @@ describe("Unique variant tests", async () => {
                 stateVariables[
                     stateVariables[
                         stateVariables["/problem"].activeChildren.filter(
-                            (x) => x.componentName,
-                        )[1].componentName
-                    ].activeChildren[1].componentName
+                            (x) => x.componentIdx,
+                        )[1].componentIdx
+                    ].activeChildren[1].componentIdx
                 ];
             let newValue = component.stateValues.value;
             let combinedValue = [category, newValue].join(",");
@@ -1231,17 +1231,17 @@ describe("Unique variant tests", async () => {
             );
             expect(
                 stateVariables[
-                    stateVariables["/p1"].activeChildren[1].componentName
+                    stateVariables["/p1"].activeChildren[1].componentIdx
                 ].stateValues.value,
             ).eq("a");
             expect(
                 stateVariables[
-                    stateVariables["/p2"].activeChildren[1].componentName
+                    stateVariables["/p2"].activeChildren[1].componentIdx
                 ].stateValues.value,
             ).eq("b");
             expect(
                 stateVariables[
-                    stateVariables["/p3"].activeChildren[1].componentName
+                    stateVariables["/p3"].activeChildren[1].componentIdx
                 ].stateValues.value,
             ).eq("c");
             expect(
@@ -1285,7 +1285,7 @@ describe("Unique variant tests", async () => {
             if (insiderAnswer) {
                 ciName =
                     stateVariables["/ans"].stateValues.inputChildren[0]
-                        .componentName;
+                        .componentIdx;
             }
 
             let choiceOrder = stateVariables[ciName].stateValues.choiceOrder;
@@ -1336,7 +1336,7 @@ describe("Unique variant tests", async () => {
         if (insiderAnswer) {
             ciName =
                 stateVariables["/ans"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
         }
         let choiceOrder = stateVariables[ciName].stateValues.choiceOrder;
         let selectedOrder = choiceOrder.join(",");
@@ -1570,10 +1570,10 @@ describe("Unique variant tests", async () => {
 
             let mathInputName =
                 stateVariables["/ans1"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathInput2Name =
                 stateVariables["/ans2"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
 
             const m = stateVariables["/m"].stateValues.value;
             msFound.push(m);
@@ -1785,7 +1785,7 @@ describe("Unique variant tests", async () => {
 
             let mathInputName =
                 stateVariables["/ans"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
 
             const m = stateVariables["/m"].stateValues.value;
             sampledValues.push(m);

--- a/packages/doenetml-worker-javascript/src/utils/copy.js
+++ b/packages/doenetml-worker-javascript/src/utils/copy.js
@@ -9,7 +9,7 @@ import { processAssignNames } from "./naming";
 
 export function postProcessCopy({
     serializedComponents,
-    componentName,
+    componentIdx,
     addShadowDependencies = true,
     markAsPrimaryShadow = false,
     uniqueIdentifiersUsed = [],
@@ -84,7 +84,7 @@ export function postProcessCopy({
                         [component.originalName]: [
                             {
                                 dependencyType: "referenceShadow",
-                                compositeName: componentName,
+                                compositeIdx: componentIdx,
                             },
                         ],
                     };
@@ -158,7 +158,7 @@ export function postProcessCopy({
 
         postProcessCopy({
             serializedComponents: component.children,
-            componentName,
+            componentIdx,
             addShadowDependencies,
             markAsPrimaryShadow,
             uniqueIdentifiersUsed,
@@ -176,7 +176,7 @@ export function postProcessCopy({
             if (attribute.component) {
                 attribute.component = postProcessCopy({
                     serializedComponents: [attribute.component],
-                    componentName,
+                    componentIdx,
                     addShadowDependencies,
                     markAsPrimaryShadow,
                     uniqueIdentifiersUsed,
@@ -194,7 +194,7 @@ export function postProcessCopy({
         if (component.replacements) {
             postProcessCopy({
                 serializedComponents: component.replacements,
-                componentName,
+                componentIdx,
                 addShadowDependencies,
                 markAsPrimaryShadow,
                 uniqueIdentifiersUsed,
@@ -472,7 +472,7 @@ export async function verifyReplacementsMatchSpecifiedType({
         replacementTypes.length !== requiredLength ||
         !replacementTypes.every((x) => x === requiredComponentType)
     ) {
-        // console.warn(`Replacements from ${component.componentType} ${component.componentName} do not match the specified createComponentOfType and numComponents`);
+        // console.warn(`Replacements from ${component.componentType} ${component.componentIdx} do not match the specified createComponentOfType and numComponents`);
 
         // if only replacement is a group
         // then give the group the createComponentOfType and numComponentsSpecified
@@ -592,7 +592,7 @@ export async function verifyReplacementsMatchSpecifiedType({
 
                 let replacementSource = replacementSources[0];
 
-                let target = components[replacementSource.componentName];
+                let target = components[replacementSource.componentIdx];
 
                 let propVariable = publicCaseInsensitiveAliasSubstitutions({
                     stateVariables: [propName],
@@ -636,10 +636,10 @@ export async function verifyReplacementsMatchSpecifiedType({
 
                 if (stateVarObj) {
                     replacements[0].downstreamDependencies = {
-                        [replacementSource.componentName]: [
+                        [replacementSource.componentIdx]: [
                             {
                                 dependencyType: "referenceShadow",
-                                compositeName: component.componentName,
+                                compositeIdx: component.componentIdx,
                                 propVariable,
                                 additionalStateVariableShadowing:
                                     stateVarObj.shadowingInstructions
@@ -660,7 +660,7 @@ export async function verifyReplacementsMatchSpecifiedType({
         let processResult = processAssignNames({
             assignNames,
             serializedComponents: replacements,
-            parentName: component.componentName,
+            parentIdx: component.componentIdx,
             parentCreatesNewNamespace: newNamespace,
             componentInfoObjects,
         });
@@ -776,11 +776,11 @@ export function renameAutonameBasedOnNewCounts(
 
                 // check if name was created from counting components
 
-                if (serializedComponent.componentName) {
+                if (serializedComponent.componentIdx) {
                     let lastSlash =
-                        serializedComponent.componentName.lastIndexOf("/");
+                        serializedComponent.componentIdx.lastIndexOf("/");
                     let originalName =
-                        serializedComponent.componentName.substring(
+                        serializedComponent.componentIdx.substring(
                             lastSlash + 1,
                         );
                     let nameStartFromComponentType =
@@ -792,8 +792,8 @@ export function renameAutonameBasedOnNewCounts(
                         ) === nameStartFromComponentType
                     ) {
                         // recreate using new count
-                        serializedComponent.componentName =
-                            serializedComponent.componentName.substring(
+                        serializedComponent.componentIdx =
+                            serializedComponent.componentIdx.substring(
                                 0,
                                 lastSlash + 1,
                             ) +
@@ -926,14 +926,14 @@ export function restrictTNamesToNamespace({
             if (parentIsCopy && component.componentType === "externalContent") {
                 // if have a external content inside a copy,
                 // then restrict children to the namespace of the externalContent
-                adjustedNamespace = component.componentName + "/";
+                adjustedNamespace = component.componentIdx + "/";
             }
             let namespaceForChildren = parentNamespace;
             if (
                 component.attributes &&
                 component.attributes.newNamespace?.primitive
             ) {
-                namespaceForChildren = component.componentName;
+                namespaceForChildren = component.componentIdx;
             }
             restrictTNamesToNamespace({
                 components: component.children,

--- a/packages/doenetml-worker-javascript/src/utils/descendants.js
+++ b/packages/doenetml-worker-javascript/src/utils/descendants.js
@@ -44,8 +44,8 @@ export function gatherDescendants({
         }
     } else {
         // add children in the order of allChildren ordered
-        for (let childName of ancestor.allChildrenOrdered) {
-            let childObj = ancestor.allChildren[childName];
+        for (let childIdx of ancestor.allChildrenOrdered) {
+            let childObj = ancestor.allChildren[childIdx];
             let child;
             let childIsActive = false;
             let childIsAdapter = false;
@@ -62,14 +62,14 @@ export function gatherDescendants({
                 // look in activeChildren
                 // include the placedholders adapted into the activeChildren
                 for (let aChild of ancestor.activeChildren) {
-                    if (aChild.placeholderInd === childName) {
+                    if (aChild.placeholderInd === childIdx) {
                         child = aChild;
                         childIsActive = true;
                         if (
-                            typeof childName === "string" &&
-                            childName.substring(
-                                childName.length - 5,
-                                childName.length,
+                            typeof childIdx === "string" &&
+                            childIdx.substring(
+                                childIdx.length - 5,
+                                childIdx.length,
                             ) === "adapt"
                         ) {
                             childIsAdapter = true;
@@ -77,7 +77,7 @@ export function gatherDescendants({
                         break;
                     } else if (
                         aChild.adaptedFrom &&
-                        achild.adaptedFrom.placeholderInd === childName
+                        achild.adaptedFrom.placeholderInd === childIdx
                     ) {
                         child = aChild.adaptedFrom;
                         break;
@@ -131,9 +131,7 @@ export function gatherDescendants({
                     })
                         .filter((x) => typeof x === "object")
                         .map((x) =>
-                            x.componentName
-                                ? x.componentName
-                                : x.placeholderInd,
+                            x.componentIdx ? x.componentIdx : x.placeholderInd,
                         ),
                 ];
             }
@@ -143,7 +141,7 @@ export function gatherDescendants({
             childrenToCheck = childrenToCheck.filter(
                 (x) =>
                     !(
-                        namesToIgnore.includes(x.componentName) ||
+                        namesToIgnore.includes(x.componentIdx) ||
                         namesToIgnore.includes(x.placeholderInd)
                     ),
             );
@@ -156,8 +154,8 @@ export function gatherDescendants({
         let matchedChild = matchChildToTypes(child);
         if (matchedChild) {
             descendants.push({
-                componentName: child.componentName
-                    ? child.componentName
+                componentIdx: child.componentIdx
+                    ? child.componentIdx
                     : child.placeholderInd,
                 componentType: child.componentType,
             });
@@ -239,15 +237,15 @@ export function ancestorsIncludingComposites(comp, components) {
         return [];
     }
 
-    let comps = [comp.ancestors[0].componentName];
+    let comps = [comp.ancestors[0].componentIdx];
 
-    let parent = components[comp.ancestors[0].componentName];
+    let parent = components[comp.ancestors[0].componentIdx];
     if (parent) {
         comps.push(...ancestorsIncludingComposites(parent, components));
     }
 
     if (comp.replacementOf) {
-        comps.push(comp.replacementOf.componentName);
+        comps.push(comp.replacementOf.componentIdx);
         let replacementAs = ancestorsIncludingComposites(
             comp.replacementOf,
             components,

--- a/packages/doenetml-worker-javascript/src/utils/feedback.js
+++ b/packages/doenetml-worker-javascript/src/utils/feedback.js
@@ -42,10 +42,10 @@ export function returnFeedbackDefinitionStateVariables() {
 
             for (let setupChild of stateValues.setupChildren) {
                 dependencies[
-                    `feedbackDefinitionsOf${setupChild.componentName}`
+                    `feedbackDefinitionsOf${setupChild.componentIdx}`
                 ] = {
                     dependencyType: "child",
-                    parentName: setupChild.componentName,
+                    parentIdx: setupChild.componentIdx,
                     childGroups: ["feedbackDefinitions"],
                     variableNames: ["value"],
                 };
@@ -75,7 +75,7 @@ export function returnFeedbackDefinitionStateVariables() {
             for (let child of dependencyValues.setupChildren) {
                 feedbackDefinitionChildren.push(
                     ...dependencyValues[
-                        `feedbackDefinitionsOf${child.componentName}`
+                        `feedbackDefinitionsOf${child.componentIdx}`
                     ],
                 );
             }

--- a/packages/doenetml-worker-javascript/src/utils/graphical.js
+++ b/packages/doenetml-worker-javascript/src/utils/graphical.js
@@ -104,7 +104,7 @@ export async function moveGraphicalObjectWithAnchorAction({
     actionId,
     sourceInformation = {},
     skipRendererUpdate = false,
-    componentName,
+    componentIdx,
     componentType,
     coreFunctions,
 }) {
@@ -123,7 +123,7 @@ export async function moveGraphicalObjectWithAnchorAction({
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName,
+                    componentIdx,
                     stateVariable: "anchor",
                     value: me.fromAst(components),
                 },
@@ -138,7 +138,7 @@ export async function moveGraphicalObjectWithAnchorAction({
             updateInstructions: [
                 {
                     updateType: "updateValue",
-                    componentName,
+                    componentIdx,
                     stateVariable: "anchor",
                     value: me.fromAst(components),
                 },
@@ -149,7 +149,7 @@ export async function moveGraphicalObjectWithAnchorAction({
             event: {
                 verb: "interacted",
                 object: {
-                    componentName,
+                    componentIdx,
                     componentType,
                 },
                 result: {

--- a/packages/doenetml-worker-javascript/src/utils/label.js
+++ b/packages/doenetml-worker-javascript/src/utils/label.js
@@ -144,8 +144,8 @@ export function returnLabelStateVariableDefinitions() {
                 variableNames: ["componentNameAndShadowSourceNames"],
             },
         }),
-        definition({ dependencyValues, componentName }) {
-            let componentNameAndShadowSourceNames = [componentName];
+        definition({ dependencyValues, componentIdx }) {
+            let componentNameAndShadowSourceNames = [componentIdx];
             if (
                 dependencyValues.shadowSource?.stateValues
                     .componentNameAndShadowSourceNames
@@ -266,7 +266,7 @@ export function returnLabelStateVariableDefinitions() {
                     }
                 }
                 if (label[0] === "_") {
-                    // if label from componentName starts with two underscores,
+                    // if label from componentIdx starts with two underscores,
                     // it is an automatically generated component name that has random characters in it
                     // Don't display name, as they are for internal use only (and the user cannot refer to them)
                     // (Nov 2024) Also now that are phasing out automatically generated names with single _,

--- a/packages/doenetml-worker-javascript/src/utils/naming.js
+++ b/packages/doenetml-worker-javascript/src/utils/naming.js
@@ -80,7 +80,7 @@ export function createComponentNames({
     namespaceStack = [],
     componentInfoObjects,
     parentDoenetAttributes = {},
-    parentName,
+    parentIdx,
     useOriginalNames = false,
     attributesByTargetComponentName,
     indOffset = 0,
@@ -257,7 +257,7 @@ export function createComponentNames({
             // put it into doenetAttributes
             doenetAttributes.prescribedName = prescribedName;
         } else if (mustCreateUniqueName) {
-            let longNameId = parentName + "|createUniqueName|";
+            let longNameId = parentIdx + "|createUniqueName|";
 
             if (serializedComponent.downstreamDependencies) {
                 longNameId += JSON.stringify(
@@ -392,9 +392,9 @@ export function createComponentNames({
             currentNamespace.componentCounts[componentType] = ++count;
         }
 
-        let componentName = "";
+        let componentIdx = "";
         for (let l = 0; l <= level; l++) {
-            componentName += namespaceStack[l].namespace + "/";
+            componentIdx += namespaceStack[l].namespace + "/";
         }
         if (!prescribedName) {
             if (useOriginalNames) {
@@ -404,14 +404,14 @@ export function createComponentNames({
                     prescribedName = serializedComponent.originalName.substring(
                         lastInd + 1,
                     );
-                    // } else if (serializedComponent.componentName) {
-                    //   let lastInd = serializedComponent.componentName.lastIndexOf("/");
-                    //   prescribedName = serializedComponent.componentName.substring(lastInd + 1);
+                    // } else if (serializedComponent.componentIdx) {
+                    //   let lastInd = serializedComponent.componentIdx.lastIndexOf("/");
+                    //   prescribedName = serializedComponent.componentIdx.substring(lastInd + 1);
                 }
             }
             if (!prescribedName) {
                 if (excludeFromComponentCounts) {
-                    let longNameId = parentName + "|createUniqueName|";
+                    let longNameId = parentIdx + "|createUniqueName|";
                     if (serializedComponent.downstreamDependencies) {
                         longNameId += JSON.stringify(
                             serializedComponent.downstreamDependencies,
@@ -480,7 +480,7 @@ export function createComponentNames({
             doenetAttributes.convertedAssignNames = true;
 
             // create unique name for copy
-            let longNameId = parentName + "|createUniqueName|";
+            let longNameId = parentIdx + "|createUniqueName|";
             doenetAttributes.createUniqueName = true;
             delete doenetAttributes.prescribedName;
 
@@ -524,16 +524,16 @@ export function createComponentNames({
             doenetAttributes.sourceIsProp = true;
         }
 
-        componentName += prescribedName;
+        componentIdx += prescribedName;
 
-        serializedComponent.componentName = componentName;
+        serializedComponent.componentIdx = componentIdx;
         if (prescribedName) {
             if (prescribedName in currentNamespace.namesUsed) {
                 foundError = true;
                 createUniqueNameDueToError = true;
                 if (!errorMessage) {
-                    let lastSlash = componentName.lastIndexOf("/");
-                    let componentNameRelative = componentName.slice(
+                    let lastSlash = componentIdx.lastIndexOf("/");
+                    let componentNameRelative = componentIdx.slice(
                         lastSlash + 1,
                     );
                     errorMessage = `Duplicate component name: ${componentNameRelative}.`;
@@ -563,7 +563,7 @@ export function createComponentNames({
             }
 
             let longNameIdBase =
-                componentName + "|createUniqueName|assignNames|";
+                componentIdx + "|createUniqueName|assignNames|";
 
             let namespace = "";
             let oldNamespace;
@@ -577,7 +577,7 @@ export function createComponentNames({
                     lastInd + 1,
                 );
             } else {
-                namespace = componentName + "/";
+                namespace = componentIdx + "/";
                 oldNamespace = serializedComponent.originalName + "/";
             }
 
@@ -674,15 +674,15 @@ export function createComponentNames({
             if (count === undefined) {
                 count = 0;
             }
-            let componentName = "";
+            let componentIdx = "";
             for (let l = 0; l <= level; l++) {
-                componentName += namespaceStack[l].namespace + "/";
+                componentIdx += namespaceStack[l].namespace + "/";
             }
             currentNamespace.componentCounts[componentType] = ++count;
 
             let prescribedName = "_" + componentType.toLowerCase() + count;
-            componentName += prescribedName;
-            serializedComponent.componentName = componentName;
+            componentIdx += prescribedName;
+            serializedComponent.componentIdx = componentIdx;
         }
 
         if (serializedComponent.children) {
@@ -713,7 +713,7 @@ export function createComponentNames({
                         namespaceStack,
                         componentInfoObjects,
                         parentDoenetAttributes: doenetAttributes,
-                        parentName: componentName,
+                        parentIdx: componentIdx,
                         useOriginalNames,
                         attributesByTargetComponentName,
                         ignoreErrors: ignoreErrorsInChildren,
@@ -730,7 +730,7 @@ export function createComponentNames({
                     namespaceStack,
                     componentInfoObjects,
                     parentDoenetAttributes: doenetAttributes,
-                    parentName: componentName,
+                    parentIdx: componentIdx,
                     useOriginalNames,
                     attributesByTargetComponentName,
                     ignoreErrors: ignoreErrorsInChildren,
@@ -771,7 +771,7 @@ export function createComponentNames({
                         namespaceStack,
                         componentInfoObjects,
                         parentDoenetAttributes: doenetAttributes,
-                        parentName: componentName,
+                        parentIdx: componentIdx,
                         useOriginalNames,
                         attributesByTargetComponentName,
                         ignoreErrors: ignoreErrorsInChildren,
@@ -831,7 +831,7 @@ export function createComponentNames({
                             namespaceStack,
                             componentInfoObjects,
                             parentDoenetAttributes: doenetAttributes,
-                            parentName: componentName,
+                            parentIdx: componentIdx,
                             useOriginalNames,
                             attributesByTargetComponentName,
                             ignoreErrors: ignoreErrorsInChildren,
@@ -852,7 +852,7 @@ export function createComponentNames({
                         namespaceStack,
                         componentInfoObjects,
                         parentDoenetAttributes: doenetAttributes,
-                        parentName: componentName,
+                        parentIdx: componentIdx,
                         useOriginalNames,
                         attributesByTargetComponentName,
                         ignoreErrors: ignoreErrorsInChildren,
@@ -887,7 +887,7 @@ export function createComponentNames({
                         namespaceStack,
                         componentInfoObjects,
                         parentDoenetAttributes: doenetAttributes,
-                        parentName: componentName,
+                        parentIdx: componentIdx,
                         useOriginalNames,
                         attributesByTargetComponentName,
                         createNameContext: attrName,
@@ -896,7 +896,7 @@ export function createComponentNames({
                     errors.push(...res.errors);
                     warnings.push(...res.warnings);
                 } else if (attribute.childrenForComponent) {
-                    // TODO: what to do about parentName/parentDoenetAttributes
+                    // TODO: what to do about parentIdx/parentDoenetAttributes
                     // since parent of these isn't created
                     // Note: the main (only?) to recurse here is to rename targets
                     let res = createComponentNames({
@@ -904,7 +904,7 @@ export function createComponentNames({
                         namespaceStack,
                         componentInfoObjects,
                         parentDoenetAttributes: doenetAttributes,
-                        parentName: componentName,
+                        parentIdx: componentIdx,
                         useOriginalNames,
                         attributesByTargetComponentName,
                         createNameContext: attrName,
@@ -960,7 +960,7 @@ function createNewAssignNamesAndrenameMatchingTargetNames({
             assignNames.push(newName);
 
             let infoForRenaming = {
-                componentName: namespace + newName,
+                componentIdx: namespace + newName,
                 originalName: oldNamespace + originalName,
             };
 
@@ -1040,11 +1040,11 @@ function convertComponentTarget({
 // - indOffset: offset assignNames by this value (compared to index of serialized components)
 //   and also offset the index used for creating unique names
 // - assignNewNamespaces: if true, also give the components a new namespace
-// - parentName: the way the name of the parent (typically the composite) is used to create the names
+// - parentIdx: the way the name of the parent (typically the composite) is used to create the names
 //   depends on parentCreatesNewNamespace
 //   - if parentCreatesNewNamespace, then the entire parent name is used for the namespace of new names
 //   - else the namespace from the parent name (the part before the last slash) is used for the namespace/
-// - parentCreatesNewNamespace: see parentName, above
+// - parentCreatesNewNamespace: see parentIdx, above
 // - shadowingComposite: If false, there is apparently some case where we have to create unique names
 //   TODO: figure out the circumstances where this special case occurs
 
@@ -1053,7 +1053,7 @@ export function processAssignNames({
     assignNewNamespaces = false,
     assignNamesForCompositeReplacement,
     serializedComponents,
-    parentName,
+    parentIdx,
     parentNameForUniqueNames,
     parentCreatesNewNamespace,
     componentInfoObjects,
@@ -1067,7 +1067,7 @@ export function processAssignNames({
     // console.log(`originalNamesAreConsistent: ${originalNamesAreConsistent}`);
     // console.log(assignNames);
     // console.log({
-    //   parentName,
+    //   parentIdx,
     //   parentCreatesNewNamespace,
     //   compositesParentNameForAssignNames,
     // });
@@ -1190,7 +1190,7 @@ export function processAssignNames({
                     // since we don't have a name for the component itself,
                     // give it an unreachable name (i.e., a unique name)
                     let longNameId =
-                        parentName + "|assignName|" + indForNames.toString();
+                        parentIdx + "|assignName|" + indForNames.toString();
                     if (parentNameForUniqueNames) {
                         longNameId = parentNameForUniqueNames + longNameId;
                     }
@@ -1205,12 +1205,12 @@ export function processAssignNames({
                 // The full component name does include namespaces.
                 // Add the appropriate namespace to the prescribed name to create the full name
 
-                let namespaceForComponent = parentName;
+                let namespaceForComponent = parentIdx;
                 if (!parentCreatesNewNamespace) {
-                    let lastSlash = parentName.lastIndexOf("/");
-                    namespaceForComponent = parentName.substring(0, lastSlash);
+                    let lastSlash = parentIdx.lastIndexOf("/");
+                    namespaceForComponent = parentIdx.substring(0, lastSlash);
                 }
-                component.componentName =
+                component.componentIdx =
                     namespaceForComponent +
                     "/" +
                     component.doenetAttributes.prescribedName;
@@ -1260,7 +1260,7 @@ export function processAssignNames({
                 name = component.originalName.slice(lastSlash + 1);
             } else {
                 let longNameId =
-                    parentName + "|assignName|" + indForNames.toString();
+                    parentIdx + "|assignName|" + indForNames.toString();
                 if (parentNameForUniqueNames) {
                     longNameId = parentNameForUniqueNames + longNameId;
                 }
@@ -1280,7 +1280,7 @@ export function processAssignNames({
         // corresponding to the desired namespace, which is the namespace from the parent
         // (including the parent's name as a namespace if parentCreatesNewNamespace)
 
-        let namespacePieces = parentName.split("/");
+        let namespacePieces = parentIdx.split("/");
         if (!parentCreatesNewNamespace) {
             namespacePieces.pop();
         }
@@ -1289,8 +1289,8 @@ export function processAssignNames({
             componentCounts: {},
             namesUsed: {},
         }));
-        if (!(parentName[0] === "/")) {
-            // if parentName doesn't begin with a /
+        if (!(parentIdx[0] === "/")) {
+            // if parentIdx doesn't begin with a /
             // still add a namespace for the root namespace at the beginning
             namespaceStack.splice(0, 0, {
                 componentCounts: {},
@@ -1328,7 +1328,7 @@ export function processAssignNames({
             }
         }
 
-        // console.log(`before create componentName`);
+        // console.log(`before create componentIdx`);
         // console.log(deepClone(component));
         // console.log(useOriginalNames);
         // console.log(component.attributes.newNamespace);
@@ -1337,7 +1337,7 @@ export function processAssignNames({
             serializedComponents: [component],
             namespaceStack,
             componentInfoObjects,
-            parentName,
+            parentIdx,
             useOriginalNames,
             attributesByTargetComponentName,
             indOffset: indForNames,
@@ -1346,7 +1346,7 @@ export function processAssignNames({
         errors.push(...res.errors);
         warnings.push(...res.warnings);
 
-        // console.log(`result of create componentName`);
+        // console.log(`result of create componentIdx`);
         // console.log(deepClone(component));
 
         processedComponents.push(component);
@@ -1454,7 +1454,7 @@ function renameMatchingTargetNames(
     if (
         component.originalName &&
         attributesByTargetComponentName &&
-        component.componentName !== component.originalName
+        component.componentIdx !== component.originalName
     ) {
         // we have a component who has been named and there are other components
         // whose targetComponentName refers to this component
@@ -1465,12 +1465,12 @@ function renameMatchingTargetNames(
                 component.originalName
             ]) {
                 if (attrObj.relativeName) {
-                    attrObj.relativeName = component.componentName;
-                    attrObj.absoluteName = component.componentName;
+                    attrObj.relativeName = component.componentIdx;
+                    attrObj.absoluteName = component.componentIdx;
                 } else {
                     // must be doenetAttributes
-                    attrObj.target = component.componentName;
-                    attrObj.targetComponentName = component.componentName;
+                    attrObj.target = component.componentIdx;
+                    attrObj.targetComponentName = component.componentIdx;
                 }
             }
         }
@@ -1489,15 +1489,15 @@ function renameMatchingTargetNames(
                     ]) {
                         if (attrObj.relativeName) {
                             attrObj.relativeName =
-                                component.componentName + "/" + originalEnding;
+                                component.componentIdx + "/" + originalEnding;
                             attrObj.absoluteName =
-                                component.componentName + "/" + originalEnding;
+                                component.componentIdx + "/" + originalEnding;
                         } else {
                             // must be doenetAttributes
                             attrObj.target =
-                                component.componentName + "/" + originalEnding;
+                                component.componentIdx + "/" + originalEnding;
                             attrObj.targetComponentName =
-                                component.componentName + "/" + originalEnding;
+                                component.componentIdx + "/" + originalEnding;
                         }
                     }
                 }
@@ -1508,9 +1508,9 @@ function renameMatchingTargetNames(
 
 function moveComponentNamesToOriginalNames(components) {
     for (let component of components) {
-        if (component.componentName) {
-            component.originalName = component.componentName;
-            delete component.componentName;
+        if (component.componentIdx) {
+            component.originalName = component.componentIdx;
+            delete component.componentIdx;
         }
         if (component.children) {
             moveComponentNamesToOriginalNames(component.children);

--- a/packages/doenetml-worker/lib-js-wasm-binding/src/CoreWorker.ts
+++ b/packages/doenetml-worker/lib-js-wasm-binding/src/CoreWorker.ts
@@ -269,12 +269,12 @@ export class CoreWorker {
     }
 
     /**
-     * Dispatch the action `actionName` of `componentName` to the Javascript core,
+     * Dispatch the action `actionName` of `componentIdx` to the Javascript core,
      * which will execute that action and return the result.
      */
     async dispatchActionJavascript(actionArgs: {
         actionName: string;
-        componentName: string | undefined;
+        componentIdx: string | undefined;
         args: Record<string, any>;
     }) {
         const isProcessingPromise = this.isProcessingPromise;

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -159,7 +159,7 @@ export function EditorViewer({
                 const data = event.data.data;
                 if (data.verb === "submitted") {
                     const object = JSON.parse(data.object);
-                    const answerId = object.componentName;
+                    const answerId = object.componentIdx;
 
                     if (answerId) {
                         const result = JSON.parse(

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -101,7 +101,7 @@ export function DocViewer({
         ({ snapshot, set }) =>
             async ({
                 coreId,
-                componentName,
+                componentIdx,
                 stateValues,
                 childrenInstructions,
                 sourceOfUpdate,
@@ -109,7 +109,7 @@ export function DocViewer({
                 actionId,
             }: {
                 coreId: string;
-                componentName: string;
+                componentIdx: string;
                 stateValues: Record<string, any>;
                 childrenInstructions?: Record<string, any>[];
                 sourceOfUpdate?: Record<string, any>;
@@ -118,7 +118,7 @@ export function DocViewer({
             }) => {
                 let ignoreUpdate = false;
 
-                let rendererName = coreId + componentName;
+                let rendererName = coreId + componentIdx;
 
                 if (baseStateVariable) {
                     let updatesToIgnore = snapshot.getLoadable(
@@ -138,7 +138,7 @@ export function DocViewer({
                                     (v, i) => valueFromCore[i] === v,
                                 ))
                         ) {
-                            // console.log(`ignoring update of ${componentName} to ${valueFromCore}`)
+                            // console.log(`ignoring update of ${componentIdx} to ${valueFromCore}`)
                             ignoreUpdate = true;
                             set(
                                 rendererUpdatesToIgnore(rendererName),
@@ -184,8 +184,8 @@ export function DocViewer({
     );
     const updateRendererUpdatesToIgnore = useRecoilCallback(
         ({ snapshot, set }) =>
-            async ({ coreId, componentName, baseVariableValue, actionId }) => {
-                let rendererName = coreId + componentName;
+            async ({ coreId, componentIdx, baseVariableValue, actionId }) => {
+                let rendererName = coreId + componentIdx;
 
                 // add to updates to ignore so don't apply change again
                 // if it comes back from core without any changes
@@ -240,7 +240,7 @@ export function DocViewer({
     const actionsBeforeCoreCreated = useRef<
         {
             actionName: string;
-            componentName: string | undefined;
+            componentIdx: string | undefined;
             args: Record<string, any>;
         }[]
     >([]);
@@ -254,10 +254,10 @@ export function DocViewer({
         {},
     );
     const actionTentativelySkipped = useRef<{
-        action: { actionName: string; componentName?: string };
+        action: { actionName: string; componentIdx?: string };
         args: Record<string, any>;
         baseVariableValue?: any;
-        componentName?: string;
+        componentIdx?: string;
         rendererType?: string;
         promiseResolve?: (value: any) => void;
     } | null>(null);
@@ -380,15 +380,15 @@ export function DocViewer({
             (window as any)["callAction" + postfixForWindowFunctions] =
                 async function ({
                     actionName,
-                    componentName,
+                    componentIdx,
                     args,
                 }: {
                     actionName: string;
-                    componentName: string;
+                    componentIdx: string;
                     args: Record<string, any>;
                 }) {
                     return await callAction({
-                        action: { actionName, componentName },
+                        action: { actionName, componentIdx },
                         args,
                     });
                 };
@@ -479,14 +479,14 @@ export function DocViewer({
         action,
         args,
         baseVariableValue,
-        componentName,
+        componentIdx,
         rendererType,
         promiseResolve,
     }: {
-        action: { actionName: string; componentName?: string };
+        action: { actionName: string; componentIdx?: string };
         args: Record<string, any>;
         baseVariableValue?: any;
-        componentName?: string;
+        componentIdx?: string;
         rendererType?: string;
         promiseResolve?: (value: any) => void;
     }) {
@@ -556,7 +556,7 @@ export function DocViewer({
                     action,
                     args,
                     baseVariableValue,
-                    componentName,
+                    componentIdx,
                     rendererType,
                     promiseResolve,
                 };
@@ -580,12 +580,12 @@ export function DocViewer({
         args = { ...args };
         args.actionId = actionId;
 
-        if (baseVariableValue !== undefined && componentName) {
+        if (baseVariableValue !== undefined && componentIdx) {
             // Update the bookkeeping variables for the optimistic UI that will tell the renderer
             // whether or not to ignore the information core sends when it finishes the action
             updateRendererUpdatesToIgnore({
                 coreId: coreId.current,
-                componentName,
+                componentIdx,
                 baseVariableValue,
                 actionId,
             });
@@ -593,7 +593,7 @@ export function DocViewer({
 
         let actionArgs = {
             actionName: action.actionName,
-            componentName: action.componentName,
+            componentIdx: action.componentIdx,
             args,
         };
 
@@ -616,7 +616,7 @@ export function DocViewer({
 
     async function executeAction(actionArgs: {
         actionName: string;
-        componentName: string | undefined;
+        componentIdx: string | undefined;
         args: Record<string, any>;
     }) {
         if (!coreCreated.current) {
@@ -646,8 +646,8 @@ export function DocViewer({
         forceShowSolution: boolean;
         forceUnsuppressCheckwork: boolean;
     }) {
-        for (let componentName in rendererState) {
-            let stateValues = rendererState[componentName].stateValues;
+        for (let componentIdx in rendererState) {
+            let stateValues = rendererState[componentIdx].stateValues;
             if (forceDisable && stateValues.disabled === false) {
                 stateValues.disabled = true;
             }
@@ -662,13 +662,13 @@ export function DocViewer({
             }
             if (
                 forceShowSolution &&
-                rendererState[componentName].childrenInstructions?.length > 0
+                rendererState[componentIdx].childrenInstructions?.length > 0
             ) {
                 // look for a child that has a componentType solution
-                for (let childInst of rendererState[componentName]
+                for (let childInst of rendererState[componentIdx]
                     .childrenInstructions) {
                     if (childInst.componentType === "solution") {
-                        let solComponentName = childInst.componentName;
+                        let solComponentName = childInst.componentIdx;
                         if (
                             rendererState[solComponentName].stateValues.hidden
                         ) {
@@ -698,13 +698,13 @@ export function DocViewer({
                     forceUnsuppressCheckwork,
                 });
             }
-            for (let componentName in args.rendererState) {
+            for (let componentIdx in args.rendererState) {
                 updateRendererSVsWithRecoil({
                     coreId: coreId.current,
-                    componentName,
-                    stateValues: args.rendererState[componentName].stateValues,
+                    componentIdx,
+                    stateValues: args.rendererState[componentIdx].stateValues,
                     childrenInstructions:
-                        args.rendererState[componentName].childrenInstructions,
+                        args.rendererState[componentIdx].childrenInstructions,
                 });
             }
         }
@@ -779,7 +779,7 @@ export function DocViewer({
                     React.createElement(documentRendererClass, {
                         key:
                             coreId.current +
-                            documentComponentInstructions.componentName,
+                            documentComponentInstructions.componentIdx,
                         componentInstructions: documentComponentInstructions,
                         rendererClasses: newRendererClasses,
                         flags,
@@ -839,14 +839,14 @@ export function DocViewer({
         for (let instruction of updateInstructions) {
             if (instruction.instructionType === "updateRendererStates") {
                 for (let {
-                    componentName,
+                    componentIdx,
                     stateValues,
                     rendererType,
                     childrenInstructions,
                 } of instruction.rendererStatesToUpdate) {
                     updateRendererSVsWithRecoil({
                         coreId: coreId.current,
-                        componentName,
+                        componentIdx,
                         stateValues,
                         childrenInstructions,
                         sourceOfUpdate: instruction.sourceOfUpdate,
@@ -939,7 +939,7 @@ export function DocViewer({
                     callAction({
                         action: {
                             actionName: "updateValue",
-                            componentName:
+                            componentIdx:
                                 rendererState.__componentNeedingUpdateValue,
                         },
                         args: { doNotIgnore: true },
@@ -1069,7 +1069,7 @@ export function DocViewer({
             callAction({
                 action: {
                     actionName: "updateValue",
-                    componentName: rendererState.__componentNeedingUpdateValue,
+                    componentIdx: rendererState.__componentNeedingUpdateValue,
                 },
                 args: { doNotIgnore: true },
             });
@@ -1192,7 +1192,7 @@ export function DocViewer({
         delay,
         animationId,
     }: {
-        action: { actionName: string; componentName?: string };
+        action: { actionName: string; componentIdx?: string };
         actionArgs: Record<string, any>;
         delay?: number;
         animationId: string;
@@ -1225,7 +1225,7 @@ export function DocViewer({
         actionArgs,
         animationId,
     }: {
-        action: { actionName: string; componentName?: string };
+        action: { actionName: string; componentIdx?: string };
         actionArgs: Record<string, any>;
         animationId: string;
     }) {
@@ -1264,7 +1264,7 @@ export function DocViewer({
     }
 
     /**
-     * Request permission to view the solution of `componentName`
+     * Request permission to view the solution of `componentIdx`
      * using SPLICE messaging.
      *
      * Sends a "SPLICE.requestSolutionView". The returned promise will
@@ -1274,7 +1274,7 @@ export function DocViewer({
      * Return a promise that will resolve to an object with key:
      * allowView: whether or not the solution can be viewed
      */
-    function requestSolutionView(componentName: string) {
+    function requestSolutionView(componentIdx: string) {
         let messageId = nanoid();
         let requestSolutionPromiseResolve: (value: {
                 allowView: boolean;
@@ -1292,7 +1292,7 @@ export function DocViewer({
                     docId,
                     attemptNumber,
                     userId,
-                    componentName,
+                    componentIdx,
                 });
             },
         );

--- a/packages/doenetml/src/Viewer/renderers/answer.tsx
+++ b/packages/doenetml/src/Viewer/renderers/answer.tsx
@@ -61,7 +61,7 @@ export default React.memo(function Answer(props) {
 
     let inputChildrenToRender = null;
     if (SVs.inputChildren.length > 0) {
-        let inputChildNames = SVs.inputChildren.map((x) => x.componentName);
+        let inputChildNames = SVs.inputChildren.map((x) => x.componentIdx);
         inputChildrenToRender = children.filter(
             //child might be null or a string
             (child) =>
@@ -69,7 +69,7 @@ export default React.memo(function Answer(props) {
                 typeof child !== "string" &&
                 inputChildNames.includes(
                     // @ts-ignore
-                    child.props.componentInstructions.componentName,
+                    child.props.componentInstructions.componentIdx,
                 ),
         );
     }

--- a/packages/doenetml/src/Viewer/renderers/figure.jsx
+++ b/packages/doenetml/src/Viewer/renderers/figure.jsx
@@ -27,7 +27,7 @@ export default React.memo(function Figure(props) {
         for (let [ind, child] of children.entries()) {
             //child might be null or a string
             if (
-                child?.props?.componentInstructions.componentName ===
+                child?.props?.componentInstructions.componentIdx ===
                 SVs.captionChildName
             ) {
                 captionChildInd = ind;

--- a/packages/doenetml/src/Viewer/renderers/hint.jsx
+++ b/packages/doenetml/src/Viewer/renderers/hint.jsx
@@ -38,7 +38,7 @@ export default React.memo(function Hint(props) {
         for (let [ind, child] of children.entries()) {
             //child might be null or a string
             if (
-                child?.props?.componentInstructions.componentName ===
+                child?.props?.componentInstructions.componentIdx ===
                 SVs.titleChildName
             ) {
                 title = children[ind];

--- a/packages/doenetml/src/Viewer/renderers/mathInput.jsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.jsx
@@ -220,7 +220,7 @@ export default function MathInput(props) {
 
     updateValidationState();
 
-    // const inputKey = this.componentName + '_input';
+    // const inputKey = this.componentIdx + '_input';
 
     let checkWorkStyle = {
         cursor: "pointer",

--- a/packages/doenetml/src/Viewer/renderers/section.jsx
+++ b/packages/doenetml/src/Viewer/renderers/section.jsx
@@ -77,7 +77,7 @@ export default React.memo(function Section(props) {
         for (let [ind, child] of children.entries()) {
             //child might be null or a string
             if (
-                child?.props?.componentInstructions.componentName ===
+                child?.props?.componentInstructions.componentIdx ===
                 SVs.titleChildName
             ) {
                 title = children[ind];

--- a/packages/doenetml/src/Viewer/renderers/table.jsx
+++ b/packages/doenetml/src/Viewer/renderers/table.jsx
@@ -28,7 +28,7 @@ export default React.memo(function Table(props) {
         for (let [ind, child] of children.entries()) {
             //child might be null or a string
             if (
-                child?.props?.componentInstructions.componentName ===
+                child?.props?.componentInstructions.componentIdx ===
                 SVs.titleChildName
             ) {
                 titleChildInd = ind;

--- a/packages/doenetml/src/Viewer/renderers/utils/composites.jsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/composites.jsx
@@ -147,7 +147,7 @@ function addCommasForCompositeRangesSub({
             if (childrenInRange.length > 0) {
                 // Whether or not we added commas, we still add a span and a anchor with the id of the composite
                 // so that links to the composite name will scroll to the right location.
-                let compositeId = cesc(range.compositeName);
+                let compositeId = cesc(range.compositeIdx);
                 childrenInRange = (
                     <React.Fragment key={compositeId}>
                         <a name={compositeId} />

--- a/packages/doenetml/src/Viewer/useDoenetRenderer.tsx
+++ b/packages/doenetml/src/Viewer/useDoenetRenderer.tsx
@@ -31,9 +31,9 @@ export default function useDoenetRenderer(
     initializeChildrenOnConstruction = true,
 ) {
     let actions = props.componentInstructions.actions;
-    let componentName = props.componentInstructions.componentName;
+    let componentIdx = props.componentInstructions.componentIdx;
     let effectiveName = props.componentInstructions.effectiveName;
-    let rendererName = props.coreId + componentName;
+    let rendererName = props.coreId + componentIdx;
     let [renderersToLoad, setRenderersToLoad] = useState({});
 
     let {
@@ -77,7 +77,7 @@ export default function useDoenetRenderer(
         }
 
         let propsForChild = {
-            key: props.coreId + childInstructions.componentName,
+            key: props.coreId + childInstructions.componentIdx,
             componentInstructions: childInstructions,
             rendererClasses: props.rendererClasses,
             coreId: props.coreId,
@@ -113,9 +113,9 @@ export default function useDoenetRenderer(
 
     let rendererType = props.componentInstructions.rendererType;
     const callAction = (argObj: Record<string, any>) => {
-        if (!argObj.componentName) {
+        if (!argObj.componentIdx) {
             argObj = { ...argObj };
-            argObj.componentName = componentName;
+            argObj.componentIdx = componentIdx;
         }
         if (!argObj.rendererType) {
             argObj = { ...argObj };

--- a/packages/test-cypress/cypress/e2e/answerValidation/pointlocation.cy.js
+++ b/packages/test-cypress/cypress/e2e/answerValidation/pointlocation.cy.js
@@ -44,12 +44,12 @@ describe("Point location validation tests", function () {
         cy.window().then(async (win) => {
             await win.callAction1({
                 actionName: "movePoint",
-                componentName: "/_point1",
+                componentIdx: "/_point1",
                 args: { x: 5.9, y: 3.5 },
             });
             await win.callAction1({
                 actionName: "movePoint",
-                componentName: "/_point1",
+                componentIdx: "/_point1",
                 args: { x: 5.9, y: 3.4 },
             });
         });
@@ -127,7 +127,7 @@ describe("Point location validation tests", function () {
         cy.window().then(async (win) => {
             await win.callAction1({
                 actionName: "movePoint",
-                componentName: "/_point1",
+                componentIdx: "/_point1",
                 args: { x: -8.8, y: 1.3 },
             });
             let stateVariables = await win.returnAllStateVariables1();
@@ -208,12 +208,12 @@ describe("Point location validation tests", function () {
         cy.window().then(async (win) => {
             await win.callAction1({
                 actionName: "movePoint",
-                componentName: "/_point1",
+                componentIdx: "/_point1",
                 args: { x: -9.4, y: -5.1 },
             });
             await win.callAction1({
                 actionName: "movePoint",
-                componentName: "/_point1",
+                componentIdx: "/_point1",
                 args: { x: -9.5, y: -5.1 },
             });
             let stateVariables = await win.returnAllStateVariables1();

--- a/packages/test-cypress/cypress/e2e/dynamicalsystem/cobwebpolyline.cy.js
+++ b/packages/test-cypress/cypress/e2e/dynamicalsystem/cobwebpolyline.cy.js
@@ -43,7 +43,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePolyline",
-                componentName: "/gradedApplet/cobwebApplet/cobwebPolyline",
+                componentIdx: "/gradedApplet/cobwebApplet/cobwebPolyline",
                 args: {
                     pointCoords: { 0: [1, 0] },
                 },
@@ -93,7 +93,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePolyline",
-                componentName: "/gradedApplet/cobwebApplet/cobwebPolyline",
+                componentIdx: "/gradedApplet/cobwebApplet/cobwebPolyline",
                 args: {
                     pointCoords: { 1: [1, x1] },
                 },
@@ -163,7 +163,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePolyline",
-                componentName: "/gradedApplet/cobwebApplet/cobwebPolyline",
+                componentIdx: "/gradedApplet/cobwebApplet/cobwebPolyline",
                 args: {
                     pointCoords: { 2: [x1, x1] },
                 },
@@ -194,7 +194,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePolyline",
-                componentName: "/gradedApplet/cobwebApplet/cobwebPolyline",
+                componentIdx: "/gradedApplet/cobwebApplet/cobwebPolyline",
                 args: {
                     pointCoords: { 3: [x1, x2] },
                 },
@@ -219,7 +219,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePolyline",
-                componentName: "/gradedApplet/cobwebApplet/cobwebPolyline",
+                componentIdx: "/gradedApplet/cobwebApplet/cobwebPolyline",
                 args: {
                     pointCoords: { 4: [x2, x2] },
                 },
@@ -245,7 +245,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePolyline",
-                componentName: "/gradedApplet/cobwebApplet/cobwebPolyline",
+                componentIdx: "/gradedApplet/cobwebApplet/cobwebPolyline",
                 args: {
                     pointCoords: { 5: [x2, x3] },
                 },
@@ -277,7 +277,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePolyline",
-                componentName: "/gradedApplet/cobwebApplet/cobwebPolyline",
+                componentIdx: "/gradedApplet/cobwebApplet/cobwebPolyline",
                 args: {
                     pointCoords: { 6: [x3, x3] },
                 },
@@ -309,7 +309,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePolyline",
-                componentName: "/gradedApplet/cobwebApplet/cobwebPolyline",
+                componentIdx: "/gradedApplet/cobwebApplet/cobwebPolyline",
                 args: {
                     pointCoords: { 7: [x3, x4] },
                 },
@@ -359,7 +359,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/cobwebTutorial/P1",
+                componentIdx: "/cobwebTutorial/P1",
                 args: { x: 0.9, y: -0.1 },
             });
         });
@@ -377,7 +377,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "moveLine",
-                componentName: "/cobwebTutorial/v1",
+                componentIdx: "/cobwebTutorial/v1",
                 args: {
                     point1coords: [1.2, 1],
                     point2coords: [1.2, 2],
@@ -398,7 +398,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "moveLine",
-                componentName: "/cobwebTutorial/h1",
+                componentIdx: "/cobwebTutorial/h1",
                 args: {
                     point1coords: [2, 1.5],
                     point2coords: [3, 1.5],
@@ -414,7 +414,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/cobwebTutorial/P2",
+                componentIdx: "/cobwebTutorial/P2",
                 args: { x: -0.1, y: 1.7 },
             });
         });
@@ -432,7 +432,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/cobwebTutorial/P3",
+                componentIdx: "/cobwebTutorial/P3",
                 args: { x: 1.8, y: 0 },
             });
         });
@@ -450,7 +450,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "moveLine",
-                componentName: "/cobwebTutorial/v2",
+                componentIdx: "/cobwebTutorial/v2",
                 args: {
                     point1coords: [1.5, 3],
                     point2coords: [1.5, 4],
@@ -471,7 +471,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "moveLine",
-                componentName: "/cobwebTutorial/h2",
+                componentIdx: "/cobwebTutorial/h2",
                 args: {
                     point1coords: [4, 2.3],
                     point2coords: [5, 2.3],
@@ -489,7 +489,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/cobwebTutorial/P4",
+                componentIdx: "/cobwebTutorial/P4",
                 args: { x: 0.1, y: 2.5 },
             });
         });
@@ -519,7 +519,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/cobwebTutorial/P1",
+                componentIdx: "/cobwebTutorial/P1",
                 args: { x: 0.9, y: -0.1 },
             });
         });
@@ -537,7 +537,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "moveLine",
-                componentName: "/cobwebTutorial/v1",
+                componentIdx: "/cobwebTutorial/v1",
                 args: {
                     point1coords: [1.2, 1],
                     point2coords: [1.2, 2],
@@ -558,7 +558,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "moveLine",
-                componentName: "/cobwebTutorial/h1",
+                componentIdx: "/cobwebTutorial/h1",
                 args: {
                     point1coords: [2, 1.5],
                     point2coords: [3, 1.5],
@@ -576,7 +576,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/cobwebTutorial/P2",
+                componentIdx: "/cobwebTutorial/P2",
                 args: { x: -0.1, y: 1.7 },
             });
         });
@@ -594,7 +594,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/cobwebTutorial/P3",
+                componentIdx: "/cobwebTutorial/P3",
                 args: { x: 1.8, y: 0 },
             });
         });
@@ -612,7 +612,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "moveLine",
-                componentName: "/cobwebTutorial/v2",
+                componentIdx: "/cobwebTutorial/v2",
                 args: {
                     point1coords: [1.5, 3],
                     point2coords: [1.5, 4],
@@ -633,7 +633,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "moveLine",
-                componentName: "/cobwebTutorial/h2",
+                componentIdx: "/cobwebTutorial/h2",
                 args: {
                     point1coords: [4, 2.3],
                     point2coords: [5, 2.3],
@@ -651,7 +651,7 @@ describe("CobwebPolyline Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/cobwebTutorial/P4",
+                componentIdx: "/cobwebTutorial/P4",
                 args: { x: 0.1, y: 2.5 },
             });
         });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/animatefromsequence.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/animatefromsequence.cy.js
@@ -617,7 +617,7 @@ describe("AnimateFromSequence Tag Tests", function () {
         cy.window().then(async (win) => {
             await win.callAction1({
                 actionName: "changeValue",
-                componentName: "/a",
+                componentIdx: "/a",
                 args: { value: 33.4 },
             });
         });
@@ -669,7 +669,7 @@ describe("AnimateFromSequence Tag Tests", function () {
         cy.window().then(async (win) => {
             await win.callAction1({
                 actionName: "changeValue",
-                componentName: "/a2",
+                componentIdx: "/a2",
                 args: { value: 64.5 },
             });
         });
@@ -759,7 +759,7 @@ describe("AnimateFromSequence Tag Tests", function () {
         cy.window().then(async (win) => {
             await win.callAction1({
                 actionName: "changeValue",
-                componentName: "/a",
+                componentIdx: "/a",
                 args: { value: 33.4 },
             });
         });
@@ -775,7 +775,7 @@ describe("AnimateFromSequence Tag Tests", function () {
         cy.window().then(async (win) => {
             await win.callAction1({
                 actionName: "changeValue",
-                componentName: "/a2",
+                componentIdx: "/a2",
                 args: { value: 4.5 },
             });
         });
@@ -795,7 +795,7 @@ describe("AnimateFromSequence Tag Tests", function () {
         cy.window().then(async (win) => {
             await win.callAction1({
                 actionName: "changeValue",
-                componentName: "/a",
+                componentIdx: "/a",
                 args: { value: 33.4 },
             });
         });
@@ -811,7 +811,7 @@ describe("AnimateFromSequence Tag Tests", function () {
         cy.window().then(async (win) => {
             await win.callAction1({
                 actionName: "changeValue",
-                componentName: "/a2",
+                componentIdx: "/a2",
                 args: { value: 4.5 },
             });
         });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/answer.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/answer.cy.js
@@ -28,7 +28,7 @@ describe("Answer Tag Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
             let mathinputName =
                 stateVariables["/_answer1"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinputAnchor = cesc2("#" + mathinputName) + " textarea";
             let mathinputSubmitAnchor = cesc2("#" + mathinputName + "_submit");
             let mathinputCorrectAnchor = cesc2(
@@ -315,7 +315,7 @@ describe("Answer Tag Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
             let textinputName =
                 stateVariables["/_answer1"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let textinputAnchor = cesc2("#" + textinputName + "_input");
             let textinputSubmitAnchor = cesc2("#" + textinputName + "_submit");
             let textinputCorrectAnchor = cesc2(
@@ -1339,7 +1339,7 @@ describe("Answer Tag Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
             let choiceinputName = cesc2(
                 stateVariables["/_answer1"].stateValues.inputChildren[0]
-                    .componentName,
+                    .componentIdx,
             );
             let choiceinputAnchor = "#" + choiceinputName;
             let choiceinputSubmitAnchor = "#" + choiceinputName + "_submit";
@@ -1635,7 +1635,7 @@ describe("Answer Tag Tests", function () {
             let inputNames = [...Array(20).keys()].map(
                 (n) =>
                     stateVariables[`/_answer${n + 1}`].stateValues
-                        .inputChildren[0].componentName,
+                        .inputChildren[0].componentIdx,
             );
 
             cy.log("Submit correct answers");
@@ -2020,7 +2020,7 @@ describe("Answer Tag Tests", function () {
             let inputNames = [...Array(20).keys()].map(
                 (n) =>
                     stateVariables[`/_answer${n + 1}`].stateValues
-                        .inputChildren[0].componentName,
+                        .inputChildren[0].componentIdx,
             );
 
             cy.log("Submit incorrect answers");
@@ -2393,7 +2393,7 @@ describe("Answer Tag Tests", function () {
         cy.window().then(async (win) => {
             await win.callAction1({
                 actionName: "movePoint",
-                componentName: "/A",
+                componentIdx: "/A",
                 args: { x: 3, y: 4 },
             });
         });
@@ -2412,7 +2412,7 @@ describe("Answer Tag Tests", function () {
         cy.window().then(async (win) => {
             await win.callAction1({
                 actionName: "movePoint",
-                componentName: "/A",
+                componentIdx: "/A",
                 args: { x: -5, y: 6 },
             });
         });
@@ -2435,7 +2435,7 @@ describe("Answer Tag Tests", function () {
         cy.window().then(async (win) => {
             await win.callAction1({
                 actionName: "movePoint",
-                componentName: "/A",
+                componentIdx: "/A",
                 args: { x: 1, y: -1 },
             });
         });
@@ -2476,22 +2476,22 @@ describe("Answer Tag Tests", function () {
 
             let mathinput1Name =
                 stateVariables["/ans1"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinput1Anchor = cesc2("#" + mathinput1Name) + " textarea";
 
             let mathinput2Name =
                 stateVariables["/ans2"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinput2Anchor = cesc2("#" + mathinput2Name) + " textarea";
 
             let mathinput3Name =
                 stateVariables["/ans3"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinput3Anchor = cesc2("#" + mathinput3Name) + " textarea";
 
             let mathinput4Name =
                 stateVariables["/ans4"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinput4Anchor = cesc2("#" + mathinput4Name) + " textarea";
 
             cy.get(cesc("#\\/ans1_submit"))
@@ -2810,12 +2810,12 @@ describe("Answer Tag Tests", function () {
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
             let mathinputName =
-                stateVariables["/x"].stateValues.inputChildren[0].componentName;
+                stateVariables["/x"].stateValues.inputChildren[0].componentIdx;
             let mathinputSubmitAnchor = cesc2("#" + mathinputName + "_submit");
 
             let choiceinputName =
                 stateVariables["/correct"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let choiceinputSubmitAnchor = cesc2(
                 "#" + choiceinputName + "_submit",
             );
@@ -2835,12 +2835,12 @@ describe("Answer Tag Tests", function () {
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
             let mathinputName =
-                stateVariables["/x"].stateValues.inputChildren[0].componentName;
+                stateVariables["/x"].stateValues.inputChildren[0].componentIdx;
             let mathinputSubmitAnchor = cesc2("#" + mathinputName + "_submit");
 
             let choiceinputName =
                 stateVariables["/correct"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let choiceinputSubmitAnchor = cesc2(
                 "#" + choiceinputName + "_submit",
             );
@@ -2959,7 +2959,7 @@ describe("Answer Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/P",
+                componentIdx: "/P",
                 args: { x: 3, y: 1 },
             });
         });
@@ -2977,7 +2977,7 @@ describe("Answer Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/P",
+                componentIdx: "/P",
                 args: { x: 4, y: 2 },
             });
         });
@@ -2995,7 +2995,7 @@ describe("Answer Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/P",
+                componentIdx: "/P",
                 args: { x: 5, y: 3 },
             });
         });
@@ -3013,7 +3013,7 @@ describe("Answer Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/P",
+                componentIdx: "/P",
                 args: { x: 6, y: 4 },
             });
         });
@@ -3031,7 +3031,7 @@ describe("Answer Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/P",
+                componentIdx: "/P",
                 args: { x: 7, y: 5 },
             });
         });
@@ -3049,7 +3049,7 @@ describe("Answer Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/P",
+                componentIdx: "/P",
                 args: { x: 8, y: 6 },
             });
         });
@@ -3067,7 +3067,7 @@ describe("Answer Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/P",
+                componentIdx: "/P",
                 args: { x: 9, y: 7 },
             });
         });
@@ -3085,7 +3085,7 @@ describe("Answer Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/P",
+                componentIdx: "/P",
                 args: { x: 3, y: -5 },
             });
         });
@@ -3114,7 +3114,7 @@ describe("Answer Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/P",
+                componentIdx: "/P",
                 args: { x: 9, y: 8 },
             });
         });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/circle.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/circle.cy.js
@@ -54,7 +54,7 @@ describe("Circle Tag Tests", function () {
         cy.window().then(async (win) => {
             await win.callAction1({
                 actionName: "moveCircle",
-                componentName: "/circ",
+                componentIdx: "/circ",
                 args: { center: [-7, 2] },
             });
 

--- a/packages/test-cypress/cypress/e2e/tagSpecific/codeeditor.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/codeeditor.cy.js
@@ -317,7 +317,7 @@ describe("Code Editor Tag Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
 
             let viewerName =
-                stateVariables["/editor"].activeChildren[0].componentName;
+                stateVariables["/editor"].activeChildren[0].componentIdx;
             let contentAnchor = "#" + cesc2(viewerName) + "_content";
 
             cy.get(cesc("#\\/_p1")).should("have.text", "");
@@ -415,7 +415,7 @@ describe("Code Editor Tag Tests", function () {
                 );
                 expect(stateVariables[viewerName].activeChildren.length).eq(1);
                 expect(
-                    stateVariables[viewerName].activeChildren[0].componentName,
+                    stateVariables[viewerName].activeChildren[0].componentIdx,
                 ).eq("/result/_p1");
                 expect(stateVariables["/result/_p1"].stateValues.text).eq(
                     "Hello!",
@@ -452,7 +452,7 @@ describe("Code Editor Tag Tests", function () {
                 );
                 expect(stateVariables[viewerName].activeChildren.length).eq(1);
                 expect(
-                    stateVariables[viewerName].activeChildren[0].componentName,
+                    stateVariables[viewerName].activeChildren[0].componentIdx,
                 ).eq("/result/_p1");
                 expect(stateVariables["/result/_p1"].stateValues.text).eq(
                     "Hello!",
@@ -487,7 +487,7 @@ describe("Code Editor Tag Tests", function () {
                 );
                 expect(stateVariables[viewerName].activeChildren.length).eq(1);
                 expect(
-                    stateVariables[viewerName].activeChildren[0].componentName,
+                    stateVariables[viewerName].activeChildren[0].componentIdx,
                 ).eq("/result/_p1");
                 expect(stateVariables["/result/_p1"].stateValues.text).eq(
                     "Hello!",
@@ -535,14 +535,14 @@ describe("Code Editor Tag Tests", function () {
                 );
                 expect(stateVariables[viewerName].activeChildren.length).eq(3);
                 expect(
-                    stateVariables[viewerName].activeChildren[0].componentName,
+                    stateVariables[viewerName].activeChildren[0].componentIdx,
                 ).eq("/result/_p1");
                 expect(stateVariables["/result/_p1"].stateValues.text).eq(
                     "Hello!",
                 );
                 expect(stateVariables[viewerName].activeChildren[1]).eq("\n");
                 expect(
-                    stateVariables[viewerName].activeChildren[2].componentName,
+                    stateVariables[viewerName].activeChildren[2].componentIdx,
                 ).eq("/result/_p2");
                 expect(stateVariables["/result/_p2"].stateValues.text).eq("2");
                 expect(stateVariables["/result/_p2"].activeChildren.length).eq(
@@ -550,7 +550,7 @@ describe("Code Editor Tag Tests", function () {
                 );
                 expect(
                     stateVariables["/result/_p2"].activeChildren[0]
-                        .componentName,
+                        .componentIdx,
                 ).eq("/result/_math1");
                 expect(stateVariables["/result/_math1"].stateValues.value).eq(
                     2,
@@ -583,7 +583,7 @@ describe("Code Editor Tag Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
 
             let viewerName =
-                stateVariables["/editor"].activeChildren[0].componentName;
+                stateVariables["/editor"].activeChildren[0].componentIdx;
 
             cy.get(cesc("#\\/px")).should(
                 "have.text",
@@ -714,14 +714,14 @@ describe("Code Editor Tag Tests", function () {
 
                 expect(stateVariables["/static"].replacements.length).eq(3);
                 expect(
-                    stateVariables["/static"].replacements[0].componentName,
+                    stateVariables["/static"].replacements[0].componentIdx,
                 ).eq("/static/_p1");
                 expect(stateVariables["/static/_p1"].stateValues.text).eq(
                     "Enter value y",
                 );
                 expect(stateVariables["/static"].replacements[1]).eq("\n");
                 expect(
-                    stateVariables["/static"].replacements[2].componentName,
+                    stateVariables["/static"].replacements[2].componentIdx,
                 ).eq("/static/_p2");
                 expect(stateVariables["/static/_p2"].stateValues.text).eq(
                     "The value is y",
@@ -780,14 +780,14 @@ describe("Code Editor Tag Tests", function () {
                 expect(stateVariables[viewerName].activeChildren.length).eq(3);
                 expect(stateVariables["/result"].replacements.length).eq(3);
                 expect(
-                    stateVariables[viewerName].activeChildren[0].componentName,
+                    stateVariables[viewerName].activeChildren[0].componentIdx,
                 ).eq("/result/_p1");
                 expect(stateVariables["/result/_p1"].stateValues.text).eq(
                     "Enter value y",
                 );
                 expect(stateVariables[viewerName].activeChildren[1]).eq("\n");
                 expect(
-                    stateVariables[viewerName].activeChildren[2].componentName,
+                    stateVariables[viewerName].activeChildren[2].componentIdx,
                 ).eq("/result/_p2");
                 expect(stateVariables["/result/_p2"].stateValues.text).eq(
                     "The value is y",
@@ -797,14 +797,14 @@ describe("Code Editor Tag Tests", function () {
 
                 expect(stateVariables["/static"].replacements.length).eq(3);
                 expect(
-                    stateVariables["/static"].replacements[0].componentName,
+                    stateVariables["/static"].replacements[0].componentIdx,
                 ).eq("/static/_p1");
                 expect(stateVariables["/static/_p1"].stateValues.text).eq(
                     "Enter value y",
                 );
                 expect(stateVariables["/static"].replacements[1]).eq("\n");
                 expect(
-                    stateVariables["/static"].replacements[2].componentName,
+                    stateVariables["/static"].replacements[2].componentIdx,
                 ).eq("/static/_p2");
                 expect(stateVariables["/static/_p2"].stateValues.text).eq(
                     "The value is y",
@@ -866,14 +866,14 @@ describe("Code Editor Tag Tests", function () {
                 expect(stateVariables[viewerName].activeChildren.length).eq(3);
                 expect(stateVariables["/result"].replacements.length).eq(3);
                 expect(
-                    stateVariables[viewerName].activeChildren[0].componentName,
+                    stateVariables[viewerName].activeChildren[0].componentIdx,
                 ).eq("/result/_p1");
                 expect(stateVariables["/result/_p1"].stateValues.text).eq(
                     "Enter value x",
                 );
                 expect(stateVariables[viewerName].activeChildren[1]).eq("\n");
                 expect(
-                    stateVariables[viewerName].activeChildren[2].componentName,
+                    stateVariables[viewerName].activeChildren[2].componentIdx,
                 ).eq("/result/_p2");
                 expect(stateVariables["/result/_p2"].stateValues.text).eq(
                     "The value is x",
@@ -883,14 +883,14 @@ describe("Code Editor Tag Tests", function () {
 
                 expect(stateVariables["/static"].replacements.length).eq(3);
                 expect(
-                    stateVariables["/static"].replacements[0].componentName,
+                    stateVariables["/static"].replacements[0].componentIdx,
                 ).eq("/static/_p1");
                 expect(stateVariables["/static/_p1"].stateValues.text).eq(
                     "Enter value y",
                 );
                 expect(stateVariables["/static"].replacements[1]).eq("\n");
                 expect(
-                    stateVariables["/static"].replacements[2].componentName,
+                    stateVariables["/static"].replacements[2].componentIdx,
                 ).eq("/static/_p2");
                 expect(stateVariables["/static/_p2"].stateValues.text).eq(
                     "The value is y",
@@ -956,14 +956,14 @@ describe("Code Editor Tag Tests", function () {
                 expect(stateVariables[viewerName].activeChildren.length).eq(3);
                 expect(stateVariables["/result"].replacements.length).eq(3);
                 expect(
-                    stateVariables[viewerName].activeChildren[0].componentName,
+                    stateVariables[viewerName].activeChildren[0].componentIdx,
                 ).eq("/result/_p1");
                 expect(stateVariables["/result/_p1"].stateValues.text).eq(
                     "Enter value x",
                 );
                 expect(stateVariables[viewerName].activeChildren[1]).eq("\n");
                 expect(
-                    stateVariables[viewerName].activeChildren[2].componentName,
+                    stateVariables[viewerName].activeChildren[2].componentIdx,
                 ).eq("/result/_p2");
                 expect(stateVariables["/result/_p2"].stateValues.text).eq(
                     "The value is x",
@@ -973,21 +973,21 @@ describe("Code Editor Tag Tests", function () {
 
                 expect(stateVariables["/static"].replacements.length).eq(5);
                 expect(
-                    stateVariables["/static"].replacements[0].componentName,
+                    stateVariables["/static"].replacements[0].componentIdx,
                 ).eq("/static/_p1");
                 expect(stateVariables["/static/_p1"].stateValues.text).eq(
                     "Enter value y",
                 );
                 expect(stateVariables["/static"].replacements[1]).eq("\n");
                 expect(
-                    stateVariables["/static"].replacements[2].componentName,
+                    stateVariables["/static"].replacements[2].componentIdx,
                 ).eq("/static/_p2");
                 expect(stateVariables["/static/_p2"].stateValues.text).eq(
                     "The value is y",
                 );
                 expect(stateVariables["/static"].replacements[3]).eq("\n");
                 expect(
-                    stateVariables["/static"].replacements[4].componentName,
+                    stateVariables["/static"].replacements[4].componentIdx,
                 ).eq("/static/_graph1");
 
                 expect(stateVariables["/static/mi"].stateValues.value).eq("y");
@@ -1054,21 +1054,21 @@ describe("Code Editor Tag Tests", function () {
                 expect(stateVariables[viewerName].activeChildren.length).eq(5);
                 expect(stateVariables["/result"].replacements.length).eq(5);
                 expect(
-                    stateVariables[viewerName].activeChildren[0].componentName,
+                    stateVariables[viewerName].activeChildren[0].componentIdx,
                 ).eq("/result/_p1");
                 expect(stateVariables["/result/_p1"].stateValues.text).eq(
                     "Enter value y",
                 );
                 expect(stateVariables[viewerName].activeChildren[1]).eq("\n");
                 expect(
-                    stateVariables[viewerName].activeChildren[2].componentName,
+                    stateVariables[viewerName].activeChildren[2].componentIdx,
                 ).eq("/result/_p2");
                 expect(stateVariables["/result/_p2"].stateValues.text).eq(
                     "The value is y",
                 );
                 expect(stateVariables[viewerName].activeChildren[3]).eq("\n");
                 expect(
-                    stateVariables[viewerName].activeChildren[4].componentName,
+                    stateVariables[viewerName].activeChildren[4].componentIdx,
                 ).eq("/result/_graph1");
                 expect(stateVariables["/result/mi"].stateValues.value).eq("y");
                 expect(stateVariables["/result/x"].stateValues.value).eq("y");
@@ -1076,21 +1076,21 @@ describe("Code Editor Tag Tests", function () {
 
                 expect(stateVariables["/static"].replacements.length).eq(5);
                 expect(
-                    stateVariables["/static"].replacements[0].componentName,
+                    stateVariables["/static"].replacements[0].componentIdx,
                 ).eq("/static/_p1");
                 expect(stateVariables["/static/_p1"].stateValues.text).eq(
                     "Enter value y",
                 );
                 expect(stateVariables["/static"].replacements[1]).eq("\n");
                 expect(
-                    stateVariables["/static"].replacements[2].componentName,
+                    stateVariables["/static"].replacements[2].componentIdx,
                 ).eq("/static/_p2");
                 expect(stateVariables["/static/_p2"].stateValues.text).eq(
                     "The value is y",
                 );
                 expect(stateVariables["/static"].replacements[3]).eq("\n");
                 expect(
-                    stateVariables["/static"].replacements[4].componentName,
+                    stateVariables["/static"].replacements[4].componentIdx,
                 ).eq("/static/_graph1");
 
                 expect(stateVariables["/static/mi"].stateValues.value).eq("y");
@@ -1103,7 +1103,7 @@ describe("Code Editor Tag Tests", function () {
             cy.window().then(async (win) => {
                 await win.callAction1({
                     actionName: "movePoint",
-                    componentName: "/result/P",
+                    componentIdx: "/result/P",
                     args: { x: 5, y: 7 },
                 });
             });
@@ -1164,21 +1164,21 @@ describe("Code Editor Tag Tests", function () {
                 expect(stateVariables[viewerName].activeChildren.length).eq(5);
                 expect(stateVariables["/result"].replacements.length).eq(5);
                 expect(
-                    stateVariables[viewerName].activeChildren[0].componentName,
+                    stateVariables[viewerName].activeChildren[0].componentIdx,
                 ).eq("/result/_p1");
                 expect(stateVariables["/result/_p1"].stateValues.text).eq(
                     "Enter value y",
                 );
                 expect(stateVariables[viewerName].activeChildren[1]).eq("\n");
                 expect(
-                    stateVariables[viewerName].activeChildren[2].componentName,
+                    stateVariables[viewerName].activeChildren[2].componentIdx,
                 ).eq("/result/_p2");
                 expect(stateVariables["/result/_p2"].stateValues.text).eq(
                     "The value is y",
                 );
                 expect(stateVariables[viewerName].activeChildren[3]).eq("\n");
                 expect(
-                    stateVariables[viewerName].activeChildren[4].componentName,
+                    stateVariables[viewerName].activeChildren[4].componentIdx,
                 ).eq("/result/_graph1");
                 expect(stateVariables["/result/mi"].stateValues.value).eq("y");
                 expect(stateVariables["/result/x"].stateValues.value).eq("y");
@@ -1186,21 +1186,21 @@ describe("Code Editor Tag Tests", function () {
 
                 expect(stateVariables["/static"].replacements.length).eq(5);
                 expect(
-                    stateVariables["/static"].replacements[0].componentName,
+                    stateVariables["/static"].replacements[0].componentIdx,
                 ).eq("/static/_p1");
                 expect(stateVariables["/static/_p1"].stateValues.text).eq(
                     "Enter value y",
                 );
                 expect(stateVariables["/static"].replacements[1]).eq("\n");
                 expect(
-                    stateVariables["/static"].replacements[2].componentName,
+                    stateVariables["/static"].replacements[2].componentIdx,
                 ).eq("/static/_p2");
                 expect(stateVariables["/static/_p2"].stateValues.text).eq(
                     "The value is y",
                 );
                 expect(stateVariables["/static"].replacements[3]).eq("\n");
                 expect(
-                    stateVariables["/static"].replacements[4].componentName,
+                    stateVariables["/static"].replacements[4].componentIdx,
                 ).eq("/static/_graph1");
 
                 expect(stateVariables["/static/mi"].stateValues.value).eq("y");

--- a/packages/test-cypress/cypress/e2e/tagSpecific/copy.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/copy.cy.js
@@ -108,7 +108,7 @@ describe("Copy Tag Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
             let mathinputName =
                 stateVariables["/problem2/_answer1"].stateValues
-                    .inputChildren[0].componentName;
+                    .inputChildren[0].componentIdx;
             let mathinputAnchor = cesc2("#" + mathinputName) + " textarea";
             let mathinputSubmitAnchor = cesc2("#" + mathinputName + "_submit");
             let mathinputCorrectAnchor = cesc2(
@@ -219,7 +219,7 @@ describe("Copy Tag Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
             let mathinputName =
                 stateVariables["/problem2/_answer1"].stateValues
-                    .inputChildren[0].componentName;
+                    .inputChildren[0].componentIdx;
             let mathinputAnchor = cesc2("#" + mathinputName) + " textarea";
             let mathinputSubmitAnchor = cesc2("#" + mathinputName + "_submit");
             let mathinputCorrectAnchor = cesc2(
@@ -354,12 +354,12 @@ describe("Copy Tag Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
             let mathinputName =
                 stateVariables["/problem2/_answer1"].stateValues
-                    .inputChildren[0].componentName;
+                    .inputChildren[0].componentIdx;
             let mathinputAnchor = cesc2("#" + mathinputName) + " textarea";
 
             let mathinput2Name =
                 stateVariables["/_answer1"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinput2Anchor = cesc2("#" + mathinput2Name) + " textarea";
 
             expect(stateVariables["/problem2"].stateValues.title).eq(
@@ -503,12 +503,12 @@ describe("Copy Tag Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
             let mathinputName =
                 stateVariables["/problem2/_answer1"].stateValues
-                    .inputChildren[0].componentName;
+                    .inputChildren[0].componentIdx;
             let mathinputAnchor = cesc2("#" + mathinputName) + " textarea";
 
             let mathinput2Name =
                 stateVariables["/problem2/_answer2"].stateValues
-                    .inputChildren[0].componentName;
+                    .inputChildren[0].componentIdx;
             let mathinput2Anchor = cesc2("#" + mathinput2Name) + " textarea";
 
             expect(stateVariables["/problem2"].stateValues.title).eq(
@@ -649,7 +649,7 @@ describe("Copy Tag Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
             let mathinputName =
                 stateVariables["/problem2/_answer1"].stateValues
-                    .inputChildren[0].componentName;
+                    .inputChildren[0].componentIdx;
             let mathinputAnchor = cesc2("#" + mathinputName) + " textarea";
 
             expect(stateVariables["/_answer1"]).eq(undefined);
@@ -755,7 +755,7 @@ describe("Copy Tag Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
             let mathinputName =
                 stateVariables["/problem12/problem2/_answer1"].stateValues
-                    .inputChildren[0].componentName;
+                    .inputChildren[0].componentIdx;
             let mathinputAnchor = cesc2("#" + mathinputName) + " textarea";
             let mathinputSubmitAnchor = cesc2("#" + mathinputName + "_submit");
             let mathinputCorrectAnchor = cesc2(
@@ -843,7 +843,7 @@ describe("Copy Tag Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
             let mathinputName =
                 stateVariables["/problem34/problem2/_answer1"].stateValues
-                    .inputChildren[0].componentName;
+                    .inputChildren[0].componentIdx;
             let mathinputAnchor = cesc2("#" + mathinputName) + " textarea";
             let mathinputSubmitAnchor = cesc2("#" + mathinputName + "_submit");
             let mathinputCorrectAnchor = cesc2(
@@ -955,7 +955,7 @@ describe("Copy Tag Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
             let mathinputName =
                 stateVariables["/problem12/problem2/_answer1"].stateValues
-                    .inputChildren[0].componentName;
+                    .inputChildren[0].componentIdx;
             let mathinputAnchor = cesc2("#" + mathinputName) + " textarea";
             let mathinputSubmitAnchor = cesc2("#" + mathinputName + "_submit");
             let mathinputCorrectAnchor = cesc2(
@@ -1043,7 +1043,7 @@ describe("Copy Tag Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
             let mathinputName =
                 stateVariables["/problem34/problem2/_answer1"].stateValues
-                    .inputChildren[0].componentName;
+                    .inputChildren[0].componentIdx;
             let mathinputAnchor = cesc2("#" + mathinputName) + " textarea";
             let mathinputSubmitAnchor = cesc2("#" + mathinputName + "_submit");
             let mathinputCorrectAnchor = cesc2(
@@ -1278,13 +1278,13 @@ describe("Copy Tag Tests", function () {
                 cesc2(
                     "#" +
                         stateVariables["/g/p/_answer1"].stateValues
-                            .inputChildren[0].componentName,
+                            .inputChildren[0].componentIdx,
                 ) + " textarea";
             let mathinput2Anchor =
                 cesc2(
                     "#" +
                         stateVariables["/g2/p/_answer1"].stateValues
-                            .inputChildren[0].componentName,
+                            .inputChildren[0].componentIdx,
                 ) + " textarea";
 
             cy.get(cesc2("#/g/ca")).should("have.text", "0");
@@ -1329,13 +1329,13 @@ describe("Copy Tag Tests", function () {
                 cesc2(
                     "#" +
                         stateVariables["/g/p/_answer1"].stateValues
-                            .inputChildren[0].componentName,
+                            .inputChildren[0].componentIdx,
                 ) + " textarea";
             let mathinput2Anchor =
                 cesc2(
                     "#" +
                         stateVariables["/g2/p/_answer1"].stateValues
-                            .inputChildren[0].componentName,
+                            .inputChildren[0].componentIdx,
                 ) + " textarea";
 
             cy.get(cesc2("#/g/ca")).should("have.text", "0");
@@ -1380,13 +1380,13 @@ describe("Copy Tag Tests", function () {
                 cesc2(
                     "#" +
                         stateVariables["/g/p/_answer1"].stateValues
-                            .inputChildren[0].componentName,
+                            .inputChildren[0].componentIdx,
                 ) + " textarea";
             let mathinput2Anchor =
                 cesc2(
                     "#" +
                         stateVariables["/g2/p/_answer1"].stateValues
-                            .inputChildren[0].componentName,
+                            .inputChildren[0].componentIdx,
                 ) + " textarea";
 
             cy.get(cesc2("#/g/ca")).should("have.text", "0");

--- a/packages/test-cypress/cypress/e2e/tagSpecific/curve.bezier.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/curve.bezier.cy.js
@@ -91,7 +91,7 @@ describe("Curve Tag Bezier Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
             await win.callAction1({
                 actionName: "moveControlVector",
-                componentName: "/_curve1",
+                componentIdx: "/_curve1",
                 args: {
                     controlVectorInd: 3,
                     controlVector: [7, -6],
@@ -99,7 +99,7 @@ describe("Curve Tag Bezier Tests", function () {
             });
             await win.callAction1({
                 actionName: "moveControlVector",
-                componentName: "/_curve1",
+                componentIdx: "/_curve1",
                 args: {
                     controlVectorInd: 2,
                     controlVector: [-6, -5],
@@ -223,7 +223,7 @@ describe("Curve Tag Bezier Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
             await win.callAction1({
                 actionName: "moveControlVector",
-                componentName: "/_curve1",
+                componentIdx: "/_curve1",
                 args: {
                     controlVectorInd: 3,
                     controlVector: [7, 0.2],
@@ -231,7 +231,7 @@ describe("Curve Tag Bezier Tests", function () {
             });
             await win.callAction1({
                 actionName: "moveControlVector",
-                componentName: "/_curve1",
+                componentIdx: "/_curve1",
                 args: {
                     controlVectorInd: 2,
                     controlVector: [0.1, -6],
@@ -346,7 +346,7 @@ describe("Curve Tag Bezier Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
             await win.callAction1({
                 actionName: "moveControlVector",
-                componentName: "/_curve1",
+                componentIdx: "/_curve1",
                 args: {
                     controlVectorInd: 3,
                     controlVector: [7, 0.125],
@@ -354,7 +354,7 @@ describe("Curve Tag Bezier Tests", function () {
             });
             await win.callAction1({
                 actionName: "moveControlVector",
-                componentName: "/_curve1",
+                componentIdx: "/_curve1",
                 args: {
                     controlVectorInd: 2,
                     controlVector: [0.125, -6],
@@ -409,7 +409,7 @@ describe("Curve Tag Bezier Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
             await win.callAction1({
                 actionName: "moveControlVector",
-                componentName: "/_curve1",
+                componentIdx: "/_curve1",
                 args: {
                     controlVectorInd: 3,
                     controlVector: [-7, 0.125],
@@ -417,7 +417,7 @@ describe("Curve Tag Bezier Tests", function () {
             });
             await win.callAction1({
                 actionName: "moveControlVector",
-                componentName: "/_curve1",
+                componentIdx: "/_curve1",
                 args: {
                     controlVectorInd: 2,
                     controlVector: [0.125, 6],

--- a/packages/test-cypress/cypress/e2e/tagSpecific/line.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/line.cy.js
@@ -48,12 +48,12 @@ describe("Line Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/A",
+                componentIdx: "/A",
                 args: { x: 9, y: 8 },
             });
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/B",
+                componentIdx: "/B",
                 args: { x: 6, y: 7 },
             });
         });
@@ -103,7 +103,7 @@ describe("Line Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/A",
+                componentIdx: "/A",
                 args: { x: 0.5, y: 3.5 },
             });
         });
@@ -153,7 +153,7 @@ describe("Line Tag Tests", function () {
         cy.window().then(async (win) => {
             win.callAction1({
                 actionName: "movePoint",
-                componentName: "/A",
+                componentIdx: "/A",
                 args: { x: 8.5, y: 1.5 },
             });
         });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/math.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/math.cy.js
@@ -444,14 +444,14 @@ describe("Math Tag Tests", function () {
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
 
-            let m1aName = stateVariables["/g2"].activeChildren[0].componentName;
-            let m2aName = stateVariables["/g2"].activeChildren[1].componentName;
-            let m1bName = stateVariables["/g3"].activeChildren[0].componentName;
-            let m2bName = stateVariables["/g3"].activeChildren[1].componentName;
-            let m1cName = stateVariables["/p1"].activeChildren[0].componentName;
-            let m2cName = stateVariables["/p1"].activeChildren[2].componentName;
-            let m1dName = stateVariables["/p2"].activeChildren[0].componentName;
-            let m2dName = stateVariables["/p2"].activeChildren[2].componentName;
+            let m1aName = stateVariables["/g2"].activeChildren[0].componentIdx;
+            let m2aName = stateVariables["/g2"].activeChildren[1].componentIdx;
+            let m1bName = stateVariables["/g3"].activeChildren[0].componentIdx;
+            let m2bName = stateVariables["/g3"].activeChildren[1].componentIdx;
+            let m1cName = stateVariables["/p1"].activeChildren[0].componentIdx;
+            let m2cName = stateVariables["/p1"].activeChildren[2].componentIdx;
+            let m1dName = stateVariables["/p2"].activeChildren[0].componentIdx;
+            let m2dName = stateVariables["/p2"].activeChildren[2].componentIdx;
 
             let m1cAnchor = "#" + cesc2(m1cName);
             let m2cAnchor = "#" + cesc2(m2cName);
@@ -479,12 +479,12 @@ describe("Math Tag Tests", function () {
             cy.window().then(async (win) => {
                 win.callAction1({
                     actionName: "moveMath",
-                    componentName: "/m1",
+                    componentIdx: "/m1",
                     args: { x: -2, y: 3 },
                 });
                 win.callAction1({
                     actionName: "moveMath",
-                    componentName: "/m2",
+                    componentIdx: "/m2",
                     args: { x: 4, y: -5 },
                 });
             });
@@ -502,12 +502,12 @@ describe("Math Tag Tests", function () {
             cy.window().then(async (win) => {
                 win.callAction1({
                     actionName: "moveMath",
-                    componentName: m1aName,
+                    componentIdx: m1aName,
                     args: { x: 7, y: 1 },
                 });
                 win.callAction1({
                     actionName: "moveMath",
-                    componentName: m2aName,
+                    componentIdx: m2aName,
                     args: { x: -8, y: 2 },
                 });
             });
@@ -525,12 +525,12 @@ describe("Math Tag Tests", function () {
             cy.window().then(async (win) => {
                 win.callAction1({
                     actionName: "moveMath",
-                    componentName: m1bName,
+                    componentIdx: m1bName,
                     args: { x: -6, y: 3 },
                 });
                 win.callAction1({
                     actionName: "moveMath",
-                    componentName: m2bName,
+                    componentIdx: m2bName,
                     args: { x: -5, y: -4 },
                 });
             });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/module.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/module.cy.js
@@ -66,12 +66,12 @@ describe("Module Tag Tests", function () {
         cy.window().then(async (win) => {
             await win.callAction1({
                 actionName: "movePoint",
-                componentName: "/m1/P",
+                componentIdx: "/m1/P",
                 args: { x: 3.2, y: 3.9 },
             });
             await win.callAction1({
                 actionName: "movePoint",
-                componentName: "/m2/P",
+                componentIdx: "/m2/P",
                 args: { x: 7.2, y: -4.9 },
             });
         });
@@ -202,17 +202,17 @@ describe("Module Tag Tests", function () {
         cy.window().then(async (win) => {
             await win.callAction1({
                 actionName: "movePoint",
-                componentName: "/g/extMod/P",
+                componentIdx: "/g/extMod/P",
                 args: { x: 1.2, y: 1.9 },
             });
             await win.callAction1({
                 actionName: "movePoint",
-                componentName: "/g2/extMod/P",
+                componentIdx: "/g2/extMod/P",
                 args: { x: 1.2, y: -4.9 },
             });
             await win.callAction1({
                 actionName: "movePoint",
-                componentName: "/g3/extMod/P",
+                componentIdx: "/g3/extMod/P",
                 args: { x: 7.2, y: 1.9 },
             });
         });
@@ -295,79 +295,79 @@ describe("Module Tag Tests", function () {
             let g2m1Anchor = cesc2(
                 "#" +
                     stateVariables[
-                        stateVariables["/g2"].replacements[3].componentName
-                    ].activeChildren[1].componentName,
+                        stateVariables["/g2"].replacements[3].componentIdx
+                    ].activeChildren[1].componentIdx,
             );
             let g2m3Anchor = cesc2(
                 "#" +
                     stateVariables[
-                        stateVariables["/g2"].replacements[5].componentName
-                    ].activeChildren[3].componentName,
+                        stateVariables["/g2"].replacements[5].componentIdx
+                    ].activeChildren[3].componentIdx,
             );
             let g2extProblem =
                 stateVariables[
                     stateVariables[
                         stateVariables[
-                            stateVariables["/g2"].replacements[7].componentName
-                        ].replacements[0].componentName
-                    ].replacements[3].componentName
+                            stateVariables["/g2"].replacements[7].componentIdx
+                        ].replacements[0].componentIdx
+                    ].replacements[3].componentIdx
                 ];
             let g2extm1Anchor = cesc2(
                 "#" +
-                    stateVariables[g2extProblem.activeChildren[2].componentName]
-                        .activeChildren[1].componentName,
+                    stateVariables[g2extProblem.activeChildren[2].componentIdx]
+                        .activeChildren[1].componentIdx,
             );
             let g2extGraph =
-                stateVariables[g2extProblem.activeChildren[4].componentName];
-            let g2extPName = g2extGraph.activeChildren[0].componentName;
+                stateVariables[g2extProblem.activeChildren[4].componentIdx];
+            let g2extPName = g2extGraph.activeChildren[0].componentIdx;
             let g2extAnswerSubmitAnchor = cesc2(
-                "#" + g2extProblem.activeChildren[6].componentName + "_submit",
+                "#" + g2extProblem.activeChildren[6].componentIdx + "_submit",
             );
             let g2extAnswerCorrectAnchor = cesc2(
-                "#" + g2extProblem.activeChildren[6].componentName + "_correct",
+                "#" + g2extProblem.activeChildren[6].componentIdx + "_correct",
             );
             let g2extAnswerIncorrectAnchor = cesc2(
                 "#" +
-                    g2extProblem.activeChildren[6].componentName +
+                    g2extProblem.activeChildren[6].componentIdx +
                     "_incorrect",
             );
             let g3m1Anchor = cesc2(
                 "#" +
                     stateVariables[
-                        stateVariables["/g3"].replacements[3].componentName
-                    ].activeChildren[1].componentName,
+                        stateVariables["/g3"].replacements[3].componentIdx
+                    ].activeChildren[1].componentIdx,
             );
             let g3m3Anchor = cesc2(
                 "#" +
                     stateVariables[
-                        stateVariables["/g3"].replacements[5].componentName
-                    ].activeChildren[3].componentName,
+                        stateVariables["/g3"].replacements[5].componentIdx
+                    ].activeChildren[3].componentIdx,
             );
             let g3extProblem =
                 stateVariables[
                     stateVariables[
                         stateVariables[
-                            stateVariables["/g3"].replacements[7].componentName
-                        ].replacements[0].componentName
-                    ].replacements[3].componentName
+                            stateVariables["/g3"].replacements[7].componentIdx
+                        ].replacements[0].componentIdx
+                    ].replacements[3].componentIdx
                 ];
             let g3extm1Anchor = cesc2(
                 "#" +
-                    stateVariables[g3extProblem.activeChildren[2].componentName]
-                        .activeChildren[1].componentName,
+                    stateVariables[g3extProblem.activeChildren[2].componentIdx]
+                        .activeChildren[1].componentIdx,
             );
             let g3extGraph =
-                stateVariables[g3extProblem.activeChildren[4].componentName];
-            let g3extPName = g3extGraph.activeChildren[0].componentName;
+                stateVariables[g3extProblem.activeChildren[4].componentIdx];
+            let g3extPName = g3extGraph.activeChildren[0].componentIdx;
             let g3extAnswerSubmitAnchor = cesc2(
-                "#" + g3extProblem.activeChildren[6].componentName + "_submit",
+                "#" + g3extProblem.activeChildren[6].componentIdx + "_submit",
             );
             let g3extAnswerCorrectAnchor = cesc2(
-                "#" + g3extProblem.activeChildren[6].componentName + "_correct",
+                "#" + g3extProblem.activeChildren[6].componentIdx + "_correct",
             );
             let g3extAnswerIncorrectAnchor = cesc2(
                 "#" +
-                    g3extProblem.activeChildren[6].componentName +
+                    g3extProblem.activeChildren[6].componentIdx +
                     "_incorrect",
             );
 
@@ -396,25 +396,25 @@ describe("Module Tag Tests", function () {
                     stateVariables["/extMod/_graph1"].stateValues.aspectRatio,
                 ).eq(1);
                 expect(
-                    stateVariables[g2extGraph.componentName].stateValues.size,
+                    stateVariables[g2extGraph.componentIdx].stateValues.size,
                 ).eq("small");
                 expect(
-                    stateVariables[g2extGraph.componentName].stateValues.width
+                    stateVariables[g2extGraph.componentIdx].stateValues.width
                         .size,
                 ).eq(smallWidth);
                 expect(
-                    stateVariables[g2extGraph.componentName].stateValues
+                    stateVariables[g2extGraph.componentIdx].stateValues
                         .aspectRatio,
                 ).eq(0.8);
                 expect(
-                    stateVariables[g3extGraph.componentName].stateValues.size,
+                    stateVariables[g3extGraph.componentIdx].stateValues.size,
                 ).eq("large");
                 expect(
-                    stateVariables[g3extGraph.componentName].stateValues.width
+                    stateVariables[g3extGraph.componentIdx].stateValues.width
                         .size,
                 ).eq(largeWidth);
                 expect(
-                    stateVariables[g3extGraph.componentName].stateValues
+                    stateVariables[g3extGraph.componentIdx].stateValues
                         .aspectRatio,
                 ).eq(1.2);
             });
@@ -433,11 +433,11 @@ describe("Module Tag Tests", function () {
                     stateVariables["/extMod/prob"].stateValues.creditAchieved,
                 ).eq(0);
                 expect(
-                    stateVariables[g2extProblem.componentName].stateValues
+                    stateVariables[g2extProblem.componentIdx].stateValues
                         .creditAchieved,
                 ).eq(0);
                 expect(
-                    stateVariables[g3extProblem.componentName].stateValues
+                    stateVariables[g3extProblem.componentIdx].stateValues
                         .creditAchieved,
                 ).eq(0);
             });
@@ -446,17 +446,17 @@ describe("Module Tag Tests", function () {
             cy.window().then(async (win) => {
                 await win.callAction1({
                     actionName: "movePoint",
-                    componentName: "/extMod/P",
+                    componentIdx: "/extMod/P",
                     args: { x: 1.2, y: 1.9 },
                 });
                 await win.callAction1({
                     actionName: "movePoint",
-                    componentName: g2extPName,
+                    componentIdx: g2extPName,
                     args: { x: 1.2, y: -4.9 },
                 });
                 await win.callAction1({
                     actionName: "movePoint",
-                    componentName: g3extPName,
+                    componentIdx: g3extPName,
                     args: { x: 7.2, y: 1.9 },
                 });
             });
@@ -485,11 +485,11 @@ describe("Module Tag Tests", function () {
                     stateVariables["/extMod/prob"].stateValues.creditAchieved,
                 ).eq(1);
                 expect(
-                    stateVariables[g2extProblem.componentName].stateValues
+                    stateVariables[g2extProblem.componentIdx].stateValues
                         .creditAchieved,
                 ).eq(1);
                 expect(
-                    stateVariables[g3extProblem.componentName].stateValues
+                    stateVariables[g3extProblem.componentIdx].stateValues
                         .creditAchieved,
                 ).eq(1);
             });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/paginator.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/paginator.cy.js
@@ -68,7 +68,7 @@ describe("Paginator Tag Tests", function () {
 
             let mathinput1Name =
                 stateVariables["/_answer1"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinput1Anchor = cesc2("#" + mathinput1Name) + " textarea";
             let mathinput1DisplayAnchor =
                 cesc2("#" + mathinput1Name) + " .mq-editable-field";
@@ -77,7 +77,7 @@ describe("Paginator Tag Tests", function () {
 
             let mathinput4Name =
                 stateVariables["/_answer4"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinput4Anchor = cesc2("#" + mathinput4Name) + " textarea";
             let mathinput4DisplayAnchor =
                 cesc2("#" + mathinput4Name) + " .mq-editable-field";
@@ -227,7 +227,7 @@ describe("Paginator Tag Tests", function () {
 
                 let mathinput2Name =
                     stateVariables["/_answer2"].stateValues.inputChildren[0]
-                        .componentName;
+                        .componentIdx;
                 let mathinput2Anchor =
                     cesc2("#" + mathinput2Name) + " textarea";
                 let mathinput2DisplayAnchor =
@@ -239,7 +239,7 @@ describe("Paginator Tag Tests", function () {
 
                 let mathinput3Name =
                     stateVariables["/_answer3"].stateValues.inputChildren[0]
-                        .componentName;
+                        .componentIdx;
                 let mathinput3Anchor =
                     cesc2("#" + mathinput3Name) + " textarea";
                 let mathinput3DisplayAnchor =
@@ -400,7 +400,7 @@ describe("Paginator Tag Tests", function () {
 
             let mathinput4Name =
                 stateVariables["/_answer4"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinput4Anchor = cesc2("#" + mathinput4Name) + " textarea";
             let mathinput4DisplayAnchor =
                 cesc2("#" + mathinput4Name) + " .mq-editable-field";
@@ -455,7 +455,7 @@ describe("Paginator Tag Tests", function () {
 
                 let mathinput2Name =
                     stateVariables["/_answer2"].stateValues.inputChildren[0]
-                        .componentName;
+                        .componentIdx;
                 let mathinput2Anchor =
                     cesc2("#" + mathinput2Name) + " textarea";
                 let mathinput2DisplayAnchor =
@@ -468,7 +468,7 @@ describe("Paginator Tag Tests", function () {
 
                 let mathinput3Name =
                     stateVariables["/_answer3"].stateValues.inputChildren[0]
-                        .componentName;
+                        .componentIdx;
                 let mathinput3Anchor =
                     cesc2("#" + mathinput3Name) + " textarea";
                 let mathinput3DisplayAnchor =
@@ -583,7 +583,7 @@ describe("Paginator Tag Tests", function () {
 
                     let mathinput1Name =
                         stateVariables["/_answer1"].stateValues.inputChildren[0]
-                            .componentName;
+                            .componentIdx;
                     let mathinput1Anchor =
                         cesc2("#" + mathinput1Name) + " textarea";
                     let mathinput1DisplayAnchor =
@@ -773,7 +773,7 @@ describe("Paginator Tag Tests", function () {
 
             let mathinput2Name =
                 stateVariables["/_answer2"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinput2Anchor = cesc2("#" + mathinput2Name) + " textarea";
             let mathinput2DisplayAnchor =
                 cesc2("#" + mathinput2Name) + " .mq-editable-field";
@@ -783,7 +783,7 @@ describe("Paginator Tag Tests", function () {
 
             let mathinput3Name =
                 stateVariables["/_answer3"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinput3Anchor = cesc2("#" + mathinput3Name) + " textarea";
             let mathinput3DisplayAnchor =
                 cesc2("#" + mathinput3Name) + " .mq-editable-field";
@@ -792,7 +792,7 @@ describe("Paginator Tag Tests", function () {
 
             let mathinput4Name =
                 stateVariables["/_answer4"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinput4Anchor = cesc2("#" + mathinput4Name) + " textarea";
             let mathinput4DisplayAnchor =
                 cesc2("#" + mathinput4Name) + " .mq-editable-field";
@@ -888,7 +888,7 @@ describe("Paginator Tag Tests", function () {
 
                 let mathinput1Name =
                     stateVariables["/_answer1"].stateValues.inputChildren[0]
-                        .componentName;
+                        .componentIdx;
                 let mathinput1Anchor =
                     cesc2("#" + mathinput1Name) + " textarea";
                 let mathinput1DisplayAnchor =
@@ -963,7 +963,7 @@ describe("Paginator Tag Tests", function () {
 
             let textinput1Name =
                 stateVariables["/_answer1"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let textinput1Anchor = cesc2("#" + textinput1Name) + "_input";
             let textinput1DisplayAnchor =
                 cesc2("#" + textinput1Name) + " .mq-editable-field";
@@ -991,7 +991,7 @@ describe("Paginator Tag Tests", function () {
 
                 let textinput2Name =
                     stateVariables["/_answer2"].stateValues.inputChildren[0]
-                        .componentName;
+                        .componentIdx;
                 let textinput2Anchor = cesc2("#" + textinput2Name) + "_input";
                 let textinput2DisplayAnchor =
                     cesc2("#" + textinput2Name) + " .mq-editable-field";
@@ -1015,7 +1015,7 @@ describe("Paginator Tag Tests", function () {
 
                     let textinput3Name =
                         stateVariables["/_answer3"].stateValues.inputChildren[0]
-                            .componentName;
+                            .componentIdx;
                     let textinput3Anchor =
                         cesc2("#" + textinput3Name) + "_input";
                     let textinput3DisplayAnchor =
@@ -1230,7 +1230,7 @@ describe("Paginator Tag Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
             let mathinput2Name =
                 stateVariables["/problem2/_answer1"].stateValues
-                    .inputChildren[0].componentName;
+                    .inputChildren[0].componentIdx;
 
             let mathinput2Anchor = cesc2(`#${mathinput2Name}`) + " textarea";
             let mathinput2Correct = cesc2(`#${mathinput2Name}_correct`);
@@ -1482,7 +1482,7 @@ describe("Paginator Tag Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
             let mathinput2Name =
                 stateVariables["/problem2/_answer1"].stateValues
-                    .inputChildren[0].componentName;
+                    .inputChildren[0].componentIdx;
 
             let mathinput2Anchor = cesc2(`#${mathinput2Name}`) + " textarea";
             let mathinput2Correct = cesc2(`#${mathinput2Name}_correct`);
@@ -1828,7 +1828,7 @@ describe("Paginator Tag Tests", function () {
                                 let mathinput1Name =
                                     stateVariables[`${thisProbName}/ans1`]
                                         .stateValues.inputChildren[0]
-                                        .componentName;
+                                        .componentIdx;
                                 let mathinput1Anchor =
                                     cesc2("#" + mathinput1Name) + " textarea";
                                 let answer1Correct = cesc2(
@@ -1838,7 +1838,7 @@ describe("Paginator Tag Tests", function () {
                                 let mathinput2Name =
                                     stateVariables[`${thisProbName}/ans2`]
                                         .stateValues.inputChildren[0]
-                                        .componentName;
+                                        .componentIdx;
                                 let mathinput2Anchor =
                                     cesc2("#" + mathinput2Name) + " textarea";
                                 let answer2Correct = cesc2(
@@ -1848,7 +1848,7 @@ describe("Paginator Tag Tests", function () {
                                 let textinput3Name =
                                     stateVariables[`${thisProbName}/ans3`]
                                         .stateValues.inputChildren[0]
-                                        .componentName;
+                                        .componentIdx;
                                 let textinput3Anchor =
                                     cesc2("#" + textinput3Name) + "_input";
                                 let answer3Correct = cesc2(
@@ -1858,7 +1858,7 @@ describe("Paginator Tag Tests", function () {
                                 let mathinput4Name =
                                     stateVariables[`${thisProbName}/ans4`]
                                         .stateValues.inputChildren[0]
-                                        .componentName;
+                                        .componentIdx;
                                 let mathinput4Anchor =
                                     cesc2("#" + mathinput4Name) + " textarea";
                                 let answer4Correct = cesc2(
@@ -1868,7 +1868,7 @@ describe("Paginator Tag Tests", function () {
                                 let textinput5Name =
                                     stateVariables[`${thisProbName}/ans5`]
                                         .stateValues.inputChildren[0]
-                                        .componentName;
+                                        .componentIdx;
                                 let textinput5Anchor =
                                     cesc2("#" + textinput5Name) + "_input";
                                 let answer5Correct = cesc2(
@@ -2052,35 +2052,35 @@ describe("Paginator Tag Tests", function () {
 
                             let mathinput1Name =
                                 stateVariables[`${thisProbName}/ans1`]
-                                    .stateValues.inputChildren[0].componentName;
+                                    .stateValues.inputChildren[0].componentIdx;
                             let answer1Correct = cesc2(
                                 "#" + mathinput1Name + "_correct",
                             );
 
                             let mathinput2Name =
                                 stateVariables[`${thisProbName}/ans2`]
-                                    .stateValues.inputChildren[0].componentName;
+                                    .stateValues.inputChildren[0].componentIdx;
                             let answer2Correct = cesc2(
                                 "#" + mathinput2Name + "_correct",
                             );
 
                             let textinput3Name =
                                 stateVariables[`${thisProbName}/ans3`]
-                                    .stateValues.inputChildren[0].componentName;
+                                    .stateValues.inputChildren[0].componentIdx;
                             let answer3Correct = cesc2(
                                 "#" + textinput3Name + "_correct",
                             );
 
                             let mathinput4Name =
                                 stateVariables[`${thisProbName}/ans4`]
-                                    .stateValues.inputChildren[0].componentName;
+                                    .stateValues.inputChildren[0].componentIdx;
                             let answer4Correct = cesc2(
                                 "#" + mathinput4Name + "_correct",
                             );
 
                             let textinput5Name =
                                 stateVariables[`${thisProbName}/ans5`]
-                                    .stateValues.inputChildren[0].componentName;
+                                    .stateValues.inputChildren[0].componentIdx;
                             let answer5Correct = cesc2(
                                 "#" + textinput5Name + "_correct",
                             );
@@ -2229,35 +2229,35 @@ describe("Paginator Tag Tests", function () {
 
                             let mathinput1Name =
                                 stateVariables[`${thisProbName}/ans1`]
-                                    .stateValues.inputChildren[0].componentName;
+                                    .stateValues.inputChildren[0].componentIdx;
                             let answer1Correct = cesc2(
                                 "#" + mathinput1Name + "_correct",
                             );
 
                             let mathinput2Name =
                                 stateVariables[`${thisProbName}/ans2`]
-                                    .stateValues.inputChildren[0].componentName;
+                                    .stateValues.inputChildren[0].componentIdx;
                             let answer2Correct = cesc2(
                                 "#" + mathinput2Name + "_correct",
                             );
 
                             let textinput3Name =
                                 stateVariables[`${thisProbName}/ans3`]
-                                    .stateValues.inputChildren[0].componentName;
+                                    .stateValues.inputChildren[0].componentIdx;
                             let answer3Correct = cesc2(
                                 "#" + textinput3Name + "_correct",
                             );
 
                             let mathinput4Name =
                                 stateVariables[`${thisProbName}/ans4`]
-                                    .stateValues.inputChildren[0].componentName;
+                                    .stateValues.inputChildren[0].componentIdx;
                             let answer4Correct = cesc2(
                                 "#" + mathinput4Name + "_correct",
                             );
 
                             let textinput5Name =
                                 stateVariables[`${thisProbName}/ans5`]
-                                    .stateValues.inputChildren[0].componentName;
+                                    .stateValues.inputChildren[0].componentIdx;
                             let answer5Correct = cesc2(
                                 "#" + textinput5Name + "_correct",
                             );
@@ -2395,7 +2395,7 @@ describe("Paginator Tag Tests", function () {
 
             let mathinput1Name =
                 stateVariables[`/problem1/_answer${n}`].stateValues
-                    .inputChildren[0].componentName;
+                    .inputChildren[0].componentIdx;
             let mathinput1Anchor = cesc2("#" + mathinput1Name) + " textarea";
             let mathinput1DisplayAnchor =
                 cesc2("#" + mathinput1Name) + " .mq-editable-field";
@@ -2404,7 +2404,7 @@ describe("Paginator Tag Tests", function () {
 
             let mathinput2Name =
                 stateVariables[`/problem1/a${n}`].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinput2Anchor = cesc2("#" + mathinput2Name) + " textarea";
             let mathinput2DisplayAnchor =
                 cesc2("#" + mathinput2Name) + " .mq-editable-field";
@@ -2472,7 +2472,7 @@ describe("Paginator Tag Tests", function () {
 
                 let mathinput3Name =
                     stateVariables[`/problem2/_answer1`].stateValues
-                        .inputChildren[0].componentName;
+                        .inputChildren[0].componentIdx;
                 let mathinput3Anchor =
                     cesc2("#" + mathinput3Name) + " textarea";
                 let mathinput3DisplayAnchor =
@@ -2481,7 +2481,7 @@ describe("Paginator Tag Tests", function () {
 
                 let mathinput4Name =
                     stateVariables[`/problem2/_answer3`].stateValues
-                        .inputChildren[0].componentName;
+                        .inputChildren[0].componentIdx;
                 let mathinput4Anchor =
                     cesc2("#" + mathinput4Name) + " textarea";
                 let mathinput4DisplayAnchor =

--- a/packages/test-cypress/cypress/e2e/tagSpecific/point.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/point.cy.js
@@ -51,7 +51,7 @@ describe("Point Tag Tests 2", function () {
                 promises.push(
                     win.callAction1({
                         actionName: "movePoint",
-                        componentName: "/P0",
+                        componentIdx: "/P0",
                         args: { x, y, skippable: true },
                     }),
                 );
@@ -85,7 +85,7 @@ describe("Point Tag Tests 2", function () {
                 promises2.push(
                     win.callAction1({
                         actionName: "movePoint",
-                        componentName: "/P0",
+                        componentIdx: "/P0",
                         args: { x, y, skippable: i % 10 !== 5 },
                     }),
                 );

--- a/packages/test-cypress/cypress/e2e/tagSpecific/problem.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/problem.cy.js
@@ -59,7 +59,7 @@ describe("Problem Tag Tests", function () {
 
             let twoxInputName =
                 stateVariables["/twox"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let twoxInputAnchor = cesc2("#" + twoxInputName) + " textarea";
             let twoxInputSubmitAnchor = cesc2("#" + twoxInputName + "_submit");
             let twoxInputCorrectAnchor = cesc2(
@@ -80,7 +80,7 @@ describe("Problem Tag Tests", function () {
 
             let helloInputName =
                 stateVariables["/hello"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let helloInputAnchor = cesc2("#" + helloInputName + "_input");
             let helloInputSubmitAnchor = cesc2(
                 "#" + helloInputName + "_submit",
@@ -283,7 +283,7 @@ describe("Problem Tag Tests", function () {
 
             let twoxInputName =
                 stateVariables["/twox"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let twoxInputAnchor = cesc2("#" + twoxInputName) + " textarea";
             let twoxInputSubmitAnchor = cesc2("#" + twoxInputName + "_submit");
             let twoxInputCorrectAnchor = cesc2(
@@ -304,7 +304,7 @@ describe("Problem Tag Tests", function () {
 
             let helloInputName =
                 stateVariables["/hello"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let helloInputAnchor = cesc2("#" + helloInputName + "_input");
             let helloInputSubmitAnchor = cesc2(
                 "#" + helloInputName + "_submit",
@@ -507,7 +507,7 @@ describe("Problem Tag Tests", function () {
 
             let twoxInputName =
                 stateVariables["/twox"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let twoxInputAnchor = cesc2("#" + twoxInputName) + " textarea";
             let twoxInputSubmitAnchor = cesc2("#" + twoxInputName + "_submit");
             let twoxInputCorrectAnchor = cesc2(
@@ -528,7 +528,7 @@ describe("Problem Tag Tests", function () {
 
             let helloInputName =
                 stateVariables["/hello"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let helloInputAnchor = cesc2("#" + helloInputName + "_input");
             let helloInputSubmitAnchor = cesc2(
                 "#" + helloInputName + "_submit",
@@ -734,7 +734,7 @@ describe("Problem Tag Tests", function () {
 
             let twoxInputName =
                 stateVariables["/twox"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let twoxInputAnchor = cesc2("#" + twoxInputName) + " textarea";
             let twoxInputSubmitAnchor = cesc2("#" + twoxInputName + "_submit");
             let twoxInputCorrectAnchor = cesc2(
@@ -755,7 +755,7 @@ describe("Problem Tag Tests", function () {
 
             let helloInputName =
                 stateVariables["/hello"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let helloInputAnchor = cesc2("#" + helloInputName + "_input");
             let helloInputSubmitAnchor = cesc2(
                 "#" + helloInputName + "_submit",
@@ -983,7 +983,7 @@ describe("Problem Tag Tests", function () {
 
             let twoxInputName =
                 stateVariables["/twox"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let twoxInputAnchor = cesc2("#" + twoxInputName) + " textarea";
             let twoxInputSubmitAnchor = cesc2("#" + twoxInputName + "_submit");
             let twoxInputCorrectAnchor = cesc2(
@@ -1004,7 +1004,7 @@ describe("Problem Tag Tests", function () {
 
             let helloInputName =
                 stateVariables["/hello"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let helloInputAnchor = cesc2("#" + helloInputName + "_input");
             let helloInputSubmitAnchor = cesc2(
                 "#" + helloInputName + "_submit",
@@ -1208,22 +1208,22 @@ describe("Problem Tag Tests", function () {
 
             let mathinput1Name =
                 stateVariables["/ans1"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinput1Anchor = cesc2("#" + mathinput1Name) + " textarea";
 
             let mathinput2Name =
                 stateVariables["/ans2"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinput2Anchor = cesc2("#" + mathinput2Name) + " textarea";
 
             let mathinput3Name =
                 stateVariables["/ans3"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinput3Anchor = cesc2("#" + mathinput3Name) + " textarea";
 
             let mathinput4Name =
                 stateVariables["/ans4"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinput4Anchor = cesc2("#" + mathinput4Name) + " textarea";
 
             cy.get(cesc("#\\/prob1_submit"))
@@ -1351,7 +1351,7 @@ describe("Problem Tag Tests", function () {
 
             let mathinput1Name =
                 stateVariables["/ans1"].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinput1Anchor = cesc2("#" + mathinput1Name) + " textarea";
 
             cy.get(cesc("#\\/doc_submit"))

--- a/packages/test-cypress/cypress/e2e/tagSpecific/sampleprimenumbers.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/sampleprimenumbers.cy.js
@@ -35,9 +35,9 @@ describe("SamplePrimeNumbers Tag Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
 
             samples = stateVariables[
-                stateVariables["/p1"].activeChildren[0].componentName
+                stateVariables["/p1"].activeChildren[0].componentIdx
             ].activeChildren.map(
-                (x) => stateVariables[x.componentName].stateValues.value,
+                (x) => stateVariables[x.componentIdx].stateValues.value,
             );
 
             expect(samples.length).eq(100);
@@ -69,9 +69,9 @@ describe("SamplePrimeNumbers Tag Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
 
             let samples2 = stateVariables[
-                stateVariables["/p1"].activeChildren[0].componentName
+                stateVariables["/p1"].activeChildren[0].componentIdx
             ].activeChildren.map(
-                (x) => stateVariables[x.componentName].stateValues.value,
+                (x) => stateVariables[x.componentIdx].stateValues.value,
             );
 
             expect(samples2.length).eq(100);
@@ -124,9 +124,9 @@ describe("SamplePrimeNumbers Tag Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
 
             samples = stateVariables[
-                stateVariables["/p1"].activeChildren[0].componentName
+                stateVariables["/p1"].activeChildren[0].componentIdx
             ].activeChildren.map(
-                (x) => stateVariables[x.componentName].stateValues.value,
+                (x) => stateVariables[x.componentIdx].stateValues.value,
             );
 
             expect(samples.length).eq(100);
@@ -168,9 +168,9 @@ describe("SamplePrimeNumbers Tag Tests", function () {
             let stateVariables = await win.returnAllStateVariables1();
 
             let samples2 = stateVariables[
-                stateVariables["/p1"].activeChildren[0].componentName
+                stateVariables["/p1"].activeChildren[0].componentIdx
             ].activeChildren.map(
-                (x) => stateVariables[x.componentName].stateValues.value,
+                (x) => stateVariables[x.componentIdx].stateValues.value,
             );
 
             expect(samples2).eqls(samples);

--- a/packages/test-cypress/cypress/e2e/tagSpecific/samplerandomnumbers.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/samplerandomnumbers.cy.js
@@ -38,9 +38,9 @@ describe("SampleRandomNumbers Tag Tests", function () {
                 (x) =>
                     stateVariables[
                         stateVariables[
-                            stateVariables[x.componentName].replacements[0]
-                                .componentName
-                        ].replacements[0].componentName
+                            stateVariables[x.componentIdx].replacements[0]
+                                .componentIdx
+                        ].replacements[0].componentIdx
                     ].stateValues.value,
             );
 
@@ -72,9 +72,9 @@ describe("SampleRandomNumbers Tag Tests", function () {
                 (x) =>
                     stateVariables[
                         stateVariables[
-                            stateVariables[x.componentName].replacements[0]
-                                .componentName
-                        ].replacements[0].componentName
+                            stateVariables[x.componentIdx].replacements[0]
+                                .componentIdx
+                        ].replacements[0].componentIdx
                     ].stateValues.value,
             );
 
@@ -127,9 +127,9 @@ describe("SampleRandomNumbers Tag Tests", function () {
                 (x) =>
                     stateVariables[
                         stateVariables[
-                            stateVariables[x.componentName].replacements[0]
-                                .componentName
-                        ].replacements[0].componentName
+                            stateVariables[x.componentIdx].replacements[0]
+                                .componentIdx
+                        ].replacements[0].componentIdx
                     ].stateValues.value,
             );
 
@@ -172,9 +172,9 @@ describe("SampleRandomNumbers Tag Tests", function () {
                 (x) =>
                     stateVariables[
                         stateVariables[
-                            stateVariables[x.componentName].replacements[0]
-                                .componentName
-                        ].replacements[0].componentName
+                            stateVariables[x.componentIdx].replacements[0]
+                                .componentIdx
+                        ].replacements[0].componentIdx
                     ].stateValues.value,
             );
 

--- a/packages/test-cypress/cypress/e2e/tagSpecific/spreadsheet.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/spreadsheet.cy.js
@@ -93,8 +93,7 @@ describe("Spreadsheet Tag Tests", function () {
             expect(stateVariables["/inAllCells"].activeChildren.length).eq(1);
             expect(
                 stateVariables[
-                    stateVariables["/inAllCells"].activeChildren[0]
-                        .componentName
+                    stateVariables["/inAllCells"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([1, 2]);
             expect(stateVariables["/inCellB3"].activeChildren.length).eq(0);
@@ -102,7 +101,7 @@ describe("Spreadsheet Tag Tests", function () {
             expect(stateVariables["/inColumn1"].activeChildren.length).eq(1);
             expect(
                 stateVariables[
-                    stateVariables["/inColumn1"].activeChildren[0].componentName
+                    stateVariables["/inColumn1"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([1, 2]);
             expect(stateVariables["/inRangeA2B4"].activeChildren.length).eq(0);
@@ -116,8 +115,8 @@ describe("Spreadsheet Tag Tests", function () {
         //   expect(stateVariables['/_spreadsheet1'].stateValues.cells[0][1]).eq('hello');
         //   expect(stateVariables['/_spreadsheet1'].stateValues.cells[0][2]).eq('5');
         //   expect(stateVariables['/inAllCells'].activeChildren.length).eq(1);
-        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[0].componentName].stateValues.xs[0]).eqls(['-', 3]);
-        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[0].componentName].stateValues.xs[1]).eq(7);
+        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[0].componentIdx].stateValues.xs[0]).eqls(['-', 3]);
+        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[0].componentIdx].stateValues.xs[1]).eq(7);
 
         // })
 
@@ -144,8 +143,7 @@ describe("Spreadsheet Tag Tests", function () {
             expect(stateVariables["/inAllCells"].activeChildren.length).eq(1);
             expect(
                 stateVariables[
-                    stateVariables["/inAllCells"].activeChildren[0]
-                        .componentName
+                    stateVariables["/inAllCells"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([4, 9]);
             expect(stateVariables["/inCellB3"].activeChildren.length).eq(0);
@@ -153,7 +151,7 @@ describe("Spreadsheet Tag Tests", function () {
             expect(stateVariables["/inColumn1"].activeChildren.length).eq(1);
             expect(
                 stateVariables[
-                    stateVariables["/inColumn1"].activeChildren[0].componentName
+                    stateVariables["/inColumn1"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([4, 9]);
             expect(stateVariables["/inRangeA2B4"].activeChildren.length).eq(0);
@@ -185,34 +183,32 @@ describe("Spreadsheet Tag Tests", function () {
             expect(stateVariables["/inAllCells"].activeChildren.length).eq(2);
             expect(
                 stateVariables[
-                    stateVariables["/inAllCells"].activeChildren[0]
-                        .componentName
+                    stateVariables["/inAllCells"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([4, 9]);
             expect(
                 stateVariables[
-                    stateVariables["/inAllCells"].activeChildren[1]
-                        .componentName
+                    stateVariables["/inAllCells"].activeChildren[1].componentIdx
                 ].stateValues.xs,
             ).eqls([5, 4]);
             expect(stateVariables["/inCellB3"].activeChildren.length).eq(1);
             expect(
                 stateVariables[
-                    stateVariables["/inCellB3"].activeChildren[0].componentName
+                    stateVariables["/inCellB3"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([5, 4]);
             expect(stateVariables["/inRow2"].activeChildren.length).eq(0);
             expect(stateVariables["/inColumn1"].activeChildren.length).eq(1);
             expect(
                 stateVariables[
-                    stateVariables["/inColumn1"].activeChildren[0].componentName
+                    stateVariables["/inColumn1"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([4, 9]);
             expect(stateVariables["/inRangeA2B4"].activeChildren.length).eq(1);
             expect(
                 stateVariables[
                     stateVariables["/inRangeA2B4"].activeChildren[0]
-                        .componentName
+                        .componentIdx
                 ].stateValues.xs,
             ).eqls([5, 4]);
         });
@@ -226,10 +222,10 @@ describe("Spreadsheet Tag Tests", function () {
         //   expect(stateVariables['/_spreadsheet1'].stateValues.cells[0][2]).eq('5');
         //   expect(stateVariables['/_spreadsheet1'].stateValues.cells[2][1]).eq('( 0, 1 )');
         //   expect(stateVariables['/inAllCells'].activeChildren.length).eq(2);
-        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[0].componentName].stateValues.xs[0]).eq(4);
-        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[0].componentName].stateValues.xs[1]).eq(9);
-        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[1].componentName].stateValues.xs[0]).eq(0);
-        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[1].componentName].stateValues.xs[1]).eq(1);
+        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[0].componentIdx].stateValues.xs[0]).eq(4);
+        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[0].componentIdx].stateValues.xs[1]).eq(9);
+        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[1].componentIdx].stateValues.xs[0]).eq(0);
+        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[1].componentIdx].stateValues.xs[1]).eq(1);
         // })
 
         cy.log("enter random text on top of point in A1");
@@ -258,14 +254,13 @@ describe("Spreadsheet Tag Tests", function () {
             expect(stateVariables["/inAllCells"].activeChildren.length).eq(1);
             expect(
                 stateVariables[
-                    stateVariables["/inAllCells"].activeChildren[0]
-                        .componentName
+                    stateVariables["/inAllCells"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([5, 4]);
             expect(stateVariables["/inCellB3"].activeChildren.length).eq(1);
             expect(
                 stateVariables[
-                    stateVariables["/inCellB3"].activeChildren[0].componentName
+                    stateVariables["/inCellB3"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([5, 4]);
             expect(stateVariables["/inRow2"].activeChildren.length).eq(0);
@@ -274,7 +269,7 @@ describe("Spreadsheet Tag Tests", function () {
             expect(
                 stateVariables[
                     stateVariables["/inRangeA2B4"].activeChildren[0]
-                        .componentName
+                        .componentIdx
                 ].stateValues.xs,
             ).eqls([5, 4]);
         });
@@ -308,40 +303,38 @@ describe("Spreadsheet Tag Tests", function () {
             expect(stateVariables["/inAllCells"].activeChildren.length).eq(2);
             expect(
                 stateVariables[
-                    stateVariables["/inAllCells"].activeChildren[0]
-                        .componentName
+                    stateVariables["/inAllCells"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([5, 4]);
             expect(
                 stateVariables[
-                    stateVariables["/inAllCells"].activeChildren[1]
-                        .componentName
+                    stateVariables["/inAllCells"].activeChildren[1].componentIdx
                 ].stateValues.xs,
             ).eqls([3, 2]);
             expect(stateVariables["/inCellB3"].activeChildren.length).eq(1);
             expect(
                 stateVariables[
-                    stateVariables["/inCellB3"].activeChildren[0].componentName
+                    stateVariables["/inCellB3"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([5, 4]);
             expect(stateVariables["/inRow2"].activeChildren.length).eq(0);
             expect(stateVariables["/inColumn1"].activeChildren.length).eq(1);
             expect(
                 stateVariables[
-                    stateVariables["/inColumn1"].activeChildren[0].componentName
+                    stateVariables["/inColumn1"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([3, 2]);
             expect(stateVariables["/inRangeA2B4"].activeChildren.length).eq(2);
             expect(
                 stateVariables[
                     stateVariables["/inRangeA2B4"].activeChildren[0]
-                        .componentName
+                        .componentIdx
                 ].stateValues.xs,
             ).eqls([5, 4]);
             expect(
                 stateVariables[
                     stateVariables["/inRangeA2B4"].activeChildren[1]
-                        .componentName
+                        .componentIdx
                 ].stateValues.xs,
             ).eqls([3, 2]);
         });
@@ -375,51 +368,48 @@ describe("Spreadsheet Tag Tests", function () {
             expect(stateVariables["/inAllCells"].activeChildren.length).eq(3);
             expect(
                 stateVariables[
-                    stateVariables["/inAllCells"].activeChildren[0]
-                        .componentName
+                    stateVariables["/inAllCells"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([7, 3]);
             expect(
                 stateVariables[
-                    stateVariables["/inAllCells"].activeChildren[1]
-                        .componentName
+                    stateVariables["/inAllCells"].activeChildren[1].componentIdx
                 ].stateValues.xs,
             ).eqls([5, 4]);
             expect(
                 stateVariables[
-                    stateVariables["/inAllCells"].activeChildren[2]
-                        .componentName
+                    stateVariables["/inAllCells"].activeChildren[2].componentIdx
                 ].stateValues.xs,
             ).eqls([3, 2]);
             expect(stateVariables["/inCellB3"].activeChildren.length).eq(1);
             expect(
                 stateVariables[
-                    stateVariables["/inCellB3"].activeChildren[0].componentName
+                    stateVariables["/inCellB3"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([5, 4]);
             expect(stateVariables["/inRow2"].activeChildren.length).eq(0);
             expect(stateVariables["/inColumn1"].activeChildren.length).eq(2);
             expect(
                 stateVariables[
-                    stateVariables["/inColumn1"].activeChildren[0].componentName
+                    stateVariables["/inColumn1"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([7, 3]);
             expect(
                 stateVariables[
-                    stateVariables["/inColumn1"].activeChildren[1].componentName
+                    stateVariables["/inColumn1"].activeChildren[1].componentIdx
                 ].stateValues.xs,
             ).eqls([3, 2]);
             expect(stateVariables["/inRangeA2B4"].activeChildren.length).eq(2);
             expect(
                 stateVariables[
                     stateVariables["/inRangeA2B4"].activeChildren[0]
-                        .componentName
+                        .componentIdx
                 ].stateValues.xs,
             ).eqls([5, 4]);
             expect(
                 stateVariables[
                     stateVariables["/inRangeA2B4"].activeChildren[1]
-                        .componentName
+                        .componentIdx
                 ].stateValues.xs,
             ).eqls([3, 2]);
         });
@@ -456,62 +446,58 @@ describe("Spreadsheet Tag Tests", function () {
             expect(stateVariables["/inAllCells"].activeChildren.length).eq(4);
             expect(
                 stateVariables[
-                    stateVariables["/inAllCells"].activeChildren[0]
-                        .componentName
+                    stateVariables["/inAllCells"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([7, 3]);
             expect(
                 stateVariables[
-                    stateVariables["/inAllCells"].activeChildren[1]
-                        .componentName
+                    stateVariables["/inAllCells"].activeChildren[1].componentIdx
                 ].stateValues.xs,
             ).eqls(["x", "q"]);
             expect(
                 stateVariables[
-                    stateVariables["/inAllCells"].activeChildren[2]
-                        .componentName
+                    stateVariables["/inAllCells"].activeChildren[2].componentIdx
                 ].stateValues.xs,
             ).eqls([5, 4]);
             expect(
                 stateVariables[
-                    stateVariables["/inAllCells"].activeChildren[3]
-                        .componentName
+                    stateVariables["/inAllCells"].activeChildren[3].componentIdx
                 ].stateValues.xs,
             ).eqls([3, 2]);
             expect(stateVariables["/inCellB3"].activeChildren.length).eq(1);
             expect(
                 stateVariables[
-                    stateVariables["/inCellB3"].activeChildren[0].componentName
+                    stateVariables["/inCellB3"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([5, 4]);
             expect(stateVariables["/inRow2"].activeChildren.length).eq(1);
             expect(
                 stateVariables[
-                    stateVariables["/inRow2"].activeChildren[0].componentName
+                    stateVariables["/inRow2"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls(["x", "q"]);
             expect(stateVariables["/inColumn1"].activeChildren.length).eq(2);
             expect(
                 stateVariables[
-                    stateVariables["/inColumn1"].activeChildren[0].componentName
+                    stateVariables["/inColumn1"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([7, 3]);
             expect(
                 stateVariables[
-                    stateVariables["/inColumn1"].activeChildren[1].componentName
+                    stateVariables["/inColumn1"].activeChildren[1].componentIdx
                 ].stateValues.xs,
             ).eqls([3, 2]);
             expect(stateVariables["/inRangeA2B4"].activeChildren.length).eq(2);
             expect(
                 stateVariables[
                     stateVariables["/inRangeA2B4"].activeChildren[0]
-                        .componentName
+                        .componentIdx
                 ].stateValues.xs,
             ).eqls([5, 4]);
             expect(
                 stateVariables[
                     stateVariables["/inRangeA2B4"].activeChildren[1]
-                        .componentName
+                        .componentIdx
                 ].stateValues.xs,
             ).eqls([3, 2]);
         });
@@ -551,84 +537,79 @@ describe("Spreadsheet Tag Tests", function () {
             expect(stateVariables["/inAllCells"].activeChildren.length).eq(5);
             expect(
                 stateVariables[
-                    stateVariables["/inAllCells"].activeChildren[0]
-                        .componentName
+                    stateVariables["/inAllCells"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([7, 3]);
             expect(
                 stateVariables[
-                    stateVariables["/inAllCells"].activeChildren[1]
-                        .componentName
+                    stateVariables["/inAllCells"].activeChildren[1].componentIdx
                 ].stateValues.xs,
             ).eqls([1, 2, 3]);
             expect(
                 stateVariables[
-                    stateVariables["/inAllCells"].activeChildren[2]
-                        .componentName
+                    stateVariables["/inAllCells"].activeChildren[2].componentIdx
                 ].stateValues.xs,
             ).eqls(["x", "q"]);
             expect(
                 stateVariables[
-                    stateVariables["/inAllCells"].activeChildren[3]
-                        .componentName
+                    stateVariables["/inAllCells"].activeChildren[3].componentIdx
                 ].stateValues.xs,
             ).eqls([5, 4]);
             expect(
                 stateVariables[
-                    stateVariables["/inAllCells"].activeChildren[4]
-                        .componentName
+                    stateVariables["/inAllCells"].activeChildren[4].componentIdx
                 ].stateValues.xs,
             ).eqls([3, 2]);
             expect(stateVariables["/inCellB3"].activeChildren.length).eq(1);
             expect(
                 stateVariables[
-                    stateVariables["/inCellB3"].activeChildren[0].componentName
+                    stateVariables["/inCellB3"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([5, 4]);
             expect(stateVariables["/inRow2"].activeChildren.length).eq(2);
             expect(
                 stateVariables[
-                    stateVariables["/inRow2"].activeChildren[0].componentName
+                    stateVariables["/inRow2"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([1, 2, 3]);
             expect(
                 stateVariables[
-                    stateVariables["/inRow2"].activeChildren[1].componentName
+                    stateVariables["/inRow2"].activeChildren[1].componentIdx
                 ].stateValues.xs,
             ).eqls(["x", "q"]);
             expect(stateVariables["/inColumn1"].activeChildren.length).eq(3);
             expect(
                 stateVariables[
-                    stateVariables["/inColumn1"].activeChildren[0].componentName
+                    stateVariables["/inColumn1"].activeChildren[0].componentIdx
                 ].stateValues.xs,
             ).eqls([7, 3]);
             expect(
                 stateVariables[
-                    stateVariables["/inColumn1"].activeChildren[1].componentName
+                    stateVariables["/inColumn1"].activeChildren[1].componentIdx
                 ].stateValues.xs,
             ).eqls([1, 2, 3]);
             expect(
                 stateVariables[
-                    stateVariables["/inColumn1"].activeChildren[2].componentName
+                    stateVariables["/inColumn1"].activeChildren[2].componentIdx
                 ].stateValues.xs,
             ).eqls([3, 2]);
             expect(stateVariables["/inRangeA2B4"].activeChildren.length).eq(3);
             expect(
                 stateVariables[
                     stateVariables["/inRangeA2B4"].activeChildren[0]
-                        .componentName
+                        .componentIdx
                 ].stateValues.xs,
             ).eqls([1, 2, 3]);
             expect(
                 stateVariables[
                     stateVariables["/inRangeA2B4"].activeChildren[1]
-                        .componentName
+                        .componentIdx
                 ].stateValues.xs,
             ).eqls([5, 4]);
             expect(
                 stateVariables[
                     stateVariables["/inRangeA2B4"].activeChildren[2]
-                        .componentName
+                        .componentIdx
                 ].stateValues.xs,
             ).eqls([3, 2]);
         });
@@ -646,17 +627,17 @@ describe("Spreadsheet Tag Tests", function () {
         //   expect(stateVariables['/_spreadsheet1'].stateValues.cells[1][3]).eq('(x,q)');
         //   expect(stateVariables['/_spreadsheet1'].stateValues.cells[1][0]).eq('(1,2,3)');
         //   expect(stateVariables['/inAllCells'].activeChildren.length).eq(5);
-        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[0].componentName].stateValues.xs[0]).eq(7);
-        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[0].componentName].stateValues.xs[1]).eq(3);
-        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[1].componentName].stateValues.xs[0]).eq(1);
-        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[1].componentName].stateValues.xs[1]).eq(2);
-        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[1].componentName].stateValues.xs[2]).eq(3);
-        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[2].componentName].stateValues.xs[0]).eq(8);
-        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[2].componentName].stateValues.xs[1]).eq(5);
-        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[3].componentName].stateValues.xs[0]).eq(0);
-        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[3].componentName].stateValues.xs[1]).eq(1);
-        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[4].componentName].stateValues.xs[0]).eq('x');
-        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[4].componentName].stateValues.xs[1]).eq('q');
+        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[0].componentIdx].stateValues.xs[0]).eq(7);
+        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[0].componentIdx].stateValues.xs[1]).eq(3);
+        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[1].componentIdx].stateValues.xs[0]).eq(1);
+        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[1].componentIdx].stateValues.xs[1]).eq(2);
+        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[1].componentIdx].stateValues.xs[2]).eq(3);
+        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[2].componentIdx].stateValues.xs[0]).eq(8);
+        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[2].componentIdx].stateValues.xs[1]).eq(5);
+        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[3].componentIdx].stateValues.xs[0]).eq(0);
+        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[3].componentIdx].stateValues.xs[1]).eq(1);
+        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[4].componentIdx].stateValues.xs[0]).eq('x');
+        //   expect(stateVariables[stateVariables['/inAllCells'].activeChildren[4].componentIdx].stateValues.xs[1]).eq('q');
         // })
     });
 

--- a/packages/test-cypress/cypress/e2e/tagSpecific/text.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/text.cy.js
@@ -236,14 +236,14 @@ describe("Text Tag Tests", function () {
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
 
-            let t1aName = stateVariables["/g2"].activeChildren[0].componentName;
-            let t2aName = stateVariables["/g2"].activeChildren[1].componentName;
-            let t1bName = stateVariables["/g3"].activeChildren[0].componentName;
-            let t2bName = stateVariables["/g3"].activeChildren[1].componentName;
-            let t1cName = stateVariables["/p1"].activeChildren[0].componentName;
-            let t2cName = stateVariables["/p1"].activeChildren[2].componentName;
-            let t1dName = stateVariables["/p2"].activeChildren[0].componentName;
-            let t2dName = stateVariables["/p2"].activeChildren[2].componentName;
+            let t1aName = stateVariables["/g2"].activeChildren[0].componentIdx;
+            let t2aName = stateVariables["/g2"].activeChildren[1].componentIdx;
+            let t1bName = stateVariables["/g3"].activeChildren[0].componentIdx;
+            let t2bName = stateVariables["/g3"].activeChildren[1].componentIdx;
+            let t1cName = stateVariables["/p1"].activeChildren[0].componentIdx;
+            let t2cName = stateVariables["/p1"].activeChildren[2].componentIdx;
+            let t1dName = stateVariables["/p2"].activeChildren[0].componentIdx;
+            let t2dName = stateVariables["/p2"].activeChildren[2].componentIdx;
 
             let t1cAnchor = "#" + cesc2(t1cName);
             let t2cAnchor = "#" + cesc2(t2cName);
@@ -271,12 +271,12 @@ describe("Text Tag Tests", function () {
             cy.window().then(async (win) => {
                 win.callAction1({
                     actionName: "moveText",
-                    componentName: "/t1",
+                    componentIdx: "/t1",
                     args: { x: -2, y: 3 },
                 });
                 win.callAction1({
                     actionName: "moveText",
-                    componentName: "/t2",
+                    componentIdx: "/t2",
                     args: { x: 4, y: -5 },
                 });
             });
@@ -294,12 +294,12 @@ describe("Text Tag Tests", function () {
             cy.window().then(async (win) => {
                 win.callAction1({
                     actionName: "moveText",
-                    componentName: t1aName,
+                    componentIdx: t1aName,
                     args: { x: 7, y: 1 },
                 });
                 win.callAction1({
                     actionName: "moveText",
-                    componentName: t2aName,
+                    componentIdx: t2aName,
                     args: { x: -8, y: 2 },
                 });
             });
@@ -317,12 +317,12 @@ describe("Text Tag Tests", function () {
             cy.window().then(async (win) => {
                 win.callAction1({
                     actionName: "moveText",
-                    componentName: t1bName,
+                    componentIdx: t1bName,
                     args: { x: -6, y: 3 },
                 });
                 win.callAction1({
                     actionName: "moveText",
-                    componentName: t2bName,
+                    componentIdx: t2bName,
                     args: { x: -5, y: -4 },
                 });
             });

--- a/packages/test-cypress/cypress/e2e/variants/specifysinglevariant.cy.js
+++ b/packages/test-cypress/cypress/e2e/variants/specifysinglevariant.cy.js
@@ -73,8 +73,8 @@ describe("Specifying single variant document tests", function () {
                 expect(variantInd).not.eq(undefined);
 
                 let secondValue =
-                    stateVariables[p.activeChildren[1].componentName]
-                        .stateValues.value;
+                    stateVariables[p.activeChildren[1].componentIdx].stateValues
+                        .value;
 
                 if (variantInd === 0) {
                     let i = [
@@ -145,7 +145,7 @@ describe("Specifying single variant document tests", function () {
                     expect(variantInd2).eq(variantInd);
 
                     let secondValue2 =
-                        stateVariables[p.activeChildren[1].componentName]
+                        stateVariables[p.activeChildren[1].componentIdx]
                             .stateValues.value;
                     expect(secondValue2).eq(secondValue);
 
@@ -515,16 +515,16 @@ describe("Specifying single variant document tests", function () {
 
             let mathinput1Name =
                 stateVariables[`/g/ans`].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinput2Name =
                 stateVariables[`/g2/ans`].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinput3Name =
                 stateVariables[`/g3/ans`].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
             let mathinput4Name =
                 stateVariables[`/ans`].stateValues.inputChildren[0]
-                    .componentName;
+                    .componentIdx;
 
             let mathinput1Anchor = cesc2("#" + mathinput1Name) + " textarea";
             let answer1Correct = cesc2("#" + mathinput1Name + "_correct");

--- a/packages/utils/src/ast/ast.js
+++ b/packages/utils/src/ast/ast.js
@@ -6,16 +6,16 @@ export function extractComponentNamesAndIndices(
 
     for (let serializedComponent of serializedComponents) {
         if (typeof serializedComponent === "object") {
-            let componentName = serializedComponent.componentName;
+            let componentIdx = serializedComponent.componentIdx;
             for (let originalName in nameSubstitutions) {
-                componentName = componentName.replace(
+                componentIdx = componentIdx.replace(
                     originalName,
                     nameSubstitutions[originalName],
                 );
             }
             if (serializedComponent.doenetAttributes?.fromCopyTarget) {
-                let lastSlash = componentName.lastIndexOf("/");
-                let originalName = componentName.slice(lastSlash + 1);
+                let lastSlash = componentIdx.lastIndexOf("/");
+                let originalName = componentIdx.slice(lastSlash + 1);
                 let newName =
                     serializedComponent.doenetAttributes
                         .assignNamesForCompositeReplacement;
@@ -23,11 +23,11 @@ export function extractComponentNamesAndIndices(
                     newName =
                         serializedComponent.doenetAttributes.assignNames[0];
                 }
-                componentName = componentName.replace(originalName, newName);
+                componentIdx = componentIdx.replace(originalName, newName);
                 nameSubstitutions[originalName] = newName;
             }
             let componentObj = {
-                componentName,
+                componentIdx,
             };
             if (serializedComponent.doenetMLrange) {
                 if (
@@ -89,7 +89,7 @@ export function extractRangeIndexPieces({
                 rangePieces.push({
                     begin: lastInd,
                     end: stopInd,
-                    componentName: enclosingComponentName,
+                    componentIdx: enclosingComponentName,
                 });
             }
             foundComponentAfterStopInd = true;
@@ -100,7 +100,7 @@ export function extractRangeIndexPieces({
             rangePieces.push({
                 begin: lastInd,
                 end: componentObj.indBegin - 1,
-                componentName: enclosingComponentName,
+                componentIdx: enclosingComponentName,
             });
         }
 
@@ -108,7 +108,7 @@ export function extractRangeIndexPieces({
             componentArray: componentArray.slice(componentInd + 1),
             lastInd: componentObj.indBegin,
             stopInd: componentObj.indEnd,
-            enclosingComponentName: componentObj.componentName,
+            enclosingComponentName: componentObj.componentIdx,
         });
 
         componentInd += extractResult.componentsConsumed + 1;
@@ -125,7 +125,7 @@ export function extractRangeIndexPieces({
         rangePieces.push({
             begin: lastInd,
             end: stopInd,
-            componentName: enclosingComponentName,
+            componentIdx: enclosingComponentName,
         });
     }
 

--- a/packages/utils/src/components/naming.ts
+++ b/packages/utils/src/components/naming.ts
@@ -36,12 +36,12 @@ export function getUniqueIdentifierFromBase(
     return uniqueIdentifier;
 }
 
-export function getNamespaceFromName(componentName: string) {
-    let lastSlash = componentName.lastIndexOf("/");
+export function getNamespaceFromName(componentIdx: string) {
+    let lastSlash = componentIdx.lastIndexOf("/");
     if (lastSlash === -1) {
         throw Error(
-            `Encountered name ${componentName} that doesn't include a slash`,
+            `Encountered name ${componentIdx} that doesn't include a slash`,
         );
     }
-    return componentName.slice(0, lastSlash + 1);
+    return componentIdx.slice(0, lastSlash + 1);
 }

--- a/packages/utils/src/copy/deepFunctions.js
+++ b/packages/utils/src/copy/deepFunctions.js
@@ -81,7 +81,7 @@ export function deepCompare(a, b, BaseComponent) {
             x instanceof BaseComponent &&
             y instanceof BaseComponent
         ) {
-            return x.componentName === y.componentName;
+            return x.componentIdx === y.componentIdx;
         }
 
         // if math-expressions, equal if exact same syntax tree

--- a/packages/utils/src/style/style.js
+++ b/packages/utils/src/style/style.js
@@ -269,13 +269,12 @@ export function returnStyleDefinitionStateVariables() {
             };
 
             for (let setupChild of stateValues.setupChildren) {
-                dependencies[`styleDefinitionsOf${setupChild.componentName}`] =
-                    {
-                        dependencyType: "child",
-                        parentName: setupChild.componentName,
-                        childGroups: ["styleDefinitions"],
-                        variableNames: ["value"],
-                    };
+                dependencies[`styleDefinitionsOf${setupChild.componentIdx}`] = {
+                    dependencyType: "child",
+                    parentIdx: setupChild.componentIdx,
+                    childGroups: ["styleDefinitions"],
+                    variableNames: ["value"],
+                };
             }
 
             return dependencies;
@@ -307,7 +306,7 @@ export function returnStyleDefinitionStateVariables() {
             for (let child of dependencyValues.setupChildren) {
                 styleDefinitionChildren.push(
                     ...dependencyValues[
-                        `styleDefinitionsOf${child.componentName}`
+                        `styleDefinitionsOf${child.componentIdx}`
                     ],
                 );
             }


### PR DESCRIPTION
This PR simply renames `componentName` to `componentIdx` and similar for related names without changing an functionality. The goal is to reduce the changeset for #318 by including non-functional changes here.