### PR TITLE
Resolve references in leftover path parts

### DIFF
--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast.rs
@@ -137,6 +137,8 @@ impl FlatError {
 /// A part of a ref path
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(test, derive(PartialEq))]
+#[serde(tag = "type")]
+#[serde(rename = "flatPathPart")]
 #[cfg_attr(feature = "web", derive(Tsify))]
 pub struct FlatPathPart {
     pub name: String,

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use tsify_next::{declare, Tsify};
 
 use super::{
-    super::{ref_resolve::RefResolution, PathPart, Position},
+    super::{ref_resolve::RefResolution, Position},
     normalized_flat_dast::{NormalizedNode, NormalizedRoot},
 };
 
@@ -17,6 +17,7 @@ pub type Index = usize;
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(test, derive(PartialEq))]
 #[cfg_attr(feature = "web", derive(Tsify))]
 pub enum UntaggedContent {
     Text(String),
@@ -133,11 +134,34 @@ impl FlatError {
     }
 }
 
+/// A part of a ref path
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(feature = "web", derive(Tsify))]
+pub struct FlatPathPart {
+    pub name: String,
+    pub index: Vec<FlatIndex>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<Position>,
+}
+
+/// An index into a ref path
+#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(feature = "web", derive(Tsify))]
+pub struct FlatIndex {
+    pub value: Vec<UntaggedContent>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<Position>,
+}
+
 #[derive(Clone, Debug, Serialize)]
 pub struct FlatRef {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent: Option<Index>,
-    pub path: Vec<PathPart>,
+    pub path: Vec<FlatPathPart>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub position: Option<Position>,
     pub idx: Index,
@@ -147,7 +171,7 @@ pub struct FlatRef {
 pub struct FlatFunctionRef {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent: Option<Index>,
-    pub path: Vec<PathPart>,
+    pub path: Vec<FlatPathPart>,
     pub input: Option<Vec<Vec<UntaggedContent>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub position: Option<Position>,

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast.test.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast.test.rs
@@ -6,7 +6,7 @@ use crate::test_utils::*;
 #[test]
 fn can_flatten_dast_root() {
     let dast_root = dast_root_no_position(
-        r#"<document>hi<foo my_attr="777 $x.y.z"/>and$$f(<bar>xxx</bar>)</document>"#,
+        r#"<document>hi<foo my_attr="777 $x.y.z[$a]"/>and$$f(<bar>xxx</bar>)</document>"#,
     );
     let flat_root = FlatRoot::from_dast(&dast_root);
     // It is easier to compare JSON, so we serialize and deserialize for the comparison.
@@ -20,7 +20,7 @@ fn can_flatten_dast_root() {
                   {
                     "type": "Element",
                     "name": "document",
-                    "children": ["hi", 1, "and", 3],
+                    "children": ["hi", 1, "and", 4],
                     "attributes": [],
                     "idx": 0
                   },
@@ -40,24 +40,32 @@ fn can_flatten_dast_root() {
                     "path": [
                       { "name": "x", "index": [] },
                       { "name": "y", "index": [] },
-                      { "name": "z", "index": [] }
+                      { "name": "z", "index": [{"value": [3]}] }
                     ],
                     "idx": 2
+                  },
+                  {
+                    "type": "Ref",
+                    "parent": 2,
+                    "path": [
+                      { "name": "a", "index": [] },
+                    ],
+                    "idx": 3
                   },
                   {
                     "type": "FunctionRef",
                     "parent": 0,
                     "path": [{ "name": "f", "index": [] }],
-                    "input": [[4]],
-                    "idx": 3
+                    "input": [[5]],
+                    "idx": 4
                   },
                   {
                     "type": "Element",
                     "name": "bar",
-                    "parent": 3,
+                    "parent": 4,
                     "children": ["xxx"],
                     "attributes": [],
-                    "idx": 4
+                    "idx": 5
                   }
                 ]
               }

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast.test.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast.test.rs
@@ -38,9 +38,9 @@ fn can_flatten_dast_root() {
                     "type": "Ref",
                     "parent": 1,
                     "path": [
-                      { "name": "x", "index": [] },
-                      { "name": "y", "index": [] },
-                      { "name": "z", "index": [{"value": [3]}] }
+                      { "type": "flatPathPart", "name": "x", "index": [] },
+                      { "type": "flatPathPart", "name": "y", "index": [] },
+                      { "type": "flatPathPart", "name": "z", "index": [{"value": [3]}] }
                     ],
                     "idx": 2
                   },
@@ -48,14 +48,14 @@ fn can_flatten_dast_root() {
                     "type": "Ref",
                     "parent": 2,
                     "path": [
-                      { "name": "a", "index": [] },
+                      { "type": "flatPathPart", "name": "a", "index": [] },
                     ],
                     "idx": 3
                   },
                   {
                     "type": "FunctionRef",
                     "parent": 0,
-                    "path": [{ "name": "f", "index": [] }],
+                    "path": [{ "type": "flatPathPart", "name": "f", "index": [] }],
                     "input": [[5]],
                     "idx": 4
                   },

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast.test.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast.test.rs
@@ -38,16 +38,16 @@ fn can_flatten_dast_root() {
                     "type": "Ref",
                     "parent": 1,
                     "path": [
-                      { "type": "pathPart", "name": "x", "index": [] },
-                      { "type": "pathPart", "name": "y", "index": [] },
-                      { "type": "pathPart", "name": "z", "index": [] }
+                      { "name": "x", "index": [] },
+                      { "name": "y", "index": [] },
+                      { "name": "z", "index": [] }
                     ],
                     "idx": 2
                   },
                   {
                     "type": "FunctionRef",
                     "parent": 0,
-                    "path": [{ "type": "pathPart", "name": "f", "index": [] }],
+                    "path": [{ "name": "f", "index": [] }],
                     "input": [[4]],
                     "idx": 3
                   },

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_compactify.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_compactify.rs
@@ -16,6 +16,22 @@ impl FlatNode {
                             UntaggedContent::Ref(idx) => Some(*idx),
                             _ => None,
                         })
+                    }))
+                    .chain(elm.extending.iter().flat_map(|extending| {
+                        extending
+                            .get_resolution()
+                            .unresolved_path
+                            .iter()
+                            .flat_map(|path| {
+                                path.iter().flat_map(|path_part| {
+                                    path_part.index.iter().flat_map(|index| {
+                                        index.value.iter().flat_map(|node| match node {
+                                            UntaggedContent::Ref(idx) => Some(*idx),
+                                            _ => None,
+                                        })
+                                    })
+                                })
+                            })
                     })),
             ),
             FlatNode::FunctionRef(function_ref) => {

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_compactify.test.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_compactify.test.rs
@@ -175,7 +175,6 @@ fn compactify_adjusts_extending_refs_and_attributes() {
                     "node_idx": 3,
                     "unresolved_path": [
                       {
-                        "type": "pathPart",
                         "name": "immediateValue",
                         "index": []
                       }

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_compactify.test.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_compactify.test.rs
@@ -175,6 +175,7 @@ fn compactify_adjusts_extending_refs_and_attributes() {
                     "node_idx": 3,
                     "unresolved_path": [
                       {
+                        "type": "flatPathPart",
                         "name": "immediateValue",
                         "index": []
                       }
@@ -194,8 +195,6 @@ fn compactify_preserves_refs_in_path_parts() {
     let mut flat_root = FlatRoot::from_dast(&dast_root);
     Expander::expand(&mut flat_root);
     flat_root.compactify();
-
-    println!("{:#?}", serde_json::to_value(&flat_root).unwrap());
 
     assert_json_eq!(
         serde_json::to_value(&flat_root).unwrap(),
@@ -251,6 +250,7 @@ fn compactify_preserves_refs_in_path_parts() {
                     "node_idx": 2,
                     "unresolved_path": [
                       {
+                        "type": "flatPathPart",
                         "name": "",
                         "index": [
                           {

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_compactify.test.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_compactify.test.rs
@@ -187,3 +187,97 @@ fn compactify_adjusts_extending_refs_and_attributes() {
         )
     );
 }
+
+#[test]
+fn compactify_preserves_refs_in_path_parts() {
+    let dast_root = dast_root_no_position(r#"<number name="n"/><point name="p"/>$p[$n]"#);
+    let mut flat_root = FlatRoot::from_dast(&dast_root);
+    Expander::expand(&mut flat_root);
+    flat_root.compactify();
+
+    println!("{:#?}", serde_json::to_value(&flat_root).unwrap());
+
+    assert_json_eq!(
+        serde_json::to_value(&flat_root).unwrap(),
+        json!(
+          {
+            "type": "FlatRoot",
+            "children": [0],
+            "nodes": [
+              {
+                "type": "Element",
+                "name": "document",
+                "children": [1, 2, 3],
+                "attributes": [],
+                "idx": 0
+              },
+              {
+                "type": "Element",
+                "name": "number",
+                "parent": 0,
+                "children": [],
+                "attributes": [
+                  {
+                    "name": "name",
+                    "parent": 1,
+                    "children": ["n"]
+                  }
+                ],
+                "idx": 1
+              },
+              {
+                "type": "Element",
+                "name": "point",
+                "parent": 0,
+                "children": [],
+                "attributes": [
+                  {
+                    "name": "name",
+                    "parent": 2,
+                    "children": ["p"]
+                  }
+                ],
+                "idx": 2,
+              },
+              {
+                "type": "Element",
+                "name": "point",
+                "parent": 0,
+                "children": [],
+                "attributes": [],
+                "idx": 3,
+                "extending": {
+                  "Ref": {
+                    "node_idx": 2,
+                    "unresolved_path": [
+                      {
+                        "name": "",
+                        "index": [
+                          {
+                            "value": [4]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "type": "Element",
+                "name": "number",
+                "parent": 3,
+                "children": [],
+                "attributes": [],
+                "idx": 4,
+                "extending": {
+                  "Ref": {
+                    "node_idx": 1,
+                    "unresolved_path": null
+                  }
+                }
+              }
+            ]
+          }
+        )
+    );
+}

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_merge.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_merge.rs
@@ -197,7 +197,7 @@ impl FlatRoot {
         idx
     }
 
-    /// Convert PathParts from dast in FlatPathPars, adding nodes to the flat root
+    /// Convert PathParts from dast to FlatPathParts, adding nodes to the flat root
     fn dast_path_to_flat_path(
         &mut self,
         dast_path: &[PathPart],

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_merge.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_merge.rs
@@ -200,7 +200,7 @@ impl FlatRoot {
     /// Convert PathParts from dast in FlatPathPars, adding nodes to the flat root
     fn dast_path_to_flat_path(
         &mut self,
-        dast_path: &Vec<PathPart>,
+        dast_path: &[PathPart],
         parent_idx: Index,
     ) -> Vec<FlatPathPart> {
         dast_path

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/ref_expand.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/ref_expand.rs
@@ -146,8 +146,8 @@ impl Expander {
         }
     }
 
-    /// Remove all `extend` attributes from the `FlatRoot` and replace them
-    /// an extending field that is a ref_resolution with the index of their referent.
+    /// Remove any `extend` attributes from nodes,
+    /// and instead set each node's `extending` to a `Source::Attribute` containing the extend's referent.
     /// This should be called _after_ all refs have been expanded into element form.
     fn consume_extend_attributes(flat_root: &mut FlatRoot) {
         for i in 0..flat_root.nodes.len() {

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/ref_expand.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/ref_expand.rs
@@ -146,7 +146,8 @@ impl Expander {
         }
     }
 
-    /// Remove all `extend` attributes from the `FlatRoot` and replace them with the index of their referent.
+    /// Remove all `extend` attributes from the `FlatRoot` and replace them
+    /// an extending field that is a ref_resolution with the index of their referent.
     /// This should be called _after_ all refs have been expanded into element form.
     fn consume_extend_attributes(flat_root: &mut FlatRoot) {
         for i in 0..flat_root.nodes.len() {

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/ref_expand.test.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/ref_expand.test.rs
@@ -125,7 +125,6 @@ fn leftover_path_parts_are_kept() {
                           {
                             "index": [],
                             "name": "x",
-                            "type": "pathPart"
                           }
                         ]
                       }

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/ref_expand.test.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/ref_expand.test.rs
@@ -137,6 +137,93 @@ fn leftover_path_parts_are_kept() {
 }
 
 #[test]
+fn references_expanded_in_leftover_path_parts() {
+    let dast_root = dast_root_no_position(r#"<point name="p" /><number name="n" />$p.x[$n]"#);
+    let mut flat_root = FlatRoot::from_dast(&dast_root);
+    Expander::expand(&mut flat_root);
+    println!("{:#?}", serde_json::to_value(&flat_root).unwrap());
+    assert_json_eq!(
+        serde_json::to_value(&flat_root).unwrap(),
+        json!(
+            {
+                "type": "FlatRoot",
+                "children": [0],
+                "nodes": [
+                  {
+                    "type": "Element",
+                    "name": "document",
+                    "children": [1, 2, 3],
+                    "attributes": [],
+                    "idx": 0
+                  },
+                  {
+                    "type": "Element",
+                    "name": "point",
+                    "parent": 0,
+                    "children": [],
+                    "attributes": [
+                      {
+                        "name": "name",
+                        "parent": 1,
+                        "children": ["p"]
+                      }
+                    ],
+                    "idx": 1
+                  },
+                  {
+                    "type": "Element",
+                    "name": "number",
+                    "parent": 0,
+                    "children": [],
+                    "attributes": [
+                      {
+                        "name": "name",
+                        "parent": 2,
+                        "children": ["n"]
+                      }
+                    ],
+                    "idx": 2
+                  },
+                  {
+                    "type": "Element",
+                    "name": "point",
+                    "parent": 0,
+                    "children": [],
+                    "attributes": [],
+                    "idx": 3,
+                    "extending": {
+                      "Ref": {
+                        "node_idx": 1,
+                        "unresolved_path": [
+                          {
+                            "index": [{ "value": [4] }],
+                            "name": "x",
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "type": "Element",
+                    "name": "number",
+                    "parent": 3,
+                    "children": [],
+                    "attributes": [],
+                    "idx": 4,
+                    "extending": {
+                      "Ref": {
+                        "node_idx": 2,
+                        "unresolved_path": null
+                      }
+                    }
+                  }
+                ]
+              }
+        )
+    );
+}
+
+#[test]
 fn refs_in_attributes_are_expanded() {
     let dast_root = dast_root_no_position(r#"<point name="p" /><a foo="$p" />"#);
     let mut flat_root = FlatRoot::from_dast(&dast_root);

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/ref_expand.test.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/ref_expand.test.rs
@@ -138,10 +138,9 @@ fn leftover_path_parts_are_kept() {
 
 #[test]
 fn references_expanded_in_leftover_path_parts() {
-    let dast_root = dast_root_no_position(r#"<point name="p" /><number name="n" />$p.x[$n]"#);
+    let dast_root = dast_root_no_position(r#"<point name="p" /><number name="n" />$p.x[$p.y[$n]]"#);
     let mut flat_root = FlatRoot::from_dast(&dast_root);
     Expander::expand(&mut flat_root);
-    println!("{:#?}", serde_json::to_value(&flat_root).unwrap());
     assert_json_eq!(
         serde_json::to_value(&flat_root).unwrap(),
         json!(
@@ -205,11 +204,30 @@ fn references_expanded_in_leftover_path_parts() {
                   },
                   {
                     "type": "Element",
-                    "name": "number",
+                    "name": "point",
                     "parent": 3,
                     "children": [],
                     "attributes": [],
                     "idx": 4,
+                    "extending": {
+                      "Ref": {
+                        "node_idx": 1,
+                        "unresolved_path": [
+                          {
+                            "index": [{ "value": [5] }],
+                            "name": "y",
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "type": "Element",
+                    "name": "number",
+                    "parent": 4,
+                    "children": [],
+                    "attributes": [],
+                    "idx": 5,
                     "extending": {
                       "Ref": {
                         "node_idx": 2,

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/ref_expand.test.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/ref_expand.test.rs
@@ -123,6 +123,7 @@ fn leftover_path_parts_are_kept() {
                         "node_idx": 1,
                         "unresolved_path": [
                           {
+                            "type": "flatPathPart",
                             "index": [],
                             "name": "x",
                           }
@@ -195,6 +196,7 @@ fn references_expanded_in_leftover_path_parts() {
                         "node_idx": 1,
                         "unresolved_path": [
                           {
+                            "type": "flatPathPart",
                             "index": [{ "value": [4] }],
                             "name": "x",
                           }
@@ -214,6 +216,7 @@ fn references_expanded_in_leftover_path_parts() {
                         "node_idx": 1,
                         "unresolved_path": [
                           {
+                            "type": "flatPathPart",
                             "index": [{ "value": [5] }],
                             "name": "y",
                           }

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/ref_resolve.test.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/ref_resolve.test.rs
@@ -1,8 +1,5 @@
 use super::*;
-use crate::{
-    dast::{DastIndex, DastText, DastTextRefContent},
-    test_utils::*,
-};
+use crate::{dast::flat_dast::FlatIndex, test_utils::*};
 use test_helpers::*;
 #[test]
 fn can_resolve_name_among_parents() {
@@ -73,7 +70,7 @@ fn can_resolve_names() {
         referent,
         Ok(RefResolution {
             node_idx: c_idx,
-            unresolved_path: Some(vec![PathPart {
+            unresolved_path: Some(vec![FlatPathPart {
                 name: "w".into(),
                 index: vec![],
                 position: None
@@ -100,12 +97,12 @@ fn resolution_stops_at_path_index() {
 
     // `$y.z`
     let path = vec![
-        PathPart {
+        FlatPathPart {
             name: "y".into(),
             index: vec![],
             position: None,
         },
-        PathPart {
+        FlatPathPart {
             name: "z".into(),
             index: vec![],
             position: None,
@@ -120,23 +117,19 @@ fn resolution_stops_at_path_index() {
         })
     );
 
-    let index = vec![DastIndex {
-        value: vec![DastTextRefContent::Text(DastText {
-            value: "2".into(),
-            position: None,
-            data: None,
-        })],
+    let index = vec![FlatIndex {
+        value: vec![UntaggedContent::Text("2".into())],
         position: None,
     }];
 
     // `$y[2].z`
     let path = vec![
-        PathPart {
+        FlatPathPart {
             name: "y".into(),
             index: index.clone(),
             position: None,
         },
-        PathPart {
+        FlatPathPart {
             name: "z".into(),
             index: vec![],
             position: None,
@@ -148,12 +141,12 @@ fn resolution_stops_at_path_index() {
         Ok(RefResolution {
             node_idx: b_idx,
             unresolved_path: Some(vec![
-                PathPart {
+                FlatPathPart {
                     name: "".into(),
                     index: index.clone(),
                     position: None
                 },
-                PathPart {
+                FlatPathPart {
                     name: "z".into(),
                     index: vec![],
                     position: None
@@ -178,22 +171,18 @@ fn resolution_matches_largest_possible_when_index_present() {
 
     let resolver = Resolver::from_flat_root(&flat_root);
 
-    let index = vec![DastIndex {
-        value: vec![DastTextRefContent::Text(DastText {
-            value: "2".into(),
-            position: None,
-            data: None,
-        })],
+    let index = vec![FlatIndex {
+        value: vec![UntaggedContent::Text("2".into())],
         position: None,
     }];
     // `$y.z[2]`
     let path = vec![
-        PathPart {
+        FlatPathPart {
             name: "y".into(),
             index: vec![],
             position: None,
         },
-        PathPart {
+        FlatPathPart {
             name: "z".into(),
             index: index.clone(),
             position: None,
@@ -205,7 +194,7 @@ fn resolution_matches_largest_possible_when_index_present() {
         referent,
         Ok(RefResolution {
             node_idx: c_idx,
-            unresolved_path: Some(vec![PathPart {
+            unresolved_path: Some(vec![FlatPathPart {
                 name: "".into(),
                 index: index.clone(),
                 position: None
@@ -238,11 +227,11 @@ mod test_helpers {
         })
     }
 
-    pub fn make_path<'a, T: AsRef<[&'a str]>>(path_str: T) -> Vec<PathPart> {
+    pub fn make_path<'a, T: AsRef<[&'a str]>>(path_str: T) -> Vec<FlatPathPart> {
         let path_str = path_str.as_ref();
         path_str
             .iter()
-            .map(|s| PathPart {
+            .map(|s| FlatPathPart {
                 name: s.to_string(),
                 index: Vec::new(),
                 position: None,

--- a/packages/doenetml-worker/lib-doenetml-core/tests/test_utils/mod.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/tests/test_utils/mod.rs
@@ -1,7 +1,8 @@
 //! This file contains utilities for testing DoenetMLCore.
 use doenetml_core::components::types::{Action, ComponentIdx, LocalPropIdx, PropPointer};
+use doenetml_core::dast::flat_dast::FlatPathPart;
 use doenetml_core::dast::ref_resolve::Resolver;
-use doenetml_core::dast::{DastRoot, FlatDastElementUpdate, FlatDastRoot, PathPart};
+use doenetml_core::dast::{DastRoot, FlatDastElementUpdate, FlatDastRoot};
 use doenetml_core::props::cache::PropWithMeta;
 use doenetml_core::props::traits::IntoPropView;
 use doenetml_core::props::{PropValue, PropView};
@@ -235,7 +236,7 @@ impl TestCore {
         let resolver = self.resolver.as_ref().unwrap();
         let resolved = resolver
             .resolve(
-                &[PathPart {
+                &[FlatPathPart {
                     name: name.to_string(),
                     index: vec![],
                     position: None,

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -156,7 +156,7 @@ export function EditorViewer({
     useEffect(() => {
         function submittedResponseListener(event: any) {
             if (event.data.subject == "SPLICE.sendEvent") {
-                const data = event.data.data;
+                const data = event.data;
                 if (data.verb === "submitted") {
                     const object = JSON.parse(data.object);
                     const answerId = object.componentIdx;


### PR DESCRIPTION
This PR extends the rust resolver to resolve references in indices of path paths. For example, in a reference `$x.y[$n]`, the `$n` from the index is resolved to its referent.
