### PR TITLE
verify no components got added while calculating replacements

### DIFF
--- a/packages/doenetml-worker-javascript/src/Core.js
+++ b/packages/doenetml-worker-javascript/src/Core.js
@@ -2517,18 +2517,31 @@ export default class Core {
         // resolveItem: a function that the composite can use to resolve any state variables
         // publicCaseInsensitiveAliasSubstitutions: a function that can be used to find a case insensitive match
         //   to a public state variable, substituting aliases if necessary
-        let result = await component.constructor.createSerializedReplacements({
-            component: this.components[component.componentIdx], // to create proxy
-            components: this.components,
-            nComponents: this.components.length,
-            workspace: component.replacementsWorkspace,
-            componentInfoObjects: this.componentInfoObjects,
-            allDoenetMLs: this.allDoenetMLs,
-            flags: this.flags,
-            resolveItem: this.dependencies.resolveItem.bind(this.dependencies),
-            publicCaseInsensitiveAliasSubstitutions:
-                this.publicCaseInsensitiveAliasSubstitutions.bind(this),
-        });
+        let initialNComponents;
+        let result;
+        do {
+            initialNComponents = this.components.length;
+            result = await component.constructor.createSerializedReplacements({
+                component: this.components[component.componentIdx], // to create proxy
+                components: this.components,
+                nComponents: this.components.length,
+                workspace: component.replacementsWorkspace,
+                componentInfoObjects: this.componentInfoObjects,
+                allDoenetMLs: this.allDoenetMLs,
+                flags: this.flags,
+                resolveItem: this.dependencies.resolveItem.bind(
+                    this.dependencies,
+                ),
+                publicCaseInsensitiveAliasSubstitutions:
+                    this.publicCaseInsensitiveAliasSubstitutions.bind(this),
+            });
+
+            // If `this.components` changed in length while `createSerializedReplacements` was executing,
+            // it means that some other action (like calling another `createSerializedReplacements`)
+            // occurred while resolving state variables.
+            // Since this would lead to collisions in assigned component indices, we rerun `createSerializedReplacements`.
+            // TODO: are there any scenarios where this will lead to an infinite loop?
+        } while (this.components.length !== initialNComponents);
 
         const newNComponents = result.nComponents;
 
@@ -9852,21 +9865,32 @@ export default class Core {
         // resolveItem: a function that the composite can use to resolve any state variables
         // publicCaseInsensitiveAliasSubstitutions: a function that can be used to find a case insensitive match
         //   to a public state variable, substituting aliases if necessary
-        const replacementResults =
-            await component.constructor.calculateReplacementChanges({
-                component: proxiedComponent,
-                componentChanges,
-                components: this.components,
-                nComponents: this.components.length,
-                workspace: component.replacementsWorkspace,
-                componentInfoObjects: this.componentInfoObjects,
-                flags: this.flags,
-                resolveItem: this.dependencies.resolveItem.bind(
-                    this.dependencies,
-                ),
-                publicCaseInsensitiveAliasSubstitutions:
-                    this.publicCaseInsensitiveAliasSubstitutions.bind(this),
-            });
+        let initialNComponents;
+        let replacementResults;
+        do {
+            initialNComponents = this.components.length;
+            replacementResults =
+                await component.constructor.calculateReplacementChanges({
+                    component: proxiedComponent,
+                    componentChanges,
+                    components: this.components,
+                    nComponents: this.components.length,
+                    workspace: component.replacementsWorkspace,
+                    componentInfoObjects: this.componentInfoObjects,
+                    flags: this.flags,
+                    resolveItem: this.dependencies.resolveItem.bind(
+                        this.dependencies,
+                    ),
+                    publicCaseInsensitiveAliasSubstitutions:
+                        this.publicCaseInsensitiveAliasSubstitutions.bind(this),
+                });
+
+            // If `this.components` changed in length while `calculateReplacementChanges` was executing,
+            // it means that some other action (like calling another `calculateReplacementChanges`)
+            // occurred while resolving state variables.
+            // Since this would lead to collisions in assigned component indices, we rerun `calculateReplacementChanges`.
+            // TODO: are there any scenarios where this will lead to an infinite loop?
+        } while (this.components.length !== initialNComponents);
 
         if (component.constructor.stateVariableToEvaluateAfterReplacements) {
             await component.stateValues[

--- a/packages/doenetml-worker-javascript/src/components/PostponeRenderContainer.js
+++ b/packages/doenetml-worker-javascript/src/components/PostponeRenderContainer.js
@@ -51,10 +51,12 @@ export default class PostponeRenderContainer extends Group {
             let replacementResults = await this.createSerializedReplacements({
                 component,
                 componentInfoObjects,
+                nComponents,
             });
             let replacements = replacementResults.replacements;
             errors.push(...replacementResults.errors);
             warnings.push(...replacementResults.warnings);
+            nComponents = replacementResults.nComponents;
 
             if (replacements.length > 0) {
                 let replacementInstruction = {

--- a/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/Copy.js
@@ -867,7 +867,6 @@ export default class Copy extends CompositeComponent {
                 ) {
                     // since `generatedVariantInfo` may be accessed when serializing a component,
                     // make sure it is resolved so we don't end up resolving it while expanding
-                    // (which could change `nComponents` and cause overlapping component)
                     dependencies.extendedVariantInfo = {
                         dependencyType: "stateVariable",
                         componentIdx:


### PR DESCRIPTION
This PR adds protection when calling functions that create serialized replacements of composite components to make sure that components were not created by other functions during the process. If they were, it's possible two components could have been assigned the same component index.