### PR TITLE
remove the `sourceAttributesToIgnore` attribute and the special case for the `isResponse` attribute

### DIFF
--- a/packages/doenetml-worker-javascript/src/Core.js
+++ b/packages/doenetml-worker-javascript/src/Core.js
@@ -2818,8 +2818,6 @@ export default class Core {
         // we'll copy the replacements of the shadowed composite
         // and make those be the replacements of the shadowing composite
         let serializedReplacements = [];
-        let sourceAttributesToIgnore =
-            await component.stateValues.sourceAttributesToIgnore;
 
         let nComponents = this._components.length;
         let newNComponents = nComponents;
@@ -2859,9 +2857,7 @@ export default class Core {
 
         for (let [idx, repl] of shadowedComposite.replacements.entries()) {
             if (typeof repl === "object") {
-                const serializedComponent = await repl.serialize({
-                    primitiveSourceAttributesToIgnore: sourceAttributesToIgnore,
-                });
+                const serializedComponent = await repl.serialize();
 
                 if (
                     component.constructor.useSerializedChildrenComponentIndices
@@ -2920,67 +2916,6 @@ export default class Core {
             serializedComponents: serializedReplacements,
             componentIdx: nameOfCompositeMediatingTheShadow,
         });
-
-        let compositeAttributesObj =
-            compositeMediatingTheShadow.constructor.createAttributesObject();
-
-        let attributesToConvert = {};
-        if (component.attributes.isResponse) {
-            // We include a special case of copying isResponse from
-            // the shadowing composite.
-            // Rationale: when we serialize a component to copy it,
-            // we set primitiveSourceAttributesToIgnore=sourceAttributesToIgnore, above,
-            // which by default is ["isResponse"]
-            // so that isResponse, is not, in general copied.
-            // (We don't want copies of responses to be responses.)
-            // However, if an award has referencesAreResponses set, then we want
-            // copies of the award to also set those sources to be responses.
-            // The award accomplishes this through preprocessSerializedChildren,
-            // which adds isResponse to copies of those targets.
-            // Those copies are the shadowing composites, and we want those
-            // isResponse attributes to be added to their replacements.
-            // TODO: Is this too confusing?
-            // Can/should we give up this functionality for the sake of simplicity?
-            // A test that fails without this intervention is
-            // "full answer tag, copied in awards, shorter form" from answer.cy.js
-            attributesToConvert.isResponse = component.attributes.isResponse;
-        }
-
-        // // if the shadowing component is a first level replacement of compositeMediatingTheShadow,
-        // // then the attributes of compositeMediatingTheShadow should be passed on
-        // if (component.firstLevelReplacement) {
-        //   Object.assign(
-        //     attributesToConvert,
-        //     compositeMediatingTheShadow.attributes,
-        //   );
-        // }
-
-        // console.log(component.attributes);
-        // console.log(compositeMediatingTheShadow.attributes);
-        // console.log("attributesToConvert:", Object.keys(attributesToConvert));
-
-        for (let repl of serializedReplacements) {
-            if (typeof repl !== "object") {
-                continue;
-            }
-
-            // add attributes
-            if (!repl.attributes) {
-                repl.attributes = {};
-            }
-            const res = convertUnresolvedAttributesForComponentType({
-                attributes: attributesToConvert,
-                componentType: repl.componentType,
-                componentInfoObjects: this.componentInfoObjects,
-                compositeAttributesObj,
-                nComponents: newNComponents,
-            });
-
-            const attributesFromComposite = res.attributes;
-            newNComponents = res.nComponents;
-
-            Object.assign(repl.attributes, attributesFromComposite);
-        }
 
         // console.log("--------------");
         // console.log(
@@ -9110,18 +9045,13 @@ export default class Core {
 
                 let composite =
                     this._components[shadowingParent.shadows.compositeIdx];
-                let sourceAttributesToIgnore =
-                    await composite.stateValues.sourceAttributesToIgnore;
 
                 let shadowingSerializeChildren = [];
                 let nComponents = this._components.length;
 
                 for (let child of newChildren) {
                     if (typeof child === "object") {
-                        const serializedComponent = await child.serialize({
-                            primitiveSourceAttributesToIgnore:
-                                sourceAttributesToIgnore,
-                        });
+                        const serializedComponent = await child.serialize();
 
                         const res = createNewComponentIndices(
                             [serializedComponent],
@@ -10352,20 +10282,11 @@ export default class Core {
             if (shadowingComponent.isExpanded) {
                 let newSerializedReplacements = [];
 
-                let compositeCreatingShadow =
-                    this._components[shadowingComponent.shadows.compositeIdx];
-                let sourceAttributesToIgnore =
-                    await compositeCreatingShadow.stateValues
-                        .sourceAttributesToIgnore;
-
                 let nComponents = this._components.length;
                 let newNComponents = nComponents;
                 for (let repl of replacementsToShadow) {
                     if (typeof repl === "object") {
-                        const serializedComponent = await repl.serialize({
-                            primitiveSourceAttributesToIgnore:
-                                sourceAttributesToIgnore,
-                        });
+                        const serializedComponent = await repl.serialize();
 
                         const res = createNewComponentIndices(
                             [serializedComponent],

--- a/packages/doenetml-worker-javascript/src/Dependencies.js
+++ b/packages/doenetml-worker-javascript/src/Dependencies.js
@@ -4910,16 +4910,6 @@ class AttributeComponentDependency extends Dependency {
                 ) {
                     break;
                 }
-            } else {
-                let composite =
-                    this.dependencyHandler._components[shadows.compositeIdx];
-                if ("sourceAttributesToIgnore" in composite.state) {
-                    let sourceAttributesToIgnore =
-                        await composite.stateValues.sourceAttributesToIgnore;
-                    if (sourceAttributesToIgnore.includes(this.attributeName)) {
-                        break;
-                    }
-                }
             }
 
             attribute = comp.attributes[this.attributeName];

--- a/packages/doenetml-worker-javascript/src/components/Collect.js
+++ b/packages/doenetml-worker-javascript/src/components/Collect.js
@@ -31,13 +31,6 @@ export default class Collect extends CompositeComponent {
             public: true,
         };
 
-        attributes.sourceAttributesToIgnore = {
-            createPrimitiveOfType: "stringArray",
-            createStateVariable: "sourceAttributesToIgnore",
-            defaultValue: ["isResponse"],
-            public: true,
-        };
-
         attributes.from = {
             createReferences: true,
         };
@@ -416,14 +409,7 @@ export default class Collect extends CompositeComponent {
             };
         }
 
-        let sourceAttributesToIgnore =
-            await component.stateValues.sourceAttributesToIgnore;
-
-        serializedReplacements = [
-            await collectedComponent.serialize({
-                primitiveSourceAttributesToIgnore: sourceAttributesToIgnore,
-            }),
-        ];
+        serializedReplacements = [await collectedComponent.serialize()];
 
         let res = createNewComponentIndices(
             serializedReplacements,

--- a/packages/doenetml-worker-javascript/src/components/Shuffle.js
+++ b/packages/doenetml-worker-javascript/src/components/Shuffle.js
@@ -341,9 +341,7 @@ export default class Shuffle extends CompositeComponent {
             if (replacementSource) {
                 componentsCopied.push(replacementSource.componentIdx);
 
-                const serializedComponent = await replacementSource.serialize({
-                    primitiveSourceAttributesToIgnore: ["isResponse"],
-                });
+                const serializedComponent = await replacementSource.serialize();
 
                 const res = createNewComponentIndices(
                     [serializedComponent],

--- a/packages/doenetml-worker-javascript/src/components/Sort.js
+++ b/packages/doenetml-worker-javascript/src/components/Sort.js
@@ -402,9 +402,7 @@ export default class Sort extends CompositeComponent {
             if (replacementSource) {
                 componentsCopied.push(replacementSource.componentIdx);
 
-                const serializedComponent = await replacementSource.serialize({
-                    primitiveSourceAttributesToIgnore: ["isResponse"],
-                });
+                const serializedComponent = await replacementSource.serialize();
 
                 const res = createNewComponentIndices(
                     [serializedComponent],

--- a/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
@@ -55,12 +55,6 @@ export default class Copy extends CompositeComponent {
             defaultValue: null,
             public: true,
         };
-        attributes.sourceAttributesToIgnore = {
-            createPrimitiveOfType: "stringArray",
-            createStateVariable: "sourceAttributesToIgnore",
-            defaultValue: ["isResponse"],
-            public: true,
-        };
         attributes.link = {
             createPrimitiveOfType: "boolean",
         };
@@ -1600,9 +1594,6 @@ export default class Copy extends CompositeComponent {
         // if creating copy directly from the target component,
         // create a serialized copy of the entire component
 
-        let sourceAttributesToIgnore =
-            await component.stateValues.sourceAttributesToIgnore;
-
         // If we are copying without linking a source that is shadowing another source,
         // then the attributes and children of the source may not be sufficient
         // to determine its state variables (as values linked from its source may be used).
@@ -1622,7 +1613,6 @@ export default class Copy extends CompositeComponent {
                     copyAll: !link,
                     componentSourceAttributesToIgnore: ["labelIsName"],
                     copyVariants: !link,
-                    primitiveSourceAttributesToIgnore: sourceAttributesToIgnore,
                     copyPrimaryEssential,
                     copyEssentialState,
                     errorIfEncounterComponent: [component.componentIdx],

--- a/packages/doenetml-worker-javascript/src/test/copying/extend.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/copying/extend.test.ts
@@ -1079,9 +1079,6 @@ describe("Extend tests", async () => {
         expect(
             stateVariables[await resolvePathToNodeIdx("p4")].stateValues.text,
         ).eq("Force to reveal: secret");
-        expect(
-            stateVariables[await resolvePathToNodeIdx("p5")].stateValues.text,
-        ).eq("Force to reveal 2: secret");
     }
 
     it("copy does not ignore hide by default, with copySource", async () => {
@@ -1091,7 +1088,6 @@ describe("Extend tests", async () => {
     <p name="p2">Hidden by default: <text extend="$hidden" /></p>
     <p name="p3">Hidden by default 2: $hidden</p>
     <p name="p4">Force to reveal: <text extend="$hidden" hide="false" /></p>
-    <p name="p5">Force to reveal 2: <text extend="$hidden" sourceAttributesToIgnore="hide" /></p>
 
     `,
         });
@@ -1136,18 +1132,6 @@ describe("Extend tests", async () => {
                 .text,
         ).eq("Revealed 2: secret");
         expect(
-            stateVariables[await resolvePathToNodeIdx("theP3")].stateValues
-                .text,
-        ).eq("Hidden text: secret");
-        expect(
-            stateVariables[await resolvePathToNodeIdx("pReveal3")].stateValues
-                .text,
-        ).eq("Revealed 3: secret");
-        expect(
-            stateVariables[await resolvePathToNodeIdx("pReveal3A")].stateValues
-                .text,
-        ).eq("Revealed 3A: secret");
-        expect(
             stateVariables[await resolvePathToNodeIdx("theP4")].stateValues
                 .text,
         ).eq("Hidden text: ");
@@ -1176,9 +1160,6 @@ describe("Extend tests", async () => {
     <p name="pHidden2">Hidden 2: <text extend="$theP2.hidden" /></p>
     <p name="pHidden2A">Hidden 2A: $theP2.hidden</p>
     <p name="pReveal2">Revealed 2: <text extend="$theP2.hidden" hide="false" /></p>
-    <p extend="$theP" sourceAttributesToIgnore="hide" name="theP3" />
-    <p name="pReveal3">Revealed 3: <text extend="$theP3.hidden" /></p>
-    <p name="pReveal3A">Revealed 3A: $theP3.hidden</p>
     <p extend="$theP" name="theP4" hide="false" />
     <p name="pHidden4">Hidden 4: <text extend="$theP4.hidden" /></p>
     <p name="pHidden4A">Hidden 4A: $theP4.hidden</p>
@@ -2362,40 +2343,6 @@ describe("Extend tests", async () => {
         });
 
         await test_copy_prop_component_index(core, resolvePathToNodeIdx, true);
-    });
-
-    it("source attributes to ignore", async () => {
-        let { core, resolvePathToNodeIdx } = await createTestCore({
-            doenetML: `
-    <p name="p1" fixed isResponse>The text: <text name="hidden_text" hide fixed isResponse>secret</text></p>
-
-    <p>Text stays hidden by default:</p>
-    <p extend="$p1" name="p2" />
-    <p name="p4">Check attributes: $p2.hidden $p2.isResponse $p2.hidden_text.hidden $p2.hidden_text.isResponse</p>
-
-    <p>Now all is revealed:</p>
-    <p extend="$p1" name="p5" sourceAttributesToIgnore="hide" />
-    <p name="p7">Check attributes: $p5.hidden $p5.isResponse $p5.hidden_text.hidden $p5.hidden_text.isResponse</p>
-
-    `,
-        });
-
-        const stateVariables = await core.returnAllStateVariables(false, true);
-        expect(
-            stateVariables[await resolvePathToNodeIdx("p1")].stateValues.text,
-        ).eq("The text: ");
-        expect(
-            stateVariables[await resolvePathToNodeIdx("p2")].stateValues.text,
-        ).eq("The text: ");
-        expect(
-            stateVariables[await resolvePathToNodeIdx("p4")].stateValues.text,
-        ).eq("Check attributes: false false true false");
-        expect(
-            stateVariables[await resolvePathToNodeIdx("p5")].stateValues.text,
-        ).eq("The text: secret");
-        expect(
-            stateVariables[await resolvePathToNodeIdx("p7")].stateValues.text,
-        ).eq("Check attributes: false true false true");
     });
 
     it("fixed and fixLocation are propagated from shadow source, even with prop", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/answer.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/answer.test.ts
@@ -4398,28 +4398,6 @@ Enter any letter:
         });
     });
 
-    it("answer award with full award and outside input, copy award and overwrite properties", async () => {
-        const doenetML = `
-<mathInput name="mi" />
-<answer name="an">
-    <award name="aw" referencesAreResponses="$mi"><when>$mi=1.1</when></award>
-    <award extend="$aw" credit="0.5" allowedErrorInNumbers="0.001" referencesAreResponses="" name="aw2" />
-</answer>
-  `;
-
-        await test_math_answer({
-            doenetML,
-            answerName: "an",
-            answers: [
-                { latex: "", credit: 0, awardsUsed: [] },
-                { latex: "1.1", credit: 1, awardsUsed: ["aw"] },
-                { latex: "1.11", credit: 0, awardsUsed: [] },
-                { latex: "1.101", credit: 0.5, awardsUsed: ["aw2"] },
-            ],
-            mathInputName: "mi",
-        });
-    });
-
     it("copied answer mirrors original", async () => {
         const doenetML = `
   <answer name="ans1">x+y</answer>


### PR DESCRIPTION
This PR removes the `sourceAttributesToIgnore` on the abstract `<_copy>` tag (which is what the `extend` attribute produces) and the `<collect>` tag. The attribute was not widely publicized, and its main purpose was to prevent the `isResponse` attribute from being copied when referencing a component. However, we decided it was an unnecessary complexity and it was better to have consistent rules for all attributes. Now, `isResponse` is copied on references like all attributes (other than the one remaining exception of `labelIsName`).