### PR TITLE
preserveLastChoice option for choice input

### DIFF
--- a/packages/doenetml-worker-javascript/src/components/Answer.js
+++ b/packages/doenetml-worker-javascript/src/components/Answer.js
@@ -207,6 +207,12 @@ export default class Answer extends InlineComponent {
             defaultValue: false,
             public: true,
         };
+        attributes.preserveLastChoice = {
+            createPrimitiveOfType: "boolean",
+            createStateVariable: "preserveLastChoice",
+            defaultValue: false,
+            public: true,
+        };
 
         attributes.splitSymbols = {
             createComponentOfType: "boolean",
@@ -505,6 +511,15 @@ export default class Answer extends InlineComponent {
                             shuffleOrder: {
                                 type: "primitive",
                                 name: "shuffleOrder",
+                                primitive: { type: "boolean", value: true },
+                            },
+                        };
+                    }
+                    if (componentAttributes.preserveLastChoice) {
+                        choiceinput.attributes = {
+                            preserveLastChoice: {
+                                type: "primitive",
+                                name: "preserveLastChoice",
                                 primitive: { type: "boolean", value: true },
                             },
                         };

--- a/packages/doenetml-worker-javascript/src/components/ChoiceInput.js
+++ b/packages/doenetml-worker-javascript/src/components/ChoiceInput.js
@@ -69,6 +69,12 @@ export default class Choiceinput extends Input {
             defaultValue: false,
             public: true,
         };
+        attributes.preserveLastChoice = {
+            createPrimitiveOfType: "boolean",
+            createStateVariable: "preserveLastChoice",
+            defaultValue: false,
+            public: true,
+        };
 
         attributes.preselectChoice = {
             createComponentOfType: "number",
@@ -199,6 +205,10 @@ export default class Choiceinput extends Input {
                     dependencyType: "stateVariable",
                     variableName: "shuffleOrder",
                 },
+                preserveLastChoice: {
+                    dependencyType: "stateVariable",
+                    variableName: "preserveLastChoice",
+                },
                 variantSeed: {
                     dependencyType: "value",
                     value: sharedParameters.variantSeed,
@@ -267,7 +277,10 @@ export default class Choiceinput extends Input {
                     choiceOrder = [...Array(numChoices).keys()].map(
                         (x) => x + 1,
                     );
-                    for (let i = numChoices - 1; i > 0; i--) {
+                    const lastShuffledIdx =
+                        numChoices -
+                        (dependencyValues.preserveLastChoice ? 2 : 1);
+                    for (let i = lastShuffledIdx; i > 0; i--) {
                         const rand = variantRng();
                         const j = Math.floor(rand * (i + 1));
                         [choiceOrder[i], choiceOrder[j]] = [
@@ -1554,8 +1567,14 @@ export default class Choiceinput extends Input {
             }
         }
 
+        const preserveLastChoice =
+            serializedComponent.attributes?.preserveLastChoice?.primitive.value;
+        const numChoicesAdjusted = preserveLastChoice
+            ? Math.max(1, numChoices - 1)
+            : numChoices;
+
         let numberOfPermutations = 1;
-        for (let i = 2; i <= numChoices; i++) {
+        for (let i = 2; i <= numChoicesAdjusted; i++) {
             numberOfPermutations *= i;
         }
 
@@ -1578,6 +1597,7 @@ export default class Choiceinput extends Input {
                     .numVariantsByDescendant,
             numberOfPermutations,
             numChoices,
+            numChoicesAdjusted,
         };
 
         return { success: true, numVariants };
@@ -1618,6 +1638,8 @@ export default class Choiceinput extends Input {
             serializedComponent.variants.uniqueVariantData.numberOfPermutations;
         let numChoices =
             serializedComponent.variants.uniqueVariantData.numChoices;
+        let numChoicesAdjusted =
+            serializedComponent.variants.uniqueVariantData.numChoicesAdjusted;
 
         // treat permutations as another descendant variant component
         let numbersOfOptions = [...numVariantsByDescendant];
@@ -1633,12 +1655,20 @@ export default class Choiceinput extends Input {
         let indicesForEachDescendant = indicesForEachOption;
 
         // choice a permutation based on permutations index
-        let indicesToPermute = [...Array(numChoices).keys()].map((x) => x + 1);
+        let indicesToPermute = [...Array(numChoicesAdjusted).keys()].map(
+            (x) => x + 1,
+        );
 
         let permutedIndices = enumeratePermutations({
             values: indicesToPermute,
             maxNumber: permutationsIndex,
         })[permutationsIndex - 1];
+
+        if (numChoicesAdjusted < numChoices) {
+            // We didn't shuffle the last index, as `preserveLastChoice` was specified.
+            // Add the last index at the end.
+            permutedIndices = [...permutedIndices, numChoices];
+        }
 
         // for each descendant, get unique variant corresponding
         // to the selected variant number and include that as a subvariant

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/answer.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/answer.test.ts
@@ -2542,6 +2542,25 @@ The animal is a <answer name="answer1" shuffleOrder>
         });
     });
 
+    it("answer with shuffled sugared choices, preserve last choice", async () => {
+        const doenetML = `
+The animal is a <answer name="answer1" shuffleOrder preserveLastChoice>
+    <choice credit="0.5">cat</choice>
+    <choice credit="1">dog</choice>
+    <choice>monkey</choice>
+</answer>
+  `;
+
+        await test_choice_answer({
+            doenetML,
+            answers: [
+                { choices: ["dog"], credit: 1 },
+                { choices: ["monkey"], credit: 0 },
+                { choices: ["cat"], credit: 0.5 },
+            ],
+        });
+    });
+
     it("answer with choiceInput, fixed order", async () => {
         const doenetML = `
 The animal is a <answer name="answer1">

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/choiceinput.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/choiceinput.test.ts
@@ -18,6 +18,7 @@ describe("ChoiceInput tag tests", async () => {
         resolvePathToNodeIdx: ResolvePathToNodeIdx,
         inline: boolean,
         shuffleOrder: boolean,
+        preserveLastChoice: boolean,
     ) {
         let originalChoices = ["cat", "dog", "monkey", "mouse"];
         const stateVariables = await core.returnAllStateVariables(false, true);
@@ -28,6 +29,12 @@ describe("ChoiceInput tag tests", async () => {
         if (!shuffleOrder) {
             expect(choiceTexts).eqls(originalChoices);
         }
+        if (preserveLastChoice) {
+            expect(choiceTexts[choiceTexts.length - 1]).eq(
+                originalChoices[originalChoices.length - 1],
+            );
+        }
+
         expect([...choiceTexts].sort()).eqls(originalChoices);
 
         expect(
@@ -37,6 +44,10 @@ describe("ChoiceInput tag tests", async () => {
             stateVariables[await resolvePathToNodeIdx("ci")].stateValues
                 .shuffleOrder,
         ).eq(shuffleOrder);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("ci")].stateValues
+                .preserveLastChoice,
+        ).eq(preserveLastChoice);
 
         async function check_items(
             selectedIndex?: number,
@@ -140,6 +151,7 @@ describe("ChoiceInput tag tests", async () => {
             resolvePathToNodeIdx,
             false,
             false,
+            false,
         );
     });
 
@@ -164,7 +176,43 @@ describe("ChoiceInput tag tests", async () => {
             requestedVariantIndex: 8,
         });
 
-        await test_animal_choice_input(core, resolvePathToNodeIdx, false, true);
+        await test_animal_choice_input(
+            core,
+            resolvePathToNodeIdx,
+            false,
+            true,
+            false,
+        );
+    });
+
+    it("shuffleOrder, preserveLastChoice", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <choiceInput shuffleOrder preserveLastChoice name="ci">
+      <choice name="choice1">cat</choice>
+      <choice name="choice2">dog</choice>
+      <choice name="choice3">monkey</choice>
+      <choice name="choice4">mouse</choice>
+    </choiceInput>
+
+    <p name="psv">Selected value: $ci.selectedValue</p>
+    <p name="psi">Selected index: $ci.selectedIndex</p>
+
+    <p name="pCat">Selected cat: $choice1.selected</p>
+    <p name="pDog">Selected dog: $choice2.selected</p>
+    <p name="pMonkey">Selected monkey: $choice3.selected</p>
+    <p name="pMouse">Selected mouse: $choice4.selected</p>
+    `,
+            requestedVariantIndex: 8,
+        });
+
+        await test_animal_choice_input(
+            core,
+            resolvePathToNodeIdx,
+            false,
+            true,
+            true,
+        );
     });
 
     it("inline", async () => {
@@ -188,7 +236,13 @@ describe("ChoiceInput tag tests", async () => {
             requestedVariantIndex: 8,
         });
 
-        await test_animal_choice_input(core, resolvePathToNodeIdx, true, false);
+        await test_animal_choice_input(
+            core,
+            resolvePathToNodeIdx,
+            true,
+            false,
+            false,
+        );
     });
 
     it("inline, shuffle order", async () => {
@@ -212,7 +266,43 @@ describe("ChoiceInput tag tests", async () => {
             requestedVariantIndex: 8,
         });
 
-        await test_animal_choice_input(core, resolvePathToNodeIdx, true, true);
+        await test_animal_choice_input(
+            core,
+            resolvePathToNodeIdx,
+            true,
+            true,
+            false,
+        );
+    });
+
+    it("inline, shuffle order, preserve last choice", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <choiceInput inline shuffleOrder preserveLastChoice name="ci">
+      <choice name="choice1">cat</choice>
+      <choice name="choice2">dog</choice>
+      <choice name="choice3">monkey</choice>
+      <choice name="choice4">mouse</choice>
+    </choiceInput>
+
+    <p name="psv">Selected value: $ci.selectedValue</p>
+    <p name="psi">Selected index: $ci.selectedIndex</p>
+
+    <p name="pCat">Selected cat: $choice1.selected</p>
+    <p name="pDog">Selected dog: $choice2.selected</p>
+    <p name="pMonkey">Selected monkey: $choice3.selected</p>
+    <p name="pMouse">Selected mouse: $choice4.selected</p>
+    `,
+            requestedVariantIndex: 8,
+        });
+
+        await test_animal_choice_input(
+            core,
+            resolvePathToNodeIdx,
+            true,
+            true,
+            true,
+        );
     });
 
     it("choiceInput references", async () => {


### PR DESCRIPTION
This PR adds a `preserveLastChoice` attribute to `<choiceInput>`. It has no effect unless the `shuffleOrder` attribute is specified, in which case all the choices are shuffled except for the last one.

Resolves #467.