### PR TITLE
fix bug when adding commas around composite replacements

### DIFF
--- a/packages/doenetml-worker-javascript/src/Core.js
+++ b/packages/doenetml-worker-javascript/src/Core.js
@@ -1019,9 +1019,7 @@ export default class Core {
         rendererStatesToUpdate.push({
             componentIdx,
             stateValues: stateValuesForRenderer,
-            childrenInstructions: childrenToRender.filter(
-                (child) => child != null,
-            ),
+            childrenInstructions: childrenToRender,
         });
         if (Object.keys(stateValuesForRendererAlwaysUpdate).length > 0) {
             rendererStatesToForceUpdate.push({
@@ -1033,9 +1031,7 @@ export default class Core {
         // this.renderState is used to save the renderer state to the database
         this.rendererState[componentIdx] = {
             stateValues: stateValuesForRenderer,
-            childrenInstructions: childrenToRender.filter(
-                (child) => child != null,
-            ),
+            childrenInstructions: childrenToRender,
         };
 
         componentsWithChangedChildrenToRenderInProgress.delete(componentIdx);

--- a/packages/doenetml/src/Viewer/renderers/section.tsx
+++ b/packages/doenetml/src/Viewer/renderers/section.tsx
@@ -302,6 +302,8 @@ export default React.memo(function Section(props) {
         // except for possibly a beginning introduction or ending conclusion,
         // as a list.
 
+        children = children.filter((child) => child !== null);
+
         const numChildren = children.length;
         let firstInd = SVs.startsWithIntroduction ? 1 : 0;
         let lastInd = SVs.endsWithConclusion
@@ -316,12 +318,9 @@ export default React.memo(function Section(props) {
 
         newChildren.push(
             <ol key="list">
-                {children
-                    .slice(firstInd, lastInd + 1)
-                    .filter((child) => child !== null)
-                    .map((child) => (
-                        <li key={child.key}>{child}</li>
-                    ))}
+                {children.slice(firstInd, lastInd + 1).map((child) => (
+                    <li key={child.key}>{child}</li>
+                ))}
             </ol>,
         );
 

--- a/packages/doenetml/src/Viewer/renderers/section.tsx
+++ b/packages/doenetml/src/Viewer/renderers/section.tsx
@@ -316,9 +316,12 @@ export default React.memo(function Section(props) {
 
         newChildren.push(
             <ol key="list">
-                {children.slice(firstInd, lastInd + 1).map((child) => (
-                    <li key={child.key}>{child}</li>
-                ))}
+                {children
+                    .slice(firstInd, lastInd + 1)
+                    .filter((child) => child !== null)
+                    .map((child) => (
+                        <li key={child.key}>{child}</li>
+                    ))}
             </ol>,
         );
 

--- a/packages/test-cypress/cypress/e2e/baseComponent/renderCommas.cy.js
+++ b/packages/test-cypress/cypress/e2e/baseComponent/renderCommas.cy.js
@@ -285,4 +285,27 @@ $fi.iterates
                 cy.get(cesc("#sec2.p3")).should("have.text", "3rd entry: 2, 2");
             });
     });
+
+    it("render commas around repeat inside document", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+<mathList name="mL">a b c</mathList>
+
+<repeat name="doublingLoop" for="$mL" itemName="v">
+   <math>2 $v</math>
+</repeat>
+
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(".doenet-viewer").should(
+            "contain.text",
+            "a, b, c\n\n2a, 2b, 2c",
+        );
+    });
 });

--- a/packages/test-cypress/cypress/e2e/baseComponent/renderCommas.cy.js
+++ b/packages/test-cypress/cypress/e2e/baseComponent/renderCommas.cy.js
@@ -308,4 +308,48 @@ $fi.iterates
             "a, b, c\n\n2a, 2b, 2c",
         );
     });
+
+    it("render commas around repeat inside section", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+<section name="s">
+    <mathList name="mL">a b c</mathList>
+
+    <repeat name="doublingLoop" for="$mL" itemName="v">
+    <math>2 $v</math>
+    </repeat>
+</section>
+
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#s")).should("contain.text", "a, b, c\n\n    2a, 2b, 2c");
+    });
+
+    it("render commas around repeat inside paragraph", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+<p name="p">
+    <mathList name="mL">a b c</mathList>
+
+    <repeat name="doublingLoop" for="$mL" itemName="v">
+    <math>2 $v</math>
+    </repeat>
+</p>
+
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#p")).should("contain.text", "a, b, c\n\n    2a, 2b, 2c");
+    });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/problem.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/problem.cy.js
@@ -1489,4 +1489,106 @@ describe("Problem Tag Tests", function () {
             cy.get(cesc("#ca")).should("have.text", "1");
         });
     });
+
+    it("tasks render as list", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+        <problem name="problem">
+            <introduction>List of tasks</introduction>
+            <task>Do this</task>
+            <task>Do that</task>
+            <conclusion>Finished</conclusion>
+        </problem>
+
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#problem")).should(
+            "contain.text",
+            "Problem 1List of tasks Do this  Do that Finished",
+        );
+
+        cy.get(cesc("#problem") + " ol > li:nth-child(1)").should(
+            "have.text",
+            " Do this ",
+        );
+
+        cy.get(cesc("#problem") + " ol > li:nth-child(2)").should(
+            "have.text",
+            " Do that ",
+        );
+    });
+
+    it("parts render as list", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+        <problem name="problem">
+            <introduction>List of parts</introduction>
+            <part>Do this</part>
+            <part>Do that</part>
+            <conclusion>Finished</conclusion>
+        </problem>
+
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#problem")).should(
+            "contain.text",
+            "Problem 1List of parts Do this  Do that Finished",
+        );
+
+        cy.get(cesc("#problem") + " ol > li:nth-child(1)").should(
+            "have.text",
+            " Do this ",
+        );
+
+        cy.get(cesc("#problem") + " ol > li:nth-child(2)").should(
+            "have.text",
+            " Do that ",
+        );
+    });
+
+    it("problems render children as list", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+        <problems name="problem">
+            <introduction>List of problems</introduction>
+            <part>Do this</part>
+            <part>Do that</part>
+            <conclusion>Finished</conclusion>
+        </problems>
+
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#problem")).should(
+            "contain.text",
+            "Problems 1List of problems Do this  Do that Finished",
+        );
+
+        cy.get(cesc("#problem") + " ol > li:nth-child(1)").should(
+            "have.text",
+            " Do this ",
+        );
+
+        cy.get(cesc("#problem") + " ol > li:nth-child(2)").should(
+            "have.text",
+            " Do that ",
+        );
+    });
 });


### PR DESCRIPTION
Fixes a regression from #512 where commas were not rendering correctly around a repeat when it was directly in the document.