### PR TITLE
Add `extend` and `copy` attributes to schema for all components

### DIFF
--- a/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
@@ -378,6 +378,16 @@ export default class BaseComponent {
                 public: true,
                 excludeFromSchema: true,
             },
+
+            // Adding `extend` and `copy` attributes so they are in the schema for all components.
+            // These attributes are unused, as the `extend` and `copy` attributes are removed
+            // from the dast when references are expanded.
+            extend: {
+                createReferences: true,
+            },
+            copy: {
+                createReferences: true,
+            },
         };
     }
 

--- a/packages/static-assets/scripts/generate-entity-map.ts
+++ b/packages/static-assets/scripts/generate-entity-map.ts
@@ -2338,7 +2338,7 @@ const smallerEntittyMap = Object.fromEntries(
 );
 
 const file = path.join(__dirname, "..", "src", "generated", "entity-map.json");
-const out = JSON.stringify(smallerEntittyMap, null, 4);
+const out = JSON.stringify(smallerEntittyMap, null, 4) + "\n";
 
 console.log("Writing", out.length / 1024, "KB to", file);
 

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -161,9 +161,7 @@ export function getSchema() {
         let children: string[] = [];
         let acceptsStringChildren = false;
 
-        // All components have the name and copySource attributes,
-        // even though they aren't in the attributes object
-        let attributes = [{ name: "name" }, { name: "copySource" }];
+        let attributes = [];
 
         let cClass = componentClasses[type];
 

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -282,6 +282,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [
@@ -816,6 +828,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "format": {
@@ -1509,6 +1533,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [
@@ -2043,6 +2079,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "forObject": {
@@ -2664,6 +2712,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "forObject": {
                     "optional": true,
                     "type": [
@@ -3281,6 +3341,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -4071,6 +4143,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [
@@ -4859,6 +4943,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -5650,6 +5746,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "draggable": {
                     "optional": true,
                     "type": [
@@ -6169,6 +6277,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [],
@@ -6282,6 +6402,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [],
@@ -6394,6 +6526,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "draggable": {
@@ -6999,6 +7143,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "draggable": {
                     "optional": true,
                     "type": [
@@ -7600,6 +7756,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "draggable": {
@@ -8210,6 +8378,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "draggable": {
                     "optional": true,
                     "type": [
@@ -8405,6 +8585,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "draggable": {
                     "optional": true,
                     "type": [
@@ -8598,6 +8790,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "draggable": {
@@ -9215,6 +9419,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "symbolicEquality": {
                     "optional": true,
                     "type": [
@@ -9739,6 +9955,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "symbolicEquality": {
                     "optional": true,
                     "type": [
@@ -10037,6 +10265,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "symbolicEquality": {
@@ -10339,6 +10579,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "symbolicEquality": {
                     "optional": true,
                     "type": [
@@ -10637,6 +10889,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "symbolicEquality": {
@@ -11110,6 +11374,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "symbolicEquality": {
                     "optional": true,
                     "type": [
@@ -11579,6 +11855,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "symbolicEquality": {
@@ -12073,6 +12361,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "format": {
@@ -12779,6 +13079,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "format": {
                     "optional": true,
                     "type": [
@@ -13481,6 +13793,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "format": {
@@ -14197,6 +14521,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "format": {
                     "optional": true,
                     "type": [
@@ -14909,6 +15245,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "format": {
@@ -15625,6 +15973,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "format": {
                     "optional": true,
                     "type": [
@@ -16328,6 +16688,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "format": {
                     "optional": true,
                     "type": [
@@ -17006,6 +17378,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "format": {
@@ -17700,6 +18084,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "format": {
                     "optional": true,
                     "type": [
@@ -18390,6 +18786,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "format": {
@@ -19084,6 +19492,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "format": {
                     "optional": true,
                     "type": [
@@ -19774,6 +20194,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "format": {
@@ -20480,6 +20912,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "format": {
                     "optional": true,
                     "type": [
@@ -21182,6 +21626,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "format": {
@@ -21900,6 +22356,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "format": {
                     "optional": true,
                     "type": [
@@ -22616,6 +23084,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "format": {
                     "optional": true,
                     "type": [
@@ -23318,6 +23798,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "format": {
@@ -24024,6 +24516,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "format": {
                     "optional": true,
                     "type": [
@@ -24726,6 +25230,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "format": {
@@ -25432,6 +25948,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "format": {
                     "optional": true,
                     "type": [
@@ -26136,6 +26664,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "format": {
                     "optional": true,
                     "type": [
@@ -26838,6 +27378,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "format": {
@@ -27561,6 +28113,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "simplify": {
@@ -28342,6 +28906,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "simplify": {
                     "optional": true,
                     "type": [
@@ -29119,6 +29695,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "simplify": {
@@ -29908,6 +30496,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "draggable": {
                     "optional": true,
                     "type": [
@@ -30378,6 +30978,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -30909,6 +31521,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [
@@ -31438,6 +32062,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -31969,6 +32605,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [
@@ -32498,6 +33146,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -33029,6 +33689,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [
@@ -33558,6 +34230,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -34089,6 +34773,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [
@@ -34618,6 +35314,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -35149,6 +35857,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [
@@ -35679,6 +36399,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [],
@@ -35796,6 +36528,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -35915,6 +36659,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [],
@@ -36032,6 +36788,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -36151,6 +36919,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [],
@@ -36268,6 +37048,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -36387,6 +37179,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [],
@@ -36505,6 +37309,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [],
@@ -36622,6 +37438,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "aggregateScores": {
@@ -37596,6 +38424,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "aggregateScores": {
                     "optional": true,
                     "type": [
@@ -38566,6 +39406,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "aggregateScores": {
@@ -39540,6 +40392,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "aggregateScores": {
                     "optional": true,
                     "type": [
@@ -40510,6 +41374,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "aggregateScores": {
@@ -41510,6 +42386,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "aggregateScores": {
                     "optional": true,
                     "type": [
@@ -42480,6 +43368,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "aggregateScores": {
@@ -43454,6 +44354,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "aggregateScores": {
                     "optional": true,
                     "type": [
@@ -44424,6 +45336,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "aggregateScores": {
@@ -45398,6 +46322,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "aggregateScores": {
                     "optional": true,
                     "type": [
@@ -46368,6 +47304,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "aggregateScores": {
@@ -47342,6 +48290,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "aggregateScores": {
                     "optional": true,
                     "type": [
@@ -48312,6 +49272,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "aggregateScores": {
@@ -49286,6 +50258,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "aggregateScores": {
                     "optional": true,
                     "type": [
@@ -50256,6 +51240,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "aggregateScores": {
@@ -51250,6 +52246,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "aggregateScores": {
                     "optional": true,
                     "type": [
@@ -52214,6 +53222,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "aggregateScores": {
@@ -53182,6 +54202,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "label": {
                     "optional": true,
                     "type": [
@@ -53328,6 +54360,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "label": {
                     "optional": true,
                     "type": [
@@ -53472,6 +54516,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -54268,6 +55324,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "independentVariable": {
                     "optional": true,
                     "type": [
@@ -54640,6 +55708,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "labelIsName": {
@@ -55161,6 +56241,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "labelIsName": {
@@ -55769,6 +56861,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "labelIsName": {
                     "optional": true,
                     "type": [
@@ -56370,6 +57474,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "labelIsName": {
@@ -57172,6 +58288,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "symbol": {
                     "optional": true,
                     "type": [
@@ -57462,6 +58590,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "symbol": {
                     "optional": true,
                     "type": [
@@ -57667,6 +58807,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "symbol": {
                     "optional": true,
                     "type": [
@@ -57833,6 +58985,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "format": {
@@ -58527,6 +59691,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "labels": {
                     "optional": true,
                     "type": [
@@ -58862,6 +60038,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "prefill": {
                     "optional": true,
                     "type": [
@@ -59012,6 +60200,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "code": {
                     "optional": true,
                     "type": [
@@ -59136,6 +60336,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [
@@ -59252,6 +60464,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "lineColor": {
@@ -59541,6 +60765,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [
@@ -59657,6 +60893,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "width": {
@@ -60035,6 +61283,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "width": {
                     "optional": true,
                     "type": [
@@ -60229,6 +61489,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -61020,6 +62292,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "draggable": {
                     "optional": true,
                     "type": [
@@ -61545,6 +62829,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [
@@ -61836,6 +63132,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -62626,6 +63934,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [
@@ -63415,6 +64735,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [
@@ -64203,6 +65535,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -65014,6 +66358,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "initialPage": {
                     "optional": true,
                     "type": [
@@ -65819,6 +67175,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "previousLabel": {
                     "optional": true,
                     "type": [
@@ -65974,6 +67342,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "numRows": {
@@ -66304,6 +67684,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -66944,6 +68336,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "documentWideCheckWork": {
@@ -67792,6 +69196,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "draggable": {
                     "optional": true,
                     "type": [
@@ -68310,6 +69726,18 @@
                         "string"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "unordered": {
                     "optional": true,
                     "type": [
@@ -68635,6 +70063,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -69173,6 +70613,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "symbolicEquality": {
                     "optional": true,
                     "type": [
@@ -69690,6 +71142,18 @@
                         "string"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "unordered": {
                     "optional": true,
                     "type": [
@@ -69850,6 +71314,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "format": {
@@ -70542,6 +72018,18 @@
                         "string"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "unordered": {
                     "optional": true,
                     "type": [
@@ -70945,6 +72433,18 @@
                     ]
                 },
                 "isResponse": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
                     "optional": true,
                     "type": [
                         "string"
@@ -71358,6 +72858,18 @@
                         "string"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "unordered": {
                     "optional": true,
                     "type": [
@@ -71681,6 +73193,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "maxNumber": {
                     "optional": true,
                     "type": [
@@ -71782,6 +73306,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "to": {
@@ -72612,6 +74148,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "labelIsName": {
                     "optional": true,
                     "type": [
@@ -73192,6 +74740,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "format": {
@@ -73879,6 +75439,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "labelIsName": {
                     "optional": true,
                     "type": [
@@ -74458,6 +76030,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "labelIsName": {
                     "optional": true,
                     "type": [
@@ -74764,6 +76348,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "labelIsName": {
                     "optional": true,
                     "type": [
@@ -75051,6 +76647,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "labelIsName": {
@@ -75435,6 +77043,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "labelIsName": {
@@ -75853,6 +77473,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "labelIsName": {
                     "optional": true,
                     "type": [
@@ -76267,6 +77899,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "labelIsName": {
@@ -76723,6 +78367,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "labelIsName": {
@@ -77229,6 +78885,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "labelIsName": {
@@ -77895,6 +79563,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "labelIsName": {
                     "optional": true,
                     "type": [
@@ -78517,6 +80197,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "labelIsName": {
@@ -79295,6 +80987,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "alwaysVisible": {
                     "optional": true,
                     "type": [
@@ -79621,6 +81325,18 @@
                     ]
                 },
                 "isResponse": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
                     "optional": true,
                     "type": [
                         "string"
@@ -80007,6 +81723,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "labelIsName": {
@@ -80614,6 +82342,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "labelIsName": {
                     "optional": true,
                     "type": [
@@ -81116,6 +82856,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "weight": {
@@ -81949,6 +83701,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "credit": {
                     "optional": true,
                     "type": [
@@ -82581,6 +84345,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "symbolicEquality": {
                     "optional": true,
                     "type": [
@@ -83120,6 +84896,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "prefill": {
@@ -83743,6 +85531,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "prefill": {
                     "optional": true,
                     "type": [
@@ -84249,6 +86049,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "prefill": {
                     "optional": true,
                     "type": [
@@ -84719,6 +86531,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "selectMultiple": {
                     "optional": true,
                     "type": [
@@ -85064,6 +86888,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "credit": {
@@ -85920,6 +87756,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "displayDigits": {
                     "optional": true,
                     "type": [
@@ -86439,6 +88287,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "displayDigits": {
@@ -86965,6 +88825,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "xmin": {
@@ -87803,6 +89675,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "simplify": {
                     "optional": true,
                     "type": [
@@ -88560,6 +90444,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "simplify": {
                     "optional": true,
                     "type": [
@@ -89077,6 +90973,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "format": {
@@ -89762,6 +91670,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "selectForVariants": {
@@ -90574,6 +92494,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "displayDigits": {
                     "optional": true,
                     "type": [
@@ -90734,6 +92666,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "type": {
@@ -91236,6 +93180,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "width": {
                     "optional": true,
                     "type": [
@@ -91535,6 +93491,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "rowNum": {
@@ -92423,6 +94391,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "rowNum": {
                     "optional": true,
                     "type": [
@@ -92633,6 +94613,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "colNum": {
                     "optional": true,
                     "type": [
@@ -92787,6 +94779,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "rowNum": {
                     "optional": true,
                     "type": [
@@ -92933,6 +94937,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "width": {
@@ -93155,6 +95171,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "suppressTableNameInTitle": {
@@ -93855,6 +95883,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "suppressFigureNameInCaption": {
                     "optional": true,
                     "type": [
@@ -94552,6 +96592,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [
@@ -94875,6 +96927,18 @@
                     ]
                 },
                 "isResponse": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
                     "optional": true,
                     "type": [
                         "string"
@@ -95669,6 +97733,18 @@
                     ]
                 },
                 "isResponse": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
                     "optional": true,
                     "type": [
                         "string"
@@ -96495,6 +98571,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "labelIsName": {
                     "optional": true,
                     "type": [
@@ -96701,6 +98789,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [
@@ -96848,6 +98948,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "dx": {
@@ -97029,6 +99141,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "buffer": {
                     "optional": true,
                     "type": [
@@ -97151,6 +99275,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "dx": {
@@ -97375,6 +99511,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "relativeToGraphScales": {
@@ -97732,6 +99880,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "relativeToGraphScales": {
@@ -98101,6 +100261,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [
@@ -98238,6 +100410,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "threshold": {
@@ -98387,6 +100571,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "relativeToGraphScales": {
@@ -98746,6 +100942,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "asList": {
                     "optional": true,
                     "type": [
@@ -98874,6 +101082,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [
@@ -98970,6 +101190,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -99507,6 +101739,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "numVariants": {
                     "optional": true,
                     "type": [
@@ -99654,6 +101898,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "displayDigits": {
@@ -99859,6 +102115,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "numToSelect": {
                     "optional": true,
                     "type": [
@@ -99986,6 +102254,18 @@
                     ]
                 },
                 "isResponse": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
                     "optional": true,
                     "type": [
                         "string"
@@ -100786,6 +103066,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "type": {
                     "optional": true,
                     "type": [
@@ -101005,6 +103297,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "format": {
@@ -101523,6 +103827,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "type": {
                     "optional": true,
                     "type": [
@@ -101741,6 +104057,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "numSamples": {
@@ -101975,6 +104303,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "minValue": {
                     "optional": true,
                     "type": [
@@ -102149,6 +104489,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "numSamples": {
                     "optional": true,
                     "type": [
@@ -102303,6 +104655,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "type": {
@@ -103193,6 +105557,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "format": {
                     "optional": true,
                     "type": [
@@ -103744,6 +106120,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "width": {
                     "optional": true,
                     "type": [
@@ -104027,6 +106415,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "width": {
                     "optional": true,
                     "type": [
@@ -104247,6 +106647,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -105048,6 +107460,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "draggable": {
                     "optional": true,
                     "type": [
@@ -105571,6 +107995,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "draggable": {
@@ -106111,6 +108547,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "condition": {
@@ -106909,6 +109357,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [
@@ -107697,6 +110157,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "condition": {
@@ -108500,6 +110972,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "minSentencesPerParagraph": {
                     "optional": true,
                     "type": [
@@ -108653,6 +111137,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "target": {
@@ -108897,6 +111393,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "target": {
                     "optional": true,
                     "type": [
@@ -109133,6 +111641,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "draggable": {
                     "optional": true,
                     "type": [
@@ -109344,6 +111864,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "numIterates": {
@@ -109572,6 +112104,18 @@
                     ]
                 },
                 "isResponse": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
                     "optional": true,
                     "type": [
                         "string"
@@ -110366,6 +112910,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [
@@ -111134,6 +113690,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -111910,6 +114478,18 @@
                         "true",
                         "false"
                     ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
                 }
             },
             "children": [
@@ -112444,6 +115024,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -113120,6 +115712,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "labelIsName": {
                     "optional": true,
                     "type": [
@@ -113724,6 +116328,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "sortVectorsBy": {
@@ -114537,6 +117153,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "type": {
                     "optional": true,
                     "type": [
@@ -115319,6 +117947,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "variables": {
                     "optional": true,
                     "type": [
@@ -115702,6 +118342,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "xmin": {
                     "optional": true,
                     "type": [
@@ -115976,6 +118628,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "format": {
@@ -116738,6 +119402,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "type": {
@@ -117530,6 +120206,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "labelIsName": {
                     "optional": true,
                     "type": [
@@ -117903,6 +120591,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "labelIsName": {
                     "optional": true,
                     "type": [
@@ -118091,6 +120791,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "labelIsName": {
@@ -118304,6 +121016,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "labelIsName": {
                     "optional": true,
                     "type": [
@@ -118500,6 +121224,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "prefill": {
@@ -119410,6 +122146,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "symbolicEquality": {
                     "optional": true,
                     "type": [
@@ -119908,6 +122656,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "source": {
                     "optional": true,
                     "type": [
@@ -120081,6 +122841,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "source": {
@@ -120340,6 +123112,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "labelIsName": {
                     "optional": true,
                     "type": [
@@ -120527,6 +123311,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "forObject": {
@@ -121148,6 +123944,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "symbolicEquality": {
                     "optional": true,
                     "type": [
@@ -121714,6 +124522,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "format": {
                     "optional": true,
                     "type": [
@@ -122214,6 +125034,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "displayDigits": {
                     "optional": true,
                     "type": [
@@ -122605,6 +125437,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 },
                 "draggable": {
@@ -123196,6 +126040,18 @@
                     "type": [
                         "true",
                         "false"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
                     ]
                 }
             },
@@ -123987,6 +126843,18 @@
                         "false"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "labelIsName": {
                     "optional": true,
                     "type": [
@@ -124418,6 +127286,18 @@
                         "string"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "unordered": {
                     "optional": true,
                     "type": [
@@ -124773,6 +127653,18 @@
                         "string"
                     ]
                 },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "unordered": {
                     "optional": true,
                     "type": [
@@ -125123,6 +128015,18 @@
                     ]
                 },
                 "isResponse": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "extend": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "copy": {
                     "optional": true,
                     "type": [
                         "string"

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -236,12 +236,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -778,12 +772,6 @@
             "name": "rightHandSide",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -1487,12 +1475,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -2029,12 +2011,6 @@
             "name": "xLabel",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -2665,12 +2641,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -3291,12 +3261,6 @@
             "name": "statement",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -4097,12 +4061,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -4893,12 +4851,6 @@
             "name": "conclusion",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -5699,12 +5651,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -6231,12 +6177,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -6356,12 +6296,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -6476,12 +6410,6 @@
             "name": "m",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -7096,12 +7024,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -7706,12 +7628,6 @@
             "name": "men",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -8331,12 +8247,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -8538,12 +8448,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -8740,12 +8644,6 @@
             "name": "mrow",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -9372,12 +9270,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -9908,12 +9800,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -10215,12 +10101,6 @@
             "name": "or",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -10532,12 +10412,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -10839,12 +10713,6 @@
             "name": "isInteger",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -11327,12 +11195,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -11805,12 +11667,6 @@
             "name": "isBetween",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -12311,12 +12167,6 @@
             "name": "sum",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -13032,12 +12882,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -13743,12 +13587,6 @@
             "name": "clampNumber",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -14474,12 +14312,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -15195,12 +15027,6 @@
             "name": "round",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -15926,12 +15752,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -16641,12 +16461,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -17328,12 +17142,6 @@
             "name": "ceil",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -18037,12 +17845,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -18736,12 +18538,6 @@
             "name": "abs",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -19445,12 +19241,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -20144,12 +19934,6 @@
             "name": "mean",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -20865,12 +20649,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -21576,12 +21354,6 @@
             "name": "variance",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -22309,12 +22081,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -23037,12 +22803,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -23748,12 +23508,6 @@
             "name": "min",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -24469,12 +24223,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -25180,12 +24928,6 @@
             "name": "mod",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -25901,12 +25643,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -26617,12 +26353,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -27328,12 +27058,6 @@
             "name": "extractMath",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -28063,12 +27787,6 @@
             "name": "clampFunction",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -28859,12 +28577,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -29645,12 +29357,6 @@
             "name": "derivative",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -30449,12 +30155,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -30928,12 +30628,6 @@
             "name": "em",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -31475,12 +31169,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -32012,12 +31700,6 @@
             "name": "q",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -32559,12 +32241,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -33096,12 +32772,6 @@
             "name": "term",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -33643,12 +33313,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -34180,12 +33844,6 @@
             "name": "tag",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -34727,12 +34385,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -35264,12 +34916,6 @@
             "name": "tagc",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -35811,12 +35457,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -36353,12 +35993,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -36478,12 +36112,6 @@
             "name": "mdash",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -36613,12 +36241,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -36738,12 +36360,6 @@
             "name": "ellipsis",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -36873,12 +36489,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -36998,12 +36608,6 @@
             "name": "rq",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -37133,12 +36737,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -37263,12 +36861,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -37388,12 +36980,6 @@
             "name": "section",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -38377,12 +37963,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -39356,12 +38936,6 @@
             "name": "subsubsection",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -40345,12 +39919,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -41324,12 +40892,6 @@
             "name": "aside",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -42339,12 +41901,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -43318,12 +42874,6 @@
             "name": "problem",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -44307,12 +43857,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -45286,12 +44830,6 @@
             "name": "question",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -46275,12 +45813,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -47254,12 +46786,6 @@
             "name": "example",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -48243,12 +47769,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -49222,12 +48742,6 @@
             "name": "note",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -50211,12 +49725,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -51190,12 +50698,6 @@
             "name": "proof",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -52199,12 +51701,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -53172,12 +52668,6 @@
             "name": "exercises",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -54155,12 +53645,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -54313,12 +53797,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -54466,12 +53944,6 @@
             "name": "li",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -55277,12 +54749,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -55658,12 +55124,6 @@
             "name": "cobwebPolyline",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -56191,12 +55651,6 @@
             "name": "equilibriumPoint",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -56814,12 +56268,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -57424,12 +56872,6 @@
             "name": "equilibriumCurve",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -58241,12 +57683,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -58543,12 +57979,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -58760,12 +58190,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -58935,12 +58359,6 @@
             "name": "electronConfiguration",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -59644,12 +59062,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -59991,12 +59403,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -60153,12 +59559,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -60290,12 +59690,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -60414,12 +59808,6 @@
             "name": "styleDefinition",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -60719,12 +60107,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -60843,12 +60225,6 @@
             "name": "sideBySide",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -61236,12 +60612,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -61439,12 +60809,6 @@
             "name": "stack",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -62245,12 +61609,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -62783,12 +62141,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -63082,12 +62434,6 @@
             "name": "div",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -63888,12 +63234,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -64689,12 +64029,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -65485,12 +64819,6 @@
             "name": "displayDoenetML",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -66311,12 +65639,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -67128,12 +66450,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -67292,12 +66608,6 @@
             "name": "matrixInput",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -67634,12 +66944,6 @@
             "name": "solution",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -68320,12 +67624,6 @@
             "name": "document",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -69149,12 +68447,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -69681,12 +68973,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -70013,12 +69299,6 @@
             "name": "p",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -70566,12 +69846,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -71097,12 +70371,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -71264,12 +70532,6 @@
             "name": "math",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -71973,12 +71235,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -72388,12 +71644,6 @@
             "name": "tupleList",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -72813,12 +72063,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -73180,12 +72424,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "fixLocation": {
                     "optional": true,
                     "type": [
@@ -73256,12 +72494,6 @@
             "name": "link",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -74101,12 +73333,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -74690,12 +73916,6 @@
             "name": "coords",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -75392,12 +74612,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -75983,12 +75197,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -76301,12 +75509,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -76597,12 +75799,6 @@
             "name": "polyline",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -76993,12 +76189,6 @@
             "name": "polygon",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -77426,12 +76616,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -77849,12 +77033,6 @@
             "name": "rectangle",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -78317,12 +77495,6 @@
             "name": "regularPolygon",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -78835,12 +78007,6 @@
             "name": "circle",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -79516,12 +78682,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -80147,12 +79307,6 @@
             "name": "curve",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -80940,12 +80094,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -81280,12 +80428,6 @@
             "name": "controlVectors",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -81673,12 +80815,6 @@
             "name": "vector",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -82295,12 +81431,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -82806,12 +81936,6 @@
             "name": "answer",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -83654,12 +82778,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -84298,12 +83416,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -84846,12 +83958,6 @@
             "name": "mathInput",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -85484,12 +84590,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -86002,12 +85102,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -86484,12 +85578,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -86838,12 +85926,6 @@
             "name": "choice",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -87709,12 +86791,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -88237,12 +87313,6 @@
             "name": "integer",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -88775,12 +87845,6 @@
             "name": "graph",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -89628,12 +88692,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -90397,12 +89455,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -90923,12 +89975,6 @@
             "name": "interval",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -91620,12 +90666,6 @@
             "name": "option",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -92448,12 +91488,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -92616,12 +91650,6 @@
             "name": "slider",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -93133,12 +92161,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -93441,12 +92463,6 @@
             "name": "cell",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -94344,12 +93360,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -94566,12 +93576,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -94732,12 +93736,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -94887,12 +93885,6 @@
             "name": "tabular",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -95121,12 +94113,6 @@
             "name": "table",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -95836,12 +94822,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -96546,12 +95526,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -96881,12 +95855,6 @@
             "name": "repeat",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -97687,12 +96655,6 @@
             "name": "repeatForSequence",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -98524,12 +97486,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -98743,12 +97699,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -98898,12 +97848,6 @@
             "name": "constrainToGrid",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -99094,12 +98038,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -99225,12 +98163,6 @@
             "name": "attractToGrid",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -99461,12 +98393,6 @@
             "name": "constrainTo",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -99830,12 +98756,6 @@
             "name": "attractTo",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -100215,12 +99135,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -100360,12 +99274,6 @@
             "name": "attractToConstraint",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -100521,12 +99429,6 @@
             "name": "constrainToInterior",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -100895,12 +99797,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -101036,12 +99932,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -101140,12 +100030,6 @@
             "name": "asList",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -101692,12 +100576,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -101849,12 +100727,6 @@
             "name": "selectFromSequence",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -102068,12 +100940,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -102208,12 +101074,6 @@
             "name": "group",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -103019,12 +101879,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -103247,12 +102101,6 @@
             "name": "evaluate",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -103780,12 +102628,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -104007,12 +102849,6 @@
             "name": "sampleRandomNumbers",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -104256,12 +103092,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -104442,12 +103272,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -104605,12 +103429,6 @@
             "name": "substitute",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -105510,12 +104328,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -106073,12 +104885,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -106368,12 +105174,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -106597,12 +105397,6 @@
             "name": "hint",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -107413,12 +106207,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -107945,12 +106733,6 @@
             "name": "pluralize",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -108504,12 +107286,6 @@
             "name": "feedback",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -109311,12 +108087,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -110107,12 +108877,6 @@
             "name": "case",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -110925,12 +109689,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -111087,12 +109845,6 @@
             "name": "updateValue",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -111346,12 +110098,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -111594,12 +110340,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -111814,12 +110554,6 @@
             "name": "functionIterates",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -112064,12 +110798,6 @@
             "name": "module",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -112864,12 +111592,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -113640,12 +112362,6 @@
             "name": "setup",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -114432,12 +113148,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -114974,12 +113684,6 @@
             "name": "caption",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -115665,12 +114369,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -116278,12 +114976,6 @@
             "name": "sort",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -117106,12 +115798,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -117900,12 +116586,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -118295,12 +116975,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -118578,12 +117252,6 @@
             "name": "subsetOfReals",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -119352,12 +118020,6 @@
             "name": "split",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -120159,12 +118821,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -120544,12 +119200,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -120741,12 +119391,6 @@
             "name": "regionBetweenCurves",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -120969,12 +119613,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -121174,12 +119812,6 @@
             "name": "codeEditor",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -122099,12 +120731,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -122609,12 +121235,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -122791,12 +121411,6 @@
             "name": "summaryStatistics",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -123065,12 +121679,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -123261,12 +121869,6 @@
             "name": "label",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -123897,12 +122499,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -124475,12 +123071,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -124987,12 +123577,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -125387,12 +123971,6 @@
             "name": "latex",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -125990,12 +124568,6 @@
             "name": "blockQuote",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"
@@ -126796,12 +125368,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -127241,12 +125807,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -127608,12 +126168,6 @@
                         "string"
                     ]
                 },
-                "copySource": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
                 "hide": {
                     "optional": true,
                     "type": [
@@ -127970,12 +126524,6 @@
             "name": "vectorList",
             "attributes": {
                 "name": {
-                    "optional": true,
-                    "type": [
-                        "string"
-                    ]
-                },
-                "copySource": {
                     "optional": true,
                     "type": [
                         "string"

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -146,12 +146,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -338,12 +332,6 @@
                 "mrow"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -931,12 +919,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -1188,12 +1170,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -1524,12 +1500,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -1952,12 +1922,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -2287,12 +2251,6 @@
                 "vectorList"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -2630,12 +2588,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -2824,12 +2776,6 @@
                 "attr"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -3089,12 +3035,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -3198,12 +3138,6 @@
             "name": "hr",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -3449,12 +3383,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -3776,12 +3704,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -4099,12 +4021,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -4291,12 +4207,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -4474,12 +4384,6 @@
                 "mrow"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -4801,12 +4705,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -5083,12 +4981,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -5357,12 +5249,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -5626,12 +5512,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -5891,12 +5771,6 @@
                 "matchesPattern"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -6221,12 +6095,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -6547,12 +6415,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -6869,12 +6731,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -7215,12 +7071,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -7759,12 +7609,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -8311,12 +8155,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -8847,12 +8685,6 @@
                 "mrow"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -9391,12 +9223,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -9931,12 +9757,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -10463,12 +10283,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -10971,12 +10785,6 @@
                 "mrow"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -11499,12 +11307,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -12019,12 +11821,6 @@
                 "mrow"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -12547,12 +12343,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -13063,12 +12853,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -13611,12 +13395,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -14151,12 +13929,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -14711,12 +14483,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -15267,12 +15033,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -15807,12 +15567,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -16355,12 +16109,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -16895,12 +16643,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -17443,12 +17185,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -17983,12 +17719,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -18535,12 +18265,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -19079,12 +18803,6 @@
                 "label"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -19666,12 +19384,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -20245,12 +19957,6 @@
                 "label"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -20837,12 +20543,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -21236,12 +20936,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -21488,12 +21182,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -21748,12 +21436,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -22000,12 +21682,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -22260,12 +21936,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -22512,12 +22182,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -22772,12 +22436,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -23024,12 +22682,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -23284,12 +22936,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -23540,12 +23186,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -23654,12 +23294,6 @@
             "name": "ndash",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -23776,12 +23410,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -23890,12 +23518,6 @@
             "name": "nbsp",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -24012,12 +23634,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -24126,12 +23742,6 @@
             "name": "lq",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -24248,12 +23858,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -24366,12 +23970,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -24480,12 +24078,6 @@
             "name": "rsq",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -24824,12 +24416,6 @@
                 "vectorList"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -25335,12 +24921,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -25838,12 +25418,6 @@
                 "vectorList"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -26349,12 +25923,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -26852,12 +26420,6 @@
                 "vectorList"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -27389,12 +26951,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -27892,12 +27448,6 @@
                 "vectorList"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -28403,12 +27953,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -28906,12 +28450,6 @@
                 "vectorList"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -29417,12 +28955,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -29920,12 +29452,6 @@
                 "vectorList"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -30431,12 +29957,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -30934,12 +30454,6 @@
                 "vectorList"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -31445,12 +30959,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -31948,12 +31456,6 @@
                 "vectorList"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -32476,12 +31978,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -32974,12 +32470,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -33248,12 +32738,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -33376,12 +32860,6 @@
                 "li"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -33736,12 +33214,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -33852,12 +33324,6 @@
                 "rightHandSide"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -34193,12 +33659,6 @@
                 "label"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -34733,12 +34193,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -35167,12 +34621,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -35595,12 +35043,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -36152,12 +35594,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -36429,12 +35865,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -36620,12 +36050,6 @@
                 "ion"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -36845,12 +36269,6 @@
                 "mrow"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -37371,12 +36789,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -37488,12 +36900,6 @@
             "name": "orbitalDiagramInput",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -37636,12 +37042,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -37757,12 +37157,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -37866,12 +37260,6 @@
             "name": "styleDefinition",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -38070,12 +37458,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -38241,12 +37623,6 @@
                 "blockQuote"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -38420,12 +37796,6 @@
                 "sideBySide"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -38827,12 +38197,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -39021,12 +38385,6 @@
                 "attr"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -39356,12 +38714,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -39671,12 +39023,6 @@
                 "vectorList"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -40014,12 +39360,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -40353,12 +39693,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -40688,12 +40022,6 @@
                 "vectorList"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -41051,12 +40379,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -41173,12 +40495,6 @@
             "name": "paginatorControls",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -41320,12 +40636,6 @@
                 "matrix"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -41806,12 +41116,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -42150,12 +41454,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "fixLocation",
                     "values": [
                         "true",
@@ -42355,12 +41653,6 @@
                 "attr"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -42687,12 +41979,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -42944,12 +42230,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -43143,12 +42423,6 @@
                 "orbitalDiagram"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -43416,12 +42690,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -43602,12 +42870,6 @@
                 "mrow"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -44126,12 +43388,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -44367,12 +43623,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -44616,12 +43866,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -44741,12 +43985,6 @@
             "name": "collect",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -45034,12 +44272,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -45249,12 +44481,6 @@
                 "bestFitLine"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -45660,12 +44886,6 @@
                 "mrow"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -46180,12 +45400,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -46519,12 +45733,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -46804,12 +46012,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -47062,12 +46264,6 @@
                 "label"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -47413,12 +46609,6 @@
                 "label"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -47800,12 +46990,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -48179,12 +47363,6 @@
                 "label"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -48593,12 +47771,6 @@
                 "label"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -49108,12 +48280,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -49603,12 +48769,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -50058,12 +49218,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -50661,12 +49815,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -50851,12 +49999,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -51075,12 +50217,6 @@
                 "bestFitLine"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -51509,12 +50645,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -51861,12 +50991,6 @@
                 "booleanList"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -52471,12 +51595,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -52914,12 +52032,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -53261,12 +52373,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -53712,12 +52818,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -54087,12 +53187,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -54308,12 +53402,6 @@
                 "choice"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -54857,12 +53945,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -55106,12 +54188,6 @@
                 "booleanInput"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -55443,12 +54519,6 @@
                 "booleanInput"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -55827,12 +54897,6 @@
                 "graph"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -56323,12 +55387,6 @@
                 "label"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -56827,12 +55885,6 @@
                 "label"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -57364,12 +56416,6 @@
                 "mrow"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -58038,12 +57084,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -58163,12 +57203,6 @@
             "name": "sequence",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -58362,12 +57396,6 @@
                 "markers"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -58636,12 +57664,6 @@
                 "dataFrame"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -59127,12 +58149,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -59318,12 +58334,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -59505,12 +58515,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -59651,12 +58655,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -59778,12 +58776,6 @@
                 "row"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -60180,12 +59172,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -60508,12 +59494,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -60713,12 +59693,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -61072,12 +60046,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -61401,12 +60369,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -61521,12 +60483,6 @@
                 "label"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -61716,12 +60672,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -61835,12 +60785,6 @@
             "name": "constrainToGrid",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -62000,12 +60944,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -62117,12 +61055,6 @@
             "name": "attractToGrid",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -62396,12 +61328,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -62599,12 +61525,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -62741,12 +61661,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -62859,12 +61773,6 @@
                 "constrainToInterior"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -63062,12 +61970,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -63199,12 +62101,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -63292,12 +62188,6 @@
                 "case"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -63527,12 +62417,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -63646,12 +62530,6 @@
             "name": "variantControl",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -63781,12 +62659,6 @@
             "name": "selectFromSequence",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -63949,12 +62821,6 @@
                 "option"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -64302,12 +63168,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -64407,12 +63267,6 @@
             "name": "animateFromSequence",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -64607,12 +63461,6 @@
             "name": "evaluate",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -65097,12 +63945,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -65277,12 +64119,6 @@
             "name": "sampleRandomNumbers",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -65477,12 +64313,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -65632,12 +64462,6 @@
             "name": "samplePrimeNumbers",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -66006,12 +64830,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -66199,12 +65017,6 @@
             "name": "periodicSet",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -66712,12 +65524,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -66964,12 +65770,6 @@
             "name": "video",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -67404,12 +66204,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -67608,12 +66402,6 @@
                 "attr"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -67959,12 +66747,6 @@
                 "attr"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -68471,12 +67253,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "disabled",
                     "values": [
                         "true",
@@ -68804,12 +67580,6 @@
                 "vectorList"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -69147,12 +67917,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -69268,12 +68032,6 @@
             "name": "lorem",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -69406,12 +68164,6 @@
                 "label"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -69628,12 +68380,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -69836,12 +68582,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -70017,12 +68757,6 @@
             "name": "functionIterates",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -70467,12 +69201,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -70794,12 +69522,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -71115,12 +69837,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -71342,12 +70058,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -71655,12 +70365,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -71842,12 +70546,6 @@
                 "bestFitLine"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -72434,12 +71132,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -72786,12 +71478,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -72958,12 +71644,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -73120,12 +71800,6 @@
             "name": "subsetOfRealsInput",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -73442,12 +72116,6 @@
                 "mrow"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -74190,12 +72858,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -74304,12 +72966,6 @@
                 "label"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -74651,12 +73307,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -74827,12 +73477,6 @@
                 "piecewiseFunction"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -75011,12 +73655,6 @@
                 "label"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -75423,12 +74061,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -75699,12 +74331,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -75984,12 +74610,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -76149,12 +74769,6 @@
             "name": "summaryStatistics",
             "children": [],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -76389,12 +75003,6 @@
                 "label"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -76707,12 +75315,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -76970,12 +75572,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -77319,12 +75915,6 @@
                 "column"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -77852,12 +76442,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -78134,12 +76718,6 @@
                 "mdn"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -78630,12 +77208,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -78820,12 +77392,6 @@
                 "stickyGroup"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },
@@ -79076,12 +77642,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -79274,12 +77834,6 @@
                     "name": "name"
                 },
                 {
-                    "name": "copySource"
-                },
-                {
-                    "name": "name"
-                },
-                {
                     "name": "hide",
                     "values": [
                         "true",
@@ -79468,12 +78022,6 @@
                 "latex"
             ],
             "attributes": [
-                {
-                    "name": "name"
-                },
-                {
-                    "name": "copySource"
-                },
                 {
                     "name": "name"
                 },

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -188,6 +188,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -378,6 +384,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "format",
@@ -961,6 +973,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -1216,6 +1234,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "forObject"
@@ -1546,6 +1570,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "forObject"
@@ -1964,6 +1994,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -2297,6 +2333,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -2630,6 +2672,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -2822,6 +2870,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "draggable",
@@ -3077,6 +3131,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -3184,6 +3244,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -3429,6 +3495,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "draggable",
@@ -3748,6 +3820,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "draggable",
                     "values": [
                         "true",
@@ -4065,6 +4143,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "draggable",
                     "values": [
                         "true",
@@ -4251,6 +4335,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "draggable",
                     "values": [
                         "true",
@@ -4430,6 +4520,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "draggable",
@@ -4749,6 +4845,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "draggable",
                     "values": [
                         "true",
@@ -5025,6 +5127,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "symbolicEquality",
                     "values": [
                         "true",
@@ -5293,6 +5401,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "symbolicEquality",
                     "values": [
                         "true",
@@ -5556,6 +5670,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "symbolicEquality",
                     "values": [
                         "true",
@@ -5817,6 +5937,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "symbolicEquality",
@@ -6139,6 +6265,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "symbolicEquality",
                     "values": [
                         "true",
@@ -6459,6 +6591,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "symbolicEquality",
                     "values": [
                         "true",
@@ -6777,6 +6915,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "symbolicEquality",
@@ -7117,6 +7261,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "format",
@@ -7655,6 +7805,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "format",
@@ -8199,6 +8355,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "format",
                     "values": [
                         "text",
@@ -8731,6 +8893,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "format",
@@ -9267,6 +9435,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "format",
                     "values": [
                         "text",
@@ -9801,6 +9975,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "format",
                     "values": [
                         "text",
@@ -10327,6 +10507,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "format",
                     "values": [
                         "text",
@@ -10831,6 +11017,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "format",
@@ -11351,6 +11543,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "format",
                     "values": [
                         "text",
@@ -11867,6 +12065,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "format",
@@ -12387,6 +12591,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "format",
                     "values": [
                         "text",
@@ -12899,6 +13109,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "format",
@@ -13439,6 +13655,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "format",
                     "values": [
                         "text",
@@ -13975,6 +14197,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "format",
@@ -14527,6 +14755,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "format",
                     "values": [
                         "text",
@@ -15077,6 +15311,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "format",
                     "values": [
                         "text",
@@ -15613,6 +15853,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "format",
@@ -16153,6 +16399,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "format",
                     "values": [
                         "text",
@@ -16689,6 +16941,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "format",
@@ -17229,6 +17487,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "format",
                     "values": [
                         "text",
@@ -17765,6 +18029,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "format",
@@ -18309,6 +18579,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "format",
                     "values": [
                         "text",
@@ -18849,6 +19125,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "simplify",
@@ -19428,6 +19710,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "simplify",
                     "values": [
                         "none",
@@ -20003,6 +20291,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "simplify",
@@ -20587,6 +20881,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "draggable",
                     "values": [
                         "true",
@@ -20978,6 +21278,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -21228,6 +21534,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -21478,6 +21790,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -21728,6 +22046,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -21978,6 +22302,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -22228,6 +22558,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -22478,6 +22814,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -22728,6 +23070,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -22978,6 +23326,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -23228,6 +23582,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -23340,6 +23700,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -23452,6 +23818,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -23564,6 +23936,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -23676,6 +24054,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -23788,6 +24172,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -23900,6 +24290,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -24012,6 +24408,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -24124,6 +24526,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -24462,6 +24870,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "aggregateScores",
@@ -24965,6 +25379,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "aggregateScores",
                     "values": [
                         "true",
@@ -25464,6 +25884,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "aggregateScores",
@@ -25967,6 +26393,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "aggregateScores",
                     "values": [
                         "true",
@@ -26466,6 +26898,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "aggregateScores",
@@ -26995,6 +27433,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "aggregateScores",
                     "values": [
                         "true",
@@ -27494,6 +27938,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "aggregateScores",
@@ -27997,6 +28447,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "aggregateScores",
                     "values": [
                         "true",
@@ -28496,6 +28952,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "aggregateScores",
@@ -28999,6 +29461,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "aggregateScores",
                     "values": [
                         "true",
@@ -29498,6 +29966,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "aggregateScores",
@@ -30001,6 +30475,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "aggregateScores",
                     "values": [
                         "true",
@@ -30500,6 +30980,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "aggregateScores",
@@ -31003,6 +31489,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "aggregateScores",
                     "values": [
                         "true",
@@ -31502,6 +31994,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "aggregateScores",
@@ -32022,6 +32520,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "aggregateScores",
                     "values": [
                         "true",
@@ -32514,6 +33018,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "aggregateScores",
                     "values": [
                         "true",
@@ -32782,6 +33292,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "label"
                 },
                 {
@@ -32906,6 +33422,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "label"
@@ -33256,6 +33778,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -33370,6 +33898,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "independentVariable"
@@ -33705,6 +34239,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "labelIsName",
@@ -34237,6 +34777,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "labelIsName",
                     "values": [
                         "true",
@@ -34665,6 +35211,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "labelIsName",
                     "values": [
                         "true",
@@ -35089,6 +35641,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "labelIsName",
@@ -35638,6 +36196,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "symbol"
                 },
                 {
@@ -35909,6 +36473,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "symbol"
                 },
                 {
@@ -36096,6 +36666,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "symbol"
@@ -36315,6 +36891,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "format",
@@ -36833,6 +37415,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "labels"
                 }
             ],
@@ -36946,6 +37534,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "prefill"
@@ -37086,6 +37680,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "code"
                 },
                 {
@@ -37199,6 +37799,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -37306,6 +37912,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "lineColor"
@@ -37500,6 +38112,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -37669,6 +38287,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "width"
@@ -37842,6 +38466,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "width"
@@ -38239,6 +38869,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -38431,6 +39067,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "draggable",
@@ -38756,6 +39398,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -39069,6 +39717,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -39402,6 +40056,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -39735,6 +40395,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -40068,6 +40734,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -40423,6 +41095,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "initialPage"
                 }
             ],
@@ -40541,6 +41219,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "previousLabel"
@@ -40682,6 +41366,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "numRows"
@@ -41158,6 +41848,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -41467,6 +42163,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "documentWideCheckWork",
                     "values": [
                         "true",
@@ -41699,6 +42401,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "draggable",
@@ -42015,6 +42723,12 @@
                     "name": "isResponse"
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "unordered",
                     "values": [
                         "true",
@@ -42272,6 +42986,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -42469,6 +43189,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "symbolicEquality",
@@ -42726,6 +43452,12 @@
                     "name": "isResponse"
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "unordered",
                     "values": [
                         "true",
@@ -42916,6 +43648,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "format",
@@ -43424,6 +44162,12 @@
                     "name": "isResponse"
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "unordered",
                     "values": [
                         "true",
@@ -43661,6 +44405,12 @@
                 },
                 {
                     "name": "isResponse"
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "unordered",
@@ -43902,6 +44652,12 @@
                     "name": "isResponse"
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "unordered",
                     "values": [
                         "true",
@@ -44000,6 +44756,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "maxNumber"
@@ -44316,6 +45078,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "to"
                 },
                 {
@@ -44527,6 +45295,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "labelIsName",
@@ -44932,6 +45706,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "format",
@@ -45444,6 +46224,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "labelIsName",
                     "values": [
                         "true",
@@ -45777,6 +46563,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "labelIsName",
                     "values": [
                         "true",
@@ -46056,6 +46848,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "labelIsName",
                     "values": [
                         "true",
@@ -46310,6 +47108,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "labelIsName",
@@ -46655,6 +47459,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "labelIsName",
@@ -47034,6 +47844,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "labelIsName",
                     "values": [
                         "true",
@@ -47409,6 +48225,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "labelIsName",
@@ -47817,6 +48639,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "labelIsName",
@@ -48324,6 +49152,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "labelIsName",
                     "values": [
                         "true",
@@ -48813,6 +49647,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "labelIsName",
                     "values": [
                         "true",
@@ -49264,6 +50104,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "labelIsName",
@@ -49859,6 +50705,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "alwaysVisible",
                     "values": [
                         "true",
@@ -50037,6 +50889,12 @@
                 },
                 {
                     "name": "isResponse"
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "unordered",
@@ -50263,6 +51121,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "labelIsName",
@@ -50689,6 +51553,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "labelIsName",
                     "values": [
                         "true",
@@ -51037,6 +51907,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "weight"
@@ -51639,6 +52515,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "credit"
                 },
                 {
@@ -52076,6 +52958,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "symbolicEquality",
                     "values": [
                         "true",
@@ -52419,6 +53307,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "prefill"
@@ -52862,6 +53756,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "prefill"
                 },
                 {
@@ -53231,6 +54131,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "prefill",
                     "values": [
                         "true",
@@ -53448,6 +54354,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "selectMultiple",
@@ -53989,6 +54901,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "credit"
                 },
                 {
@@ -54234,6 +55152,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "displayDigits"
@@ -54565,6 +55489,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "displayDigits"
@@ -54943,6 +55873,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "xmin"
@@ -55433,6 +56369,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "simplify",
@@ -55931,6 +56873,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "simplify",
@@ -56462,6 +57410,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "format",
@@ -57128,6 +58082,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "selectForVariants"
                 },
                 {
@@ -57245,6 +58205,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "displayDigits"
@@ -57442,6 +58408,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "type",
@@ -57710,6 +58682,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "width"
@@ -58193,6 +59171,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "rowNum"
                 },
                 {
@@ -58378,6 +59362,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "rowNum"
                 },
                 {
@@ -58559,6 +59549,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "colNum"
                 },
                 {
@@ -58699,6 +59695,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "rowNum"
                 },
                 {
@@ -58822,6 +59824,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "width"
@@ -59216,6 +60224,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "suppressTableNameInTitle",
                     "values": [
                         "true",
@@ -59538,6 +60552,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "suppressFigureNameInCaption",
                     "values": [
                         "true",
@@ -59739,6 +60759,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -60086,6 +61112,12 @@
                     "name": "isResponse"
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "itemName"
                 },
                 {
@@ -60409,6 +61441,12 @@
                     "name": "isResponse"
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "type",
                     "values": [
                         "number",
@@ -60529,6 +61567,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "labelIsName",
@@ -60714,6 +61758,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -60831,6 +61881,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "dx"
@@ -60988,6 +62044,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "buffer"
                 }
             ],
@@ -61101,6 +62163,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "dx"
@@ -61372,6 +62440,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "relativeToGraphScales",
                     "values": [
                         "true",
@@ -61569,6 +62643,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "relativeToGraphScales",
                     "values": [
                         "true",
@@ -61703,6 +62783,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -61819,6 +62905,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "threshold"
@@ -62014,6 +63106,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "relativeToGraphScales",
                     "values": [
                         "true",
@@ -62145,6 +63243,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "asList",
                     "values": [
                         "true",
@@ -62234,6 +63338,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -62459,6 +63569,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -62576,6 +63692,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "numVariants"
@@ -62701,6 +63823,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "displayDigits"
@@ -62867,6 +63995,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "numToSelect"
@@ -63208,6 +64342,12 @@
                     "name": "isResponse"
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "rendered",
                     "values": [
                         "true",
@@ -63313,6 +64453,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "type",
@@ -63507,6 +64653,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "format",
@@ -63989,6 +65141,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "type",
                     "values": [
                         "uniform",
@@ -64165,6 +65323,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "numSamples"
@@ -64357,6 +65521,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "minValue"
                 },
                 {
@@ -64508,6 +65678,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "numSamples"
@@ -64874,6 +66050,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "type",
                     "values": [
                         "math",
@@ -65063,6 +66245,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "format",
@@ -65568,6 +66756,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "width"
                 },
                 {
@@ -65816,6 +67010,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "width"
@@ -66246,6 +67446,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -66448,6 +67654,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "draggable",
@@ -66793,6 +68005,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "draggable",
@@ -67290,6 +68508,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "condition",
                     "values": [
                         "true",
@@ -67626,6 +68850,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -67961,6 +69191,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "condition",
                     "values": [
                         "true",
@@ -68078,6 +69314,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "minSentencesPerParagraph"
@@ -68210,6 +69452,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "target"
@@ -68424,6 +69672,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "target"
                 },
                 {
@@ -68626,6 +69880,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "draggable",
                     "values": [
                         "true",
@@ -68803,6 +70063,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "numIterates"
@@ -69238,6 +70504,12 @@
                     "name": "isResponse"
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "rendered",
                     "values": [
                         "true",
@@ -69564,6 +70836,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -69879,6 +71157,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -70104,6 +71388,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -70407,6 +71697,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -70592,6 +71888,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "labelIsName",
@@ -71176,6 +72478,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "sortVectorsBy",
                     "values": [
                         "displacement",
@@ -71522,6 +72830,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "type"
                 },
                 {
@@ -71688,6 +73002,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "variables"
                 },
                 {
@@ -71846,6 +73166,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "xmin"
@@ -72162,6 +73488,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "format",
@@ -72902,6 +74234,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "type",
                     "values": [
                         "text"
@@ -73012,6 +74350,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "labelIsName",
@@ -73351,6 +74695,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "labelIsName",
                     "values": [
                         "true",
@@ -73523,6 +74873,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "labelIsName",
@@ -73701,6 +75057,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "labelIsName",
@@ -74105,6 +75467,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "prefill"
                 },
                 {
@@ -74377,6 +75745,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "symbolicEquality",
@@ -74654,6 +76028,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "source"
                 },
                 {
@@ -74815,6 +76195,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "source"
@@ -75049,6 +76435,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "labelIsName",
@@ -75359,6 +76751,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "forObject"
                 },
                 {
@@ -75618,6 +77016,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "symbolicEquality",
@@ -75961,6 +77365,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "format",
@@ -76486,6 +77896,12 @@
                     ]
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "displayDigits"
                 },
                 {
@@ -76764,6 +78180,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "draggable",
@@ -77250,6 +78672,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 }
             ],
             "properties": [
@@ -77438,6 +78866,12 @@
                         "true",
                         "false"
                     ]
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "labelIsName",
@@ -77678,6 +79112,12 @@
                     "name": "isResponse"
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "unordered",
                     "values": [
                         "true",
@@ -77870,6 +79310,12 @@
                     "name": "isResponse"
                 },
                 {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
+                },
+                {
                     "name": "unordered",
                     "values": [
                         "true",
@@ -78060,6 +79506,12 @@
                 },
                 {
                     "name": "isResponse"
+                },
+                {
+                    "name": "extend"
+                },
+                {
+                    "name": "copy"
                 },
                 {
                     "name": "unordered",


### PR DESCRIPTION
The PR adds an `extend` and a `copy` attribute to the base component so they show up in the schema. It also does a little clean up on static assets.