### PR TITLE
fix rectangle vertex coordinates

### DIFF
--- a/packages/doenetml-worker-javascript/src/components/Rectangle.js
+++ b/packages/doenetml-worker-javascript/src/components/Rectangle.js
@@ -623,6 +623,7 @@ export default class Rectangle extends Polygon {
             },
             isArray: true,
             numDimensions: 2,
+            indexAliases: [[], ["x", "y", "z"]],
             entryPrefixes: ["vertexX", "vertex"],
             returnEntryDimensions: (prefix) => (prefix === "vertex" ? 1 : 0),
             getArrayKeysFromVarName({

--- a/packages/doenetml-worker-javascript/src/components/Rectangle.js
+++ b/packages/doenetml-worker-javascript/src/components/Rectangle.js
@@ -914,12 +914,13 @@ export default class Rectangle extends Polygon {
                                         .specifiedWidth;
 
                                 if (vertexInd === "0" || vertexInd === "3") {
-                                    vertices[arrayKey] =
-                                        centerComponent.subtract(width / 2);
+                                    vertices[arrayKey] = centerComponent
+                                        .subtract(width / 2)
+                                        .simplify();
                                 } else {
-                                    vertices[arrayKey] = centerComponent.add(
-                                        width / 2,
-                                    );
+                                    vertices[arrayKey] = centerComponent
+                                        .add(width / 2)
+                                        .simplify();
                                 }
                             } else {
                                 let height =
@@ -927,12 +928,13 @@ export default class Rectangle extends Polygon {
                                         .specifiedHeight;
 
                                 if (vertexInd === "0" || vertexInd === "1") {
-                                    vertices[arrayKey] =
-                                        centerComponent.subtract(height / 2);
+                                    vertices[arrayKey] = centerComponent
+                                        .subtract(height / 2)
+                                        .simplify();
                                 } else {
-                                    vertices[arrayKey] = centerComponent.add(
-                                        height / 2,
-                                    );
+                                    vertices[arrayKey] = centerComponent
+                                        .add(height / 2)
+                                        .simplify();
                                 }
                             }
                         }
@@ -952,8 +954,9 @@ export default class Rectangle extends Polygon {
                                     let width =
                                         dependencyValuesByKey[arrayKey]
                                             .specifiedWidth;
-                                    vertices[arrayKey] =
-                                        vertComponent.add(width);
+                                    vertices[arrayKey] = vertComponent
+                                        .add(width)
+                                        .simplify();
                                 }
                             } else {
                                 if (vertexInd === "0" || vertexInd === "1") {
@@ -962,8 +965,9 @@ export default class Rectangle extends Polygon {
                                     let height =
                                         dependencyValuesByKey[arrayKey]
                                             .specifiedHeight;
-                                    vertices[arrayKey] =
-                                        vertComponent.add(height);
+                                    vertices[arrayKey] = vertComponent
+                                        .add(height)
+                                        .simplify();
                                 }
                             }
                         }
@@ -1005,7 +1009,8 @@ export default class Rectangle extends Polygon {
                                 vertices[arrayKey] = vertComponent.add(
                                     centerComponent
                                         .subtract(vertComponent)
-                                        .multiply(2),
+                                        .multiply(2)
+                                        .simplify(),
                                 );
                             }
                         }
@@ -1038,8 +1043,9 @@ export default class Rectangle extends Polygon {
                                     let width =
                                         dependencyValuesByKey[arrayKey]
                                             .specifiedWidth;
-                                    vertices[arrayKey] =
-                                        vertComponent.add(width);
+                                    vertices[arrayKey] = vertComponent
+                                        .add(width)
+                                        .simplify();
                                 }
                             } else {
                                 if (vertexInd === "0" || vertexInd === "1") {
@@ -1048,8 +1054,9 @@ export default class Rectangle extends Polygon {
                                     let height =
                                         dependencyValuesByKey[arrayKey]
                                             .specifiedHeight;
-                                    vertices[arrayKey] =
-                                        vertComponent.add(height);
+                                    vertices[arrayKey] = vertComponent
+                                        .add(height)
+                                        .simplify();
                                 }
                             }
                         }

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/rectangle.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/rectangle.test.ts
@@ -1614,4 +1614,52 @@ describe("Rectangle tag tests", async () => {
                 .value,
         ).eq(perimeter);
     });
+
+    it("reference vertex coordinates", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <graph>
+    <rectangle name="r"/>
+  </graph>
+  <p name="p1">Coordinates of vertex 1: $r.vertex1.x, $r.vertex1.y</p>
+  <p name="p2">Coordinates of vertex 2: $r.vertices[2].x, $r.vertices[2].y</p>
+  <p name="p3">Coordinates of vertex 3: $r.vertex3.x, $r.vertex3.y</p>
+  <p name="p4">Coordinates of vertex 4: $r.vertices[4].x, $r.vertices[4].y</p>
+  `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("p1")].stateValues.text,
+        ).eq("Coordinates of vertex 1: 0, 0");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("p2")].stateValues.text,
+        ).eq("Coordinates of vertex 2: 1, 0");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("p3")].stateValues.text,
+        ).eq("Coordinates of vertex 3: 1, 1");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("p4")].stateValues.text,
+        ).eq("Coordinates of vertex 4: 0, 1");
+
+        await movePolygon({
+            componentIdx: await resolvePathToNodeIdx("r"),
+            pointCoords: { 1: [9, -3], 3: [-5, 2] },
+            core,
+        });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("p1")].stateValues.text,
+        ).eq("Coordinates of vertex 1: -5, -3");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("p2")].stateValues.text,
+        ).eq("Coordinates of vertex 2: 9, -3");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("p3")].stateValues.text,
+        ).eq("Coordinates of vertex 3: 9, 2");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("p4")].stateValues.text,
+        ).eq("Coordinates of vertex 4: -5, 2");
+    });
 });


### PR DESCRIPTION
The PR adds index aliases to the `vertices` state variable of `<rectangle name="r">` so that vertex coordinates can be referenced with `x`, etc.,  e.g., by `$r.vertices[1].x`. This feature is avaiable for `<polygon>` but was overlooked for `<rectangle>`.

The PR also simplifies rectangle vertices so they don't display as, for example, `1+1`.