### PR TITLE
compactify bug fix: handle references in index of extend attribute

### DIFF
--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_compactify.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_compactify.rs
@@ -174,7 +174,7 @@ impl FlatRoot {
         // We are going to trim all the nodes that are not referenced.
         // We make a map of old indices to new indices.
         let mut current_shift = 0;
-        let old_to_new_indices = is_referenced
+        let old_to_new_indices_prelim = is_referenced
             .iter()
             .enumerate()
             .map(|(old_idx, is_referenced)| {
@@ -185,6 +185,31 @@ impl FlatRoot {
                 ret
             })
             .collect::<Vec<_>>();
+
+        // We need to handle the special case of a reference inside the index of an extend attribute,
+        // for example the `$n` in: `<math extend="$m[$n]" />`.
+        // In this case, the outer reference `$m` will be removed but the inner reference `$n` stays.
+        // The parent of `$n` was originally the index of `$m`; it needs to be shifted to the index of the parent `$m`.
+        // To accomplish this, we map references of removed nodes to their parents,
+        // recursing if parent is also removed
+        let old_to_new_indices = old_to_new_indices_prelim
+            .iter()
+            .enumerate()
+            .map(|(old_idx, new_idx)| {
+                if is_referenced[old_idx] {
+                    *new_idx
+                } else {
+                    let mut parent = self.nodes[old_idx].parent();
+                    while parent.is_some_and(|idx| !is_referenced[idx]) {
+                        parent = self.nodes[parent.unwrap()].parent();
+                    }
+                    // if a removed element doesn't have a parent, set it to the document root
+                    parent.unwrap_or_default()
+                }
+            })
+            .collect::<Vec<_>>();
+
+        self.nodes.retain(|node| is_referenced[node.idx()]);
 
         self.nodes.retain(|node| is_referenced[node.idx()]);
 

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_compactify.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_compactify.rs
@@ -204,12 +204,10 @@ impl FlatRoot {
                         parent = self.nodes[parent.unwrap()].parent();
                     }
                     // if a removed element doesn't have a parent, set it to the document root
-                    parent.unwrap_or_default()
+                    old_to_new_indices_prelim[parent.unwrap_or_default()]
                 }
             })
             .collect::<Vec<_>>();
-
-        self.nodes.retain(|node| is_referenced[node.idx()]);
 
         self.nodes.retain(|node| is_referenced[node.idx()]);
 

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_compactify.test.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_compactify.test.rs
@@ -805,3 +805,99 @@ fn compactify_index_in_extend() {
         )
     );
 }
+
+#[test]
+fn compactify_index_in_extend_additional_compactification_before() {
+    let dast_root = dast_root_no_position(
+        r#"<number name="n"/><math name="m" extend="$n" /><math extend="$m[$n]" />"#,
+    );
+    let mut flat_root = FlatRoot::from_dast(&dast_root);
+    Expander::expand(&mut flat_root);
+    flat_root.compactify(None);
+
+    assert_json_eq!(
+        serde_json::to_value(&flat_root).unwrap(),
+        json!(
+          {
+            "type": "flatRoot",
+            "children": [0],
+            "nodes": [
+              {
+                "type": "element",
+                "name": "document",
+                "children": [1, 2, 3],
+                "attributes": [],
+                "idx": 0
+              },
+              {
+                "type": "element",
+                "name": "number",
+                "parent": 0,
+                "children": [],
+                "attributes": [
+                  {
+                    "type": "attribute",
+                    "name": "name",
+                    "parent": 1,
+                    "children": ["n"]
+                  }
+                ],
+                "idx": 1
+              },
+              {
+                "type": "element",
+                "name": "math",
+                "parent": 0,
+                "children": [],
+                "attributes": [
+                  {
+                    "type": "attribute",
+                    "name": "name",
+                    "parent": 2,
+                    "children": ["m"]
+                  }
+                ],
+                "idx": 2,
+                "extending": {
+                  "ExtendAttribute": {
+                    "nodeIdx": 1,
+                    "unresolvedPath": null,
+                    "originalPath": [{ "type": "flatPathPart", "name": "n", "index": [] }],
+                  }
+                }
+              },
+              {
+                "type": "element",
+                "name": "math",
+                "parent": 0,
+                "children": [],
+                "attributes": [],
+                "idx": 3,
+                "extending": {
+                  "ExtendAttribute": {
+                    "nodeIdx": 2,
+                    "unresolvedPath": [{ "type": "flatPathPart", "name": "", "index": [{ "value": [4] }] }],
+                    "originalPath": [{ "type": "flatPathPart", "name": "m", "index": [{ "value": [4] }] }],
+                  }
+                }
+              },
+              {
+                "type": "element",
+                "name": "number",
+                "parent": 3,
+                "children": [],
+                "attributes": [],
+                "idx": 4,
+                "extending": {
+                  "Ref": {
+                    "nodeIdx": 1,
+                    "unresolvedPath": null,
+                    "originalPath": [{ "type": "flatPathPart", "name": "n", "index": [] }],
+                  }
+                }
+              },
+            ]
+          }
+        )
+    );
+}

