### PR TITLE
Remove update syntax converter from editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20329,7 +20329,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.0-alpha49",
+            "version": "0.7.0-alpha50",
             "license": "AGPL-3.0-or-later",
             "peerDependencies": {
                 "react": "^19.1.0",
@@ -20339,7 +20339,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.0-alpha49",
+            "version": "0.7.0-alpha50",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -21496,7 +21496,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.0-alpha49",
+            "version": "0.7.0-alpha50",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml-iframe",
     "type": "module",
     "description": "A renderer for DoenetML contained in an iframe",
-    "version": "0.7.0-alpha49",
+    "version": "0.7.0-alpha50",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.7.0-alpha49",
+    "version": "0.7.0-alpha50",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -52,8 +52,7 @@
                 "../ui-components:build",
                 "../utils:build",
                 "../virtual-keyboard:build",
-                "../parser:build",
-                "../parser:build:v06-to-v07"
+                "../parser:build"
             ]
         }
     },

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -300,33 +300,6 @@ export function EditorViewer({
             }
         };
     }, []);
-    const updateSyntaxFromV06toV07 = React.useCallback(async () => {
-        const source = editorDoenetMLRef.current;
-        const { updateSyntaxFromV06toV07 } = await import(
-            "@doenet/parser/v06-to-v07"
-        );
-        const update = await updateSyntaxFromV06toV07(source);
-        const upgraded = toXml(update.dast);
-        onEditorChange(upgraded);
-        if (update.vfile.messages.length > 0) {
-            console.warn(
-                "There were warnings during syntax update:",
-                update.vfile.messages,
-            );
-            if (lspRef.current) {
-                lspRef.current.lsp.sendAdditionalDiagnostics(
-                    lspRef.current.documentUri,
-                    update.vfile.messages.map((msg) => {
-                        return vfileMessageToLSPDiagnostic(
-                            msg,
-                            DiagnosticSeverity.Error,
-                        );
-                    }),
-                );
-            }
-        }
-        console.log("Syntax updated to v0.7");
-    }, []);
 
     const tabStore = useTabStore();
     const codeMirror = (
@@ -434,39 +407,9 @@ export function EditorViewer({
                         </UiButton>
                     </>
                 ) : null}
-                <MenuProvider>
-                    <MenuButton
-                        render={
-                            <div
-                                className="doenetml-version"
-                                title="DoenetML version"
-                            >
-                                Version: {DOENETML_VERSION}
-                                <div className="update-syntax-icon">
-                                    <BsArrowBarUp />
-                                </div>
-                            </div>
-                        }
-                    ></MenuButton>
-                    <Menu className="update-syntax-menu">
-                        <MenuItem
-                            render={
-                                <UiButton>
-                                    Update Syntax to DoenetML v0.7
-                                </UiButton>
-                            }
-                            onClick={updateSyntaxFromV06toV07}
-                            onKeyDown={(e) => {
-                                if (e.key === "Enter") {
-                                    updateSyntaxFromV06toV07();
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                }
-                            }}
-                            title="Update Syntax to DoenetML v0.7 by automatically changing old-style references and namespaces to the new DoenetML v0.7 syntax."
-                        ></MenuItem>
-                    </Menu>
-                </MenuProvider>
+                <div className="doenetml-version" title="DoenetML version">
+                    Version: {DOENETML_VERSION}
+                </div>
             </div>
         </div>
     );

--- a/packages/doenetml/src/EditorViewer/editor-viewer.css
+++ b/packages/doenetml/src/EditorViewer/editor-viewer.css
@@ -25,14 +25,6 @@
     display: flex;
     align-items: center;
     gap: 0.2rem;
-    cursor: pointer;
-    .update-syntax-icon {
-        display: flex;
-        align-items: center;
-    }
-    &:hover .update-syntax-icon {
-        color: var(--mainBlue);
-    }
 }
 
 .editor-panel .error-warning-response-tabs {

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.7.0-alpha49",
+    "version": "0.7.0-alpha50",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,


### PR DESCRIPTION
This PR removes the `v06-to-v07` syntax updater from the editor in the `doenetml` package. This way, the package size won't be quite so large. We'll package the syntax updater as a separate package that can be loaded by an app.