### PR TITLE
Normalize capitalization of graph limits

### DIFF
--- a/packages/doenetml-prototype/src/renderers/doenet/graph.tsx
+++ b/packages/doenetml-prototype/src/renderers/doenet/graph.tsx
@@ -273,9 +273,9 @@ function NavButtons({ board }: { board: JSG.Board | null }) {
                     className="button center"
                     title="Center"
                     onClick={() => {
-                        const [xmin, ymax, xmax, ymin] = board.getBoundingBox();
-                        const width = xmax - xmin;
-                        const height = ymax - ymin;
+                        const [xMin, yMax, xMax, yMin] = board.getBoundingBox();
+                        const width = xMax - xMin;
+                        const height = yMax - yMin;
 
                         board.setBoundingBox([
                             -width / 2,

--- a/packages/doenetml-worker-javascript/src/components/ConstrainToGraph.js
+++ b/packages/doenetml-worker-javascript/src/components/ConstrainToGraph.js
@@ -71,27 +71,27 @@ export default class ConstrainToGraph extends ConstraintComponent {
                                 return {};
                             }
 
-                            let xmin =
+                            let xMin =
                                 dependencyValues.constraintAncestor.stateValues
                                     .graphXmin;
-                            let xmax =
+                            let xMax =
                                 dependencyValues.constraintAncestor.stateValues
                                     .graphXmax;
 
                             if (
                                 !(
-                                    Number.isFinite(xmin) &&
-                                    Number.isFinite(xmax)
+                                    Number.isFinite(xMin) &&
+                                    Number.isFinite(xMax)
                                 )
                             ) {
                                 return {};
                             }
 
-                            let lowerBound = xmin;
-                            let upperBound = xmax;
+                            let lowerBound = xMin;
+                            let upperBound = xMax;
                             let buffer = dependencyValues.buffer;
                             if (buffer > 0) {
-                                let bufferAdjust = buffer * (xmax - xmin);
+                                let bufferAdjust = buffer * (xMax - xMin);
                                 lowerBound += bufferAdjust;
                                 upperBound -= bufferAdjust;
                             }
@@ -115,27 +115,27 @@ export default class ConstrainToGraph extends ConstraintComponent {
                                 return {};
                             }
 
-                            let ymin =
+                            let yMin =
                                 dependencyValues.constraintAncestor.stateValues
                                     .graphYmin;
-                            let ymax =
+                            let yMax =
                                 dependencyValues.constraintAncestor.stateValues
                                     .graphYmax;
 
                             if (
                                 !(
-                                    Number.isFinite(ymin) &&
-                                    Number.isFinite(ymax)
+                                    Number.isFinite(yMin) &&
+                                    Number.isFinite(yMax)
                                 )
                             ) {
                                 return {};
                             }
 
-                            let lowerBound = ymin;
-                            let upperBound = ymax;
+                            let lowerBound = yMin;
+                            let upperBound = yMax;
                             let buffer = dependencyValues.buffer;
                             if (buffer > 0) {
-                                let bufferAdjust = buffer * (ymax - ymin);
+                                let bufferAdjust = buffer * (yMax - yMin);
                                 lowerBound += bufferAdjust;
                                 upperBound -= bufferAdjust;
                             }

--- a/packages/doenetml-worker-javascript/src/components/Curve.js
+++ b/packages/doenetml-worker-javascript/src/components/Curve.js
@@ -406,7 +406,7 @@ export default class Curve extends GraphicalComponent {
                 graphAncestor: {
                     dependencyType: "ancestor",
                     componentType: "graph",
-                    variableNames: ["xmin", "xmax", "ymin", "ymax"],
+                    variableNames: ["xMin", "xMax", "yMin", "yMax"],
                 },
             }),
             definition({ dependencyValues }) {
@@ -414,13 +414,13 @@ export default class Curve extends GraphicalComponent {
                     return {
                         setValue: {
                             graphXmin:
-                                dependencyValues.graphAncestor.stateValues.xmin,
+                                dependencyValues.graphAncestor.stateValues.xMin,
                             graphXmax:
-                                dependencyValues.graphAncestor.stateValues.xmax,
+                                dependencyValues.graphAncestor.stateValues.xMax,
                             graphYmin:
-                                dependencyValues.graphAncestor.stateValues.ymin,
+                                dependencyValues.graphAncestor.stateValues.yMin,
                             graphYmax:
-                                dependencyValues.graphAncestor.stateValues.ymax,
+                                dependencyValues.graphAncestor.stateValues.yMax,
                         },
                     };
                 } else {

--- a/packages/doenetml-worker-javascript/src/components/Graph.js
+++ b/packages/doenetml-worker-javascript/src/components/Graph.js
@@ -27,22 +27,22 @@ export default class Graph extends BlockComponent {
 
     static createAttributesObject() {
         let attributes = super.createAttributesObject();
-        attributes.xmin = {
+        attributes.xMin = {
             createComponentOfType: "number",
             createStateVariable: "xminPrelim",
             defaultValue: -10,
         };
-        attributes.xmax = {
+        attributes.xMax = {
             createComponentOfType: "number",
             createStateVariable: "xmaxPrelim",
             defaultValue: 10,
         };
-        attributes.ymin = {
+        attributes.yMin = {
             createComponentOfType: "number",
             createStateVariable: "yminPrelim",
             defaultValue: -10,
         };
-        attributes.ymax = {
+        attributes.yMax = {
             createComponentOfType: "number",
             createStateVariable: "ymaxPrelim",
             defaultValue: 10,
@@ -687,7 +687,7 @@ export default class Graph extends BlockComponent {
             },
         };
 
-        stateVariableDefinitions.xmin = {
+        stateVariableDefinitions.xMin = {
             stateVariablesDeterminingDependencies: [
                 "identicalAxisScales",
                 "aspectRatioFromAxisScales",
@@ -716,7 +716,7 @@ export default class Graph extends BlockComponent {
                     graphParentXmin: {
                         dependencyType: "parentStateVariable",
                         parentComponentType: "graph",
-                        variableName: "xmin",
+                        variableName: "xMin",
                     },
                 };
 
@@ -746,21 +746,21 @@ export default class Graph extends BlockComponent {
             definition({ dependencyValues, usedDefault }) {
                 if (dependencyValues.graphParentXmin !== null) {
                     return {
-                        setValue: { xmin: dependencyValues.graphParentXmin },
+                        setValue: { xMin: dependencyValues.graphParentXmin },
                     };
                 }
                 if (
                     !dependencyValues.identicalAxisScales ||
                     dependencyValues.aspectRatioFromAxisScales
                 ) {
-                    return { setValue: { xmin: dependencyValues.xminPrelim } };
+                    return { setValue: { xMin: dependencyValues.xminPrelim } };
                 }
 
                 let xminSpecified = !usedDefault.xminPrelim;
 
-                // always use xmin if specified
+                // always use xMin if specified
                 if (xminSpecified) {
-                    return { setValue: { xmin: dependencyValues.xminPrelim } };
+                    return { setValue: { xMin: dependencyValues.xminPrelim } };
                 }
 
                 let xmaxSpecified = !usedDefault.xmaxPrelim;
@@ -778,25 +778,25 @@ export default class Graph extends BlockComponent {
                     if (xmaxSpecified) {
                         return {
                             setValue: {
-                                xmin:
+                                xMin:
                                     dependencyValues.xmaxPrelim -
                                     yscaleAdjusted,
                             },
                         };
                     } else {
-                        return { setValue: { xmin: -yscaleAdjusted / 2 } };
+                        return { setValue: { xMin: -yscaleAdjusted / 2 } };
                     }
                 } else {
                     if (xmaxSpecified) {
                         // use the default xscale of 20
                         return {
                             setValue: {
-                                xmin: dependencyValues.xmaxPrelim - 20,
+                                xMin: dependencyValues.xmaxPrelim - 20,
                             },
                         };
                     } else {
-                        // use the default value of xmin
-                        return { setValue: { xmin: -10 } };
+                        // use the default value of xMin
+                        return { setValue: { xMin: -10 } };
                     }
                 }
             },
@@ -812,7 +812,7 @@ export default class Graph extends BlockComponent {
                         instructions: [
                             {
                                 setDependency: "graphParentXmin",
-                                desiredValue: desiredStateVariableValues.xmin,
+                                desiredValue: desiredStateVariableValues.xMin,
                             },
                         ],
                     };
@@ -825,14 +825,14 @@ export default class Graph extends BlockComponent {
                     instructions: [
                         {
                             setDependency: "xminPrelim",
-                            desiredValue: desiredStateVariableValues.xmin,
+                            desiredValue: desiredStateVariableValues.xMin,
                         },
                     ],
                 };
             },
         };
 
-        stateVariableDefinitions.xmax = {
+        stateVariableDefinitions.xMax = {
             stateVariablesDeterminingDependencies: [
                 "identicalAxisScales",
                 "aspectRatioFromAxisScales",
@@ -861,7 +861,7 @@ export default class Graph extends BlockComponent {
                     graphParentXmax: {
                         dependencyType: "parentStateVariable",
                         parentComponentType: "graph",
-                        variableName: "xmax",
+                        variableName: "xMax",
                     },
                 };
 
@@ -891,14 +891,14 @@ export default class Graph extends BlockComponent {
             definition({ dependencyValues, usedDefault }) {
                 if (dependencyValues.graphParentXmax !== null) {
                     return {
-                        setValue: { xmax: dependencyValues.graphParentXmax },
+                        setValue: { xMax: dependencyValues.graphParentXmax },
                     };
                 }
                 if (
                     !dependencyValues.identicalAxisScales ||
                     dependencyValues.aspectRatioFromAxisScales
                 ) {
-                    return { setValue: { xmax: dependencyValues.xmaxPrelim } };
+                    return { setValue: { xMax: dependencyValues.xmaxPrelim } };
                 }
 
                 let xminSpecified = !usedDefault.xminPrelim;
@@ -909,7 +909,7 @@ export default class Graph extends BlockComponent {
                 let yscaleSpecified = yminSpecified && ymaxSpecified;
                 let xscaleSpecified = xminSpecified && xmaxSpecified;
 
-                let xmin = dependencyValues.xminPrelim;
+                let xMin = dependencyValues.xminPrelim;
 
                 if (yscaleSpecified) {
                     let aspectRatio = dependencyValues.aspectRatio;
@@ -919,35 +919,35 @@ export default class Graph extends BlockComponent {
                         aspectRatio;
 
                     if (xscaleSpecified) {
-                        let xscale = dependencyValues.xmaxPrelim - xmin;
+                        let xscale = dependencyValues.xmaxPrelim - xMin;
                         let maxScale = Math.max(xscale, yscaleAdjusted);
 
-                        return { setValue: { xmax: xmin + maxScale } };
+                        return { setValue: { xMax: xMin + maxScale } };
                     } else {
                         if (xminSpecified) {
                             return {
-                                setValue: { xmax: xmin + yscaleAdjusted },
+                                setValue: { xMax: xMin + yscaleAdjusted },
                             };
                         } else if (xmaxSpecified) {
                             return {
-                                setValue: { xmax: dependencyValues.xmaxPrelim },
+                                setValue: { xMax: dependencyValues.xmaxPrelim },
                             };
                         } else {
-                            return { setValue: { xmax: yscaleAdjusted / 2 } };
+                            return { setValue: { xMax: yscaleAdjusted / 2 } };
                         }
                     }
                 } else {
                     // no yscale specified
                     if (xmaxSpecified) {
                         return {
-                            setValue: { xmax: dependencyValues.xmaxPrelim },
+                            setValue: { xMax: dependencyValues.xmaxPrelim },
                         };
                     } else if (xminSpecified) {
                         // use the default xscale of 20
-                        return { setValue: { xmax: xmin + 20 } };
+                        return { setValue: { xMax: xMin + 20 } };
                     } else {
-                        // use the default xmax
-                        return { setValue: { xmax: 10 } };
+                        // use the default xMax
+                        return { setValue: { xMax: 10 } };
                     }
                 }
             },
@@ -963,7 +963,7 @@ export default class Graph extends BlockComponent {
                         instructions: [
                             {
                                 setDependency: "graphParentXmax",
-                                desiredValue: desiredStateVariableValues.xmax,
+                                desiredValue: desiredStateVariableValues.xMax,
                             },
                         ],
                     };
@@ -976,14 +976,14 @@ export default class Graph extends BlockComponent {
                     instructions: [
                         {
                             setDependency: "xmaxPrelim",
-                            desiredValue: desiredStateVariableValues.xmax,
+                            desiredValue: desiredStateVariableValues.xMax,
                         },
                     ],
                 };
             },
         };
 
-        stateVariableDefinitions.ymin = {
+        stateVariableDefinitions.yMin = {
             stateVariablesDeterminingDependencies: [
                 "identicalAxisScales",
                 "aspectRatioFromAxisScales",
@@ -1012,7 +1012,7 @@ export default class Graph extends BlockComponent {
                     graphParentYmin: {
                         dependencyType: "parentStateVariable",
                         parentComponentType: "graph",
-                        variableName: "ymin",
+                        variableName: "yMin",
                     },
                 };
 
@@ -1042,21 +1042,21 @@ export default class Graph extends BlockComponent {
             definition({ dependencyValues, usedDefault }) {
                 if (dependencyValues.graphParentYmin !== null) {
                     return {
-                        setValue: { ymin: dependencyValues.graphParentYmin },
+                        setValue: { yMin: dependencyValues.graphParentYmin },
                     };
                 }
                 if (
                     !dependencyValues.identicalAxisScales ||
                     dependencyValues.aspectRatioFromAxisScales
                 ) {
-                    return { setValue: { ymin: dependencyValues.yminPrelim } };
+                    return { setValue: { yMin: dependencyValues.yminPrelim } };
                 }
 
                 let yminSpecified = !usedDefault.yminPrelim;
 
-                // always use ymin if specified
+                // always use yMin if specified
                 if (yminSpecified) {
-                    return { setValue: { ymin: dependencyValues.yminPrelim } };
+                    return { setValue: { yMin: dependencyValues.yminPrelim } };
                 }
 
                 let ymaxSpecified = !usedDefault.ymaxPrelim;
@@ -1074,27 +1074,27 @@ export default class Graph extends BlockComponent {
                     if (ymaxSpecified) {
                         return {
                             setValue: {
-                                ymin:
+                                yMin:
                                     dependencyValues.ymaxPrelim -
                                     xscaleAdjusted,
                             },
                         };
                     } else {
-                        return { setValue: { ymin: -xscaleAdjusted / 2 } };
+                        return { setValue: { yMin: -xscaleAdjusted / 2 } };
                     }
                 } else {
                     if (ymaxSpecified) {
                         // use the default xscale of 20, adjusted for aspect ratio
                         return {
                             setValue: {
-                                ymin:
+                                yMin:
                                     dependencyValues.ymaxPrelim -
                                     20 / aspectRatio,
                             },
                         };
                     } else {
-                        // use the default value of ymin, adjusted for aspect ration
-                        return { setValue: { ymin: -10 / aspectRatio } };
+                        // use the default value of yMin, adjusted for aspect ration
+                        return { setValue: { yMin: -10 / aspectRatio } };
                     }
                 }
             },
@@ -1110,7 +1110,7 @@ export default class Graph extends BlockComponent {
                         instructions: [
                             {
                                 setDependency: "graphParentYmin",
-                                desiredValue: desiredStateVariableValues.ymin,
+                                desiredValue: desiredStateVariableValues.yMin,
                             },
                         ],
                     };
@@ -1123,14 +1123,14 @@ export default class Graph extends BlockComponent {
                     instructions: [
                         {
                             setDependency: "yminPrelim",
-                            desiredValue: desiredStateVariableValues.ymin,
+                            desiredValue: desiredStateVariableValues.yMin,
                         },
                     ],
                 };
             },
         };
 
-        stateVariableDefinitions.ymax = {
+        stateVariableDefinitions.yMax = {
             stateVariablesDeterminingDependencies: [
                 "identicalAxisScales",
                 "aspectRatioFromAxisScales",
@@ -1159,7 +1159,7 @@ export default class Graph extends BlockComponent {
                     graphParentYmax: {
                         dependencyType: "parentStateVariable",
                         parentComponentType: "graph",
-                        variableName: "ymax",
+                        variableName: "yMax",
                     },
                 };
 
@@ -1189,14 +1189,14 @@ export default class Graph extends BlockComponent {
             definition({ dependencyValues, usedDefault }) {
                 if (dependencyValues.graphParentYmax !== null) {
                     return {
-                        setValue: { ymax: dependencyValues.graphParentYmax },
+                        setValue: { yMax: dependencyValues.graphParentYmax },
                     };
                 }
                 if (
                     !dependencyValues.identicalAxisScales ||
                     dependencyValues.aspectRatioFromAxisScales
                 ) {
-                    return { setValue: { ymax: dependencyValues.ymaxPrelim } };
+                    return { setValue: { yMax: dependencyValues.ymaxPrelim } };
                 }
 
                 let xminSpecified = !usedDefault.xminPrelim;
@@ -1207,7 +1207,7 @@ export default class Graph extends BlockComponent {
                 let yscaleSpecified = yminSpecified && ymaxSpecified;
                 let xscaleSpecified = xminSpecified && xmaxSpecified;
 
-                let ymin = dependencyValues.yminPrelim;
+                let yMin = dependencyValues.yminPrelim;
 
                 let aspectRatio = dependencyValues.aspectRatio;
 
@@ -1218,35 +1218,35 @@ export default class Graph extends BlockComponent {
                         aspectRatio;
 
                     if (yscaleSpecified) {
-                        let yscale = dependencyValues.ymaxPrelim - ymin;
+                        let yscale = dependencyValues.ymaxPrelim - yMin;
                         let maxScale = Math.max(yscale, xscaleAdjusted);
 
-                        return { setValue: { ymax: ymin + maxScale } };
+                        return { setValue: { yMax: yMin + maxScale } };
                     } else {
                         if (yminSpecified) {
                             return {
-                                setValue: { ymax: ymin + xscaleAdjusted },
+                                setValue: { yMax: yMin + xscaleAdjusted },
                             };
                         } else if (ymaxSpecified) {
                             return {
-                                setValue: { ymax: dependencyValues.ymaxPrelim },
+                                setValue: { yMax: dependencyValues.ymaxPrelim },
                             };
                         } else {
-                            return { setValue: { ymax: xscaleAdjusted / 2 } };
+                            return { setValue: { yMax: xscaleAdjusted / 2 } };
                         }
                     }
                 } else {
                     // no xscale specified
                     if (ymaxSpecified) {
                         return {
-                            setValue: { ymax: dependencyValues.ymaxPrelim },
+                            setValue: { yMax: dependencyValues.ymaxPrelim },
                         };
                     } else if (yminSpecified) {
                         // use the default yscale of 20, adjusted for aspect ratio
-                        return { setValue: { ymax: ymin + 20 / aspectRatio } };
+                        return { setValue: { yMax: yMin + 20 / aspectRatio } };
                     } else {
-                        // use the default ymax, adjusted for aspect ratio
-                        return { setValue: { ymax: 10 / aspectRatio } };
+                        // use the default yMax, adjusted for aspect ratio
+                        return { setValue: { yMax: 10 / aspectRatio } };
                     }
                 }
             },
@@ -1262,7 +1262,7 @@ export default class Graph extends BlockComponent {
                         instructions: [
                             {
                                 setDependency: "graphParentYmax",
-                                desiredValue: desiredStateVariableValues.ymax,
+                                desiredValue: desiredStateVariableValues.yMax,
                             },
                         ],
                     };
@@ -1275,7 +1275,7 @@ export default class Graph extends BlockComponent {
                     instructions: [
                         {
                             setDependency: "ymaxPrelim",
-                            desiredValue: desiredStateVariableValues.ymax,
+                            desiredValue: desiredStateVariableValues.yMax,
                         },
                     ],
                 };
@@ -1285,31 +1285,31 @@ export default class Graph extends BlockComponent {
         stateVariableDefinitions.boundingbox = {
             forRenderer: true,
             returnDependencies: () => ({
-                xmin: {
+                xMin: {
                     dependencyType: "stateVariable",
-                    variableName: "xmin",
+                    variableName: "xMin",
                 },
-                xmax: {
+                xMax: {
                     dependencyType: "stateVariable",
-                    variableName: "xmax",
+                    variableName: "xMax",
                 },
-                ymin: {
+                yMin: {
                     dependencyType: "stateVariable",
-                    variableName: "ymin",
+                    variableName: "yMin",
                 },
-                ymax: {
+                yMax: {
                     dependencyType: "stateVariable",
-                    variableName: "ymax",
+                    variableName: "yMax",
                 },
             }),
             definition({ dependencyValues }) {
                 return {
                     setValue: {
                         boundingbox: [
-                            dependencyValues.xmin,
-                            dependencyValues.ymax,
-                            dependencyValues.xmax,
-                            dependencyValues.ymin,
+                            dependencyValues.xMin,
+                            dependencyValues.yMax,
+                            dependencyValues.xMax,
+                            dependencyValues.yMin,
                         ],
                     },
                 };
@@ -1324,19 +1324,19 @@ export default class Graph extends BlockComponent {
                     returnRoundingAttributeComponentShadowing(),
             },
             returnDependencies: () => ({
-                xmin: {
+                xMin: {
                     dependencyType: "stateVariable",
-                    variableName: "xmin",
+                    variableName: "xMin",
                 },
-                xmax: {
+                xMax: {
                     dependencyType: "stateVariable",
-                    variableName: "xmax",
+                    variableName: "xMax",
                 },
             }),
             definition({ dependencyValues }) {
                 return {
                     setValue: {
-                        xscale: dependencyValues.xmax - dependencyValues.xmin,
+                        xscale: dependencyValues.xMax - dependencyValues.xMin,
                     },
                 };
             },
@@ -1350,19 +1350,19 @@ export default class Graph extends BlockComponent {
                     returnRoundingAttributeComponentShadowing(),
             },
             returnDependencies: () => ({
-                ymin: {
+                yMin: {
                     dependencyType: "stateVariable",
-                    variableName: "ymin",
+                    variableName: "yMin",
                 },
-                ymax: {
+                yMax: {
                     dependencyType: "stateVariable",
-                    variableName: "ymax",
+                    variableName: "yMax",
                 },
             }),
             definition({ dependencyValues }) {
                 return {
                     setValue: {
-                        yscale: dependencyValues.ymax - dependencyValues.ymin,
+                        yscale: dependencyValues.yMax - dependencyValues.yMin,
                     },
                 };
             },
@@ -1612,46 +1612,46 @@ export default class Graph extends BlockComponent {
     }
 
     async changeAxisLimits({
-        xmin,
-        xmax,
-        ymin,
-        ymax,
+        xMin,
+        xMax,
+        yMin,
+        yMax,
         actionId,
         sourceInformation = {},
         skipRendererUpdate = false,
     }) {
         let updateInstructions = [];
 
-        if (xmin !== undefined) {
+        if (xMin !== undefined) {
             updateInstructions.push({
                 updateType: "updateValue",
                 componentIdx: this.componentIdx,
-                stateVariable: "xmin",
-                value: xmin,
+                stateVariable: "xMin",
+                value: xMin,
             });
         }
-        if (xmax !== undefined) {
+        if (xMax !== undefined) {
             updateInstructions.push({
                 updateType: "updateValue",
                 componentIdx: this.componentIdx,
-                stateVariable: "xmax",
-                value: xmax,
+                stateVariable: "xMax",
+                value: xMax,
             });
         }
-        if (ymin !== undefined) {
+        if (yMin !== undefined) {
             updateInstructions.push({
                 updateType: "updateValue",
                 componentIdx: this.componentIdx,
-                stateVariable: "ymin",
-                value: ymin,
+                stateVariable: "yMin",
+                value: yMin,
             });
         }
-        if (ymax !== undefined) {
+        if (yMax !== undefined) {
             updateInstructions.push({
                 updateType: "updateValue",
                 componentIdx: this.componentIdx,
-                stateVariable: "ymax",
-                value: ymax,
+                stateVariable: "yMax",
+                value: yMax,
             });
         }
 
@@ -1667,10 +1667,10 @@ export default class Graph extends BlockComponent {
                     componentType: this.componentType,
                 },
                 result: {
-                    xmin,
-                    xmax,
-                    ymin,
-                    ymax,
+                    xMin,
+                    xMax,
+                    yMin,
+                    yMax,
                 },
             },
         });

--- a/packages/doenetml-worker-javascript/src/components/Legend.js
+++ b/packages/doenetml-worker-javascript/src/components/Legend.js
@@ -364,7 +364,7 @@ export default class Legend extends GraphicalComponent {
                 graphAncestor: {
                     dependencyType: "ancestor",
                     componentType: "graph",
-                    variableNames: ["xmin", "xmax", "ymin", "ymax"],
+                    variableNames: ["xMin", "xMax", "yMin", "yMax"],
                 },
             }),
             definition({ dependencyValues }) {

--- a/packages/doenetml-worker-javascript/src/components/SubsetOfRealsInput.js
+++ b/packages/doenetml-worker-javascript/src/components/SubsetOfRealsInput.js
@@ -24,16 +24,16 @@ export default class SubsetOfRealsInput extends BlockComponent {
 
     static createAttributesObject() {
         let attributes = super.createAttributesObject();
-        attributes.xmin = {
+        attributes.xMin = {
             createComponentOfType: "number",
-            createStateVariable: "xmin",
+            createStateVariable: "xMin",
             defaultValue: -10,
             public: true,
             forRenderer: true,
         };
-        attributes.xmax = {
+        attributes.xMax = {
             createComponentOfType: "number",
-            createStateVariable: "xmax",
+            createStateVariable: "xMax",
             defaultValue: 10,
             public: true,
             forRenderer: true,
@@ -338,8 +338,8 @@ export default class SubsetOfRealsInput extends BlockComponent {
         let roundedValue =
             Math.round(
                 Math.max(
-                    await this.stateValues.xmin,
-                    Math.min(await this.stateValues.xmax, value),
+                    await this.stateValues.xMin,
+                    Math.min(await this.stateValues.xMax, value),
                 ) / dx,
             ) * dx;
 
@@ -697,8 +697,8 @@ export default class SubsetOfRealsInput extends BlockComponent {
         let roundedValue =
             Math.round(
                 Math.max(
-                    await this.stateValues.xmin,
-                    Math.min(await this.stateValues.xmax, value),
+                    await this.stateValues.xMin,
+                    Math.min(await this.stateValues.xMax, value),
                 ) / dx,
             ) * dx;
 

--- a/packages/doenetml-worker-javascript/src/components/dynamicalSystems/CobwebPolyline.js
+++ b/packages/doenetml-worker-javascript/src/components/dynamicalSystems/CobwebPolyline.js
@@ -358,7 +358,7 @@ export default class CobwebPolyline extends Polyline {
                     graphAncestor: {
                         dependencyType: "ancestor",
                         componentType: "graph",
-                        variableNames: ["xmin", "xmax", "ymin", "ymax"],
+                        variableNames: ["xMin", "xMax", "yMin", "yMax"],
                     },
                     defaultPoint: {
                         dependencyType: "attributeComponent",
@@ -385,21 +385,21 @@ export default class CobwebPolyline extends Polyline {
                             }
                             if (globalDependencyValues.graphAncestor) {
                                 if (arrayIndices[1] === 0) {
-                                    let xmin =
+                                    let xMin =
                                         globalDependencyValues.graphAncestor
-                                            .stateValues.xmin;
-                                    let xmax =
+                                            .stateValues.xMin;
+                                    let xMax =
                                         globalDependencyValues.graphAncestor
-                                            .stateValues.xmax;
-                                    return me.fromAst((xmin + xmax) / 2);
+                                            .stateValues.xMax;
+                                    return me.fromAst((xMin + xMax) / 2);
                                 } else if (arrayIndices[1] === 1) {
-                                    let ymin =
+                                    let yMin =
                                         globalDependencyValues.graphAncestor
-                                            .stateValues.ymin;
-                                    let ymax =
+                                            .stateValues.yMin;
+                                    let yMax =
                                         globalDependencyValues.graphAncestor
-                                            .stateValues.ymax;
-                                    return me.fromAst((ymin + ymax) / 2);
+                                            .stateValues.yMax;
+                                    return me.fromAst((yMin + yMax) / 2);
                                 }
                             }
                             return me.fromAst(0);

--- a/packages/doenetml-worker-javascript/src/test/copying/unlinked copy.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/copying/unlinked copy.test.ts
@@ -37,7 +37,7 @@ async function test_no_overwritten_attributes({
     expect(
         stateVariables[
             await resolvePathToNodeIdx(`${parentPrefix}${graphNamePostfix}`)
-        ].stateValues.xmax,
+        ].stateValues.xMax,
     ).eq(5);
     expect(
         stateVariables[
@@ -60,7 +60,7 @@ async function test_no_overwritten_attributes({
     expect(
         stateVariables[
             await resolvePathToNodeIdx(`${parentPrefix}2${graphNamePostfix}`)
-        ].stateValues.xmax,
+        ].stateValues.xMax,
     ).eq(5);
     expect(
         stateVariables[
@@ -83,7 +83,7 @@ async function test_no_overwritten_attributes({
     expect(
         stateVariables[
             await resolvePathToNodeIdx(`${parentPrefix}3${graphNamePostfix}`)
-        ].stateValues.xmax,
+        ].stateValues.xMax,
     ).eq(5);
     expect(
         stateVariables[
@@ -112,10 +112,10 @@ async function test_linked_copy_overwrites_attributes({
     resolvePathToNodeIdx: ResolvePathToNodeIdx;
 }) {
     let stateVariables = await core.returnAllStateVariables(false, true);
-    expect(stateVariables[await resolvePathToNodeIdx("g")].stateValues.xmin).eq(
+    expect(stateVariables[await resolvePathToNodeIdx("g")].stateValues.xMin).eq(
         -10,
     );
-    expect(stateVariables[await resolvePathToNodeIdx("g")].stateValues.xmax).eq(
+    expect(stateVariables[await resolvePathToNodeIdx("g")].stateValues.xMax).eq(
         5,
     );
     expect(
@@ -138,10 +138,10 @@ async function test_linked_copy_overwrites_attributes({
     ).eq(1);
 
     expect(
-        stateVariables[await resolvePathToNodeIdx("g2")].stateValues.xmin,
+        stateVariables[await resolvePathToNodeIdx("g2")].stateValues.xMin,
     ).eq(-3);
     expect(
-        stateVariables[await resolvePathToNodeIdx("g2")].stateValues.xmax,
+        stateVariables[await resolvePathToNodeIdx("g2")].stateValues.xMax,
     ).eq(7);
     expect(
         stateVariables[await resolvePathToNodeIdx("g2.A")].stateValues.xs.map(
@@ -163,10 +163,10 @@ async function test_linked_copy_overwrites_attributes({
     ).eq(3);
 
     expect(
-        stateVariables[await resolvePathToNodeIdx("g3")].stateValues.xmin,
+        stateVariables[await resolvePathToNodeIdx("g3")].stateValues.xMin,
     ).eq(-3);
     expect(
-        stateVariables[await resolvePathToNodeIdx("g3")].stateValues.xmax,
+        stateVariables[await resolvePathToNodeIdx("g3")].stateValues.xMax,
     ).eq(7);
     expect(
         stateVariables[await resolvePathToNodeIdx("g3.A")].stateValues.xs.map(
@@ -197,13 +197,13 @@ async function test_unlinked_copy_overwrites_attributes({
 }) {
     // TODO: overwriting attributes of unlinked copy of linked copy isn't working as we'd like.
     let stateVariables = await core.returnAllStateVariables(false, true);
-    expect(stateVariables[await resolvePathToNodeIdx("g")].stateValues.xmin).eq(
+    expect(stateVariables[await resolvePathToNodeIdx("g")].stateValues.xMin).eq(
         -10,
     );
-    expect(stateVariables[await resolvePathToNodeIdx("g")].stateValues.xmax).eq(
+    expect(stateVariables[await resolvePathToNodeIdx("g")].stateValues.xMax).eq(
         5,
     );
-    expect(stateVariables[await resolvePathToNodeIdx("g")].stateValues.ymax).eq(
+    expect(stateVariables[await resolvePathToNodeIdx("g")].stateValues.yMax).eq(
         10,
     );
     expect(
@@ -226,13 +226,13 @@ async function test_unlinked_copy_overwrites_attributes({
     ).eqls(1);
 
     expect(
-        stateVariables[await resolvePathToNodeIdx("g2")].stateValues.xmax,
+        stateVariables[await resolvePathToNodeIdx("g2")].stateValues.xMax,
     ).eq(5);
     expect(
-        stateVariables[await resolvePathToNodeIdx("g2")].stateValues.xmin,
+        stateVariables[await resolvePathToNodeIdx("g2")].stateValues.xMin,
     ).eq(-3);
     expect(
-        stateVariables[await resolvePathToNodeIdx("g2")].stateValues.ymax,
+        stateVariables[await resolvePathToNodeIdx("g2")].stateValues.yMax,
     ).eq(10);
     expect(
         stateVariables[await resolvePathToNodeIdx("g2.A")].stateValues.xs.map(
@@ -254,13 +254,13 @@ async function test_unlinked_copy_overwrites_attributes({
     ).eqls(1);
 
     expect(
-        stateVariables[await resolvePathToNodeIdx("g3")].stateValues.xmax,
+        stateVariables[await resolvePathToNodeIdx("g3")].stateValues.xMax,
     ).eq(7);
     expect(
-        stateVariables[await resolvePathToNodeIdx("g3")].stateValues.xmin,
+        stateVariables[await resolvePathToNodeIdx("g3")].stateValues.xMin,
     ).eq(-5);
     expect(
-        stateVariables[await resolvePathToNodeIdx("g3")].stateValues.ymax,
+        stateVariables[await resolvePathToNodeIdx("g3")].stateValues.yMax,
     ).eq(8);
     expect(
         stateVariables[await resolvePathToNodeIdx("g3.A")].stateValues.xs.map(

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
@@ -209,19 +209,19 @@ describe("Graph tag tests", async () => {
             );
             expect(
                 stateVariables[await resolvePathToNodeIdx("g")].stateValues
-                    .xmin,
+                    .xMin,
             ).eq(xmin);
             expect(
                 stateVariables[await resolvePathToNodeIdx("g")].stateValues
-                    .xmax,
+                    .xMax,
             ).eq(xmax);
             expect(
                 stateVariables[await resolvePathToNodeIdx("g")].stateValues
-                    .ymin,
+                    .yMin,
             ).eq(ymin);
             expect(
                 stateVariables[await resolvePathToNodeIdx("g")].stateValues
-                    .ymax,
+                    .yMax,
             ).eq(ymax);
         }
 
@@ -353,10 +353,10 @@ describe("Graph tag tests", async () => {
     <graph name="g" identicalAxisScales />
 
 
-    <p>Change xmin: <mathInput name="xminInput" bindValueTo="$g.xmin" /></p>
-    <p>Change xmax: <mathInput name="xmaxInput" bindValueTo="$g.xmax" /></p>
-    <p>Change ymin: <mathInput name="yminInput" bindValueTo="$g.ymin" /></p>
-    <p>Change ymax: <mathInput name="ymaxInput" bindValueTo="$g.ymax" /></p>
+    <p>Change xmin: <mathInput name="xminInput" bindValueTo="$g.xMin" /></p>
+    <p>Change xmax: <mathInput name="xmaxInput" bindValueTo="$g.xMax" /></p>
+    <p>Change ymin: <mathInput name="yminInput" bindValueTo="$g.yMin" /></p>
+    <p>Change ymax: <mathInput name="ymaxInput" bindValueTo="$g.yMax" /></p>
 
     `,
         });
@@ -368,19 +368,19 @@ describe("Graph tag tests", async () => {
             );
             expect(
                 stateVariables[await resolvePathToNodeIdx("g")].stateValues
-                    .xmin,
+                    .xMin,
             ).eq(xmin);
             expect(
                 stateVariables[await resolvePathToNodeIdx("g")].stateValues
-                    .xmax,
+                    .xMax,
             ).eq(xmax);
             expect(
                 stateVariables[await resolvePathToNodeIdx("g")].stateValues
-                    .ymin,
+                    .yMin,
             ).eq(ymin);
             expect(
                 stateVariables[await resolvePathToNodeIdx("g")].stateValues
-                    .ymax,
+                    .yMax,
             ).eq(ymax);
 
             expect(
@@ -1185,19 +1185,19 @@ describe("Graph tag tests", async () => {
     <graph name="gdg3b" displayDigits="5" extend="$gdc5a" />
     <graph name="gdc5b" displayDecimals="5" extend="$gdg3a" />
 
-    <p name="p">$g.xmin, $g.xmax, $g.ymin, $g.ymax</p>
+    <p name="p">$g.xMin, $g.xMax, $g.yMin, $g.yMax</p>
 
-    <p name="pdg3">$gdg3.xmin, $gdg3.xmax, $gdg3.ymin, $gdg3.ymax</p>
-    <p name="pdg3a">$gdg3a.xmin, $gdg3a.xmax, $gdg3a.ymin, $gdg3a.ymax</p>
-    <p name="pdg3b">$gdg3b.xmin, $gdg3b.xmax, $gdg3b.ymin, $gdg3b.ymax</p>
-    <p name="pdg3c"><setup><graph extend="$g" name="g5" displayDigits="5" /></setup>$g5.xmin, $g5.xmax, $g5.ymin, $g5.ymax</p>
-    <p name="pdg3d"><setup><graph extend="$gdc5" name="gdc55" displayDigits="5" /></setup>$gdc55.xmin, $gdc55.xmax, $gdc55.ymin, $gdc55.ymax</p>
+    <p name="pdg3">$gdg3.xMin, $gdg3.xMax, $gdg3.yMin, $gdg3.yMax</p>
+    <p name="pdg3a">$gdg3a.xMin, $gdg3a.xMax, $gdg3a.yMin, $gdg3a.yMax</p>
+    <p name="pdg3b">$gdg3b.xMin, $gdg3b.xMax, $gdg3b.yMin, $gdg3b.yMax</p>
+    <p name="pdg3c"><setup><graph extend="$g" name="g5" displayDigits="5" /></setup>$g5.xMin, $g5.xMax, $g5.yMin, $g5.yMax</p>
+    <p name="pdg3d"><setup><graph extend="$gdc5" name="gdc55" displayDigits="5" /></setup>$gdc55.xMin, $gdc55.xMax, $gdc55.yMin, $gdc55.yMax</p>
 
-    <p name="pdc5">$gdc5.xmin, $gdc5.xmax, $gdc5.ymin, $gdc5.ymax</p>
-    <p name="pdc5a">$gdc5a.xmin, $gdc5a.xmax, $gdc5a.ymin, $gdc5a.ymax</p>
-    <p name="pdc5b">$gdc5b.xmin, $gdc5b.xmax, $gdc5b.ymin, $gdc5b.ymax</p>
-    <p name="pdc5c"><setup><graph extend="$g" name="g5" displayDecimals="5" /></setup>$g5.xmin, $g5.xmax, $g5.ymin, $g5.ymax</p>
-    <p name="pdc5d"><setup><graph extend="$gdg3" name="gdg35" displayDecimals="5" /></setup>$gdg35.xmin, $gdg35.xmax, $gdg35.ymin, $gdg35.ymax</p>
+    <p name="pdc5">$gdc5.xMin, $gdc5.xMax, $gdc5.yMin, $gdc5.yMax</p>
+    <p name="pdc5a">$gdc5a.xMin, $gdc5a.xMax, $gdc5a.yMin, $gdc5a.yMax</p>
+    <p name="pdc5b">$gdc5b.xMin, $gdc5b.xMax, $gdc5b.yMin, $gdc5b.yMax</p>
+    <p name="pdc5c"><setup><graph extend="$g" name="g5" displayDecimals="5" /></setup>$g5.xMin, $g5.xMax, $g5.yMin, $g5.yMax</p>
+    <p name="pdc5d"><setup><graph extend="$gdg3" name="gdg35" displayDecimals="5" /></setup>$gdg35.xMin, $gdg35.xMax, $gdg35.yMin, $gdg35.yMax</p>
 
     `,
         });
@@ -1342,19 +1342,19 @@ describe("Graph tag tests", async () => {
         let stateVariables = await core.returnAllStateVariables(false, true);
         expect(
             stateVariables[await resolvePathToNodeIdx("g1inner")].stateValues
-                .xmin,
+                .xMin,
         ).eq(-10);
         expect(
             stateVariables[await resolvePathToNodeIdx("g1inner")].stateValues
-                .xmax,
+                .xMax,
         ).eq(10);
         expect(
             stateVariables[await resolvePathToNodeIdx("g1inner")].stateValues
-                .ymin,
+                .yMin,
         ).eq(-10);
         expect(
             stateVariables[await resolvePathToNodeIdx("g1inner")].stateValues
-                .ymax,
+                .yMax,
         ).eq(10);
     });
 });

--- a/packages/doenetml-worker-javascript/src/utils/constraints.js
+++ b/packages/doenetml-worker-javascript/src/utils/constraints.js
@@ -80,7 +80,7 @@ export function returnConstraintGraphInfoDefinitions() {
                 graphAncestor: {
                     dependencyType: "ancestor",
                     componentType: "graph",
-                    variableNames: ["xmin", "xmax", "ymin", "ymax"],
+                    variableNames: ["xMin", "xMax", "yMin", "yMax"],
                 },
                 shadowedConstraints: {
                     dependencyType: "shadowSource",
@@ -122,10 +122,10 @@ export function returnConstraintGraphInfoDefinitions() {
                     }
                 }
 
-                let graphXmin = dependencyValues.graphAncestor.stateValues.xmin;
-                let graphXmax = dependencyValues.graphAncestor.stateValues.xmax;
-                let graphYmin = dependencyValues.graphAncestor.stateValues.ymin;
-                let graphYmax = dependencyValues.graphAncestor.stateValues.ymax;
+                let graphXmin = dependencyValues.graphAncestor.stateValues.xMin;
+                let graphXmax = dependencyValues.graphAncestor.stateValues.xMax;
+                let graphYmin = dependencyValues.graphAncestor.stateValues.yMin;
+                let graphYmax = dependencyValues.graphAncestor.stateValues.yMax;
 
                 if (
                     [graphXmin, graphXmax, graphYmin, graphYmax].every(

--- a/packages/doenetml/src/Viewer/renderers/booleanInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/booleanInput.tsx
@@ -231,7 +231,7 @@ export default React.memo(function BooleanInput(props: UseDoenetRendererProps) {
                 dragged.current = true;
             }
 
-            let [xmin, ymax, xmax, ymin] = board.getBoundingBox();
+            let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
             let width = newInputJXG.size[0] / board.unitX;
             let height = newInputJXG.size[1] / board.unitY;
 
@@ -251,10 +251,10 @@ export default React.memo(function BooleanInput(props: UseDoenetRendererProps) {
                 offsety = -height;
             }
 
-            let xminAdjusted = xmin + 0.04 * (xmax - xmin) - offsetx - width;
-            let xmaxAdjusted = xmax - 0.04 * (xmax - xmin) - offsetx;
-            let yminAdjusted = ymin + 0.04 * (ymax - ymin) - offsety - height;
-            let ymaxAdjusted = ymax - 0.04 * (ymax - ymin) - offsety;
+            let xminAdjusted = xMin + 0.04 * (xMax - xMin) - offsetx - width;
+            let xmaxAdjusted = xMax - 0.04 * (xMax - xMin) - offsetx;
+            let yminAdjusted = yMin + 0.04 * (yMax - yMin) - offsety - height;
+            let ymaxAdjusted = yMax - 0.04 * (yMax - yMin) - offsety;
 
             if (viaPointer && pointAtDown.current && pointerAtDown.current) {
                 // the reason we calculate point position with this algorithm,

--- a/packages/doenetml/src/Viewer/renderers/button.tsx
+++ b/packages/doenetml/src/Viewer/renderers/button.tsx
@@ -170,7 +170,7 @@ export default React.memo(function ButtonComponent(
                 dragged.current = true;
             }
 
-            let [xmin, ymax, xmax, ymin] = board.getBoundingBox();
+            let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
             let width = newButtonJXG.size[0] / board.unitX;
             let height = newButtonJXG.size[1] / board.unitY;
 
@@ -190,10 +190,10 @@ export default React.memo(function ButtonComponent(
                 offsety = -height;
             }
 
-            let xminAdjusted = xmin + 0.04 * (xmax - xmin) - offsetx - width;
-            let xmaxAdjusted = xmax - 0.04 * (xmax - xmin) - offsetx;
-            let yminAdjusted = ymin + 0.04 * (ymax - ymin) - offsety - height;
-            let ymaxAdjusted = ymax - 0.04 * (ymax - ymin) - offsety;
+            let xminAdjusted = xMin + 0.04 * (xMax - xMin) - offsetx - width;
+            let xmaxAdjusted = xMax - 0.04 * (xMax - xMin) - offsetx;
+            let yminAdjusted = yMin + 0.04 * (yMax - yMin) - offsety - height;
+            let ymaxAdjusted = yMax - 0.04 * (yMax - yMin) - offsety;
 
             if (viaPointer && pointerAtDown.current && pointAtDown.current) {
                 // the reason we calculate point position with this algorithm,

--- a/packages/doenetml/src/Viewer/renderers/curve.tsx
+++ b/packages/doenetml/src/Viewer/renderers/curve.tsx
@@ -193,20 +193,20 @@ export default React.memo(function Curve(props) {
         } else {
             let f = createFunctionFromDefinition(SVs.fDefinitions[0]);
             if (SVs.flipFunction) {
-                let ymin = SVs.graphYmin;
-                let ymax = SVs.graphYmax;
-                let minForF = Math.max(ymin - (ymax - ymin) * 0.1, SVs.parMin);
-                let maxForF = Math.min(ymax + (ymax - ymin) * 0.1, SVs.parMax);
+                let yMin = SVs.graphYmin;
+                let yMax = SVs.graphYmax;
+                let minForF = Math.max(yMin - (yMax - yMin) * 0.1, SVs.parMin);
+                let maxForF = Math.min(yMax + (yMax - yMin) * 0.1, SVs.parMax);
                 newCurveJXG = board.create(
                     "curve",
                     [f, (x) => x, minForF, maxForF],
                     curveAttributes,
                 );
             } else {
-                let xmin = SVs.graphXmin;
-                let xmax = SVs.graphXmax;
-                let minForF = Math.max(xmin - (xmax - xmin) * 0.1, SVs.parMin);
-                let maxForF = Math.min(xmax + (xmax - xmin) * 0.1, SVs.parMax);
+                let xMin = SVs.graphXmin;
+                let xMax = SVs.graphXmax;
+                let minForF = Math.max(xMin - (xMax - xMin) * 0.1, SVs.parMin);
+                let maxForF = Math.min(xMax + (xMax - xMin) * 0.1, SVs.parMax);
                 newCurveJXG = board.create(
                     "functiongraph",
                     [f, minForF, maxForF],
@@ -808,28 +808,28 @@ export default React.memo(function Curve(props) {
                 let f = createFunctionFromDefinition(SVs.fDefinitions[0]);
                 if (SVs.flipFunction) {
                     curveJXG.current.X = f;
-                    let ymin = SVs.graphYmin;
-                    let ymax = SVs.graphYmax;
+                    let yMin = SVs.graphYmin;
+                    let yMax = SVs.graphYmax;
                     let minForF = Math.max(
-                        ymin - (ymax - ymin) * 0.1,
+                        yMin - (yMax - yMin) * 0.1,
                         SVs.parMin,
                     );
                     let maxForF = Math.min(
-                        ymax + (ymax - ymin) * 0.1,
+                        yMax + (yMax - yMin) * 0.1,
                         SVs.parMax,
                     );
                     curveJXG.current.minX = () => minForF;
                     curveJXG.current.maxX = () => maxForF;
                 } else {
                     curveJXG.current.Y = f;
-                    let xmin = SVs.graphXmin;
-                    let xmax = SVs.graphXmax;
+                    let xMin = SVs.graphXmin;
+                    let xMax = SVs.graphXmax;
                     let minForF = Math.max(
-                        xmin - (xmax - xmin) * 0.1,
+                        xMin - (xMax - xMin) * 0.1,
                         SVs.parMin,
                     );
                     let maxForF = Math.min(
-                        xmax + (xmax - xmin) * 0.1,
+                        xMax + (xMax - xMin) * 0.1,
                         SVs.parMax,
                     );
                     curveJXG.current.minX = () => minForF;

--- a/packages/doenetml/src/Viewer/renderers/graph.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graph.tsx
@@ -56,7 +56,7 @@ export default React.memo(function Graph(props) {
             return;
         }
 
-        let boundingbox = [SVs.xmin, SVs.ymax, SVs.xmax, SVs.ymin];
+        let boundingbox = [SVs.xMin, SVs.yMax, SVs.xMax, SVs.yMin];
         previousBoundingbox.current = boundingbox;
 
         JXG.Options.layer.numlayers = 100;
@@ -92,11 +92,11 @@ export default React.memo(function Graph(props) {
                 )
             ) {
                 let newBoundingbox = newBoard.getBoundingBox();
-                let [xmin, ymax, xmax, ymin] = newBoundingbox;
+                let [xMin, yMax, xMax, yMin] = newBoundingbox;
 
                 // look for a change in bounding box that isn't due to roundoff error
-                let xscale = Math.abs(xmax - xmin);
-                let yscale = Math.abs(ymax - ymin);
+                let xscale = Math.abs(xMax - xMin);
+                let yscale = Math.abs(yMax - yMin);
                 let diffs = newBoundingbox.map((v, i) =>
                     Math.abs(v - previousBoundingbox.current[i]),
                 );
@@ -111,7 +111,7 @@ export default React.memo(function Graph(props) {
                     previousBoundingbox.current = newBoundingbox;
                     callAction({
                         action: actions.changeAxisLimits,
-                        args: { xmin, xmax, ymin, ymax },
+                        args: { xMin, xMax, yMin, yMax },
                         baseVariableValue: newBoundingbox,
                     });
                 }
@@ -413,7 +413,7 @@ export default React.memo(function Graph(props) {
         // since baseStateVariable is boundingbox,
         // ignoreUpdate means ignore change in boundingbox
         if (!ignoreUpdate) {
-            let boundingbox = [SVs.xmin, SVs.ymax, SVs.xmax, SVs.ymin];
+            let boundingbox = [SVs.xMin, SVs.yMax, SVs.xMax, SVs.yMin];
 
             if (
                 boundingbox.some((v, i) => v !== previousBoundingbox.current[i])

--- a/packages/doenetml/src/Viewer/renderers/image.tsx
+++ b/packages/doenetml/src/Viewer/renderers/image.tsx
@@ -255,21 +255,21 @@ export default React.memo(function Image(props) {
                 dragged.current = true;
             }
 
-            let [xmin, ymax, xmax, ymin] = board.getBoundingBox();
+            let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
             let xminAdjusted =
-                xmin +
-                0.01 * (xmax - xmin) -
+                xMin +
+                0.01 * (xMax - xMin) -
                 currentOffset.current[0] -
                 currentSize.current[0];
             let xmaxAdjusted =
-                xmax - 0.01 * (xmax - xmin) - currentOffset.current[0];
+                xMax - 0.01 * (xMax - xMin) - currentOffset.current[0];
             let yminAdjusted =
-                ymin +
-                0.01 * (ymax - ymin) -
+                yMin +
+                0.01 * (yMax - yMin) -
                 currentOffset.current[1] -
                 currentSize.current[1];
             let ymaxAdjusted =
-                ymax - 0.01 * (ymax - ymin) - currentOffset.current[1];
+                yMax - 0.01 * (yMax - yMin) - currentOffset.current[1];
 
             if (viaPointer) {
                 // the reason we calculate point position with this algorithm,

--- a/packages/doenetml/src/Viewer/renderers/label.tsx
+++ b/packages/doenetml/src/Viewer/renderers/label.tsx
@@ -201,7 +201,7 @@ export default React.memo(function Label(props) {
                 dragged.current = true;
             }
 
-            let [xmin, ymax, xmax, ymin] = board.getBoundingBox();
+            let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
             let width = newLabelJXG.size[0] / board.unitX;
             let height = newLabelJXG.size[1] / board.unitY;
 
@@ -221,10 +221,10 @@ export default React.memo(function Label(props) {
                 offsety = -height;
             }
 
-            let xminAdjusted = xmin + 0.04 * (xmax - xmin) - offsetx - width;
-            let xmaxAdjusted = xmax - 0.04 * (xmax - xmin) - offsetx;
-            let yminAdjusted = ymin + 0.04 * (ymax - ymin) - offsety - height;
-            let ymaxAdjusted = ymax - 0.04 * (ymax - ymin) - offsety;
+            let xminAdjusted = xMin + 0.04 * (xMax - xMin) - offsetx - width;
+            let xmaxAdjusted = xMax - 0.04 * (xMax - xMin) - offsetx;
+            let yminAdjusted = yMin + 0.04 * (yMax - yMin) - offsety - height;
+            let ymaxAdjusted = yMax - 0.04 * (yMax - yMin) - offsety;
 
             if (viaPointer) {
                 // the reason we calculate point position with this algorithm,

--- a/packages/doenetml/src/Viewer/renderers/legend.tsx
+++ b/packages/doenetml/src/Viewer/renderers/legend.tsx
@@ -24,22 +24,22 @@ export default React.memo(function Legend(props) {
     }, []);
 
     function createLegend() {
-        let { xmin, xmax, ymin, ymax } = SVs.graphLimits;
+        let { xMin, xMax, yMin, yMax } = SVs.graphLimits;
 
-        let legendDy = (ymax - ymin) * 0.06;
-        let legendLineLength = (xmax - xmin) * 0.05;
-        let legendDx = (xmax - xmin) * 0.02;
+        let legendDy = (yMax - yMin) * 0.06;
+        let legendLineLength = (xMax - xMin) * 0.05;
+        let legendDx = (xMax - xMin) * 0.02;
 
-        let legendX = xmin + (xmax - xmin) * 0.05;
+        let legendX = xMin + (xMax - xMin) * 0.05;
 
         let legendY;
 
         if (SVs.position.slice(0, 5) === "upper") {
-            legendY = ymin + (ymax - ymin) * 0.95;
+            legendY = yMin + (yMax - yMin) * 0.95;
         } else {
             legendY =
-                ymin +
-                (ymax - ymin) * 0.05 +
+                yMin +
+                (yMax - yMin) * 0.05 +
                 legendDy * SVs.legendElements.length;
         }
 
@@ -90,7 +90,7 @@ export default React.memo(function Legend(props) {
         if (atRight) {
             legendX = Math.max(
                 legendX,
-                xmax - legendLineLength - 3 * legendDx - maxTextWidth,
+                xMax - legendLineLength - 3 * legendDx - maxTextWidth,
             );
         }
 
@@ -183,7 +183,7 @@ export default React.memo(function Legend(props) {
 
                 legendX = Math.max(
                     legendX,
-                    xmax - legendLineLength - 3 * legendDx - maxTextWidth,
+                    xMax - legendLineLength - 3 * legendDx - maxTextWidth,
                 );
 
                 for (let [ind, swatch] of swatches.current.entries()) {

--- a/packages/doenetml/src/Viewer/renderers/math.tsx
+++ b/packages/doenetml/src/Viewer/renderers/math.tsx
@@ -238,7 +238,7 @@ export default React.memo(function MathComponent(
                 dragged.current = true;
             }
 
-            let [xmin, ymax, xmax, ymin] = board.getBoundingBox();
+            let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
             let width = newMathJXG.size[0] / board.unitX;
             let height = newMathJXG.size[1] / board.unitY;
 
@@ -258,10 +258,10 @@ export default React.memo(function MathComponent(
                 offsety = -height;
             }
 
-            let xminAdjusted = xmin + 0.04 * (xmax - xmin) - offsetx - width;
-            let xmaxAdjusted = xmax - 0.04 * (xmax - xmin) - offsetx;
-            let yminAdjusted = ymin + 0.04 * (ymax - ymin) - offsety - height;
-            let ymaxAdjusted = ymax - 0.04 * (ymax - ymin) - offsety;
+            let xminAdjusted = xMin + 0.04 * (xMax - xMin) - offsetx - width;
+            let xmaxAdjusted = xMax - 0.04 * (xMax - xMin) - offsetx;
+            let yminAdjusted = yMin + 0.04 * (yMax - yMin) - offsety - height;
+            let ymaxAdjusted = yMax - 0.04 * (yMax - yMin) - offsety;
 
             if (viaPointer && pointAtDown.current && pointerAtDown.current) {
                 // the reason we calculate point position with this algorithm,

--- a/packages/doenetml/src/Viewer/renderers/number.tsx
+++ b/packages/doenetml/src/Viewer/renderers/number.tsx
@@ -200,7 +200,7 @@ export default React.memo(function NumberComponent(props) {
                 dragged.current = true;
             }
 
-            let [xmin, ymax, xmax, ymin] = board.getBoundingBox();
+            let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
             let width = newNumberJXG.size[0] / board.unitX;
             let height = newNumberJXG.size[1] / board.unitY;
 
@@ -220,10 +220,10 @@ export default React.memo(function NumberComponent(props) {
                 offsety = -height;
             }
 
-            let xminAdjusted = xmin + 0.04 * (xmax - xmin) - offsetx - width;
-            let xmaxAdjusted = xmax - 0.04 * (xmax - xmin) - offsetx;
-            let yminAdjusted = ymin + 0.04 * (ymax - ymin) - offsety - height;
-            let ymaxAdjusted = ymax - 0.04 * (ymax - ymin) - offsety;
+            let xminAdjusted = xMin + 0.04 * (xMax - xMin) - offsetx - width;
+            let xmaxAdjusted = xMax - 0.04 * (xMax - xMin) - offsetx;
+            let yminAdjusted = yMin + 0.04 * (yMax - yMin) - offsety - height;
+            let ymaxAdjusted = yMax - 0.04 * (yMax - yMin) - offsety;
 
             if (viaPointer) {
                 // the reason we calculate point position with this algorithm,

--- a/packages/doenetml/src/Viewer/renderers/pegboard.tsx
+++ b/packages/doenetml/src/Viewer/renderers/pegboard.tsx
@@ -50,12 +50,12 @@ export default React.memo(function Pegboard(props) {
     }, []);
 
     function createPegboardJXG() {
-        let [xmin, ymax, xmax, ymin] = board.getBoundingBox();
+        let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
 
-        let xind1 = (xmin - xoffset.current) / dx.current;
-        let xind2 = (xmax - xoffset.current) / dx.current;
-        let yind1 = (ymin - yoffset.current) / dy.current;
-        let yind2 = (ymax - yoffset.current) / dy.current;
+        let xind1 = (xMin - xoffset.current) / dx.current;
+        let xind2 = (xMax - xoffset.current) / dx.current;
+        let yind1 = (yMin - yoffset.current) / dy.current;
+        let yind2 = (yMax - yoffset.current) / dy.current;
 
         // Note: use round from mathjs so that it rounds -0.5 to -1, not 0.
         let minXind = me.math.round(Math.min(xind1, xind2) + 1);
@@ -92,12 +92,12 @@ export default React.memo(function Pegboard(props) {
         }
 
         board.on("boundingbox", () => {
-            let [xmin, ymax, xmax, ymin] = board.getBoundingBox();
+            let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
 
-            let xind1 = (xmin - xoffset.current) / dx.current;
-            let xind2 = (xmax - xoffset.current) / dx.current;
-            let yind1 = (ymin - yoffset.current) / dy.current;
-            let yind2 = (ymax - yoffset.current) / dy.current;
+            let xind1 = (xMin - xoffset.current) / dx.current;
+            let xind2 = (xMax - xoffset.current) / dx.current;
+            let yind1 = (yMin - yoffset.current) / dy.current;
+            let yind2 = (yMax - yoffset.current) / dy.current;
 
             // Note: use round from mathjs so that it rounds -0.5 to -1, not 0.
             let minXind = me.math.round(Math.min(xind1, xind2) + 1);
@@ -218,12 +218,12 @@ export default React.memo(function Pegboard(props) {
         if (pegboardJXG.current === null) {
             createPegboardJXG();
         } else {
-            let [xmin, ymax, xmax, ymin] = board.getBoundingBox();
+            let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
 
-            let xind1 = (xmin - xoffset.current) / dx.current;
-            let xind2 = (xmax - xoffset.current) / dx.current;
-            let yind1 = (ymin - yoffset.current) / dy.current;
-            let yind2 = (ymax - yoffset.current) / dy.current;
+            let xind1 = (xMin - xoffset.current) / dx.current;
+            let xind2 = (xMax - xoffset.current) / dx.current;
+            let yind1 = (yMin - yoffset.current) / dy.current;
+            let yind2 = (yMax - yoffset.current) / dy.current;
 
             // Note: use round from mathjs so that it rounds -0.5 to -1, not 0.
             let minXind = me.math.round(Math.min(xind1, xind2) + 1);

--- a/packages/doenetml/src/Viewer/renderers/point.tsx
+++ b/packages/doenetml/src/Viewer/renderers/point.tsx
@@ -296,17 +296,17 @@ export default React.memo(function Point(props: UseDoenetRendererProps) {
                     dragged.current = true;
                 }
 
-                let [xmin, ymax, xmax, ymin] = board.getBoundingBox();
+                let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
 
-                let xminAdjusted = xmin;
-                let xmaxAdjusted = xmax;
-                let yminAdjusted = ymin;
-                let ymaxAdjusted = ymax;
+                let xminAdjusted = xMin;
+                let xmaxAdjusted = xMax;
+                let yminAdjusted = yMin;
+                let ymaxAdjusted = yMax;
 
-                if (xmax < xmin) {
+                if (xMax < xMin) {
                     [xmaxAdjusted, xminAdjusted] = [xminAdjusted, xmaxAdjusted];
                 }
-                if (ymax < ymin) {
+                if (yMax < yMin) {
                     [ymaxAdjusted, yminAdjusted] = [yminAdjusted, ymaxAdjusted];
                 }
 
@@ -461,25 +461,25 @@ export default React.memo(function Point(props: UseDoenetRendererProps) {
         let flippedX = false;
         let flippedY = false;
 
-        let [xmin, ymax, xmax, ymin] = board.getBoundingBox();
+        let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
 
-        if (xmax < xmin) {
+        if (xMax < xMin) {
             flippedX = true;
-            [xmax, xmin] = [xmin, xmax];
+            [xMax, xMin] = [xMin, xMax];
         }
-        if (ymax < ymin) {
+        if (yMax < yMin) {
             flippedY = true;
-            [ymax, ymin] = [ymin, ymax];
+            [yMax, yMin] = [yMin, yMax];
         }
 
-        let xscale = xmax - xmin;
-        let yscale = ymax - ymin;
+        let xscale = xMax - xMin;
+        let yscale = yMax - yMin;
 
         // TODO: use a measure of label width rather than 0.05 for x
-        let xminAdjusted = xmin + xscale * 0.05;
-        let xmaxAdjusted = xmax - xscale * 0.05;
-        let yminAdjusted = ymin + yscale * 0.05;
-        let ymaxAdjusted = ymax - yscale * 0.05;
+        let xminAdjusted = xMin + xscale * 0.05;
+        let xmaxAdjusted = xMax - xscale * 0.05;
+        let yminAdjusted = yMin + yscale * 0.05;
+        let ymaxAdjusted = yMax - yscale * 0.05;
 
         if (
             Number.isFinite(lastPositionFromCore.current[0]) &&

--- a/packages/doenetml/src/Viewer/renderers/text.tsx
+++ b/packages/doenetml/src/Viewer/renderers/text.tsx
@@ -199,7 +199,7 @@ export default React.memo(function Text(props) {
                 dragged.current = true;
             }
 
-            let [xmin, ymax, xmax, ymin] = board.getBoundingBox();
+            let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
             let width = newTextJXG.size[0] / board.unitX;
             let height = newTextJXG.size[1] / board.unitY;
 
@@ -219,10 +219,10 @@ export default React.memo(function Text(props) {
                 offsety = -height;
             }
 
-            let xminAdjusted = xmin + 0.04 * (xmax - xmin) - offsetx - width;
-            let xmaxAdjusted = xmax - 0.04 * (xmax - xmin) - offsetx;
-            let yminAdjusted = ymin + 0.04 * (ymax - ymin) - offsety - height;
-            let ymaxAdjusted = ymax - 0.04 * (ymax - ymin) - offsety;
+            let xminAdjusted = xMin + 0.04 * (xMax - xMin) - offsetx - width;
+            let xmaxAdjusted = xMax - 0.04 * (xMax - xMin) - offsetx;
+            let yminAdjusted = yMin + 0.04 * (yMax - yMin) - offsety - height;
+            let ymaxAdjusted = yMax - 0.04 * (yMax - yMin) - offsety;
 
             if (viaPointer) {
                 // the reason we calculate point position with this algorithm,

--- a/packages/doenetml/src/Viewer/renderers/textInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/textInput.tsx
@@ -346,7 +346,7 @@ export default function TextInput(props: UseDoenetRendererProps) {
                 dragged.current = true;
             }
 
-            let [xmin, ymax, xmax, ymin] = board.getBoundingBox();
+            let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
             let width = newInputJXG.size[0] / board.unitX;
             let height = newInputJXG.size[1] / board.unitY;
 
@@ -366,10 +366,10 @@ export default function TextInput(props: UseDoenetRendererProps) {
                 offsety = -height;
             }
 
-            let xminAdjusted = xmin + 0.04 * (xmax - xmin) - offsetx - width;
-            let xmaxAdjusted = xmax - 0.04 * (xmax - xmin) - offsetx;
-            let yminAdjusted = ymin + 0.04 * (ymax - ymin) - offsety - height;
-            let ymaxAdjusted = ymax - 0.04 * (ymax - ymin) - offsety;
+            let xminAdjusted = xMin + 0.04 * (xMax - xMin) - offsetx - width;
+            let xmaxAdjusted = xMax - 0.04 * (xMax - xMin) - offsetx;
+            let yminAdjusted = yMin + 0.04 * (yMax - yMin) - offsety - height;
+            let ymaxAdjusted = yMax - 0.04 * (yMax - yMin) - offsety;
 
             if (viaPointer && pointAtDown.current && pointerAtDown.current) {
                 // the reason we calculate point position with this algorithm,

--- a/packages/doenetml/src/Viewer/renderers/utils/graph.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/graph.ts
@@ -15,18 +15,18 @@ export function getEffectiveBoundingBox(board: JXGObject) {
     let flippedX = false;
     let flippedY = false;
 
-    let [xmin, ymax, xmax, ymin] = board.getBoundingBox();
+    let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
 
-    if (xmax < xmin) {
+    if (xMax < xMin) {
         flippedX = true;
-        [xmax, xmin] = [xmin, xmax];
+        [xMax, xMin] = [xMin, xMax];
     }
-    if (ymax < ymin) {
+    if (yMax < yMin) {
         flippedY = true;
-        [ymax, ymin] = [ymin, ymax];
+        [yMax, yMin] = [yMin, yMax];
     }
 
-    return { flippedX, flippedY, xmin, xmax, ymin, ymax };
+    return { flippedX, flippedY, xMin, xMax, yMin, yMax };
 }
 
 export function getGraphCornerWithBuffer(
@@ -34,19 +34,19 @@ export function getGraphCornerWithBuffer(
     direction: [number, number],
     buffer = 0.01,
 ): [number, number] {
-    let { flippedX, flippedY, xmin, xmax, ymin, ymax } =
+    let { flippedX, flippedY, xMin, xMax, yMin, yMax } =
         getEffectiveBoundingBox(board);
 
     let xSign = flippedX ? -1 : 1;
     let ySign = flippedY ? -1 : 1;
 
-    let xscale = xmax - xmin;
-    let yscale = ymax - ymin;
+    let xscale = xMax - xMin;
+    let yscale = yMax - yMin;
 
-    let xminAdjusted = xmin + xscale * buffer;
-    let xmaxAdjusted = xmax - xscale * buffer;
-    let yminAdjusted = ymin + yscale * buffer;
-    let ymaxAdjusted = ymax - yscale * buffer;
+    let xminAdjusted = xMin + xscale * buffer;
+    let xmaxAdjusted = xMax - xscale * buffer;
+    let yminAdjusted = yMin + yscale * buffer;
+    let ymaxAdjusted = yMax - yscale * buffer;
 
     let x = direction[0] * xSign === 1 ? xmaxAdjusted : xminAdjusted;
     let y = direction[1] * ySign === 1 ? ymaxAdjusted : yminAdjusted;

--- a/packages/doenetml/src/Viewer/renderers/utils/offGraphIndicators.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/offGraphIndicators.ts
@@ -2,16 +2,16 @@ import { JXGObject } from "../jsxgraph-distrib/types";
 import { getEffectiveBoundingBox } from "./graph";
 
 export function characterizeOffGraphPoint(coords: number[], board: JXGObject) {
-    let { flippedX, flippedY, xmin, xmax, ymin, ymax } =
+    let { flippedX, flippedY, xMin, xMax, yMin, yMax } =
         getEffectiveBoundingBox(board);
 
-    let xscale = xmax - xmin;
-    let yscale = ymax - ymin;
+    let xscale = xMax - xMin;
+    let yscale = yMax - yMin;
 
-    let xminAdjusted = xmin + xscale * 0.01;
-    let xmaxAdjusted = xmax - xscale * 0.01;
-    let yminAdjusted = ymin + yscale * 0.01;
-    let ymaxAdjusted = ymax - yscale * 0.01;
+    let xminAdjusted = xMin + xscale * 0.01;
+    let xmaxAdjusted = xMax - xscale * 0.01;
+    let yminAdjusted = yMin + yscale * 0.01;
+    let ymaxAdjusted = yMax - yscale * 0.01;
 
     let indicatorCoords = [...coords] as [number, number];
     let indicatorSides: [number, number] = [0, 0];
@@ -61,19 +61,19 @@ export function characterizeOffGraphCircleArc({
     // check to see if the arc of the circle (determine by directionToCheck)
     // intersects the edge of the graph (adjusted inward by a buffer)
 
-    let { flippedX, flippedY, xmin, xmax, ymin, ymax } =
+    let { flippedX, flippedY, xMin, xMax, yMin, yMax } =
         getEffectiveBoundingBox(board);
 
     let xSign = flippedX ? -1 : 1;
     let ySign = flippedY ? -1 : 1;
 
-    let xscale = xmax - xmin;
-    let yscale = ymax - ymin;
+    let xscale = xMax - xMin;
+    let yscale = yMax - yMin;
 
-    let xminAdjusted = xmin + xscale * 0.01;
-    let xmaxAdjusted = xmax - xscale * 0.01;
-    let yminAdjusted = ymin + yscale * 0.01;
-    let ymaxAdjusted = ymax - yscale * 0.01;
+    let xminAdjusted = xMin + xscale * 0.01;
+    let xmaxAdjusted = xMax - xscale * 0.01;
+    let yminAdjusted = yMin + yscale * 0.01;
+    let ymaxAdjusted = yMax - yscale * 0.01;
 
     let xToCheck =
         directionToCheck[0] * xSign === 1 ? xmaxAdjusted : xminAdjusted;

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -27283,7 +27283,8 @@
                         "operand",
                         "function",
                         "functionargument",
-                        "numoperands"
+                        "numoperands",
+                        "recursiveoperands"
                     ]
                 },
                 "operandNumber": {
@@ -90065,25 +90066,25 @@
                         "string"
                     ]
                 },
-                "xmin": {
+                "xMin": {
                     "optional": true,
                     "type": [
                         "string"
                     ]
                 },
-                "xmax": {
+                "xMax": {
                     "optional": true,
                     "type": [
                         "string"
                     ]
                 },
-                "ymin": {
+                "yMin": {
                     "optional": true,
                     "type": [
                         "string"
                     ]
                 },
-                "ymax": {
+                "yMax": {
                     "optional": true,
                     "type": [
                         "string"
@@ -90809,22 +90810,22 @@
                     "isArray": false
                 },
                 {
-                    "name": "xmin",
+                    "name": "xMin",
                     "type": "number",
                     "isArray": false
                 },
                 {
-                    "name": "xmax",
+                    "name": "xMax",
                     "type": "number",
                     "isArray": false
                 },
                 {
-                    "name": "ymin",
+                    "name": "yMin",
                     "type": "number",
                     "isArray": false
                 },
                 {
-                    "name": "ymax",
+                    "name": "yMax",
                     "type": "number",
                     "isArray": false
                 },
@@ -119298,13 +119299,13 @@
                         "string"
                     ]
                 },
-                "xmin": {
+                "xMin": {
                     "optional": true,
                     "type": [
                         "string"
                     ]
                 },
-                "xmax": {
+                "xMax": {
                     "optional": true,
                     "type": [
                         "string"
@@ -119389,12 +119390,12 @@
                     "isArray": false
                 },
                 {
-                    "name": "xmin",
+                    "name": "xMin",
                     "type": "number",
                     "isArray": false
                 },
                 {
-                    "name": "xmax",
+                    "name": "xMax",
                     "type": "number",
                     "isArray": false
                 },

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -18437,7 +18437,8 @@
                         "operand",
                         "function",
                         "functionargument",
-                        "numoperands"
+                        "numoperands",
+                        "recursiveoperands"
                     ]
                 },
                 {
@@ -56015,16 +56016,16 @@
                     "name": "copy"
                 },
                 {
-                    "name": "xmin"
+                    "name": "xMin"
                 },
                 {
-                    "name": "xmax"
+                    "name": "xMax"
                 },
                 {
-                    "name": "ymin"
+                    "name": "yMin"
                 },
                 {
-                    "name": "ymax"
+                    "name": "yMax"
                 },
                 {
                     "name": "width"
@@ -56344,22 +56345,22 @@
                     "isArray": false
                 },
                 {
-                    "name": "xmin",
+                    "name": "xMin",
                     "type": "number",
                     "isArray": false
                 },
                 {
-                    "name": "xmax",
+                    "name": "xMax",
                     "type": "number",
                     "isArray": false
                 },
                 {
-                    "name": "ymin",
+                    "name": "yMin",
                     "type": "number",
                     "isArray": false
                 },
                 {
-                    "name": "ymax",
+                    "name": "yMax",
                     "type": "number",
                     "isArray": false
                 },
@@ -72954,10 +72955,10 @@
                     "name": "copy"
                 },
                 {
-                    "name": "xmin"
+                    "name": "xMin"
                 },
                 {
-                    "name": "xmax"
+                    "name": "xMax"
                 },
                 {
                     "name": "width"
@@ -73015,12 +73016,12 @@
                     "isArray": false
                 },
                 {
-                    "name": "xmin",
+                    "name": "xMin",
                     "type": "number",
                     "isArray": false
                 },
                 {
-                    "name": "xmax",
+                    "name": "xMax",
                     "type": "number",
                     "isArray": false
                 },


### PR DESCRIPTION
This PR normalizes the capitalization of graph limits to `xMin`, `xMax`, `yMin`, and `yMax` so that the JS core matches the conventions of the rust core.