### PR TITLE
showCorrectness attribute on section and document

### DIFF
--- a/packages/doenetml-worker-javascript/src/components/Document.js
+++ b/packages/doenetml-worker-javascript/src/components/Document.js
@@ -41,6 +41,11 @@ export default class Document extends BaseComponent {
             defaultValue: false,
             public: true,
         };
+        attributes.showCorrectness = {
+            createComponentOfType: "boolean",
+            createStateVariable: "showCorrectnessPreliminary",
+            defaultValue: null,
+        };
         attributes.submitLabel = {
             createComponentOfType: "text",
             createStateVariable: "submitLabel",
@@ -478,14 +483,24 @@ export default class Document extends BaseComponent {
         stateVariableDefinitions.showCorrectness = {
             forRenderer: true,
             returnDependencies: () => ({
+                showCorrectnessPreliminary: {
+                    dependencyType: "stateVariable",
+                    variableName: "showCorrectnessPreliminary",
+                },
                 showCorrectnessFlag: {
                     dependencyType: "flag",
                     flagName: "showCorrectness",
                 },
             }),
-            definition({ dependencyValues }) {
-                let showCorrectness =
-                    dependencyValues.showCorrectnessFlag !== false;
+            definition({ dependencyValues, usedDefault }) {
+                let showCorrectness;
+                if (!usedDefault.showCorrectnessPreliminary) {
+                    showCorrectness =
+                        dependencyValues.showCorrectnessPreliminary;
+                } else {
+                    showCorrectness =
+                        dependencyValues.showCorrectnessFlag !== false;
+                }
                 return { setValue: { showCorrectness } };
             },
         };

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -49,6 +49,11 @@ export class SectioningComponent extends BlockComponent {
             defaultValue: false,
             public: true,
         };
+        attributes.showCorrectness = {
+            createComponentOfType: "boolean",
+            createStateVariable: "showCorrectnessPreliminary",
+            defaultValue: null,
+        };
         attributes.submitLabel = {
             createComponentOfType: "text",
             createStateVariable: "submitLabel",
@@ -656,14 +661,24 @@ export class SectioningComponent extends BlockComponent {
         stateVariableDefinitions.showCorrectness = {
             forRenderer: true,
             returnDependencies: () => ({
+                showCorrectnessPreliminary: {
+                    dependencyType: "stateVariable",
+                    variableName: "showCorrectnessPreliminary",
+                },
                 showCorrectnessFlag: {
                     dependencyType: "flag",
                     flagName: "showCorrectness",
                 },
             }),
-            definition({ dependencyValues }) {
-                let showCorrectness =
-                    dependencyValues.showCorrectnessFlag !== false;
+            definition({ dependencyValues, usedDefault }) {
+                let showCorrectness;
+                if (!usedDefault.showCorrectnessPreliminary) {
+                    showCorrectness =
+                        dependencyValues.showCorrectnessPreliminary;
+                } else {
+                    showCorrectness =
+                        dependencyValues.showCorrectnessFlag !== false;
+                }
                 return { setValue: { showCorrectness } };
             },
         };

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/problem.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/problem.test.ts
@@ -452,6 +452,7 @@ describe("Problem tag tests", async () => {
         core: PublicDoenetMLCore,
         resolvePathToNodeIdx: ResolvePathToNodeIdx,
         sectionName = "theProblem",
+        showCorrectness = true,
     ) {
         let stateVariables = await core.returnAllStateVariables(false, true);
         let answerNames = ["twox", "hello", "fruit", "sum3"];
@@ -577,6 +578,10 @@ describe("Problem tag tests", async () => {
             stateVariables[await resolvePathToNodeIdx(sectionName)].stateValues
                 .createSubmitAllButton,
         ).eq(true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx(sectionName)].stateValues
+                .showCorrectness,
+        ).eq(showCorrectness);
         expect(
             stateVariables[await resolvePathToNodeIdx(sectionName)].stateValues
                 .justSubmitted,
@@ -768,6 +773,86 @@ describe("Problem tag tests", async () => {
             core,
             resolvePathToNodeIdx,
             "theDocument",
+        );
+    });
+
+    it("section wide checkWork, show correctness turned off", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+        <p>Section wide checkWork: <booleanInput name="swcw" /></p>
+        <problem sectionWideCheckWork="$swcw" name="theProblem" showCorrectness="false">
+        <title>Problem 1</title>
+      
+        <p>2x: <answer name="twox">2x</answer></p>
+      
+        <p>hello: <answer type="text" name="hello">hello</answer></p>
+
+        <p>banana: 
+        <answer name="fruit">
+          <choiceInput name="fruitInput">
+            <choice credit="1">banana</choice>
+            <choice>apple</choice>
+            <choice>orange</choice>
+          </choiceInput>
+        </answer>
+        </p>
+      
+        <p>Numbers that add to 3: <mathInput name="n1" /> <mathInput name="n2" />
+        <answer name="sum3">
+          <award referencesAreResponses="n1 n2">
+            <when>$n1+$n2=3</when>
+          </award>
+        </answer></p>
+      
+      </problem>
+    `,
+        });
+
+        await test_section_wide_check_work(
+            core,
+            resolvePathToNodeIdx,
+            undefined,
+            false,
+        );
+    });
+
+    it("document wide checkWork, show correctness turned off", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+        <document documentWideCheckWork="$swcw" name="theDocument" showCorrectness="false">
+        <title>The problem</title>
+
+        <p>Document wide checkWork: <booleanInput name="swcw" /></p>
+      
+        <p>2x: <answer name="twox">2x</answer></p>
+      
+        <p>hello: <answer type="text" name="hello">hello</answer></p>
+
+        <p>banana: 
+        <answer name="fruit">
+          <choiceInput shuffleOrder name="fruitInput">
+            <choice credit="1">banana</choice>
+            <choice>apple</choice>
+            <choice>orange</choice>
+          </choiceInput>
+        </answer>
+        </p>
+      
+        <p>Numbers that add to 3: <mathInput name="n1" /> <mathInput name="n2" />
+        <answer name="sum3">
+          <award referencesAreResponses="n1 n2">
+            <when>$n1+$n2=3</when>
+          </award>
+        </answer></p>
+        </document>
+    `,
+        });
+
+        await test_section_wide_check_work(
+            core,
+            resolvePathToNodeIdx,
+            "theDocument",
+            false,
         );
     });
 

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -165,27 +165,35 @@ export function EditorViewer({
                             nanInfinityReviver,
                         );
                         const answerCreditAchieved = result.creditAchieved;
-                        const response: unknown[] = result.response;
-                        const componentTypes: string[] = result.componentTypes;
+                        const response: unknown[] | undefined = result.response;
+                        const componentTypes: string[] | undefined =
+                            result.componentTypes;
 
-                        const responseElement = formatResponse(
-                            response,
-                            componentTypes,
-                        );
+                        if (
+                            response !== undefined &&
+                            componentTypes !== undefined &&
+                            response.length === componentTypes.length
+                        ) {
+                            const responseElement = formatResponse(
+                                response,
+                                componentTypes,
+                            );
 
-                        setResponses((was) => {
-                            const arr = [...was];
-                            arr.push({
-                                answerId:
-                                    answerId[0] === "/"
-                                        ? answerId.substring(1)
-                                        : answerId,
-                                response: responseElement,
-                                creditAchieved: answerCreditAchieved,
-                                submittedAt: new Date().toLocaleTimeString(),
+                            setResponses((was) => {
+                                const arr = [...was];
+                                arr.push({
+                                    answerId:
+                                        answerId[0] === "/"
+                                            ? answerId.substring(1)
+                                            : answerId,
+                                    response: responseElement,
+                                    creditAchieved: answerCreditAchieved,
+                                    submittedAt:
+                                        new Date().toLocaleTimeString(),
+                                });
+                                return arr;
                             });
-                            return arr;
-                        });
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This PR adds a `showCorrectness` attribute to `<document>` and sectioning components. It has an effect only if `documentWideCheckWork` or `sectionWideCheckWork` is set. Then, if `showCorrectness` is set to `false`, the document-wide/section-wide check work button does not indicate if the submitted answer is correct.

Fixes #465.