--- a/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_compactify.test.rs
+++ b/packages/doenetml-worker/lib-doenetml-core/src/dast/flat_dast/untagged_flat_dast_compactify.test.rs
@@ -717,3 +717,91 @@ fn compactify_shifts_refs_in_path_parts() {
         )
     );
 }
+
+#[test]
+fn compactify_index_in_extend() {
+    let dast_root =
+        dast_root_no_position(r#"<number name="n"/><math name="m"/><math extend="$m[$n]" />"#);
+    let mut flat_root = FlatRoot::from_dast(&dast_root);
+    Expander::expand(&mut flat_root);
+    flat_root.compactify(None);
+
+    assert_json_eq!(
+        serde_json::to_value(&flat_root).unwrap(),
+        json!(
+          {
+            "type": "flatRoot",
+            "children": [0],
+            "nodes": [
+              {
+                "type": "element",
+                "name": "document",
+                "children": [1, 2, 3],
+                "attributes": [],
+                "idx": 0
+              },
+              {
+                "type": "element",
+                "name": "number",
+                "parent": 0,
+                "children": [],
+                "attributes": [
+                  {
+                    "type": "attribute",
+                    "name": "name",
+                    "parent": 1,
+                    "children": ["n"]
+                  }
+                ],
+                "idx": 1
+              },
+              {
+                "type": "element",
+                "name": "math",
+                "parent": 0,
+                "children": [],
+                "attributes": [
+                  {
+                    "type": "attribute",
+                    "name": "name",
+                    "parent": 2,
+                    "children": ["m"]
+                  }
+                ],
+                "idx": 2,
+              },
+              {
+                "type": "element",
+                "name": "math",
+                "parent": 0,
+                "children": [],
+                "attributes": [],
+                "idx": 3,
+                "extending": {
+                  "ExtendAttribute": {
+                    "nodeIdx": 2,
+                    "unresolvedPath": [{ "type": "flatPathPart", "name": "", "index": [{ "value": [4] }] }],
+                    "originalPath": [{ "type": "flatPathPart", "name": "m", "index": [{ "value": [4] }] }],
+                  }
+                }
+              },
+              {
+                "type": "element",
+                "name": "number",
+                "parent": 3,
+                "children": [],
+                "attributes": [],
+                "idx": 4,
+                "extending": {
+                  "Ref": {
+                    "nodeIdx": 1,
+                    "unresolvedPath": null,
+                    "originalPath": [{ "type": "flatPathPart", "name": "n", "index": [] }],
+                  }
+                }
+              },
+            ]
+          }
+        )
+    );
+}


### PR DESCRIPTION
This PR fixes a bug in the compactify algorithm that was leading to circular references.

The bug occurred when one had a references inside the index of an extend attribute, as the `$n` in this example.
```
<math extend="$m[$n]" />
```
In these circumstances, the reference `$m` is removed in the compactification but the reference `$n` remains. If this was the only removed element, then `$n` is shifted to take on the former index of `$m`. But, since its parent was `$m` and we didn't shift indices of removed elements, the parent of `$n` ends up being itself, creating a circular reference!

The solution is to shift references to removed indices to their parent.