### PR TITLE
Fix the vscode extension

### DIFF
--- a/packages/doenetml-worker/lib-js-wasm-binding/src/CoreWorker.ts
+++ b/packages/doenetml-worker/lib-js-wasm-binding/src/CoreWorker.ts
@@ -47,7 +47,6 @@ try {
         wasmBlobUrl = URL.createObjectURL(
             new Blob([byteArray], { type: "application/wasm" }),
         );
-        console.log("BLOB URL", wasmBlobUrl);
     }
 } catch (e) {
     console.warn("Error while creating blob URL for wasm bundle", e);

--- a/packages/vscode-extension/extension/package.json
+++ b/packages/vscode-extension/extension/package.json
@@ -6,7 +6,7 @@
     "author": "Jason Siefken",
     "license": "AGPL",
     "publisher": "doenet",
-    "version": "0.7.8",
+    "version": "0.7.9",
     "repository": {
         "type": "git",
         "url": "https://github.com/Doenet/DoenetML"
@@ -34,7 +34,8 @@
                     "DoenetML"
                 ],
                 "extensions": [
-                    ".doenet"
+                    ".doenet",
+                    ".doenetml"
                 ],
                 "configuration": "./config/language-configuration.json"
             }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -4,7 +4,7 @@
     "description": "A language server for DoenetML",
     "author": "Jason Siefken",
     "license": "AGPL",
-    "version": "0.7.8",
+    "version": "0.7.9",
     "repository": {
         "type": "git",
         "url": "https://github.com/Doenet/DoenetML"
@@ -28,8 +28,8 @@
         "build:language-server": "wireit",
         "build:extension": "wireit",
         "build:preview-window": "wireit",
-        "dev": "vite -c vite.preview-window.config.ts",
-        "watch": "npm run build && vite -c vite.language-server.config.ts build --watch",
+        "dev": "vite -c vite.preview-window.config.mts",
+        "watch": "npm run build && vite -c vite.language-server.config.mts build --watch",
         "test": "vitest",
         "package": "cd ./extension && vsce package --no-dependencies --out ../",
         "run-in-browser:firefox": "vscode-test-web --browserType=firefox --extensionDevelopmentPath=./extension .",

--- a/packages/vscode-extension/src/extension/index.ts
+++ b/packages/vscode-extension/src/extension/index.ts
@@ -38,7 +38,10 @@ async function setupLanguageServer(context: ExtensionContext) {
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
         // Register the server for plain text documents
-        documentSelector: [{ language: "doenet" }],
+        documentSelector: [
+            { scheme: "file", language: "doenet" },
+            { scheme: "untitled", language: "doenet" },
+        ],
     };
 
     // Create a worker. The worker main file implements the language server.

--- a/packages/vscode-extension/src/extension/preview-panel/doenet-preview-panel.ts
+++ b/packages/vscode-extension/src/extension/preview-panel/doenet-preview-panel.ts
@@ -139,11 +139,12 @@ export class DoenetPreviewPanel {
                 `default-src 'none';`,
                 `style-src ${webview.cspSource} 'unsafe-inline' 'self';`,
                 // Note: If there is a path-name, it must end with a slash to include subfolders (e.g., https://example.com/foo will not match https://example.com/foo/bar)
-                `script-src 'nonce-${nonce}' 'unsafe-eval' vscode-webview: https://*.vscode-resource.vscode-cdn.net https://cdnjs.cloudflare.com/ajax/libs/mathjax/ https://doenet.vscode-unpkg.net;`,
-                `script-src-elem 'nonce-${nonce}' 'unsafe-eval' vscode-webview: https://*.vscode-resource.vscode-cdn.net https://cdnjs.cloudflare.com/ajax/libs/mathjax/ https://doenet.vscode-unpkg.net http://localhost:3000/static/devextensions/;`,
+                `script-src 'nonce-${nonce}' 'unsafe-eval' vscode-webview: https://*.vscode-resource.vscode-cdn.net https://cdn.jsdelivr.net/npm/mathjax@3/es5/ https://doenet.vscode-unpkg.net;`,
+                `script-src-elem 'nonce-${nonce}' 'unsafe-eval' vscode-webview: https://*.vscode-resource.vscode-cdn.net https://cdn.jsdelivr.net/npm/mathjax@3/es5/ https://doenet.vscode-unpkg.net http://localhost:3000/static/devextensions/;`,
                 `worker-src blob:;`,
+                `connect-src blob: data:;`,
                 `img-src 'self';`,
-                `font-src https://cdnjs.cloudflare.com/ajax/libs/mathjax/ https://*.vscode-resource.vscode-cdn.net https://doenet.vscode-unpkg.net http://localhost:3000/static/devextensions/;`,
+                `font-src https://cdn.jsdelivr.net/npm/mathjax@3/es5/ https://*.vscode-resource.vscode-cdn.net https://doenet.vscode-unpkg.net http://localhost:3000/static/devextensions/;`,
             ].join(" ")}"
           />
           <link rel="stylesheet" type="text/css" href="${stylesUri}">


### PR DESCRIPTION
This PR fixes data-uri nonesense when loading the `.wasm` file for the Rust core so that the vscode extension works.