### PR TITLE
decrease precedence of not operator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
                 "jszip": "^3.10.1",
                 "katex": "^0.16.22",
                 "lorem-ipsum": "^2.0.8",
-                "math-expressions": "^2.0.0-alpha75",
+                "math-expressions": "^2.0.0-alpha76",
                 "micromark": "^4.0.2",
                 "nanoid": "^5.1.5",
                 "nextra": "^3.3.1",
@@ -11494,9 +11494,9 @@
             }
         },
         "node_modules/math-expressions": {
-            "version": "2.0.0-alpha75",
-            "resolved": "https://registry.npmjs.org/math-expressions/-/math-expressions-2.0.0-alpha75.tgz",
-            "integrity": "sha512-DVwwE/cD48nnNcQGRJ2lgLpdLMOOc/43CRM6EfQSDpFIyM3OgWpR3mkNXdc696jf+1OgZtkJDSVakzk7YofrtQ==",
+            "version": "2.0.0-alpha76",
+            "resolved": "https://registry.npmjs.org/math-expressions/-/math-expressions-2.0.0-alpha76.tgz",
+            "integrity": "sha512-99efuEXAbBSCx5DBPLUsU14ZMqCqCVRsh990RGIFwj8COdClFmNioP+JexG4z2SDyhaZjPJk4dCYP+b5VySrKA==",
             "dev": true,
             "license": "(GPL-3.0 OR Apache-2.0)",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
                 "jszip": "^3.10.1",
                 "katex": "^0.16.22",
                 "lorem-ipsum": "^2.0.8",
-                "math-expressions": "^2.0.0-alpha74",
+                "math-expressions": "^2.0.0-alpha75",
                 "micromark": "^4.0.2",
                 "nanoid": "^5.1.5",
                 "nextra": "^3.3.1",
@@ -519,12 +519,11 @@
             "license": "MIT"
         },
         "node_modules/@babel/runtime": {
-            "version": "7.26.9",
+            "version": "7.27.6",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+            "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "regenerator-runtime": "^0.14.0"
-            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -6321,6 +6320,8 @@
         },
         "node_modules/complex.js": {
             "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.4.2.tgz",
+            "integrity": "sha512-qtx7HRhPGSCBtGiST4/WGHuW+zeaND/6Ld+db6PbrulIB1i2Ev/2UPiqcmpQNPSyfBKraC0EOvOKCB5dGZKt3g==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8178,6 +8179,8 @@
         },
         "node_modules/escape-latex": {
             "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+            "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==",
             "dev": true,
             "license": "MIT"
         },
@@ -10543,6 +10546,8 @@
         },
         "node_modules/javascript-natural-sort": {
             "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+            "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
             "dev": true,
             "license": "MIT"
         },
@@ -11489,13 +11494,15 @@
             }
         },
         "node_modules/math-expressions": {
-            "version": "2.0.0-alpha74",
+            "version": "2.0.0-alpha75",
+            "resolved": "https://registry.npmjs.org/math-expressions/-/math-expressions-2.0.0-alpha75.tgz",
+            "integrity": "sha512-DVwwE/cD48nnNcQGRJ2lgLpdLMOOc/43CRM6EfQSDpFIyM3OgWpR3mkNXdc696jf+1OgZtkJDSVakzk7YofrtQ==",
             "dev": true,
             "license": "(GPL-3.0 OR Apache-2.0)",
             "dependencies": {
                 "@babel/cli": "^7.25.7",
                 "babel-upgrade": "^1.0.1",
-                "mathjs": "^13.2.0",
+                "mathjs": "^14.5.2",
                 "number-theory": "1.1.0",
                 "numeric": "1.2.6",
                 "seedrandom": "^3.0.5",
@@ -11522,15 +11529,17 @@
             }
         },
         "node_modules/mathjs": {
-            "version": "13.2.3",
+            "version": "14.5.2",
+            "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-14.5.2.tgz",
+            "integrity": "sha512-51U6hp7j4M4Rj+l+q2KbmXAV9EhQVQzUdw1wE67RnUkKKq5ibxdrl9Ky2YkSUEIc2+VU8/IsThZNu6QSHUoyTA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@babel/runtime": "^7.25.7",
+                "@babel/runtime": "^7.26.10",
                 "complex.js": "^2.2.5",
                 "decimal.js": "^10.4.3",
                 "escape-latex": "^1.2.0",
-                "fraction.js": "^4.3.7",
+                "fraction.js": "^5.2.1",
                 "javascript-natural-sort": "^0.7.1",
                 "seedrandom": "^3.0.5",
                 "tiny-emitter": "^2.1.0",
@@ -11541,6 +11550,20 @@
             },
             "engines": {
                 "node": ">= 18"
+            }
+        },
+        "node_modules/mathjs/node_modules/fraction.js": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.2.2.tgz",
+            "integrity": "sha512-uXBDv5knpYmv/2gLzWQ5mBHGBRk9wcKTeWu6GLTUEQfjCxO09uM/mHDrojlL+Q1mVGIIFo149Gba7od1XPgSzQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/rawify"
             }
         },
         "node_modules/mdast-util-find-and-replace": {
@@ -15136,11 +15159,6 @@
                 "redux": "^5.0.0"
             }
         },
