### PR TITLE
Optimize CI

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -42,7 +42,7 @@ jobs:
                   name: build-artifacts
                   include-hidden-files: true
                   path: |
-                      ./packages/*/.wireit/**
+                      ./packages/*/.wireit/**/*
 
     test:
         name: Test
@@ -67,7 +67,10 @@ jobs:
                   path: ./
 
             - name: Debug Build Artifacts
-              run: ls -la ./packages/parser/.wireit/ || echo "No .wireit directory in parser"
+              run: |
+                  ls -la ./packages/parser/.wireit/ || echo "No .wireit directory in parser"
+                  ls -la ./
+
 
             # with the wireit cache saved, this build step should be fast.
             - name: Build (cached)

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -12,7 +12,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [18.x]
+                node-version: [20.x]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
         steps:
@@ -25,6 +25,42 @@ jobs:
             - run: npm ci
 
             - name: Build
+              run: |
+                  export NODE_OPTIONS="--max_old_space_size=4096"
+                  npm run build && npm run build:all
+
+            # upload all the .wireit directories so that the test job can use them.
+            - name: Upload build artifacts
+              uses: actions/upload-artifact@v3
+              with:
+                  name: build-artifacts
+                  path: |
+                      packages/**/.wireit/**
+
+    test:
+        name: Test
+        runs-on: ubuntu-latest
+        needs: build
+        strategy:
+            matrix:
+                node-version: [20.x]
+                # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        steps:
+            - uses: actions/checkout@v3
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: "npm"
+            - run: npm ci
+            - name: Download build artifacts
+              uses: actions/download-artifact@v3
+              with:
+                  name: build-artifacts
+                  path: ./
+
+            # with the wireit cache saved, this build step should be fast.
+            - name: Build (cached)
               run: |
                   export NODE_OPTIONS="--max_old_space_size=4096"
                   npm run build && npm run build:all
@@ -55,8 +91,11 @@ jobs:
             - name: Cargo clippy
               working-directory: ./packages/doenetml-worker
               run: cargo clippy -- -D warnings
+
     build-docs:
         runs-on: ubuntu-latest
+        needs: build
+        name: Build Docs
 
         strategy:
             matrix:
@@ -72,6 +111,13 @@ jobs:
                   cache: "npm"
             - run: npm ci
 
+            - name: Download build artifacts
+              uses: actions/download-artifact@v3
+              with:
+                  name: build-artifacts
+                  path: ./
+
+            # with the wireit cache saved, this build step should be fast.
             - name: Build Docs
               run: |
                   export NODE_OPTIONS="--max_old_space_size=4096"

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -28,18 +28,15 @@ jobs:
             - name: Build
               run: |
                   export NODE_OPTIONS="--max_old_space_size=4096"
-                  cd packages/parser
-                  npm run build
+                  npm run build && npm run build:all
               # set the environmental variable WIREIT_CACHE="local" so that the wireit cache is saved in the .wireit directory.
               env:
                   WIREIT_CACHE: "local"
-              #npm run build && npm run build:all
 
             - name: Debug Build Artifacts
               run: |
-                  ls -la ./packages/parser/.wireit/ || echo "No .wireit directory in parser"
-                  ls -la ./packages/parser/.wireit/*/
-                  du -sh ./packages/parser/.wireit/*/
+                  ls -la ./packages/*/.wireit/ || echo "No .wireit directory in parser"
+                  du -sh ./packages/*/.wireit/*/
 
             # upload all the .wireit directories so that the test job can use them.
             - name: Upload build artifacts
@@ -76,8 +73,7 @@ jobs:
 
             - name: Debug Build Artifacts
               run: |
-                  ls -la ./packages/parser/.wireit/ || echo "No .wireit directory in parser"
-                  ls -la ./
+                  ls -la ./packages/*/.wireit/ || echo "No .wireit directory in parser"
 
             # with the wireit cache saved, this build step should be fast.
             - name: Build (cached)

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -47,8 +47,11 @@ jobs:
               with:
                   name: build-artifacts
                   include-hidden-files: true
+                  # Include package.json from the root so the file tree matches the full file tree of the repo
+                  # (otherwise everything is normalized to the closest common ancestor folder)
                   path: |
                       ./packages/*/.wireit/**/*
+                      ./package.json
 
     test:
         name: Test

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -28,7 +28,9 @@ jobs:
             - name: Build
               run: |
                   export NODE_OPTIONS="--max_old_space_size=4096"
-                  npm run build && npm run build:all
+                  cd packages/parser
+                  npm run build
+              #npm run build && npm run build:all
 
             - name: Debug Build Artifacts
               run: ls -la ./packages/parser/.wireit/ || echo "No .wireit directory in parser"
@@ -63,6 +65,9 @@ jobs:
               with:
                   name: build-artifacts
                   path: ./
+
+            - name: Debug Build Artifacts
+              run: ls -la ./packages/parser/.wireit/ || echo "No .wireit directory in parser"
 
             # with the wireit cache saved, this build step should be fast.
             - name: Build (cached)

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -30,6 +30,9 @@ jobs:
                   export NODE_OPTIONS="--max_old_space_size=4096"
                   cd packages/parser
                   npm run build
+              # set the environmental variable WIREIT_CACHE="local" so that the wireit cache is saved in the .wireit directory.
+              env:
+                  WIREIT_CACHE: "local"
               #npm run build && npm run build:all
 
             - name: Debug Build Artifacts
@@ -79,6 +82,8 @@ jobs:
               run: |
                   export NODE_OPTIONS="--max_old_space_size=4096"
                   npm run build && npm run build:all
+              env:
+                  WIREIT_CACHE: "local"
 
             - name: Test
               run: npm test
