### PR TITLE
Correctly adjust indices when compactifying the flat dast

### DIFF
--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast.rs
@@ -76,6 +76,14 @@ impl Source<RefResolution> {
         }
     }
 
+    /// Unwraps the `RefResolution` from `self` and returns a mutable reference.
+    pub fn get_resolution_mut(&mut self) -> &mut RefResolution {
+        match self {
+            Source::Attribute(a) => a,
+            Source::Ref(m) => m,
+        }
+    }
+
     /// Similar to `get_resolution`, but consumes `self` and returns the `RefResolution`.
     pub fn take_resolution(self) -> RefResolution {
         match self {

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_compactify.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_compactify.rs
@@ -81,6 +81,20 @@ impl FlatNode {
                 if let Some(extending) = &mut elm.extending {
                     let new_idx = ref_index_map[extending.idx()];
                     extending.set_idx(new_idx);
+
+                    // extending might also have indices that are references that also need fixing.
+                    let resolution = extending.get_resolution_mut();
+                    resolution.unresolved_path.iter_mut().for_each(|paths| {
+                        paths.iter_mut().for_each(|path_part| {
+                            path_part.index.iter_mut().for_each(|index| {
+                                index.value.iter_mut().for_each(|node| {
+                                    if let UntaggedContent::Ref(idx) = node {
+                                        *idx = ref_index_map[*idx];
+                                    }
+                                })
+                            })
+                        });
+                    });
                 }
             }
             FlatNode::FunctionRef(function_ref) => {

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_compactify.test.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_compactify.test.rs
@@ -281,3 +281,111 @@ fn compactify_preserves_refs_in_path_parts() {
         )
     );
 }
+
+#[test]
+fn compactify_shifts_refs_in_path_parts() {
+    let dast_root =
+        dast_root_no_position(r#"<number name="n"/><point name="p"/><point extend="$p" />$p[$n]"#);
+    let mut flat_root = FlatRoot::from_dast(&dast_root);
+    Expander::expand(&mut flat_root);
+    flat_root.compactify();
+
+    assert_json_eq!(
+        serde_json::to_value(&flat_root).unwrap(),
+        json!(
+          {
+            "type": "FlatRoot",
+            "children": [0],
+            "nodes": [
+              {
+                "type": "Element",
+                "name": "document",
+                "children": [1, 2, 3, 4],
+                "attributes": [],
+                "idx": 0
+              },
+              {
+                "type": "Element",
+                "name": "number",
+                "parent": 0,
+                "children": [],
+                "attributes": [
+                  {
+                    "name": "name",
+                    "parent": 1,
+                    "children": ["n"]
+                  }
+                ],
+                "idx": 1
+              },
+              {
+                "type": "Element",
+                "name": "point",
+                "parent": 0,
+                "children": [],
+                "attributes": [
+                  {
+                    "name": "name",
+                    "parent": 2,
+                    "children": ["p"]
+                  }
+                ],
+                "idx": 2,
+              },
+              {
+                "type": "Element",
+                "name": "point",
+                "parent": 0,
+                "children": [],
+                "attributes": [],
+                "idx": 3,
+                "extending": {
+                  "Attribute": {
+                    "node_idx": 2,
+                    "unresolved_path": null
+                  }
+                }
+              },
+              {
+                "type": "Element",
+                "name": "point",
+                "parent": 0,
+                "children": [],
+                "attributes": [],
+                "idx": 4,
+                "extending": {
+                  "Ref": {
+                    "node_idx": 2,
+                    "unresolved_path": [
+                      {
+                        "type": "flatPathPart",
+                        "name": "",
+                        "index": [
+                          {
+                            "value": [5]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "type": "Element",
+                "name": "number",
+                "parent": 4,
+                "children": [],
+                "attributes": [],
+                "idx": 5,
+                "extending": {
+                  "Ref": {
+                    "node_idx": 1,
+                    "unresolved_path": null
+                  }
+                }
+              }
+            ]
+          }
+        )
+    );
+}


### PR DESCRIPTION
The PR fixes a bug in flat dast compactification, where the indices of unresolved paths were not shifted.