### PR TITLE
don't recreate replacements for conditional content with one case

### DIFF
--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/answer.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/answer.test.ts
@@ -4173,13 +4173,17 @@ Enter any letter:
         stateVariables = await core.returnAllStateVariables(false, true);
 
         expect(
-            stateVariables[await resolvePathToNodeIdx("cond")].replacements!
-                .length,
-        ).eq(0);
+            stateVariables[await resolvePathToNodeIdx("cond")].replacements,
+        ).eqls([
+            {
+                componentIdx: await resolvePathToNodeIdx("cond[1]"),
+                componentType: "group",
+            },
+        ]);
         expect(
             stateVariables[await resolvePathToNodeIdx("cond")]
                 .replacementsToWithhold,
-        ).eq(0);
+        ).eq(1);
         expect(
             stateVariables[await resolvePathToNodeIdx("ans")].stateValues
                 .justSubmitted,
@@ -4210,6 +4214,10 @@ Enter any letter:
             },
         ]);
         expect(
+            stateVariables[await resolvePathToNodeIdx("cond")]
+                .replacementsToWithhold,
+        ).eq(0);
+        expect(
             stateVariables[await resolvePathToNodeIdx("cond[1][1]")].stateValues
                 .text,
         ).eq("The answer was just submitted.");
@@ -4234,13 +4242,17 @@ Enter any letter:
         });
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(
-            stateVariables[await resolvePathToNodeIdx("cond")].replacements!
-                .length,
-        ).eq(0);
+            stateVariables[await resolvePathToNodeIdx("cond")].replacements,
+        ).eqls([
+            {
+                componentIdx: await resolvePathToNodeIdx("cond[1]"),
+                componentType: "group",
+            },
+        ]);
         expect(
             stateVariables[await resolvePathToNodeIdx("cond")]
                 .replacementsToWithhold,
-        ).eq(0);
+        ).eq(1);
         expect(
             stateVariables[await resolvePathToNodeIdx("ans")].stateValues
                 .justSubmitted,


### PR DESCRIPTION
This PR reimplements an optimization from DoenetML version 0.6. If a `<conditionalContent>` has a single `<case>` (or zero cases, for which a single `<case>` is sugared in), then don't recreate the replacements when the single condition switches being satisfied. Instead, withhold the replacements when the condition is not satisfied and stop withholding them when the condition is again satisfied.