### PR TITLE
Shrink size of `standalone` to less than 50mb

### DIFF
--- a/packages/doenetml-worker-javascript/vite.config.ts
+++ b/packages/doenetml-worker-javascript/vite.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
             },
             formats: ["es"],
         },
+        rollupOptions: {
+            // `math-expressions` is also pulled in by `doenetml-worker`; we don't need two copies.
+            external: ["math-expressions"],
+        },
     },
     test: {
         testTimeout: 180000,


### PR DESCRIPTION
The size has been reduced to 44mb by
 - Preventing the loading an extra copy of core's wasm
 - Deduplicating an instance of `math-expressions`