### PR TITLE
Don't minify the docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19781,7 +19781,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.0-alpha41",
+            "version": "0.7.0-alpha42",
             "license": "AGPL-3.0-or-later",
             "peerDependencies": {
                 "react": "^18.3.1",
@@ -19791,7 +19791,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.0-alpha41",
+            "version": "0.7.0-alpha42",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -19881,7 +19881,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.0-alpha41",
+            "version": "0.7.0-alpha42",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19932,7 +19932,7 @@
         },
         "packages/vscode-extension": {
             "name": "@doenet/vscode-extension",
-            "version": "0.7.8",
+            "version": "0.7.9",
             "license": "AGPL",
             "devDependencies": {
                 "@types/vscode": "^1.99.0",

--- a/packages/docs-nextra/next-env.d.ts
+++ b/packages/docs-nextra/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/docs-nextra/next.config.mjs
+++ b/packages/docs-nextra/next.config.mjs
@@ -134,7 +134,9 @@ const withNextra = nextraConfig({
 let assetPrefix = "";
 let basePath = "";
 
-export default withNextra({
+const fullConfig = withNextra({
+    compress: false,
+    productionBrowserSourceMaps: true,
     output: "export",
     assetPrefix,
     basePath,
@@ -142,6 +144,17 @@ export default withNextra({
         unoptimized: true,
     },
 });
+// 2025-05-15 With Next.js 14 and Nextra 3, minification results in an error about
+// a duplicate identifier `e`. Preventing minification seems to fix the issue.
+// Since Nextra deeply modifies the Next.js config webpack config, we
+// apply its configuration and then our own.
+// Replace the webpack config with the one that prevents minification
+const nextraWebpackConfig = fullConfig.webpack;
+fullConfig.webpack = (config, options) => {
+    const newConfig = nextraWebpackConfig(config, options);
+    newConfig.optimization.minimizer = [];
+    newConfig.optimization.minimize = false;
+    return config;
+};
 
-// If you have other Next.js configurations, you can pass them as the parameter:
-// module.exports = withNextra({ /* other next.js config */ })
+export default fullConfig;

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml-iframe",
     "type": "module",
     "description": "A renderer for DoenetML contained in an iframe",
-    "version": "0.7.0-alpha41",
+    "version": "0.7.0-alpha42",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.7.0-alpha41",
+    "version": "0.7.0-alpha42",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.7.0-alpha41",
+    "version": "0.7.0-alpha42",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,


### PR DESCRIPTION
Minifying the docs causes an error because two instances of the minified variable `e` are created. This PR stops minification when building the docs.

After this, the docs should work in Chrome, but they appear not to work in Firefox, with no discernable reason why...