### PR TITLE
use root names to identify answers in answer response menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19895,7 +19895,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.0-alpha45",
+            "version": "0.7.0-alpha46",
             "license": "AGPL-3.0-or-later",
             "peerDependencies": {
                 "react": "^19.1.0",
@@ -19905,7 +19905,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.0-alpha45",
+            "version": "0.7.0-alpha46",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -21053,7 +21053,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.0-alpha45",
+            "version": "0.7.0-alpha46",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml-iframe",
     "type": "module",
     "description": "A renderer for DoenetML contained in an iframe",
-    "version": "0.7.0-alpha45",
+    "version": "0.7.0-alpha46",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.7.0-alpha45",
+    "version": "0.7.0-alpha46",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/src/Viewer/renderers/answer.tsx
+++ b/packages/doenetml/src/Viewer/renderers/answer.tsx
@@ -90,7 +90,8 @@ export default React.memo(function Answer(props: UseDoenetRendererProps) {
     if (showAnswerResponseMenu) {
         answerResponseMenu = (
             <AnswerResponseMenu
-                answerId={componentIdx}
+                answerId={id}
+                answerComponentIdx={componentIdx}
                 docId={docId}
                 activityId={activityId}
                 numResponses={answerResponseCounts?.[componentIdx]}

--- a/packages/doenetml/src/Viewer/renderers/utils/AnswerResponseMenu.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/AnswerResponseMenu.tsx
@@ -4,17 +4,17 @@ import "./AnswerResponseMenu.css";
 
 export function AnswerResponseMenu({
     answerId,
+    answerComponentIdx,
     activityId,
     docId,
     numResponses = 0,
 }: {
-    answerId: number;
+    answerId: string;
+    answerComponentIdx: number;
     activityId: string;
     docId: string;
     numResponses?: number;
 }) {
-    // XXX: we need to send in the actual answer name, as displaying the component index is not useful for instructors
-    const modifiedId = answerId;
     return (
         <MenuProvider>
             <MenuButton className="doenet-button action-button answer-response-menu-trigger">
@@ -26,6 +26,7 @@ export function AnswerResponseMenu({
                     onClick={() => {
                         window.postMessage({
                             subject: "requestAnswerResponses",
+                            answerComponentIdx,
                             answerId,
                             activityId,
                             docId,
@@ -33,7 +34,7 @@ export function AnswerResponseMenu({
                     }}
                 >
                     Show {numResponses} response
-                    {numResponses === 1 ? "" : "s"} to {modifiedId}
+                    {numResponses === 1 ? "" : "s"} to {answerId}
                 </MenuItem>
             </Menu>
         </MenuProvider>

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.7.0-alpha45",
+    "version": "0.7.0-alpha46",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,


### PR DESCRIPTION
This PR changes the answer response menus to use root names, if they exist, rather than component indices to identify the answers. In this way, instructors will see descriptive terms rather than numbers when view student responses.

Fixes #487 