### PR TITLE
Editor sets variants state variable only if changed

### DIFF
--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/utils/parse_json.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/utils/parse_json.rs
@@ -1,16 +1,7 @@
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, rc::Rc};
+use std::rc::Rc;
 
 use crate::components::prelude::PropValue;
-
-/// The structure of the json argument in a call to dispatch_action.
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct ActionStructure {
-    component_idx: usize,
-    action_name: String,
-    args: HashMap<String, ArgValue>,
-}
 
 /// Each value in an action args must be a quantity that can be converted
 /// into a `PropValue` or a vector of `PropValue`.

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -525,11 +525,24 @@ export function EditorViewer({
                                 typeof x.variantInfo.index === "number"
                             ) {
                                 const index = x.variantInfo.index;
-                                setVariants({
-                                    index,
-                                    numVariants,
-                                    allPossibleVariants,
-                                });
+
+                                // If the variant generated does not match the variant prescribed,
+                                // set the variants state variable to match.
+                                if (
+                                    index !== variants.index ||
+                                    numVariants !== variants.numVariants ||
+                                    allPossibleVariants.some(
+                                        (v, i) =>
+                                            v !==
+                                            variants.allPossibleVariants[i],
+                                    )
+                                ) {
+                                    setVariants({
+                                        index,
+                                        numVariants,
+                                        allPossibleVariants,
+                                    });
+                                }
                             }
                         }
                     }}


### PR DESCRIPTION
The PR fixes a bug where, if one changes the variant via the editor's variant selector too quickly, then an infinite loop oscillating between two variants could be induced. The infinite loop is prevented by setting the `variants` state variable only if changed when receiving the generated variant from the Doenet viewer.