### PR TITLE
mechanisms for reducing credit with wrong answers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20345,7 +20345,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.0-alpha55",
+            "version": "0.7.0-beta1",
             "license": "AGPL-3.0-or-later",
             "peerDependencies": {
                 "react": "^19.1.1",
@@ -20355,7 +20355,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.0-alpha55",
+            "version": "0.7.0-beta1",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -21523,7 +21523,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.0-alpha55",
+            "version": "0.7.0-beta1",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },
@@ -21569,7 +21569,7 @@
         },
         "packages/v06-to-v07": {
             "name": "@doenet/v06-to-v07",
-            "version": "0.7.0-alpha55",
+            "version": "0.7.0-beta1",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/packages/codemirror/src/extensions/theme.ts
+++ b/packages/codemirror/src/extensions/theme.ts
@@ -2,13 +2,13 @@ import { EditorView } from "@codemirror/view";
 
 export const colorTheme = EditorView.theme({
     "&": {
-        color: "var(--canvastext)",
+        color: "var(--canvasText)",
         height: "100%",
         //backgroundColor: "var(--canvas)",
     },
     ".cm-content": {
         caretColor: "#0e9",
-        borderDownColor: "var(--canvastext)",
+        borderDownColor: "var(--canvasText)",
     },
     ".cm-editor": {
         caretColor: "#0e9",
@@ -16,13 +16,13 @@ export const colorTheme = EditorView.theme({
     },
     "&.cm-focused .cm-cursor": {
         backgroundColor: "var(--lightBlue)",
-        borderLeftColor: "var(--canvastext)",
+        borderLeftColor: "var(--canvasText)",
     },
     "&.cm-focused .cm-selectionBackground, ::selection": {
         backgroundColor: "var(--mainGray)",
     },
     "&.cm-focused": {
-        color: "var(--canvastext)",
+        color: "var(--canvasText)",
     },
     "cm-selectionLayer": {
         backgroundColor: "var(--mainGreen)",
@@ -40,12 +40,12 @@ export const colorTheme = EditorView.theme({
 
 export const readOnlyColorTheme = EditorView.theme({
     "&": {
-        color: "var(--canvastext)",
+        color: "var(--canvasText)",
         height: "100%",
     },
     ".cm-content": {
         caretColor: "#0e9",
-        borderDownColor: "var(--canvastext)",
+        borderDownColor: "var(--canvasText)",
         backgroundColor: "#77777720",
     },
     ".cm-editor": {
@@ -53,13 +53,13 @@ export const readOnlyColorTheme = EditorView.theme({
     },
     "&.cm-focused .cm-cursor": {
         backgroundColor: "var(--lightBlue)",
-        borderLeftColor: "var(--canvastext)",
+        borderLeftColor: "var(--canvasText)",
     },
     "&.cm-focused .cm-selectionBackground, ::selection": {
         backgroundColor: "var(--mainGray)",
     },
     "&.cm-focused": {
-        color: "var(--canvastext)",
+        color: "var(--canvasText)",
     },
     "cm-selectionLayer": {
         backgroundColor: "var(--mainGreen)",

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml-iframe",
     "type": "module",
     "description": "A renderer for DoenetML contained in an iframe",
-    "version": "0.7.0-alpha55",
+    "version": "0.7.0-beta1",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml-prototype/src/renderers/doenet/graph.css
+++ b/packages/doenetml-prototype/src/renderers/doenet/graph.css
@@ -2,7 +2,7 @@
     .graph-container {
         @apply max-w-full aspect-square border-2 border-black rounded-md touch-none select-none w-72 relative;
         background-color: var(--canvas);
-        color: var(--canvastext);
+        color: var(--canvasText);
     }
     .jsxgraph-container {
         @apply w-full h-full;

--- a/packages/doenetml-prototype/src/renderers/doenet/graph.tsx
+++ b/packages/doenetml-prototype/src/renderers/doenet/graph.tsx
@@ -89,11 +89,11 @@ export const Graph: BasicComponent<GraphData> = ({ node }) => {
                     visible: true,
                     majorHeight: 10,
                     minorHeight: 5,
-                    strokeColor: "var(--canvastext)",
+                    strokeColor: "var(--canvasText)",
                     strokeWidth: 1,
                 },
                 highlight: false,
-                strokeColor: "var(--canvastext)",
+                strokeColor: "var(--canvasText)",
             },
         );
         setXaxis(xaxis);
@@ -108,11 +108,11 @@ export const Graph: BasicComponent<GraphData> = ({ node }) => {
                     visible: true,
                     majorHeight: 10,
                     minorHeight: 5,
-                    strokeColor: "var(--canvastext)",
+                    strokeColor: "var(--canvasText)",
                     strokeWidth: 1,
                 },
                 highlight: false,
-                strokeColor: "var(--canvastext)",
+                strokeColor: "var(--canvasText)",
             },
         );
         setYaxis(yaxis);

--- a/packages/doenetml-prototype/src/styles/layout.css
+++ b/packages/doenetml-prototype/src/styles/layout.css
@@ -28,7 +28,7 @@
     --dn-primary: rgb(var(--dn-primary-color-raw));
     --dn-primary-accent: rgb(var(--dn-primary-color-accent-raw));
 
-    --canvastext: var(--dn-text);
+    --canvasText: var(--dn-text);
     --canvas: var(--dn-bg);
 
     color: var(--dn-text);

--- a/packages/doenetml-to-pretext/src/renderers/pretext-xml/graph.tsx
+++ b/packages/doenetml-to-pretext/src/renderers/pretext-xml/graph.tsx
@@ -52,7 +52,7 @@ export const Graph: BasicComponent = ({ node }) => {
         const style = svgDom.createElement("style");
         style.textContent = `
             :root {
-              --canvastext: black;
+              --canvasText: black;
               --lightBlue: hsl(209, 54%, 82%);
               --solidLightBlue: #8fb8de;
               --mainGray: #e3e3e3;

--- a/packages/doenetml-worker-javascript/src/components/Choice.js
+++ b/packages/doenetml-worker-javascript/src/components/Choice.js
@@ -1,3 +1,4 @@
+import { renameStateVariable } from "../utils/stateVariables";
 import { textFromChildren } from "../utils/text";
 import InlineComponent from "./abstract/InlineComponent";
 import me from "math-expressions";
@@ -50,6 +51,13 @@ export default class Choice extends InlineComponent {
 
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        // rename disabled to disabledOriginal
+        renameStateVariable({
+            stateVariableDefinitions,
+            oldName: "disabled",
+            newName: "disabledOriginal",
+        });
 
         stateVariableDefinitions.text = {
             public: true,
@@ -132,7 +140,7 @@ export default class Choice extends InlineComponent {
                     variableNames: ["selected"],
                 },
             }),
-            definition({ dependencyValues, componentIdx }) {
+            definition({ dependencyValues }) {
                 let selected;
                 if (dependencyValues.childIndicesSelected) {
                     selected = dependencyValues.childIndicesSelected.includes(
@@ -157,12 +165,20 @@ export default class Choice extends InlineComponent {
                 createComponentOfType: "boolean",
             },
             doNotShadowEssential: true,
+            additionalStateVariablesDefined: [
+                {
+                    variableName: "hasBeenSubmitted",
+                    defaultValue: false,
+                    hasEssential: true,
+                    doNotShadowEssential: true,
+                },
+            ],
             returnDependencies: () => ({
                 // Note: existence of primary shadow means that the choice is inside a shuffle or sort
                 // and the replacement from the shuffle/sort is the primary shadow (and the only one visible to parent)
                 primaryShadow: {
                     dependencyType: "primaryShadow",
-                    variableNames: ["submitted"],
+                    variableNames: ["submitted", "hasBeenSubmitted"],
                 },
             }),
             definition({ dependencyValues }) {
@@ -172,12 +188,16 @@ export default class Choice extends InlineComponent {
                             submitted:
                                 dependencyValues.primaryShadow.stateValues
                                     .submitted,
+                            hasBeenSubmitted:
+                                dependencyValues.primaryShadow.stateValues
+                                    .hasBeenSubmitted,
                         },
                     };
                 } else
                     return {
                         useEssentialOrDefaultValue: {
                             submitted: true,
+                            hasBeenSubmitted: true,
                         },
                     };
             },
@@ -186,20 +206,62 @@ export default class Choice extends InlineComponent {
                 dependencyValues,
             }) {
                 if (dependencyValues.primaryShadow) {
-                    // if have a primary shadow, then inversee definition should never be called
+                    // if have a primary shadow, then inverse definition should never be called
                     // as it will be called only on the shadow
                     return { success: false };
                 } else {
+                    const instructions = [
+                        {
+                            setEssentialValue: "submitted",
+                            value: desiredStateVariableValues.submitted,
+                        },
+                    ];
+                    if (desiredStateVariableValues.submitted) {
+                        instructions.push({
+                            setEssentialValue: "hasBeenSubmitted",
+                            value: desiredStateVariableValues.submitted,
+                        });
+                    }
                     return {
                         success: true,
-                        instructions: [
-                            {
-                                setEssentialValue: "submitted",
-                                value: desiredStateVariableValues.submitted,
-                            },
-                        ],
+                        instructions,
                     };
                 }
+            },
+        };
+
+        stateVariableDefinitions.disabled = {
+            public: true,
+            shadowingInstructions: {
+                createComponentOfType: "boolean",
+            },
+            forRenderer: true,
+            returnDependencies: () => ({
+                disabledOriginal: {
+                    dependencyType: "stateVariable",
+                    variableName: "disabledOriginal",
+                },
+                hasBeenSubmitted: {
+                    dependencyType: "stateVariable",
+                    variableName: "hasBeenSubmitted",
+                },
+                credit: {
+                    dependencyType: "stateVariable",
+                    variableName: "credit",
+                },
+                disableWrongChoices: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "choiceInput",
+                    variableName: "disableWrongChoices",
+                },
+            }),
+            definition({ dependencyValues }) {
+                const disabled =
+                    dependencyValues.disabledOriginal ||
+                    (dependencyValues.disableWrongChoices &&
+                        dependencyValues.hasBeenSubmitted &&
+                        dependencyValues.credit === 0);
+                return { setValue: { disabled } };
             },
         };
 

--- a/packages/doenetml-worker-javascript/src/components/Choice.js
+++ b/packages/doenetml-worker-javascript/src/components/Choice.js
@@ -254,13 +254,19 @@ export default class Choice extends InlineComponent {
                     parentComponentType: "choiceInput",
                     variableName: "disableWrongChoices",
                 },
+                selectMultiple: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "choiceInput",
+                    variableName: "selectMultiple",
+                },
             }),
             definition({ dependencyValues }) {
                 const disabled =
                     dependencyValues.disabledOriginal ||
                     (dependencyValues.disableWrongChoices &&
                         dependencyValues.hasBeenSubmitted &&
-                        dependencyValues.credit === 0);
+                        dependencyValues.credit < 1 &&
+                        !dependencyValues.selectMultiple);
                 return { setValue: { disabled } };
             },
         };

--- a/packages/doenetml-worker-javascript/src/components/ChoiceInput.js
+++ b/packages/doenetml-worker-javascript/src/components/ChoiceInput.js
@@ -534,6 +534,26 @@ export default class Choiceinput extends Input {
             },
         };
 
+        stateVariableDefinitions.disableWrongChoices = {
+            returnDependencies: () => ({
+                answerAncestor: {
+                    dependencyType: "ancestor",
+                    componentType: "answer",
+                    variableNames: ["disableWrongChoices"],
+                },
+            }),
+            definition: function ({ dependencyValues }) {
+                return {
+                    setValue: {
+                        disableWrongChoices: Boolean(
+                            dependencyValues.answerAncestor?.stateValues
+                                .disableWrongChoices,
+                        ),
+                    },
+                };
+            },
+        };
+
         stateVariableDefinitions.choicesDisabled = {
             isArray: true,
             forRenderer: true,

--- a/packages/doenetml-worker-javascript/src/components/Pretzel.js
+++ b/packages/doenetml-worker-javascript/src/components/Pretzel.js
@@ -348,20 +348,19 @@ export default class Pretzel extends BlockScoredComponent {
         sourceInformation = {},
         skipRendererUpdate = false,
     }) {
-        let numAttemptsLeft = await this.stateValues.numAttemptsLeft;
+        const numAttemptsLeft = await this.stateValues.numAttemptsLeft;
         if (numAttemptsLeft < 1) {
             return;
         }
 
-        let disabled = await this.stateValues.disabled;
+        const disabled = await this.stateValues.disabled;
         if (disabled) {
             return;
         }
 
-        let creditAchieved = await this.stateValues.creditAchievedIfSubmit;
-        if (await this.stateValues.handGraded) {
-            creditAchieved = 0;
-        }
+        const creditAchieved = (await this.stateValues.handGraded)
+            ? 0
+            : await this.stateValues.creditAchievedIfSubmit;
 
         // request to update credit
         let instructions = [
@@ -381,7 +380,6 @@ export default class Pretzel extends BlockScoredComponent {
 
         // add submitted responses to instruction for answer
         let currentResponses = await this.stateValues.currentResponses;
-        // let currentResponses = await this.state.currentResponses.value;
 
         instructions.push({
             updateType: "updateValue",
@@ -411,8 +409,17 @@ export default class Pretzel extends BlockScoredComponent {
             value: (await this.stateValues.numSubmissions) + 1,
         });
 
-        let responseText = [];
-        for (let response of currentResponses) {
+        if (creditAchieved < 1) {
+            instructions.push({
+                updateType: "updateValue",
+                componentIdx: this.componentIdx,
+                stateVariable: "numIncorrectSubmissions",
+                value: (await this.stateValues.numIncorrectSubmissions) + 1,
+            });
+        }
+
+        const responseText = [];
+        for (const response of currentResponses) {
             if (response.toString) {
                 try {
                     responseText.push(response.toString());

--- a/packages/doenetml-worker-javascript/src/components/abstract/Input.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/Input.js
@@ -36,6 +36,10 @@ export default class Input extends InlineComponent {
                         "showCorrectness",
                         "numAttemptsLeft",
                         "creditIsReducedByAttempt",
+                        "numIncorrectSubmissions",
+                        "numPreviousIncorrectSubmissions",
+                        "creditFactorUsed",
+                        "nextCreditFactor",
                     ],
                 },
             }),
@@ -201,6 +205,90 @@ export default class Input extends InlineComponent {
                     numAttemptsLeft = Infinity;
                 }
                 return { setValue: { numAttemptsLeft } };
+            },
+        };
+
+        stateVariableDefinitions.numIncorrectSubmissions = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                answerAncestor: {
+                    dependencyType: "stateVariable",
+                    variableName: "answerAncestor",
+                },
+            }),
+            definition({ dependencyValues }) {
+                let numIncorrectSubmissions;
+                if (dependencyValues.answerAncestor) {
+                    numIncorrectSubmissions =
+                        dependencyValues.answerAncestor.stateValues
+                            .numIncorrectSubmissions;
+                } else {
+                    numIncorrectSubmissions = 0;
+                }
+                return { setValue: { numIncorrectSubmissions } };
+            },
+        };
+
+        stateVariableDefinitions.numPreviousIncorrectSubmissions = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                answerAncestor: {
+                    dependencyType: "stateVariable",
+                    variableName: "answerAncestor",
+                },
+            }),
+            definition({ dependencyValues }) {
+                let numPreviousIncorrectSubmissions;
+                if (dependencyValues.answerAncestor) {
+                    numPreviousIncorrectSubmissions =
+                        dependencyValues.answerAncestor.stateValues
+                            .numPreviousIncorrectSubmissions;
+                } else {
+                    numPreviousIncorrectSubmissions = 0;
+                }
+                return { setValue: { numPreviousIncorrectSubmissions } };
+            },
+        };
+
+        stateVariableDefinitions.creditFactorUsed = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                answerAncestor: {
+                    dependencyType: "stateVariable",
+                    variableName: "answerAncestor",
+                },
+            }),
+            definition({ dependencyValues }) {
+                let creditFactorUsed;
+                if (dependencyValues.answerAncestor) {
+                    creditFactorUsed =
+                        dependencyValues.answerAncestor.stateValues
+                            .creditFactorUsed;
+                } else {
+                    creditFactorUsed = 1;
+                }
+                return { setValue: { creditFactorUsed } };
+            },
+        };
+
+        stateVariableDefinitions.nextCreditFactor = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                answerAncestor: {
+                    dependencyType: "stateVariable",
+                    variableName: "answerAncestor",
+                },
+            }),
+            definition({ dependencyValues }) {
+                let nextCreditFactor;
+                if (dependencyValues.answerAncestor) {
+                    nextCreditFactor =
+                        dependencyValues.answerAncestor.stateValues
+                            .nextCreditFactor;
+                } else {
+                    nextCreditFactor = 1;
+                }
+                return { setValue: { nextCreditFactor } };
             },
         };
 

--- a/packages/doenetml-worker-javascript/src/components/abstract/Input.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/Input.js
@@ -35,6 +35,7 @@ export default class Input extends InlineComponent {
                         "creditAchieved",
                         "showCorrectness",
                         "numAttemptsLeft",
+                        "creditIsReducedByAttempt",
                     ],
                 },
             }),
@@ -111,27 +112,27 @@ export default class Input extends InlineComponent {
                 };
             },
         };
-        //TODO: disabled is now in basecomponent - how to make it work with collaborateGroups
-        // stateVariableDefinitions.disabled = {
-        //   forRenderer: true,
-        //   returnDependencies: () => ({
-        //     collaborateGroups: {
-        //       dependencyType: "stateVariable",
-        //       variableName: "collaborateGroups"
-        //     },
-        //     collaboration: {
-        //       dependencyType: "flag",
-        //       flagName: "collaboration"
-        //     }
-        //   }),
-        //   definition: function ({ dependencyValues }) {
-        //     let disabled = false;
-        //     if (dependencyValues.collaborateGroups) {
-        //       disabled = !dependencyValues.collaborateGroups.matchGroup(dependencyValues.collaboration)
-        //     }
-        //     return { setValue: { disabled } }
-        //   }
-        // }
+
+        stateVariableDefinitions.creditIsReducedByAttempt = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                answerAncestor: {
+                    dependencyType: "stateVariable",
+                    variableName: "answerAncestor",
+                },
+            }),
+            definition: function ({ dependencyValues }) {
+                let creditIsReducedByAttempt = false;
+                if (dependencyValues.answerAncestor) {
+                    creditIsReducedByAttempt =
+                        dependencyValues.answerAncestor.stateValues
+                            .creditIsReducedByAttempt;
+                }
+                return {
+                    setValue: { creditIsReducedByAttempt },
+                };
+            },
+        };
 
         stateVariableDefinitions.justSubmitted = {
             forRenderer: true,

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/answer.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/answer.test.ts
@@ -6534,6 +6534,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(1);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(1);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(0);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(0);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(1);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(1);
 
         // resubmitting correct answer does not reduce credit
         await updateMathInputValue({
@@ -6550,6 +6560,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(1);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(2);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(0);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(0);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(1);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(1);
 
         // submit incorrect answer
         await updateMathInputValue({
@@ -6561,6 +6581,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(3);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(1);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(0);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(1);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(0.8);
 
         // credit for correct answer is reduced
         await updateMathInputValue({
@@ -6572,6 +6602,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.8);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(4);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(1);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(1);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(0.8);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(0.8);
 
         // resubmitting correct answer does not reduce credit
         await updateMathInputValue({
@@ -6588,6 +6628,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.8);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(5);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(1);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(1);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(0.8);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(0.8);
 
         // submit incorrect answer
         await updateMathInputValue({
@@ -6599,6 +6649,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(6);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(2);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(1);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(0.8);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(0.7);
 
         // credit for correct answer is further reduced
         await updateMathInputValue({
@@ -6610,6 +6670,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.7);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(7);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(2);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(2);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(0.7);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(0.7);
 
         // submit incorrect answer
         await updateMathInputValue({
@@ -6621,6 +6691,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(8);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(3);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(2);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(0.7);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(0.7);
 
         // credit for correct answer is not reduced further
         await updateMathInputValue({
@@ -6632,6 +6712,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.7);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(9);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(3);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(3);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(0.7);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(0.7);
     });
 
     it("credit reduction per attempt", async () => {
@@ -6656,6 +6746,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(1);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(1);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(0);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(0);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(1);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(1);
 
         // resubmitting correct answer does not reduce credit
         await updateMathInputValue({
@@ -6672,6 +6772,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(1);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(2);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(0);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(0);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(1);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(1);
 
         // submit incorrect answer
         await updateMathInputValue({
@@ -6683,6 +6793,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(3);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(1);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(0);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(1);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(0.6);
 
         // credit for correct answer is reduced
         await updateMathInputValue({
@@ -6694,6 +6814,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.6);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(4);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(1);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(1);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(0.6);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(0.6);
 
         // resubmitting correct answer does not reduce credit
         await updateMathInputValue({
@@ -6710,6 +6840,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.6);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(5);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(1);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(1);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(0.6);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(0.6);
 
         // submit incorrect answer
         await updateMathInputValue({
@@ -6721,6 +6861,19 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(6);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(2);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(1);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(0.6);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).closeTo(
+            0.2,
+            1e-14,
+        );
 
         // credit for correct answer is further reduced
         await updateMathInputValue({
@@ -6735,6 +6888,22 @@ What is the derivative of <function name="f">x^2</function>?
             0.2,
             1e-14,
         );
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(7);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(2);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(2);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).closeTo(
+            0.2,
+            1e-14,
+        );
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).closeTo(
+            0.2,
+            1e-14,
+        );
 
         // submit incorrect answer
         await updateMathInputValue({
@@ -6746,6 +6915,22 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(8);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(3);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(2);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).closeTo(
+            0.2,
+            1e-14,
+        );
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).closeTo(
+            0.01,
+            1e-14,
+        );
 
         // credit for correct answer is reduced to default limit
         await updateMathInputValue({
@@ -6760,6 +6945,22 @@ What is the derivative of <function name="f">x^2</function>?
             0.01,
             1e-14,
         );
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(9);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(3);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(3);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).closeTo(
+            0.01,
+            1e-14,
+        );
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).closeTo(
+            0.01,
+            1e-14,
+        );
 
         // submit incorrect answer
         await updateMathInputValue({
@@ -6771,6 +6972,22 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(10);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(4);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(3);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).closeTo(
+            0.01,
+            1e-14,
+        );
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).closeTo(
+            0.01,
+            1e-14,
+        );
 
         // credit for correct answer is not reduced further
         await updateMathInputValue({
@@ -6782,6 +6999,22 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).closeTo(
+            0.01,
+            1e-14,
+        );
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(11);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(4);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(4);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).closeTo(
+            0.01,
+            1e-14,
+        );
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).closeTo(
             0.01,
             1e-14,
         );
@@ -6809,6 +7042,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(1);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(1);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(0);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(0);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(1);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(1);
 
         // resubmitting correct answer does not reduce credit
         await updateMathInputValue({
@@ -6825,6 +7068,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(1);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(2);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(0);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(0);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(1);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(1);
 
         // submit incorrect answer
         await updateMathInputValue({
@@ -6836,6 +7089,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(3);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(1);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(0);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(1);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(0.6);
 
         // credit for correct answer is reduced
         await updateMathInputValue({
@@ -6847,6 +7110,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.6);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(4);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(1);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(1);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(0.6);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(0.6);
 
         // resubmitting correct answer does not reduce credit
         await updateMathInputValue({
@@ -6863,6 +7136,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.6);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(5);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(1);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(1);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(0.6);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(0.6);
 
         // submit incorrect answer
         await updateMathInputValue({
@@ -6874,6 +7157,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(6);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(2);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(1);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(0.6);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(0.4);
 
         // credit for correct answer is further reduced
         await updateMathInputValue({
@@ -6885,6 +7178,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.4);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(7);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(2);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(2);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(0.4);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(0.4);
 
         // submit incorrect answer
         await updateMathInputValue({
@@ -6896,6 +7199,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(8);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(3);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(2);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(0.4);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(0.4);
 
         // credit for correct answer is not reduced further
         await updateMathInputValue({
@@ -6907,6 +7220,16 @@ What is the derivative of <function name="f">x^2</function>?
 
         stateVariables = await core.returnAllStateVariables(false, true);
         expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.4);
+        expect(stateVariables[answerIdx].stateValues.numSubmissions).eq(9);
+        expect(
+            stateVariables[answerIdx].stateValues.numIncorrectSubmissions,
+        ).eq(3);
+        expect(
+            stateVariables[answerIdx].stateValues
+                .numPreviousIncorrectSubmissions,
+        ).eq(3);
+        expect(stateVariables[answerIdx].stateValues.creditFactorUsed).eq(0.4);
+        expect(stateVariables[answerIdx].stateValues.nextCreditFactor).eq(0.4);
     });
 
     it("credit factor by attempt supersedes credit reduction per attempt and credit reduction limit", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/answer.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/answer.test.ts
@@ -6511,4 +6511,624 @@ What is the derivative of <function name="f">x^2</function>?
                 .creditAchieved,
         ).eq(1);
     });
+
+    it("credit factor by attempt", async () => {
+        const doenetML = `
+    <answer name="ans" creditFactorByAttempt="1 0.8 0.7">x</answer>
+  `;
+
+        let { core, resolvePathToNodeIdx } = await createTestCore({ doenetML });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        const answerIdx = await resolvePathToNodeIdx("ans");
+        const mathInputIdx =
+            stateVariables[answerIdx].stateValues.inputChildren[0].componentIdx;
+
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(1);
+
+        // resubmitting correct answer does not reduce credit
+        await updateMathInputValue({
+            latex: "y",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(1);
+
+        // submit incorrect answer
+        await updateMathInputValue({
+            latex: "y",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+
+        // credit for correct answer is reduced
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.8);
+
+        // resubmitting correct answer does not reduce credit
+        await updateMathInputValue({
+            latex: "z",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.8);
+
+        // submit incorrect answer
+        await updateMathInputValue({
+            latex: "y",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+
+        // credit for correct answer is further reduced
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.7);
+
+        // submit incorrect answer
+        await updateMathInputValue({
+            latex: "z",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+
+        // credit for correct answer is not reduced further
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.7);
+    });
+
+    it("credit reduction per attempt", async () => {
+        const doenetML = `
+    <answer name="ans" creditReductionPerAttempt="0.4">x</answer>
+  `;
+
+        let { core, resolvePathToNodeIdx } = await createTestCore({ doenetML });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        const answerIdx = await resolvePathToNodeIdx("ans");
+        const mathInputIdx =
+            stateVariables[answerIdx].stateValues.inputChildren[0].componentIdx;
+
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(1);
+
+        // resubmitting correct answer does not reduce credit
+        await updateMathInputValue({
+            latex: "y",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(1);
+
+        // submit incorrect answer
+        await updateMathInputValue({
+            latex: "y",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+
+        // credit for correct answer is reduced
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.6);
+
+        // resubmitting correct answer does not reduce credit
+        await updateMathInputValue({
+            latex: "z",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.6);
+
+        // submit incorrect answer
+        await updateMathInputValue({
+            latex: "y",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+
+        // credit for correct answer is further reduced
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).closeTo(
+            0.2,
+            1e-14,
+        );
+
+        // submit incorrect answer
+        await updateMathInputValue({
+            latex: "z",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+
+        // credit for correct answer is reduced to default limit
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).closeTo(
+            0.01,
+            1e-14,
+        );
+
+        // submit incorrect answer
+        await updateMathInputValue({
+            latex: "x^2",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+
+        // credit for correct answer is not reduced further
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).closeTo(
+            0.01,
+            1e-14,
+        );
+    });
+
+    it("credit reduction per attempt with credit reduction limit", async () => {
+        const doenetML = `
+    <answer name="ans" creditReductionPerAttempt="0.4" creditReductionLimit="0.6">x</answer>
+  `;
+
+        let { core, resolvePathToNodeIdx } = await createTestCore({ doenetML });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        const answerIdx = await resolvePathToNodeIdx("ans");
+        const mathInputIdx =
+            stateVariables[answerIdx].stateValues.inputChildren[0].componentIdx;
+
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(1);
+
+        // resubmitting correct answer does not reduce credit
+        await updateMathInputValue({
+            latex: "y",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(1);
+
+        // submit incorrect answer
+        await updateMathInputValue({
+            latex: "y",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+
+        // credit for correct answer is reduced
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.6);
+
+        // resubmitting correct answer does not reduce credit
+        await updateMathInputValue({
+            latex: "z",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.6);
+
+        // submit incorrect answer
+        await updateMathInputValue({
+            latex: "y",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+
+        // credit for correct answer is further reduced
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.4);
+
+        // submit incorrect answer
+        await updateMathInputValue({
+            latex: "z",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+
+        // credit for correct answer is not reduced further
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.4);
+    });
+
+    it("credit factor by attempt supersedes credit reduction per attempt and credit reduction limit", async () => {
+        const doenetML = `
+    <answer name="ans" creditFactorByAttempt="1 0.8 0.7" creditReductionPerAttempt="0.4" creditReductionLimit="0.1">x</answer>
+  `;
+
+        let { core, resolvePathToNodeIdx } = await createTestCore({ doenetML });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        const answerIdx = await resolvePathToNodeIdx("ans");
+        const mathInputIdx =
+            stateVariables[answerIdx].stateValues.inputChildren[0].componentIdx;
+
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(1);
+
+        // resubmitting correct answer does not reduce credit
+        await updateMathInputValue({
+            latex: "y",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(1);
+
+        // submit incorrect answer
+        await updateMathInputValue({
+            latex: "y",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+
+        // credit for correct answer is reduced
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.8);
+
+        // resubmitting correct answer does not reduce credit
+        await updateMathInputValue({
+            latex: "z",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.8);
+
+        // submit incorrect answer
+        await updateMathInputValue({
+            latex: "y",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+
+        // credit for correct answer is further reduced
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.7);
+
+        // submit incorrect answer
+        await updateMathInputValue({
+            latex: "z",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+
+        // credit for correct answer is not reduced further
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: mathInputIdx,
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0.7);
+    });
+
+    it("disable wrong choices", async () => {
+        const doenetML = `
+    <answer name="ans" disableWrongChoices>
+        <choice>A</choice>
+        <choice credit="1">B</choice>
+        <choice>C</choice>
+    </answer>
+  `;
+
+        let { core, resolvePathToNodeIdx } = await createTestCore({ doenetML });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        const answerIdx = await resolvePathToNodeIdx("ans");
+        const choiceInputIdx =
+            stateVariables[answerIdx].stateValues.inputChildren[0].componentIdx;
+        const choiceIndices = stateVariables[choiceInputIdx].activeChildren.map(
+            (child) => child.componentIdx,
+        );
+
+        expect(
+            choiceIndices.map(
+                (idx) => stateVariables[idx].stateValues.disabled,
+            ),
+        ).eqls([false, false, false]);
+
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+        expect(
+            choiceIndices.map(
+                (idx) => stateVariables[idx].stateValues.disabled,
+            ),
+        ).eqls([false, false, false]);
+
+        // submit correct answer
+        await updateSelectedIndices({
+            componentIdx: choiceInputIdx,
+            selectedIndices: [2],
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(1);
+        expect(
+            choiceIndices.map(
+                (idx) => stateVariables[idx].stateValues.disabled,
+            ),
+        ).eqls([false, false, false]);
+
+        // submitting incorrect answer disables choice
+        await updateSelectedIndices({
+            componentIdx: choiceInputIdx,
+            selectedIndices: [1],
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+        expect(
+            choiceIndices.map(
+                (idx) => stateVariables[idx].stateValues.disabled,
+            ),
+        ).eqls([true, false, false]);
+
+        // submit correct answer again
+        await updateSelectedIndices({
+            componentIdx: choiceInputIdx,
+            selectedIndices: [2],
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(1);
+        expect(
+            choiceIndices.map(
+                (idx) => stateVariables[idx].stateValues.disabled,
+            ),
+        ).eqls([true, false, false]);
+
+        // submit other incorrect answer disables that choice
+        await updateSelectedIndices({
+            componentIdx: choiceInputIdx,
+            selectedIndices: [3],
+            core,
+        });
+        await submitAnswer({ componentIdx: answerIdx, core });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(stateVariables[answerIdx].stateValues.creditAchieved).eq(0);
+        expect(
+            choiceIndices.map(
+                (idx) => stateVariables[idx].stateValues.disabled,
+            ),
+        ).eqls([true, false, true]);
+    });
 });

--- a/packages/doenetml-worker-javascript/src/utils/answer.js
+++ b/packages/doenetml-worker-javascript/src/utils/answer.js
@@ -382,6 +382,7 @@ export function returnStandardAnswerStateVariableDefinition() {
     stateVariableDefinitions.numIncorrectSubmissions = {
         defaultValue: 0,
         hasEssential: true,
+        forRenderer: true,
         returnDependencies: () => ({}),
         definition: () => ({
             useEssentialOrDefaultValue: {

--- a/packages/doenetml-worker-javascript/src/utils/answer.js
+++ b/packages/doenetml-worker-javascript/src/utils/answer.js
@@ -379,6 +379,26 @@ export function returnStandardAnswerStateVariableDefinition() {
         }),
     };
 
+    stateVariableDefinitions.numIncorrectSubmissions = {
+        defaultValue: 0,
+        hasEssential: true,
+        returnDependencies: () => ({}),
+        definition: () => ({
+            useEssentialOrDefaultValue: {
+                numIncorrectSubmissions: true,
+            },
+        }),
+        inverseDefinition: ({ desiredStateVariableValues }) => ({
+            success: true,
+            instructions: [
+                {
+                    setEssentialValue: "numIncorrectSubmissions",
+                    value: desiredStateVariableValues.numIncorrectSubmissions,
+                },
+            ],
+        }),
+    };
+
     stateVariableDefinitions.numAttemptsLeft = {
         public: true,
         shadowingInstructions: {

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.7.0-alpha55",
+    "version": "0.7.0-beta1",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml/src/DoenetML.css
+++ b/packages/doenetml/src/DoenetML.css
@@ -70,7 +70,7 @@ html {
     --lightRed: hsl(0, 54%, 82%);
     --mainGreen: #459152;
     --canvas: white;
-    --canvastext: black;
+    --canvasText: black;
     --lightGreen: #a6f19f;
     --lightYellow: #f5ed85;
     --whiteBlankLink: #6d4445;
@@ -93,7 +93,7 @@ html {
     --lightRed: hsl(0, 54%, 82%);
     --mainGreen: #459152;
     --canvas: #121212;
-    --canvastext: white;
+    --canvasText: white;
     --lightGreen: #a6f19f;
     --lightYellow: #f5ed85;
     --whiteBlankLink: #a9abe5;
@@ -102,7 +102,7 @@ html {
 }
 .doenet-viewer {
     font-family: "Open Sans" !important;
-    color: var(--canvastext);
+    color: var(--canvasText);
 }
 .doenet-viewer h1 {
     font-size: 2em;

--- a/packages/doenetml/src/Viewer/renderers/booleanInput.css
+++ b/packages/doenetml/src/Viewer/renderers/booleanInput.css
@@ -47,7 +47,7 @@
     width: 18px;
     background-color: var(--mainGray);
     border-style: solid;
-    border-color: var(--canvastext);
+    border-color: var(--canvasText);
     border-radius: var(--mainBorderRadius);
     border-width: 2px;
     box-sizing: content-box;
@@ -81,7 +81,7 @@
 .doenetml-boolean-container:focus-within
     input[type="checkbox"]
     ~ .doenetml-checkmark {
-    outline: 2px solid var(--canvastext);
+    outline: 2px solid var(--canvasText);
     outline-offset: 2px;
 }
 

--- a/packages/doenetml/src/Viewer/renderers/booleanInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/booleanInput.tsx
@@ -94,8 +94,8 @@ export default React.memo(function BooleanInput(props: UseDoenetRendererProps) {
             disabled: SVs.disabled,
             checked: rendererValue,
             useMathJax: SVs.labelHasLatex,
-            strokeColor: "var(--canvastext)",
-            highlightStrokeColor: "var(--canvastext)",
+            strokeColor: "var(--canvasText)",
+            highlightStrokeColor: "var(--canvasText)",
             highlight: !fixLocation.current,
             parse: false,
         };

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.css
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.css
@@ -48,7 +48,7 @@
     width: 18px;
     background-color: var(--mainGray);
     border-style: solid;
-    border-color: var(--canvastext);
+    border-color: var(--canvasText);
     border-radius: 50%;
 }
 
@@ -151,7 +151,7 @@
     width: 18px;
     background-color: var(--mainGray);
     border-style: solid;
-    border-color: var(--canvastext);
+    border-color: var(--canvasText);
     border-radius: var(--mainBorderRadius);
 }
 

--- a/packages/doenetml/src/Viewer/renderers/circle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/circle.tsx
@@ -142,7 +142,7 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
             if (SVs.applyStyleToLabel) {
                 jsxCircleAttributes.label.strokeColor = lineColor;
             } else {
-                jsxCircleAttributes.label.strokeColor = "var(--canvastext)";
+                jsxCircleAttributes.label.strokeColor = "var(--canvasText)";
             }
         }
 
@@ -201,7 +201,7 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
             if (SVs.applyStyleToLabel) {
                 jsxPointAttributes.label.strokeColor = markerColor;
             } else {
-                jsxPointAttributes.label.strokeColor = "var(--canvastext)";
+                jsxPointAttributes.label.strokeColor = "var(--canvasText)";
             }
         } else {
             jsxPointAttributes.label = {
@@ -931,7 +931,7 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
                     circleJXG.current.label.visProp.strokecolor = lineColor;
                 } else {
                     circleJXG.current.label.visProp.strokecolor =
-                        "var(--canvastext)";
+                        "var(--canvasText)";
                 }
                 circleJXG.current.label.needsUpdate = true;
                 circleJXG.current.label.update();
@@ -1007,7 +1007,7 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
                             markerColor;
                     } else {
                         indicatorJXG.current.label.visProp.strokecolor =
-                            "var(--canvastext)";
+                            "var(--canvasText)";
                     }
 
                     let labelPosition = adjustPointLabelPosition(

--- a/packages/doenetml/src/Viewer/renderers/curve.tsx
+++ b/packages/doenetml/src/Viewer/renderers/curve.tsx
@@ -160,7 +160,7 @@ export default React.memo(function Curve(props) {
             if (SVs.applyStyleToLabel) {
                 curveAttributes.label.strokeColor = lineColor;
             } else {
-                curveAttributes.label.strokeColor = "var(canvastext)";
+                curveAttributes.label.strokeColor = "var(canvasText)";
             }
         } else {
             curveAttributes.label = {
@@ -849,7 +849,7 @@ export default React.memo(function Curve(props) {
                     curveJXG.current.label.visProp.strokecolor = lineColor;
                 } else {
                     curveJXG.current.label.visProp.strokecolor =
-                        "var(canvastext)";
+                        "var(canvasText)";
                 }
                 curveJXG.current.label.update();
             }

--- a/packages/doenetml/src/Viewer/renderers/feedback.tsx
+++ b/packages/doenetml/src/Viewer/renderers/feedback.tsx
@@ -11,12 +11,12 @@ const FeedbackStyling = styled.aside`
     background-color: var(--canvas);
     margin: 0px 4px 12px 4px;
     padding: 1em;
-    border: 2px solid var(--canvastext);
+    border: 2px solid var(--canvasText);
     border-top: 0px;
     border-bottom-left-radius: 5px;
     border-bottom-right-radius: 5px;
     //   &: focus {
-    //   outline: 2px solid var(--canvastext);
+    //   outline: 2px solid var(--canvasText);
     //   outline-offset: 2px;
     //  }
 `;
@@ -24,12 +24,12 @@ const SpanStyling = styled.span`
     display: block;
     margin: 12px 4px 0px 4px;
     padding: 6px;
-    border: 2px solid var(--canvastext);
+    border: 2px solid var(--canvasText);
     border-top-left-radius: 5px;
     border-top-right-radius: 5px;
     background-color: var(--mainGray);
     &: focus {
-        outline: 2px solid var(--canvastext);
+        outline: 2px solid var(--canvasText);
         outline-offset: 2px;
     }
 `;

--- a/packages/doenetml/src/Viewer/renderers/graph.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graph.tsx
@@ -60,8 +60,8 @@ export default React.memo(function Graph(props) {
         previousBoundingbox.current = boundingbox;
 
         JXG.Options.layer.numlayers = 100;
-        JXG.Options.navbar.highlightFillColor = "var(--canvastext)";
-        JXG.Options.navbar.strokeColor = "var(--canvastext)";
+        JXG.Options.navbar.highlightFillColor = "var(--canvasText)";
+        JXG.Options.navbar.strokeColor = "var(--canvasText)";
 
         // check if have grid with specified width
         let haveFixedGrid = false;
@@ -211,14 +211,14 @@ export default React.memo(function Graph(props) {
     }
 
     if (SVs.showBorder) {
-        divStyle.border = "2px solid var(--canvastext)";
+        divStyle.border = "2px solid var(--canvasText)";
     } else {
         divStyle.border = "none";
     }
     divStyle.marginBottom = "12px";
     divStyle.marginTop = "12px";
     divStyle.backgroundColor = "var(--canvas)";
-    divStyle.color = "var(--canvastext)";
+    divStyle.color = "var(--canvasText)";
 
     if (!board) {
         return (
@@ -463,7 +463,7 @@ export default React.memo(function Graph(props) {
                 position,
                 offset,
                 anchorx,
-                strokeColor: "var(--canvastext)",
+                strokeColor: "var(--canvasText)",
                 highlight: false,
             };
             if (SVs.yLabelHasLatex) {
@@ -472,7 +472,7 @@ export default React.memo(function Graph(props) {
         }
         previousYaxisWithLabel.current = Boolean(SVs.yLabel);
 
-        yaxisOptions.strokeColor = "var(--canvastext)";
+        yaxisOptions.strokeColor = "var(--canvasText)";
         yaxisOptions.highlight = false;
 
         yaxisOptions.ticks = {
@@ -480,11 +480,11 @@ export default React.memo(function Graph(props) {
             label: {
                 offset: [12, -2],
                 layer: 2,
-                strokeColor: "var(--canvastext)",
-                highlightStrokeColor: "var(--canvastext)",
+                strokeColor: "var(--canvasText)",
+                highlightStrokeColor: "var(--canvasText)",
                 highlightStrokeOpacity: 1,
             },
-            strokeColor: "var(--canvastext)",
+            strokeColor: "var(--canvasText)",
             strokeOpacity: 0.5,
             // minorTicks: 4,
             precision: 4,
@@ -658,7 +658,7 @@ export default React.memo(function Graph(props) {
                 position,
                 offset,
                 anchorx,
-                strokeColor: "var(--canvastext)",
+                strokeColor: "var(--canvasText)",
                 highlight: false,
             };
             if (SVs.xLabelHasLatex) {
@@ -672,11 +672,11 @@ export default React.memo(function Graph(props) {
             label: {
                 offset: [-5, -15],
                 layer: 2,
-                strokeColor: "var(--canvastext)",
-                highlightStrokeColor: "var(--canvastext)",
+                strokeColor: "var(--canvasText)",
+                highlightStrokeColor: "var(--canvasText)",
                 highlightStrokeOpacity: 1,
             },
-            strokeColor: "var(--canvastext)",
+            strokeColor: "var(--canvasText)",
             strokeOpacity: 0.5,
             // minorTicks: 4,
             precision: 4,
@@ -691,7 +691,7 @@ export default React.memo(function Graph(props) {
                 xaxisOptions.ticks.scaleSymbol = scaleSymbol;
             }
         }
-        xaxisOptions.strokeColor = "var(--canvastext)";
+        xaxisOptions.strokeColor = "var(--canvasText)";
         xaxisOptions.highlight = false;
 
         if (SVs.grid === "dense") {
@@ -884,7 +884,7 @@ export default React.memo(function Graph(props) {
             navigationBar.appendChild(button);
             button.setAttribute(
                 "style",
-                "color: var(--canvastext); opacity: 0.7",
+                "color: var(--canvasText); opacity: 0.7",
             );
             let text_node = document.createTextNode(label);
             button.appendChild(text_node);

--- a/packages/doenetml/src/Viewer/renderers/hint.tsx
+++ b/packages/doenetml/src/Viewer/renderers/hint.tsx
@@ -12,7 +12,7 @@ import { addCommasForCompositeRanges } from "./utils/composites";
 
 const SpanStyling = styled.span`
     &: focus {
-        outline: 2px solid var(--canvastext);
+        outline: 2px solid var(--canvasText);
         outline-offset: 2px;
     }
 `;
@@ -94,7 +94,7 @@ export default React.memo(function Hint(props: UseDoenetRendererProps) {
             display: "block",
             margin: "0px 4px 12px 4px",
             padding: "6px",
-            border: "2px solid var(--canvastext)",
+            border: "2px solid var(--canvasText)",
             borderTop: "0px",
             borderBottomLeftRadius: "5px",
             borderBottomRightRadius: "5px",
@@ -122,7 +122,7 @@ export default React.memo(function Hint(props: UseDoenetRendererProps) {
                     display: "block",
                     margin: SVs.open ? "12px 4px 0px 4px" : "12px 4px 12px 4px",
                     padding: "6px",
-                    border: "2px solid var(--canvastext)",
+                    border: "2px solid var(--canvasText)",
                     borderTopLeftRadius: "5px",
                     borderTopRightRadius: "5px",
                     borderBottomLeftRadius: SVs.open ? "0px" : "5px",

--- a/packages/doenetml/src/Viewer/renderers/line.tsx
+++ b/packages/doenetml/src/Viewer/renderers/line.tsx
@@ -127,7 +127,7 @@ export default React.memo(function Line(props) {
             if (SVs.applyStyleToLabel) {
                 jsxLineAttributes.label.strokeColor = lineColor;
             } else {
-                jsxLineAttributes.label.strokeColor = "var(--canvastext)";
+                jsxLineAttributes.label.strokeColor = "var(--canvasText)";
             }
         } else {
             jsxLineAttributes.label = {
@@ -454,7 +454,7 @@ export default React.memo(function Line(props) {
                     lineJXG.current.label.visProp.strokecolor = lineColor;
                 } else {
                     lineJXG.current.label.visProp.strokecolor =
-                        "var(--canvastext)";
+                        "var(--canvasText)";
                 }
                 if (SVs.labelPosition !== previousLabelPosition.current) {
                     let anchorx, anchory, offset;

--- a/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
+++ b/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
@@ -129,7 +129,7 @@ export default React.memo(function LineSegment(props) {
             if (SVs.applyStyleToLabel) {
                 jsxSegmentAttributes.label.strokeColor = lineColor;
             } else {
-                jsxSegmentAttributes.label.strokeColor = "var(--canvastext)";
+                jsxSegmentAttributes.label.strokeColor = "var(--canvasText)";
             }
         } else {
             jsxSegmentAttributes.label = {
@@ -698,7 +698,7 @@ export default React.memo(function LineSegment(props) {
                         lineColor;
                 } else {
                     lineSegmentJXG.current.label.visProp.strokecolor =
-                        "var(--canvastext)";
+                        "var(--canvasText)";
                 }
                 if (SVs.labelPosition !== previousLabelPosition.current) {
                     let anchorx, anchory, offset;

--- a/packages/doenetml/src/Viewer/renderers/mathInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.tsx
@@ -210,13 +210,13 @@ export default function MathInput(props: UseDoenetRendererProps) {
     let mathInputStyle: React.CSSProperties = {
         /* Set each border attribute separately since the borderColor is updated during rerender (checking mathInput's disabled state)
     Currently does not work with border: "var(--mainBorder)" */
-        borderColor: "var(--canvastext)",
+        borderColor: "var(--canvasText)",
         borderStyle: "solid",
         borderWidth: "2px",
         margin: "0px",
         boxShadow: "none",
         outlineOffset: "2px",
-        outlineColor: "var(--canvastext)",
+        outlineColor: "var(--canvasText)",
         outlineWidth: "2px",
         backgroundColor: "var(--canvas)",
         minWidth: `${SVs.minWidth > 0 ? SVs.minWidth : 0}px`,

--- a/packages/doenetml/src/Viewer/renderers/point.tsx
+++ b/packages/doenetml/src/Viewer/renderers/point.tsx
@@ -146,7 +146,7 @@ export default React.memo(function Point(props: UseDoenetRendererProps) {
             if (SVs.applyStyleToLabel) {
                 jsxPointAttributes.label.strokeColor = markerColor;
             } else {
-                jsxPointAttributes.label.strokeColor = "var(--canvastext)";
+                jsxPointAttributes.label.strokeColor = "var(--canvasText)";
             }
         } else {
             jsxPointAttributes.label = {
@@ -636,7 +636,7 @@ export default React.memo(function Point(props: UseDoenetRendererProps) {
                     pointJXG.current.label.visProp.strokecolor = markerColor;
                 } else {
                     pointJXG.current.label.visProp.strokecolor =
-                        "var(--canvastext)";
+                        "var(--canvasText)";
                 }
 
                 let labelPosition = adjustPointLabelPosition(

--- a/packages/doenetml/src/Viewer/renderers/polygon.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polygon.tsx
@@ -127,7 +127,7 @@ export default React.memo(function Polygon(props) {
         if (SVs.applyStyleToLabel) {
             jsxPolygonAttributes.label.strokeColor = lineColor;
         } else {
-            jsxPolygonAttributes.label.strokeColor = "var(--canvastext)";
+            jsxPolygonAttributes.label.strokeColor = "var(--canvasText)";
         }
 
         if (SVs.filled) {
@@ -581,7 +581,7 @@ export default React.memo(function Polygon(props) {
                     polygonJXG.current.label.visProp.strokecolor = lineColor;
                 } else {
                     polygonJXG.current.label.visProp.strokecolor =
-                        "var(--canvastext)";
+                        "var(--canvasText)";
                 }
                 polygonJXG.current.label.needsUpdate = true;
                 polygonJXG.current.label.update();

--- a/packages/doenetml/src/Viewer/renderers/polyline.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polyline.tsx
@@ -126,7 +126,7 @@ export default React.memo(function Polyline(props) {
         if (SVs.applyStyleToLabel) {
             jsxPolylineAttributes.label.strokeColor = lineColor;
         } else {
-            jsxPolylineAttributes.label.strokeColor = "var(--canvastext)";
+            jsxPolylineAttributes.label.strokeColor = "var(--canvasText)";
         }
 
         // create invisible points at endpoints
@@ -627,7 +627,7 @@ export default React.memo(function Polyline(props) {
                     polylineJXG.current.label.visProp.strokecolor = lineColor;
                 } else {
                     polylineJXG.current.label.visProp.strokecolor =
-                        "var(--canvastext)";
+                        "var(--canvasText)";
                 }
                 polylineJXG.current.label.needsUpdate = true;
                 polylineJXG.current.label.update();

--- a/packages/doenetml/src/Viewer/renderers/pretzel.tsx
+++ b/packages/doenetml/src/Viewer/renderers/pretzel.tsx
@@ -34,9 +34,7 @@ export default React.memo(function Pretzel(props: UseDoenetRendererProps) {
         return null;
     }
 
-    let disabled = SVs.disabled;
-
-    let submitAnswer = () =>
+    const submitAnswer = () =>
         callAction({
             action: actions.submitAnswer,
         });

--- a/packages/doenetml/src/Viewer/renderers/ray.tsx
+++ b/packages/doenetml/src/Viewer/renderers/ray.tsx
@@ -98,7 +98,7 @@ export default React.memo(function Ray(props) {
         if (SVs.applyStyleToLabel) {
             jsxRayAttributes.label.strokeColor = lineColor;
         } else {
-            jsxRayAttributes.label.strokeColor = "var(--canvastext)";
+            jsxRayAttributes.label.strokeColor = "var(--canvasText)";
         }
 
         let through = [
@@ -391,7 +391,7 @@ export default React.memo(function Ray(props) {
                     rayJXG.current.label.visProp.strokecolor = lineColor;
                 } else {
                     rayJXG.current.label.visProp.strokecolor =
-                        "var(--canvastext)";
+                        "var(--canvasText)";
                 }
                 rayJXG.current.label.needsUpdate = true;
                 rayJXG.current.label.update();

--- a/packages/doenetml/src/Viewer/renderers/ref.tsx
+++ b/packages/doenetml/src/Viewer/renderers/ref.tsx
@@ -11,7 +11,7 @@ const RefButton = styled.button`
     display: inline-block;
     color: white;
     color: ${(props) =>
-        props.disabled ? "var(--canvastext)" : "var(--canvas)"};
+        props.disabled ? "var(--canvasText)" : "var(--canvas)"};
     background-color: ${(props) =>
         props.disabled ? "var(--mainGray)" : "var(--mainBlue)"};
 
@@ -26,7 +26,7 @@ const RefButton = styled.button`
         background-color: ${(props) =>
             props.disabled ? "var(--mainGray)" : "var(--lightBlue)"};
         color: ${(props) =>
-            props.disabled ? "var(--canvastext)" : "var(--canvas)"};
+            props.disabled ? "var(--canvasText)" : "var(--canvas)"};
     }
 
     &:focus {

--- a/packages/doenetml/src/Viewer/renderers/slider.tsx
+++ b/packages/doenetml/src/Viewer/renderers/slider.tsx
@@ -37,7 +37,7 @@ const SubContainer2 = styled.div`
 const StyledSlider = styled.div<{ width: string }>`
     position: relative;
     border-radius: 3px;
-    background-color: var(--canvastext);
+    background-color: var(--canvasText);
     height: 2px;
     width: ${(props) => props.width};
     user-select: none;
@@ -75,7 +75,7 @@ const Tick = styled.div<{ x: string }>`
 const Label = styled.p<{ x: string }>`
     position: absolute;
     left: ${(props) => props.x};
-    color: var(--canvastext);
+    color: var(--canvasText);
     font-size: 12px;
     top: 1px;
     user-select: none;

--- a/packages/doenetml/src/Viewer/renderers/solution.tsx
+++ b/packages/doenetml/src/Viewer/renderers/solution.tsx
@@ -19,7 +19,7 @@ const SpanStyling = styled.span`
     // background-color: var(--mainGray);
     // cursor: pointer;
     &: focus {
-        outline: 2px solid var(--canvastext);
+        outline: 2px solid var(--canvasText);
         outline-offset: 2px;
     }
 `;
@@ -63,7 +63,7 @@ export default React.memo(function Solution(props: UseDoenetRendererProps) {
             display: "block",
             margin: "0px 4px 12px 4px",
             padding: "6px",
-            border: "2px solid var(--canvastext)",
+            border: "2px solid var(--canvasText)",
             borderTop: "0px",
             borderBottomLeftRadius: "5px",
             borderBottomRightRadius: "5px",
@@ -111,7 +111,7 @@ export default React.memo(function Solution(props: UseDoenetRendererProps) {
                     display: "block",
                     margin: SVs.open ? "12px 4px 0px 4px" : "12px 4px 12px 4px",
                     padding: "6px",
-                    border: "2px solid var(--canvastext)",
+                    border: "2px solid var(--canvasText)",
                     borderTopLeftRadius: "5px",
                     borderTopRightRadius: "5px",
                     borderBottomLeftRadius: SVs.open ? "0px" : "5px",

--- a/packages/doenetml/src/Viewer/renderers/tabular.tsx
+++ b/packages/doenetml/src/Viewer/renderers/tabular.tsx
@@ -20,7 +20,7 @@ export default React.memo(function Tabular(props: UseDoenetRendererProps) {
         width: sizeToCSS(SVs.width),
         height: sizeToCSS(SVs.height),
         borderCollapse: "collapse",
-        borderColor: "var(--canvastext)",
+        borderColor: "var(--canvasText)",
         borderRadius: "var(--mainBorderRadius)",
         tableLayout: "fixed",
     };

--- a/packages/doenetml/src/Viewer/renderers/textInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/textInput.tsx
@@ -195,8 +195,8 @@ export default function TextInput(props: UseDoenetRendererProps) {
             fixed: fixed.current,
             disabled: SVs.disabled,
             useMathJax: SVs.labelHasLatex,
-            strokeColor: "var(--canvastext)",
-            highlightStrokeColor: "var(--canvastext)",
+            strokeColor: "var(--canvasText)",
+            highlightStrokeColor: "var(--canvasText)",
             highlight: !fixLocation.current,
             parse: false,
         };
@@ -262,9 +262,9 @@ export default function TextInput(props: UseDoenetRendererProps) {
         newInputJXG.rendNodeInput.addEventListener("focus", handleFocus);
 
         newInputJXG.rendNodeInput.style.width = width!;
-        newInputJXG.rendNodeInput.style.color = "var(--canvastext)";
+        newInputJXG.rendNodeInput.style.color = "var(--canvasText)";
         newInputJXG.rendNodeInput.style.background = "var(--canvas)";
-        newInputJXG.rendNodeInput.style.borderColor = "var(--canvastext)";
+        newInputJXG.rendNodeInput.style.borderColor = "var(--canvasText)";
 
         newInputJXG.rendNodeLabel.style.marginRight = "2px";
 
@@ -600,7 +600,7 @@ export default function TextInput(props: UseDoenetRendererProps) {
                     onFocus={handleFocus}
                     style={{
                         margin: "0px 4px 4px 4px",
-                        color: "var(--canvastext)",
+                        color: "var(--canvasText)",
                         background: "var(--canvas)",
                         width,
                         height,
@@ -625,7 +625,7 @@ export default function TextInput(props: UseDoenetRendererProps) {
                     width={width}
                     style={{
                         margin: "0px 4px 4px 4px",
-                        color: "var(--canvastext)",
+                        color: "var(--canvasText)",
                         background: "var(--canvas)",
                     }}
                 />

--- a/packages/doenetml/src/Viewer/renderers/vector.tsx
+++ b/packages/doenetml/src/Viewer/renderers/vector.tsx
@@ -150,7 +150,7 @@ export default React.memo(function Vector(props) {
         if (SVs.applyStyleToLabel) {
             jsxVectorAttributes.label.strokeColor = lineColor;
         } else {
-            jsxVectorAttributes.label.strokeColor = "var(--canvastext)";
+            jsxVectorAttributes.label.strokeColor = "var(--canvasText)";
         }
 
         let newVectorJXG = board.create(
@@ -652,7 +652,7 @@ export default React.memo(function Vector(props) {
                     vectorJXG.current.label.visProp.strokecolor = lineColor;
                 } else {
                     vectorJXG.current.label.visProp.strokecolor =
-                        "var(--canvastext)";
+                        "var(--canvasText)";
                 }
                 vectorJXG.current.label.needsUpdate = true;
                 vectorJXG.current.label.update();

--- a/packages/doenetml/src/Viewer/renderers/video.tsx
+++ b/packages/doenetml/src/Viewer/renderers/video.tsx
@@ -10,7 +10,7 @@ import { useRecordVisibilityChanges } from "../../utils/visibility";
 import styled from "styled-components";
 const VideoStyling = styled.div`
     &: focus {
-        outline: 2px solid var(--canvastext);
+        outline: 2px solid var(--canvasText);
         outline-offset: 2px;
     }
 `;

--- a/packages/doenetml/src/utils/checkWork.tsx
+++ b/packages/doenetml/src/utils/checkWork.tsx
@@ -216,10 +216,16 @@ export function createCheckWorkComponent(
     }
 
     if (SVs.creditIsReducedByAttempt) {
+        const message =
+            SVs.numIncorrectSubmissions === 0
+                ? "wrong answers reduce credit"
+                : SVs.creditAchieved > 0
+                  ? `credit reduced by ${Math.round(100 * SVs.creditFactorUsed)}% due to ${SVs.numPreviousIncorrectSubmissions} wrong answer${SVs.numPreviousIncorrectSubmissions > 1 ? "s" : ""}`
+                  : `credit will be reduced by ${Math.round(100 * SVs.nextCreditFactor)}% due to ${SVs.numIncorrectSubmissions} wrong answer${SVs.numIncorrectSubmissions > 1 ? "s" : ""}`;
         checkWorkComponent = (
             <>
                 {checkWorkComponent}
-                <span>(wrong answers reduce credit)</span>
+                <span>({message})</span>
             </>
         );
     }

--- a/packages/doenetml/src/utils/checkWork.tsx
+++ b/packages/doenetml/src/utils/checkWork.tsx
@@ -157,11 +157,10 @@ export function createCheckWorkComponent(
             checkWorkStyle.backgroundColor = "#efab34";
             const percent = Math.round(SVs.creditAchieved * 100);
             const checkWorkText = showText
-                ? `${percent}% Correct`
+                ? SVs.creditIsReducedByAttempt
+                    ? `${percent}% Credit`
+                    : `${percent}% Correct`
                 : `${percent} %`;
-            if (!showText) {
-                checkWorkStyle.width = "44px";
-            }
 
             checkWorkComponent = (
                 <Button
@@ -212,6 +211,15 @@ export function createCheckWorkComponent(
             <>
                 {checkWorkComponent}
                 <span>({SVs.numAttemptsLeft} attempts remaining)</span>
+            </>
+        );
+    }
+
+    if (SVs.creditIsReducedByAttempt) {
+        checkWorkComponent = (
+            <>
+                {checkWorkComponent}
+                <span>(wrong answers reduce credit)</span>
             </>
         );
     }

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.7.0-alpha55",
+    "version": "0.7.0-beta1",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/test-cypress/cypress/e2e/tagSpecific/answer.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/answer.cy.js
@@ -3113,4 +3113,185 @@ d
         cy.get(cesc("#ti_submit")).click();
         cy.get(cesc("#ti_correct")).should("be.visible");
     });
+
+    it("credit factor by attempt and disable wrong choices", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+
+  <p><answer name="answer1" inline creditFactorByAttempt="1 0.6 0.4" disableWrongChoices>
+    <choiceInput name="choiceInput1">
+      <choice credit="1">A</choice>
+      <choice>B</choice>
+      <choice>C</choice>
+      <choice>D</choice>
+    </choiceInput>
+  </answer></p>
+  <p><answer name="answer2" inline creditFactorByAttempt="1 0.6 0.4" disableWrongChoices forceFullCheckworkButton>
+    <choiceInput name="choiceInput2">
+      <choice credit="1">A</choice>
+      <choice>B</choice>
+      <choice>C</choice>
+      <choice>D</choice>
+    </choiceInput>
+  </answer></p>
+   `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#answer1")).should(
+            "contain.text",
+            "wrong answers reduce credit",
+        );
+        cy.get(cesc("#answer2")).should(
+            "contain.text",
+            "wrong answers reduce credit",
+        );
+
+        cy.log("Submit correct answers");
+        cy.get(cesc("#choiceInput1")).select(`A`);
+        cy.get(cesc("#choiceInput2")).select(`A`);
+        cy.get(cesc("#choiceInput1_submit")).click();
+        cy.get(cesc("#answer2_submit")).click();
+        cy.get(cesc("#choiceInput1_correct")).should("be.visible");
+        cy.get(cesc("#answer2_correct")).should("be.visible");
+
+        cy.get(cesc("#answer1")).should(
+            "contain.text",
+            "wrong answers reduce credit",
+        );
+        cy.get(cesc("#answer2")).should(
+            "contain.text",
+            "wrong answers reduce credit",
+        );
+
+        cy.log("Submit incorrect answers");
+        cy.get(cesc("#choiceInput1")).select(`B`);
+        cy.get(cesc("#choiceInput2")).select(`B`);
+        cy.get(cesc("#choiceInput1_submit")).click();
+        cy.get(cesc("#answer2_submit")).click();
+        cy.get(cesc("#choiceInput1_incorrect")).should("be.visible");
+        cy.get(cesc("#answer2_incorrect")).should("be.visible");
+
+        cy.get(cesc("#answer1")).should(
+            "contain.text",
+            "credit will be reduced by 60% due to 1 wrong answer",
+        );
+        cy.get(cesc("#answer2")).should(
+            "contain.text",
+            "credit will be reduced by 60% due to 1 wrong answer",
+        );
+        cy.get(cesc("#choiceInput1")).get(`[value="2"]`).should("be.disabled");
+        cy.get(cesc("#choiceInput2")).get(`[value="2"]`).should("be.disabled");
+
+        cy.log("Submit correct answers for reduced credit");
+        cy.get(cesc("#choiceInput1")).select(`A`);
+        cy.get(cesc("#choiceInput2")).select(`A`);
+        cy.get(cesc("#choiceInput1_submit")).click();
+        cy.get(cesc("#answer2_submit")).click();
+        cy.get(cesc("#choiceInput1_partial")).should("have.text", "60 %");
+        cy.get(cesc("#answer2_partial")).should("contain.text", "60% Credit");
+
+        cy.get(cesc("#answer1")).should(
+            "contain.text",
+            "credit reduced by 60% due to 1 wrong answer",
+        );
+        cy.get(cesc("#answer2")).should(
+            "contain.text",
+            "credit reduced by 60% due to 1 wrong answer",
+        );
+        cy.get(cesc("#choiceInput1")).get(`[value="2"]`).should("be.disabled");
+        cy.get(cesc("#choiceInput2")).get(`[value="2"]`).should("be.disabled");
+
+        cy.log("Submit second incorrect answers");
+        cy.get(cesc("#choiceInput1")).select(`D`);
+        cy.get(cesc("#choiceInput2")).select(`D`);
+        cy.get(cesc("#choiceInput1_submit")).click();
+        cy.get(cesc("#answer2_submit")).click();
+        cy.get(cesc("#choiceInput1_incorrect")).should("be.visible");
+        cy.get(cesc("#answer2_incorrect")).should("be.visible");
+
+        cy.get(cesc("#answer1")).should(
+            "contain.text",
+            "credit will be reduced by 40% due to 2 wrong answers",
+        );
+        cy.get(cesc("#answer2")).should(
+            "contain.text",
+            "credit will be reduced by 40% due to 2 wrong answers",
+        );
+        cy.get(cesc("#choiceInput1")).get(`[value="2"]`).should("be.disabled");
+        cy.get(cesc("#choiceInput2")).get(`[value="2"]`).should("be.disabled");
+        cy.get(cesc("#choiceInput1")).get(`[value="4"]`).should("be.disabled");
+        cy.get(cesc("#choiceInput2")).get(`[value="4"]`).should("be.disabled");
+
+        cy.log("Submit correct answers for further reduced credit");
+        cy.get(cesc("#choiceInput1")).select(`A`);
+        cy.get(cesc("#choiceInput2")).select(`A`);
+        cy.get(cesc("#choiceInput1_submit")).click();
+        cy.get(cesc("#answer2_submit")).click();
+        cy.get(cesc("#choiceInput1_partial")).should("have.text", "40 %");
+        cy.get(cesc("#answer2_partial")).should("contain.text", "40% Credit");
+
+        cy.get(cesc("#answer1")).should(
+            "contain.text",
+            "credit reduced by 40% due to 2 wrong answers",
+        );
+        cy.get(cesc("#answer2")).should(
+            "contain.text",
+            "credit reduced by 40% due to 2 wrong answers",
+        );
+        cy.get(cesc("#choiceInput1")).get(`[value="2"]`).should("be.disabled");
+        cy.get(cesc("#choiceInput2")).get(`[value="2"]`).should("be.disabled");
+        cy.get(cesc("#choiceInput1")).get(`[value="4"]`).should("be.disabled");
+        cy.get(cesc("#choiceInput2")).get(`[value="4"]`).should("be.disabled");
+
+        cy.log("Submit third incorrect answers");
+        cy.get(cesc("#choiceInput1")).select(`C`);
+        cy.get(cesc("#choiceInput2")).select(`C`);
+        cy.get(cesc("#choiceInput1_submit")).click();
+        cy.get(cesc("#answer2_submit")).click();
+        cy.get(cesc("#choiceInput1_incorrect")).should("be.visible");
+        cy.get(cesc("#answer2_incorrect")).should("be.visible");
+
+        cy.get(cesc("#answer1")).should(
+            "contain.text",
+            "credit will be reduced by 40% due to 3 wrong answers",
+        );
+        cy.get(cesc("#answer2")).should(
+            "contain.text",
+            "credit will be reduced by 40% due to 3 wrong answers",
+        );
+        cy.get(cesc("#choiceInput1")).get(`[value="2"]`).should("be.disabled");
+        cy.get(cesc("#choiceInput2")).get(`[value="2"]`).should("be.disabled");
+        cy.get(cesc("#choiceInput1")).get(`[value="3"]`).should("be.disabled");
+        cy.get(cesc("#choiceInput2")).get(`[value="3"]`).should("be.disabled");
+        cy.get(cesc("#choiceInput1")).get(`[value="4"]`).should("be.disabled");
+        cy.get(cesc("#choiceInput2")).get(`[value="4"]`).should("be.disabled");
+
+        cy.log("Submit correct answers, credit not further reduced");
+        cy.get(cesc("#choiceInput1")).select(`A`);
+        cy.get(cesc("#choiceInput2")).select(`A`);
+        cy.get(cesc("#choiceInput1_submit")).click();
+        cy.get(cesc("#answer2_submit")).click();
+        cy.get(cesc("#choiceInput1_partial")).should("have.text", "40 %");
+        cy.get(cesc("#answer2_partial")).should("contain.text", "40% Credit");
+
+        cy.get(cesc("#answer1")).should(
+            "contain.text",
+            "credit reduced by 40% due to 3 wrong answers",
+        );
+        cy.get(cesc("#answer2")).should(
+            "contain.text",
+            "credit reduced by 40% due to 3 wrong answers",
+        );
+        cy.get(cesc("#choiceInput1")).get(`[value="2"]`).should("be.disabled");
+        cy.get(cesc("#choiceInput2")).get(`[value="2"]`).should("be.disabled");
+        cy.get(cesc("#choiceInput1")).get(`[value="3"]`).should("be.disabled");
+        cy.get(cesc("#choiceInput2")).get(`[value="3"]`).should("be.disabled");
+        cy.get(cesc("#choiceInput1")).get(`[value="4"]`).should("be.disabled");
+        cy.get(cesc("#choiceInput2")).get(`[value="4"]`).should("be.disabled");
+    });
 });

--- a/packages/test-cypress/src/CypressTest.tsx
+++ b/packages/test-cypress/src/CypressTest.tsx
@@ -547,7 +547,7 @@ export function CypressTest() {
         <div
             style={{
                 backgroundColor: "var(--canvas)",
-                color: "var(--canvastext)",
+                color: "var(--canvasText)",
             }}
             data-theme={darkMode}
         >

--- a/packages/v06-to-v07/package.json
+++ b/packages/v06-to-v07/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/v06-to-v07",
     "type": "module",
     "description": "Convert DoenetML v0.6 syntax to v0.7 syntax",
-    "version": "0.7.0-alpha55",
+    "version": "0.7.0-beta1",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,


### PR DESCRIPTION
This PR adds a number of attributes to the `<answer>` tag to give authors options for reducing credit as a penalty for wrong answers:
- `creditFactorByAttempt`: a list of factors that will multiply the original credit achieved to adjust it based on the number of incorrect attempts submitted. For example, given `<answer creditFactorByAttempt="1 0.7 0.5" />`, a correct answer on the first attempt would get full credit, obtaining the correct answer after one incorrect response would give 70% credit, while getting the correct response after two or more incorrect responses would yield 50% credit.
- `creditReductionPerAttempt`: if `creditFactorByAttempt` is not supplied, then `creditReductionPerAttempt` can specify a value to subtract from the credit for each incorrect attempt. For example, given `<answer creditReductionPerAttempt="0.4" />`, a correct answer on the first attempt would get full credit, obtaining the correct after one incorrect response would give 60% credit, while getting the response after two incorrect responses would yield 20% credit. With three or more incorrect responses, credit is prevented by going negative by the value of `creditReductionLimit`, which defaults to 0.99, meaning the credit doesn't drop below 1%.
- `creditReductionLimit`: the maximum amount of credit reduced by incorrect answers when `creditReductionPerAttempt` is in force. It defaults to `0.99`. If the previous example were modified to `<answer creditReductionPerAttempt="0.4" creditReductionLimit="0.6" />`, then the credit after two or more incorrect responses would stay at 40%.

In addition, one more attribute controls the behavior wrong answers in multiple choice questions:
- `disableWrongChoices`: if `true`, then incorrect choices are disabled after they have been submitted.