### PR TITLE
Dont convert &dollar; directly to $ if it would create a new macro

### DIFF
--- a/packages/doenetml-worker-javascript/src/test/copying/extend_references.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/copying/extend_references.test.ts
@@ -6577,7 +6577,9 @@ describe("Extend and references tests", async () => {
                 stateVariables[await resolvePathToNodeIdx("sec3")]
                     .activeChildren[1].componentIdx
             ].stateValues.text,
-        ).eq("Reference $\u200Bp does not add ability to reference names: (, ).");
+        ).eq(
+            "Reference $\u200Bp does not add ability to reference names: (, ).",
+        );
         expect(
             stateVariables[
                 stateVariables[await resolvePathToNodeIdx("sec4")]

--- a/packages/doenetml-worker-javascript/src/test/copying/extend_references.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/copying/extend_references.test.ts
@@ -6577,7 +6577,7 @@ describe("Extend and references tests", async () => {
                 stateVariables[await resolvePathToNodeIdx("sec3")]
                     .activeChildren[1].componentIdx
             ].stateValues.text,
-        ).eq("Reference $p does not add ability to reference names: (, ).");
+        ).eq("Reference $\u200Bp does not add ability to reference names: (, ).");
         expect(
             stateVariables[
                 stateVariables[await resolvePathToNodeIdx("sec4")]

--- a/packages/parser/src/lezer-to-dast/lezer-to-dast-utils.ts
+++ b/packages/parser/src/lezer-to-dast/lezer-to-dast-utils.ts
@@ -21,7 +21,15 @@ export function entityToString(node: SyntaxNode, source: string): string {
         case "CharacterReference":
         case "EntityReference": {
             const entity = extractContent(node, source);
-            return entityStringToRawString(entity);
+            const converted = entityStringToRawString(entity);
+            // Special care must be taken for things like `$dollar;` which
+            // convert to `$`. If they are followed by [a-zA-Z_], then converting
+            // `&dollar;` to `$` will insert a macro reference where there was previously none.
+            if (converted === "$" && /[a-zA-Z_]/.test(source.charAt(node.to))) {
+                // If the next character is a letter, add a zero-width space afterward.
+                return converted + "\u200B";
+            }
+            return converted;
         }
     }
     throw new Error(

--- a/packages/parser/test/pretty-print.test.ts
+++ b/packages/parser/test/pretty-print.test.ts
@@ -140,4 +140,25 @@ describe("Prettier", async () => {
             expect(prettyPrinted).toEqual(outStr);
         }
     });
+
+    it("Don't create new macro names when &dollar; entity appears in text", async () => {
+        const cases = [
+            {
+                inStr: "<p>&dollar;x</p>",
+                outStr: "<p>$\u200Bx</p>",
+            },
+            {
+                inStr: "<p>&dollar;</p>",
+                outStr: "<p>$</p>",
+            },
+        ];
+
+        for (const { inStr, outStr } of cases) {
+            const prettyPrinted = await prettyPrint(inStr, {
+                doenetSyntax: false,
+                printWidth: 30,
+            });
+            expect(prettyPrinted).toEqual(outStr);
+        }
+    });
 });


### PR DESCRIPTION
Fixes #500 

Not the perfect fix, but I think it should handle any user surprise. A zero-width space is inserted after `&dollar;` if converting it to `$` would produce a new ref. 