### PR TITLE
graph fixes

### DIFF
--- a/packages/doenetml-worker-javascript/src/components/Graph.js
+++ b/packages/doenetml-worker-javascript/src/components/Graph.js
@@ -163,10 +163,8 @@ export default class Graph extends BlockComponent {
         };
         attributes.fixAxes = {
             createComponentOfType: "boolean",
-            createStateVariable: "fixAxes",
+            createStateVariable: "fixAxesPreliminary",
             defaultValue: false,
-            public: true,
-            forRenderer: true,
         };
         attributes.grid = {
             createComponentOfType: "text",
@@ -241,6 +239,33 @@ export default class Graph extends BlockComponent {
             stateVariableDefinitions,
             returnRoundingStateVariableDefinitions(),
         );
+
+        stateVariableDefinitions.fixAxes = {
+            forRenderer: true,
+            public: true,
+            shadowingInstructions: {
+                createComponentOfType: "boolean",
+            },
+            returnDependencies: () => ({
+                fixAxesPreliminary: {
+                    dependencyType: "stateVariable",
+                    variableName: "fixAxesPreliminary",
+                },
+                fixed: {
+                    dependencyType: "stateVariable",
+                    variableName: "fixed",
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        fixAxes:
+                            dependencyValues.fixAxesPreliminary ||
+                            dependencyValues.fixed,
+                    },
+                };
+            },
+        };
 
         stateVariableDefinitions.xLabel = {
             forRenderer: true,

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
@@ -1357,4 +1357,27 @@ describe("Graph tag tests", async () => {
                 .yMax,
         ).eq(10);
     });
+
+    it("fixed graph implies fixAxes", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <graph name="g" fixed />
+    
+    <boolean extend="$g.fixAxes" name="fixAxes" />
+
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("g")].stateValues.fixed,
+        ).eq(true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("g")].stateValues.fixAxes,
+        ).eq(true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fixAxes")].stateValues
+                .value,
+        ).eq(true);
+    });
 });

--- a/packages/doenetml/src/Viewer/renderers/graph.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graph.tsx
@@ -380,6 +380,9 @@ export default React.memo(function Graph(props) {
             yaxis.current = null;
         }
 
+        board.attr.zoom.wheel = !SVs.fixAxes;
+        board.attr.pan.enabled = !SVs.fixAxes;
+
         if (showNavigation) {
             if (!previousShowNavigation.current) {
                 addNavigationButtons();

--- a/packages/doenetml/src/Viewer/renderers/graph.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graph.tsx
@@ -925,7 +925,7 @@ export default React.memo(function Graph(props) {
     }
 
     function removeNavigationButtons() {
-        for (let i = 7; i >= 1; i--) {
+        for (let i = 3; i >= 1; i--) {
             let button = document.querySelector(
                 "#" + cesc(id) + `_navigationbar > :first-child`,
             );

--- a/packages/test-cypress/cypress/e2e/tagSpecific/graph.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/graph.cy.js
@@ -361,4 +361,28 @@ describe("Graph Tag Tests", function () {
         cy.get(cesc("#ignoreBad")).should("contain.text", "10");
         cy.get(cesc("#ignoreBad")).should("contain.text", "−10");
     });
+
+    it("changing show navigation", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <booleanInput name="showControls" prefill="true" />
+    <graph showNavigation="$showControls" name="g" />
+    <boolean name="showControls2" extend="$g.showNavigation" />
+    `,
+                },
+                "*",
+            );
+        });
+
+        // Make sure render doesn't crash when remove or add navigation buttons
+        cy.get(cesc("#showControls2")).should("have.text", "true");
+
+        cy.get(cesc("#showControls")).click();
+        cy.get(cesc("#showControls2")).should("have.text", "false");
+
+        cy.get(cesc("#showControls")).click();
+        cy.get(cesc("#showControls2")).should("have.text", "true");
+    });
 });


### PR DESCRIPTION
The PR fixes a few issues with graphs.

1. Fixes a bug where a graph crashes when navigation buttons are removed.
2. Fixes glitch when panning/zooming a fixed graph.
3. The zoom/pan settings change dynamically with the `fixAxes` state variable.

Fixes #592