### PR TITLE
Bugfix: account for hidden or components without renderers when adding commas from composites

### DIFF
--- a/packages/doenetml-worker-javascript/src/Core.js
+++ b/packages/doenetml-worker-javascript/src/Core.js
@@ -1085,12 +1085,15 @@ export default class Core {
             let componentInstruction = this.componentsToRender[componentIdx];
             if (componentInstruction) {
                 for (let child of componentInstruction.children) {
-                    let additionalDeleted = this.deleteFromComponentsToRender({
-                        componentIdx: child.componentIdx,
-                        recurseToChildren,
-                        componentsWithChangedChildrenToRenderInProgress,
-                    });
-                    deletedComponentNames.push(...additionalDeleted);
+                    if (child) {
+                        let additionalDeleted =
+                            this.deleteFromComponentsToRender({
+                                componentIdx: child.componentIdx,
+                                recurseToChildren,
+                                componentsWithChangedChildrenToRenderInProgress,
+                            });
+                        deletedComponentNames.push(...additionalDeleted);
+                    }
                 }
             }
         }

--- a/packages/doenetml-worker-javascript/src/Core.js
+++ b/packages/doenetml-worker-javascript/src/Core.js
@@ -779,7 +779,11 @@ export default class Core {
                                     `number${renderedInd}:${child.toString()}`,
                                 );
                                 renderedInd++;
+                            } else {
+                                currentChildIdentifiers.push("");
                             }
+                        } else {
+                            currentChildIdentifiers.push("");
                         }
                     }
                 }
@@ -789,7 +793,9 @@ export default class Core {
 
                 let previousChildIdentifiers = [];
                 for (let [ind, child] of previousChildRenderers.entries()) {
-                    if (child.componentIdx) {
+                    if (child === null) {
+                        previousChildIdentifiers.push("");
+                    } else if (child.componentIdx) {
                         previousChildIdentifiers.push(
                             `nameType:${child.componentIdx};${child.componentType}`,
                         );
@@ -811,7 +817,7 @@ export default class Core {
                 ) {
                     // delete old renderers
                     for (let child of previousChildRenderers) {
-                        if (child.componentIdx) {
+                        if (child?.componentIdx) {
                             let deletedNames =
                                 this.deleteFromComponentsToRender({
                                     componentIdx: child.componentIdx,
@@ -846,7 +852,11 @@ export default class Core {
                                     childrenToRender.push(child);
                                 } else if (typeof child === "number") {
                                     childrenToRender.push(child.toString());
+                                } else {
+                                    childrenToRender.push(null);
                                 }
+                            } else {
+                                childrenToRender.push(null);
                             }
                         }
                     }
@@ -999,7 +1009,11 @@ export default class Core {
                         childrenToRender.push(child);
                     } else if (typeof child === "number") {
                         childrenToRender.push(child.toString());
+                    } else {
+                        childrenToRender.push(null);
                     }
+                } else {
+                    childrenToRender.push(null);
                 }
             }
         }

--- a/packages/doenetml/src/Viewer/useDoenetRenderer.tsx
+++ b/packages/doenetml/src/Viewer/useDoenetRenderer.tsx
@@ -69,10 +69,13 @@ export default function useDoenetRenderer(
     }, [renderersToLoad, props.rendererClasses]);
 
     function createChildFromInstructions(
-        childInstructions: Record<string, any> | string,
+        childInstructions: Record<string, any> | string | null,
         loadMoreRenderers: boolean,
     ) {
-        if (typeof childInstructions === "string") {
+        if (
+            typeof childInstructions === "string" ||
+            childInstructions === null
+        ) {
             return childInstructions;
         }
 

--- a/packages/test-cypress/cypress/e2e/baseComponent/renderCommas.cy.js
+++ b/packages/test-cypress/cypress/e2e/baseComponent/renderCommas.cy.js
@@ -1,0 +1,26 @@
+import { cesc2 } from "@doenet/utils";
+
+describe("Render commas tests", function () {
+    beforeEach(() => {
+        cy.clearIndexedDB();
+        cy.visit("/");
+    });
+
+    it("render commas accounts for hidden and components without renderers", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+<function name="f">x+5</function>
+<number hide>5</number>
+<functionIterates name="fi" function="$f" numIterates="3" initialValue="4" />
+$fi.iterates
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(".doenet-viewer").should("contain.text", "9, 14, 19");
+    });
+});


### PR DESCRIPTION
This PR fixes a bug where the calculations to add commas to composite replacements did not account for the fact that hidden components and components without renderers were removed from the list of rendered components.