### PR TITLE
Add protection in case load undefined renderer state

### DIFF
--- a/packages/doenetml/src/state/slices/main.ts
+++ b/packages/doenetml/src/state/slices/main.ts
@@ -142,8 +142,12 @@ export const mainThunks = {
                 let previousRendererState =
                     mainSlice.selectors.componentInfo(getState())[rendererName];
 
+                // TODO: create a test that reproduces the situation where `previousRendererState` is not defined at this stage.
+                // One case where the variable `previousRendererState` can be `undefined` is in a React dev server
+                // where functions are called twice to test robustness.
+                // In this case, one can get a new core and a new `coreId` so that `rendererName` no longer corresponds to a saved state.
                 childrenInstructions2 =
-                    previousRendererState.childrenInstructions;
+                    previousRendererState?.childrenInstructions ?? null;
             } else {
                 childrenInstructions2 = childrenInstructions;
             }


### PR DESCRIPTION
This PR checks to make sure a loaded renderer state is defined when attempting to update the renderer state.

It could be undefined in an edge case where an app is causing core to be recreated.