### PR TITLE
rename iframe style file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20345,7 +20345,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.0-beta1",
+            "version": "0.7.0-beta2",
             "license": "AGPL-3.0-or-later",
             "peerDependencies": {
                 "react": "^19.1.1",
@@ -20355,7 +20355,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.0-beta1",
+            "version": "0.7.0-beta2",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -21523,7 +21523,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.0-beta1",
+            "version": "0.7.0-beta2",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },
@@ -21569,7 +21569,7 @@
         },
         "packages/v06-to-v07": {
             "name": "@doenet/v06-to-v07",
-            "version": "0.7.0-beta1",
+            "version": "0.7.0-beta2",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml-iframe",
     "type": "module",
     "description": "A renderer for DoenetML contained in an iframe",
-    "version": "0.7.0-beta1",
+    "version": "0.7.0-beta2",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/doenetml-iframe/vite.config.ts
+++ b/packages/doenetml-iframe/vite.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
             entry: "./src/index.tsx",
             fileName: "index",
             formats: ["es"],
+            cssFileName: "style",
         },
         rollupOptions: {
             external: EXTERNAL_DEPS,

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/doenetml",
     "type": "module",
     "description": "Semantic markup for building interactive web activities",
-    "version": "0.7.0-beta1",
+    "version": "0.7.0-beta2",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/standalone",
     "type": "module",
     "description": "Standalone renderer for DoenetML suitable for being included in a web page",
-    "version": "0.7.0-beta1",
+    "version": "0.7.0-beta2",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/v06-to-v07/package.json
+++ b/packages/v06-to-v07/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/v06-to-v07",
     "type": "module",
     "description": "Convert DoenetML v0.6 syntax to v0.7 syntax",
-    "version": "0.7.0-beta1",
+    "version": "0.7.0-beta2",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,


### PR DESCRIPTION
This PR simply renames the exported style file of `doenetml-iframe` to be `style.css`.