### PR TITLE
editor correctly follows viewerLocation attribute

### DIFF
--- a/packages/ui-components/src/components/ResizablePanelPair.tsx
+++ b/packages/ui-components/src/components/ResizablePanelPair.tsx
@@ -34,7 +34,7 @@ export function ResizablePanelPair({
             for (const entry of entries) {
                 const width = entry.contentRect.width;
                 const desiredDirection =
-                    width < 430 ? "vertical" : "horizontal";
+                    width < 430 ? "vertical" : preferredDirection;
                 if (desiredDirection !== direction) {
                     setDirection(desiredDirection);
                 }


### PR DESCRIPTION
This PR fixes a bug where the editor was not adhering to the `viewerLocation` attribute.