-        "node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/regex-not": {
             "version": "1.0.2",
             "dev": true,
@@ -17672,6 +17690,8 @@
         },
         "node_modules/typed-function": {
             "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.1.tgz",
+            "integrity": "sha512-EGjWssW7Tsk4DGfE+5yluuljS1OGYWiI1J6e8puZz9nTMM51Oug8CD5Zo4gWMsOhq5BI+1bF+rWTm4Vbj3ivRA==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
         "jszip": "^3.10.1",
         "katex": "^0.16.22",
         "lorem-ipsum": "^2.0.8",
-        "math-expressions": "^2.0.0-alpha75",
+        "math-expressions": "^2.0.0-alpha76",
         "micromark": "^4.0.2",
         "nanoid": "^5.1.5",
         "nextra": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
         "jszip": "^3.10.1",
         "katex": "^0.16.22",
         "lorem-ipsum": "^2.0.8",
-        "math-expressions": "^2.0.0-alpha74",
+        "math-expressions": "^2.0.0-alpha75",
         "micromark": "^4.0.2",
         "nanoid": "^5.1.5",
         "nextra": "^3.3.1",

--- a/packages/doenetml-worker-javascript/src/test/math/mathExpressionsEquality.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/math/mathExpressionsEquality.test.ts
@@ -963,6 +963,30 @@ describe("Math expressions equality tests", async () => {
                 symbolicSimplifyEqual: true,
                 symbolicSimplifyExpandEqual: true,
             },
+            {
+                expr1: "<math>not a = b</math>",
+                expr2: "<math>not (a = b)</math>",
+                equal: true,
+                symbolicEqual: true,
+                symbolicSimplifyEqual: true,
+                symbolicSimplifyExpandEqual: true,
+            },
+            {
+                expr1: "<math>not a = b</math>",
+                expr2: "<math>(not a) = b</math>",
+                equal: false,
+                symbolicEqual: false,
+                symbolicSimplifyEqual: false,
+                symbolicSimplifyExpandEqual: false,
+            },
+            {
+                expr1: "<math>a = not b</math>",
+                expr2: "<math>a = (not b)</math>",
+                equal: true,
+                symbolicEqual: true,
+                symbolicSimplifyEqual: true,
+                symbolicSimplifyExpandEqual: true,
+            },
         ];
 
         let doenetML = "";

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/periodicset.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/periodicset.test.ts
@@ -147,6 +147,7 @@ describe("PeriodicSet tag tests", async () => {
             period,
         });
         stateVariables = await core.returnAllStateVariables(false, true);
+
         expect(
             stateVariables[await resolvePathToNodeIdx("ans")].stateValues
                 .creditAchieved,

--- a/packages/doenetml-worker-javascript/src/utils/periodicSetEquality.js
+++ b/packages/doenetml-worker-javascript/src/utils/periodicSetEquality.js
@@ -268,13 +268,13 @@ function contained_in(tree, i_set, match_partial) {
         if (typeof period !== "number" || Number.isNaN(period)) return false;
 
         let frac = me.math.fraction(period);
-        let p = frac.n;
+        let p = me.math.number(frac.n);
 
         if (p > 1000) {
             return false;
         }
 
-        let q = frac.d;
+        let q = me.math.number(frac.d);
         data.push([p, q, offset, period]);
     }
 


### PR DESCRIPTION
With this PR, the precedence of the `not` operator in `<math>` tags reverts to the behavior from version 0.6, where `not` has a lower precedence than relation operators.

Feedback from users was that they preferred to not have parentheses for expressions such as
```
<boolean>not $x = 3</boolean>
```
Instead, one will need parentheses for logical operations such as if `$A` and `$B` are booleans in the expression:
```
<boolean>($not A)  = $B</boolean>
```

This reverts a change that came in with the upgrade of `math-expressions` to `2.0.0-alpha71` in #249. With upgrading `math-expressions` to `2.0.0-alpha76`, we have reverted to the lower precedence of `not`.