### PR TITLE
Doenet viewer components add youtube api to header

### DIFF
--- a/packages/codemirror/index.html
+++ b/packages/codemirror/index.html
@@ -5,7 +5,6 @@
         <link rel="shortcut icon" href="/favicon.ico" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>DoenetML Viewer</title>
-        <script src="https://www.youtube.com/iframe_api"></script>
     </head>
     <body>
         <div id="root"></div>

--- a/packages/doenetml-iframe/index.html
+++ b/packages/doenetml-iframe/index.html
@@ -5,7 +5,6 @@
         <link rel="shortcut icon" href="/favicon.ico" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>DoenetML Viewer</title>
-        <script src="https://www.youtube.com/iframe_api"></script>
     </head>
     <body>
         <h1>Below is DoenetML rendered in an iframe</h1>

--- a/packages/doenetml/src/Viewer/renderers/video.tsx
+++ b/packages/doenetml/src/Viewer/renderers/video.tsx
@@ -466,7 +466,7 @@ export default React.memo(function Video(props) {
                 src={
                     "https://www.youtube.com/embed/" +
                     SVs.youtube +
-                    "?enablejsapi=1&rel=0&modestbranding=1"
+                    "?enablejsapi=1&rel=0"
                 }
                 allow="autoplay; fullscreen"
             />

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -134,6 +134,19 @@ export function DoenetViewer({
      */
     onInit?: (elm: HTMLElement) => void;
 }) {
+    useEffect(() => {
+        // Add a YouTube iframe api to the document header if it doesn't exist
+        if (
+            !document.querySelector(
+                'script[src="https://www.youtube.com/iframe_api"]',
+            )
+        ) {
+            const script = document.createElement("script");
+            script.src = "https://www.youtube.com/iframe_api";
+            document.head.appendChild(script);
+        }
+    }, []);
+
     const [variants, setVariants] = useState({
         index: 1,
         numVariants: 1,
@@ -330,6 +343,19 @@ export function DoenetEditor({
     initialWarnings?: WarningRecord[];
     fetchExternalDoenetML?: (arg: string) => Promise<string>;
 }) {
+    useEffect(() => {
+        // Add a YouTube iframe api to the document header if it doesn't exist
+        if (
+            !document.querySelector(
+                'script[src="https://www.youtube.com/iframe_api"]',
+            )
+        ) {
+            const script = document.createElement("script");
+            script.src = "https://www.youtube.com/iframe_api";
+            document.head.appendChild(script);
+        }
+    }, []);
+
     const editor = (
         <EditorViewer
             doenetML={doenetML}

--- a/packages/standalone/index.html
+++ b/packages/standalone/index.html
@@ -5,7 +5,6 @@
         <link rel="shortcut icon" href="/favicon.ico" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>DoenetML Viewer</title>
-        <script src="https://www.youtube.com/iframe_api"></script>
     </head>
     <body>
         <div id="root"></div>

--- a/packages/test-cypress/index.html
+++ b/packages/test-cypress/index.html
@@ -5,7 +5,6 @@
         <link rel="shortcut icon" href="/favicon.ico" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>DoenetML Viewer</title>
-        <script src="https://www.youtube.com/iframe_api"></script>
     </head>
     <body>
         <div id="root"></div>

--- a/packages/test-viewer/index-inline-worker.html
+++ b/packages/test-viewer/index-inline-worker.html
@@ -5,7 +5,6 @@
         <link rel="shortcut icon" href="/favicon.ico" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>DoenetML Viewer</title>
-        <script src="https://www.youtube.com/iframe_api"></script>
     </head>
     <body>
         <div id="root"></div>

--- a/packages/test-viewer/index.html
+++ b/packages/test-viewer/index.html
@@ -5,7 +5,6 @@
         <link rel="icon" href="data:;base64,iVBORw0KGgo=">
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>DoenetML Viewer</title>
-        <script src="https://www.youtube.com/iframe_api"></script>
     </head>
     <body>
         <div id="root"></div>

--- a/packages/ui-components/index.html
+++ b/packages/ui-components/index.html
@@ -5,7 +5,6 @@
         <link rel="shortcut icon" href="/favicon.ico" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>DoenetML Viewer</title>
-        <script src="https://www.youtube.com/iframe_api"></script>
     </head>
     <body>
         <div id="root"></div>

--- a/packages/utils/index.html
+++ b/packages/utils/index.html
@@ -5,7 +5,6 @@
         <link rel="shortcut icon" href="/favicon.ico" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>DoenetML Viewer</title>
-        <script src="https://www.youtube.com/iframe_api"></script>
     </head>
     <body>
         <div id="root"></div>

--- a/packages/virtual-keyboard/index.html
+++ b/packages/virtual-keyboard/index.html
@@ -5,7 +5,6 @@
         <link rel="shortcut icon" href="/favicon.ico" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Virtual Keyboard Viewer</title>
-        <script src="https://www.youtube.com/iframe_api"></script>
     </head>
     <body>
         <div id="root"></div>


### PR DESCRIPTION
This PR adds the YouTube iframe api script to the document head when loading the `<DoenetViewer>` or `<DoenetEditor>` components rather that relying on the containing html to have the script.