### PR TITLE
bugfix: mark latex of piecewise function as forRenderer

### DIFF
--- a/packages/doenetml-worker-javascript/src/components/PiecewiseFunction.js
+++ b/packages/doenetml-worker-javascript/src/components/PiecewiseFunction.js
@@ -521,6 +521,7 @@ export default class PiecewiseFunction extends Function {
 
         stateVariableDefinitions.latex = {
             public: true,
+            forRenderer: true,
             shadowingInstructions: {
                 createComponentOfType: "latex",
             },

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/piecewisefunction.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/piecewisefunction.test.ts
@@ -1694,6 +1694,23 @@ describe("Piecewise Function Tag Tests", async () => {
 \\end{cases}`);
     });
 
+    it("latex is marked forRenderer", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <piecewiseFunction name="f">
+      <function domain="(1,3)">x</function>
+      <function domain="[4,5)">x^2</function>
+    </piecewiseFunction>
+    `,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+
+        const fIdx = await resolvePathToNodeIdx("f");
+
+        expect(core.core?._components![fIdx].state.latex.forRenderer).eq(true);
+    });
+
     it("extrema of a function with piecewise function child", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `


### PR DESCRIPTION
This PR addresses a bug where the `latex` state variable of a piecewise function was not marked `forRenderer`. This meant that a `<piecewiseFunction>` that wasn't inside a component like `<m>` was rendered as `undefined`.