@@ -140,6 +145,8 @@ jobs:
                   npm run build
                   cd ../docs-nextra
                   npm run build
+              env:
+                  WIREIT_CACHE: "local"
 
     lint-ts:
         name: Lint Typescript Code

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -37,6 +37,7 @@ jobs:
               uses: actions/upload-artifact@v4
               with:
                   name: build-artifacts
+                  include-hidden-files: true
                   path: |
                       ./packages/parser/.wireit/
                       ./packages/*/.wireit/**

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -28,7 +28,9 @@ jobs:
             - name: Build
               run: |
                   export NODE_OPTIONS="--max_old_space_size=4096"
-                  npm run build && npm run build:all
+                  cd packages/parser
+                  npm run build
+              #npm run build && npm run build:all
 
             # upload all the .wireit directories so that the test job can use them.
             - name: Upload build artifacts
@@ -36,6 +38,7 @@ jobs:
               with:
                   name: build-artifacts
                   path: |
+                      ./packages/parser/.wireit/
                       ./packages/*/.wireit/**
 
     test:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -28,9 +28,7 @@ jobs:
             - name: Build
               run: |
                   export NODE_OPTIONS="--max_old_space_size=4096"
-                  cd packages/parser
-                  npm run build
-              #npm run build && npm run build:all
+                  npm run build && npm run build:all
 
             - name: Debug Build Artifacts
               run: ls -la ./packages/parser/.wireit/ || echo "No .wireit directory in parser"
@@ -42,7 +40,6 @@ jobs:
                   name: build-artifacts
                   include-hidden-files: true
                   path: |
-                      ./packages/parser/.wireit/**
                       ./packages/*/.wireit/**
 
     test:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -36,7 +36,7 @@ jobs:
               with:
                   name: build-artifacts
                   path: |
-                      packages/**/.wireit/**
+                      ./packages/*/.wireit/**
 
     test:
         name: Test

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
     build:
+        name: Build
         runs-on: ubuntu-latest
 
         strategy:
@@ -31,7 +32,7 @@ jobs:
 
             # upload all the .wireit directories so that the test job can use them.
             - name: Upload build artifacts
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: build-artifacts
                   path: |
@@ -54,7 +55,7 @@ jobs:
                   cache: "npm"
             - run: npm ci
             - name: Download build artifacts
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                   name: build-artifacts
                   path: ./
@@ -112,7 +113,7 @@ jobs:
             - run: npm ci
 
             - name: Download build artifacts
-              uses: actions/download-artifact@v3
+              uses: actions/download-artifact@v4
               with:
                   name: build-artifacts
                   path: ./
@@ -132,7 +133,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [18.x]
+                node-version: [20.x]
 
         steps:
             - name: Checkout sources

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -70,7 +70,6 @@ jobs:
               uses: actions/download-artifact@v4
               with:
                   name: build-artifacts
-                  path: ./
 
             - name: Debug Build Artifacts
               run: |

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -33,7 +33,10 @@ jobs:
               #npm run build && npm run build:all
 
             - name: Debug Build Artifacts
-              run: ls -la ./packages/parser/.wireit/ || echo "No .wireit directory in parser"
+              run: |
+                  ls -la ./packages/parser/.wireit/ || echo "No .wireit directory in parser"
+                  ls -la ./packages/parser/.wireit/*/
+                  du -sh ./packages/parser/.wireit/*/
 
             # upload all the .wireit directories so that the test job can use them.
             - name: Upload build artifacts
@@ -70,7 +73,6 @@ jobs:
               run: |
                   ls -la ./packages/parser/.wireit/ || echo "No .wireit directory in parser"
                   ls -la ./
-
 
             # with the wireit cache saved, this build step should be fast.
             - name: Build (cached)

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -32,6 +32,9 @@ jobs:
                   npm run build
               #npm run build && npm run build:all
 
+            - name: Debug Build Artifacts
+              run: ls -la ./packages/parser/.wireit/ || echo "No .wireit directory in parser"
+
             # upload all the .wireit directories so that the test job can use them.
             - name: Upload build artifacts
               uses: actions/upload-artifact@v4
@@ -39,7 +42,7 @@ jobs:
                   name: build-artifacts
                   include-hidden-files: true
                   path: |
-                      ./packages/parser/.wireit/
+                      ./packages/parser/.wireit/**
                       ./packages/*/.wireit/**
 
     test:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -79,7 +79,7 @@ jobs:
             - name: Build (cached)
               run: |
                   export NODE_OPTIONS="--max_old_space_size=4096"
-                  npm run build && npm run build:all
+                  npm run build
               env:
                   WIREIT_CACHE: "local"
 

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -43,7 +43,8 @@
                 "dist/**/*.js",
                 "dist/**/*.d.ts",
                 "dist/**/*.css",
-                "dist/**/*.json"
+                "dist/**/*.json",
+                "dist/fonts/**/*"
             ],
             "dependencies": [
                 "../doenetml-worker:build",

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -42,6 +42,7 @@
             "output": [
                 "dist/**/*.js",
                 "dist/**/*.d.ts",
+                "dist/**/*.css",
                 "dist/**/*.json"
             ],
             "dependencies": [

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -31,11 +31,13 @@
                 "src/**/*.js",
                 "src/**/*.tsx",
                 "src/**/*.jsx",
+                "dist/**/*.css",
                 "tsconfig.json"
             ],
             "output": [
                 "dist/**/*.js",
                 "dist/**/*.d.ts",
+                "dist/**/*.css",
                 "dist/**/*.json"
             ]
         }


### PR DESCRIPTION
Use the wireit cache to optimize building in the CI so that tests and build can happen in different jobs.