### PR TITLE
Add: initial prototype of Markdown in Doenet

### DIFF
--- a/packages/parser/test/dast-basic.test.ts
+++ b/packages/parser/test/dast-basic.test.ts
@@ -13,6 +13,7 @@ import {
     splitTextAtSpecialChars,
     splitTextNodeAt,
 } from "../src/lezer-to-dast/gobble-function-arguments";
+import { normalizeDocumentDast } from "../src/dast-normalize/normalize-dast";
 
 const origLog = console.log;
 console.log = (...args) => {
@@ -469,5 +470,15 @@ describe("DAST", async () => {
             "type": "root",
           }
         `);
+    });
+    it("converts Markdown text to HTML", () => {
+        let source: string;
+        let dast: ReturnType<typeof lezerToDast>;
+
+        source = `*hi*\n\n# there!`;
+        dast = lezerToDast(source);
+        expect(toXml(normalizeDocumentDast(dast))).toEqual(
+            "<document><p><em>hi</em></p><h1>there!</h1></document>",
+        );
     });
 });

--- a/packages/test-viewer/src/test/testCode.doenet
+++ b/packages/test-viewer/src/test/testCode.doenet
@@ -1,3 +1,5 @@
+**test**
+
 <graph>
     <point name="P" x="3" y="1" />
     <rectangle width="40" height="40" center="(0,0)" filled name="R" />
@@ -17,8 +19,8 @@
   <p>A lovely section.</p>
   <problem>
     <p>
-      This problem is nested inside a section. The default number does not
-      include the parent number.
+    This problem is nested inside a section. The default number does not
+    include the parent number.
     </p>
   </problem>
 </section>
@@ -27,8 +29,8 @@
   <p>Another section!</p>
   <problem includeParentNumber="true">
     <p>
-      This exercise is nested inside a section. Rendering of the parent section
-      number has been included.
+    This exercise is nested inside a section. Rendering of the parent section
+    number has been included.
     </p>
   </problem>
 </section>


### PR DESCRIPTION
Several tests fail; a quick inspection shows failures related to treating text as Markdown, so I'm ignoring these failures until we decide to move in this direction.

The test I added in `dast-basic.test.ts` shows that text is correctly parsed as Markdown by `normalizeDocumentDast`. However, the test-viewer application doesn't render the resulting DAST, even though the resulting DAST tree I print from `normalizeDocumentDast` seems correct when comparing `<p><em>testing</em></p>` and its Markdown equivalent, `*testing*`. Any ideas on why this DAST doesn't render?

The resulting DAST:
![image](https://github.com/user-attachments/assets/52ebcd12-f780-4da4-b4a2-624363c7fa49)

This renders as:
![image](https://github.com/user-attachments/assets/c508bd86-f24a-4b71-a4e0-a243747d6597)
