### PR TITLE
convert tutorials to 0.7

### DIFF
--- a/packages/docs-nextra/pages/tutorials/intermediateTutorial/iT2-1-cartesian.mdx
+++ b/packages/docs-nextra/pages/tutorials/intermediateTutorial/iT2-1-cartesian.mdx
@@ -5,22 +5,21 @@ import { DoenetViewer, DoenetEditor, DoenetExample } from "../../../components"
 One of the most powerful features of DoenetML is the ability to create complicated graphics with a few lines of code. This section covers the basics of the `<graph>` tag and its attributes, and shows you how to graph a function $y = f(x)$. Later sections will demonstrate how to graph points, lines, polygons, circles, and other objects.
 
 By default, the following code creates the Cartesian grid, which goes from -10 to 10 in both the $x$ and $y$ directions. 
-```doenet
+```doenet-editor-horiz
 <graph></graph>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 (If all we want is a blank graph, we could use the self-closing `<graph/>` tag. In practice, however, we'll almost always include items between the opening and closing `<graph>`and `</graph>` tags, which is why we've used that style here.)
 
-Take a moment to experiment with the controls at the bottom right of the graph. Clicking the arrows will pan left, down, up and right. The `+` and `-` allow you to zoom in and out, and `o` resets the view.
+Take a moment to experiment with the controls at the bottom right of the graph. The `+` and `-` allow you to zoom in and out, and `o` resets the view. (You can also hold down Shift and scroll to zoom.) You can pan the graph of dragging with the mouse.
 
 
 
 ### Basic Graph Attributes
 
-DoenetML has attributes to adjust various features of a graph: the range of $x$ and $y$ values; whether or not the zoom/navigation controls and a background grid are displayed; whether a border is drawn around the graph; the size of the graph; and whether the graph is centered on the page, or drawn on the left or right edge of the document.
+DoenetML has attributes to adjust various features of a graph: the range of $x$ and $y$ values; whether or not the graph can be zoomed or panned;  whether or not a background grid are displayed; whether a border is drawn around the graph; the size of the graph; and whether the graph is centered on the page, or drawn on the left or right edge of the document.
 
-Rather that listing out all of the possible attributes and values, documentation-style, you can learn these options by experimenting with the controls below. Try adjusting values and see how the graph changes. Doenet also provides you with the corresponding code to create the graph; you can copy and paste that code into your own documents.
+Rather than listing out all of the possible attributes and values, documentation-style, you can learn these options by experimenting with the controls below. Try adjusting values and see how the graph changes. Doenet also provides you with the corresponding code to create the graph; you can copy and paste that code into your own documents.
 
 ```doenet-example
  <tabular top="minor" bottom="minor">
@@ -37,8 +36,8 @@ Rather that listing out all of the possible attributes and values, documentation
       <cell halign="left"><mathInput name="yMin" prefill="-2" /></cell>
       <cell halign="right"><c>ymax</c></cell>
       <cell halign="left"><mathInput name="yMax" prefill="10" /></cell>
-      <cell halign="right"><c>controls</c></cell>
-      <cell halign="left"><booleanInput name="showControls" prefill="true" /></cell>
+      <cell halign="right"><c>fix axes</c></cell>
+      <cell halign="left"><booleanInput name="fixAxes" prefill="false" /></cell>
     </row>
     <row>
       <cell halign="right"><c>size</c></cell>
@@ -71,9 +70,7 @@ Rather that listing out all of the possible attributes and values, documentation
       size="$sizeChoice"
     </conditionalContent>
     <conditionalContent condition="$showGrid">grid</conditionalContent>
-    <conditionalContent condition="! $showControls">
-      showNavigation="$showControls"
-    </conditionalContent>
+    <conditionalContent condition="$fixAxes">fixAxes</conditionalContent>
     <conditionalContent condition="! $showBorder">
       border="$showBorder"
     </conditionalContent>
@@ -84,7 +81,7 @@ Rather that listing out all of the possible attributes and values, documentation
   
   <graph xmin="$xMin" xmax="$xMax" ymin="$yMin" ymax="$yMax"
     size="$sizeChoice" grid="$showGrid"
-    showNavigation="$showControls" 
+    fixAxes="$fixAxes" 
     showBorder="$showBorder"
     horizontalAlign="$alignChoice"/>
 ```
@@ -92,31 +89,34 @@ Rather that listing out all of the possible attributes and values, documentation
 Notice that the `<graph></graph>` code above includes `grid` (which is equivalent to `grid="true"`) when you check the grid box, but the tag does not include `grid="false"` if the grid is turned off. That's because `false` is the default value for `grid`; hence the attribute doesn't need to be included in that case. Similarly, the other attributes are suppressed if their default values are chosen:
 
 * `grid="false"`
-* `showNavigation="false"`
+* `fixAxes="false"`
 * `showBorder="true"`
 * `size="medium"`
 * `horizontalAlign="center"`
 
-One additional attribute which was not demonstrated above is `identicalAxisScales`. By default, Deonet will always display a square graph. If you adjust the ranges of $x$ and $y$, that often means the axes are scaled differently. That's true in the following graph; $x$ ranges from -10 to 10, but $y$ only stretches from -4 to 4.
+One additional attribute which was not demonstrated above is `identicalAxisScales`. By default, Deonet will always display a square graph. If you adjust the ranges of $x$ and $y$, that often means the axes are scaled differently. That's true in the following graph; $x$ ranges from -10 to 10, but $y$ only stretches from -4 to 4. The unit `<circle />` is squashed into an ellipse.
 
-```doenet
-    <graph ymin="-4" ymax="4" showNavigation="false"/>
+```doenet-editor-horiz
+<graph ymin="-4" ymax="4" fixAxes >
+  <circle />
+</graph>
 ```
 
 
-By including the `identicalAxisScales` attribute (equivalent to `identicalAxisScales="true"`), we force Doenet to use the same scaling for both axes, which results in a rectangular graph.
+By including the `identicalAxisScales` attribute (equivalent to `identicalAxisScales="true"`), we force Doenet to use the same scaling for both axes, which results in a rectangular graph.  The unit `<circle />` now displays as a circle.
 
-```doenet
-    <graph ymin="-4" ymax="4" identicalAxisScales="true" showNavigation="false" />
+```doenet-editor-horiz
+<graph ymin="-4" ymax="4" identicalAxisScales="true" fixAxes >
+  <circle />
+</graph>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 ### Axes Labels
 
-By default, the axes in Doenet graphs are unlabeled. You can adjust this behavior, but not with an attribute. Similar to the `<label>` tag in a slider, axis labels are provided with tags that are nested between `<graph>` and `</graph>`. (As mentioned in a previous section, they're known as children of the `<graph>` object.) The `<xLabel>` child specifies the label for the horizontal axes, and you can provide a label for the vertical axis with `<yLabel>`. As Either label can contain text, an `<m>` tag, or even a `<math>` object, as shown in the following example.
+By default, the axes in Doenet graphs are unlabeled. You can adjust this behavior, but not with an attribute. Similar to the `<label>` tag in a slider, axis labels are provided with tags that are nested between `<graph>` and `</graph>`. (As mentioned in a previous section, they're known as children of the `<graph>` object.) The `<xLabel>` child specifies the label for the horizontal axes, and you can provide a label for the vertical axis with `<yLabel>`. Either label can contain text, an `<m>` tag, or even a `<math>` object, as shown in the following example.
 
-```doenet {5,6}
-<graph showNavigation="false"
+```doenet-editor-horiz
+<graph fixAxes
        xmin="-1" xmax="8" 
        ymin="-2" ymax="10" >
     <line>y = x/2</line>
@@ -124,12 +124,11 @@ By default, the axes in Doenet graphs are unlabeled. You can adjust this behavio
     <yLabel>dist</yLabel>
 </graph>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 ### Graphing Functions
 Graphing a function in DoenetML is easy: simply create your graph, using whichever attributes and labels you want, and then include the function between the opening and closing tags. You can either define the function inside the graph, or define it elsewhere (say, in a `<setup>` block) and simply reference it within the graph using the `$functionName` notation. The example below shows both methods. Notice that Doenet also pays attention to the `domain` of a function when displaying its graph!
 
-```doenet {2-4,8,9}
+```doenet-editor-horiz
 <setup>
   <function name="f" domain="[-2pi,pi]">
     sin(x)-4
@@ -141,38 +140,37 @@ Graphing a function in DoenetML is easy: simply create your graph, using whichev
   <function name="g">x^2+1</function>
 </graph>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 **Warning**: this could be a good time to go back and review the [difference between `$` and `$$`](../introdTutorial/iT1-7-functions.mdx). In this instance we want `$f`, because we are referencing the entire definition (formula and domain!) of `f` in the `<graph>` object. We are not evaluating `f` at a single point.
 
 If a function changes because of user interaction, e.g. a `<mathInput>` or `<slider>`, then its graph will automatically change as well. Try adjusting the value of $a$ below and notice the effects on the graph.
 
-```doenet
+```doenet-editor-horiz
 <p>Graph of <m>y = (x-1)(x+1)(x-a)</m>.</p>
 
 <slider from="-3" to="3" name="a" step="1" initialValue="2" >
   <label><m>a</m></label>
 </slider>
 
-<graph xmin="-4" xmax="4" ymin="-6" ymax="6" size="small" showNavigation="false">
+<graph xmin="-4" xmax="4" ymin="-6" ymax="6" size="small" fixAxes>
   <function>(x^2-1)(x-$a)</function>
 </graph>
 ```
 
-### A Word about styleNumbers
+### A word about style numbers
 
-If you have multiple functions graphed at once, it can be confusing if they're all the same color and style. In DoenetML you can adjust styles by adding `styleNumber="n"` to a function, where $n$ values for default styles range from 1 to 6. (In fact, $n$ can be any natural number, but by default, the styles repeat once you get beyond 6, unless you have defined custom style numbers using the `<styleDefinition>` component. See the example below for default styles 1 to 3.
+If you have multiple functions graphed at once, it can be confusing if they're all the same color and style. In DoenetML you can adjust styles by adding `styleNumber="n"` to a function, where $n$ values for default styles range from 1 to 6. (In fact, $n$ can be any natural number, but by default, the styles do not change beyond 6, unless you have defined custom style numbers using the `<styleDefinition>` component.) See the example below for default styles 1 to 3.
 
-```doenet
-<graph showNavigation="false">
+```doenet-editor-horiz
+<graph fixAxes>
     <function styleNumber="1">x^2+3</function>
     <function styleNumber="2">ln(x+2)</function>
     <function styleNumber="3">-6</function>
 </graph>
 ```
-The styles associated with each `styleNumber` vary in terms of color and width. Some styles will have solid lines, others might be dotted or dashed. The default styles are chosen to make sure each style is distinguishable from each other. (For example, the colors are chosen from a palatte of colors which still look different to most color-blind users.) In the following example, you can use the slider below to "scroll" through the different possible default style numbers.
+The styles associated with each `styleNumber` vary in terms of color and width. Some styles will have solid lines, others might be dotted or dashed. The default styles are chosen to make sure each style is distinguishable from each other. (For example, the colors are chosen from a palette of colors which still look different to most color-blind users.) In the following example, you can use the slider below to "scroll" through the different possible default style numbers.
 
-```doenet
+```doenet-editor-horiz
 <slider from="1" to="6" step="1" name="styleSlider" width="200px">
     <label>stylenumber</label>
 </slider>
@@ -181,7 +179,6 @@ The styles associated with each `styleNumber` vary in terms of color and width. 
     <function styleNumber="$styleSlider">x sin(5/x)</function>
 </graph>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 ### Next Steps
 Now that you're acquainted with the basics of Doenet graphs, it's time to learn about more graphical objects. In the coming sections you'll see points, polygons, circles, and more.

--- a/packages/docs-nextra/pages/tutorials/intermediateTutorial/iT2-2-points.mdx
+++ b/packages/docs-nextra/pages/tutorials/intermediateTutorial/iT2-2-points.mdx
@@ -13,28 +13,27 @@ In DoenetML, a point is defined using the `<point>` tag. By default, a point wil
   
 You can graph a point by including it inside of `<graph>` and `</graph>` tags. Alternatively, you can define a point within the regular text of your document, in which case Doenet will render its coordinates. If you want to define a point outside of a `<graph>` component, but don't want the coordinates displayed, you can place the definition in a setup block. Even if you create a point outside of a `<graph>` component, you can still display it within a graph by referencing it with `$pointName`.
 
-The following example illustrates everything we've discussed so far about points. In the test editor, try changing some of the coordinates and clicking update to make sure you understand the definitions.
+The following example illustrates everything we've discussed so far about points. Try changing some of the coordinates and clicking *Update* to make sure you understand the definitions.
 
-```doenet
+```doenet-editor-horiz
 <setup>
   <point name="A">(-8,2)</point>
 </setup>
 
 <m>B = </m> <point name="B" coords="(6,6)" />
 
-<graph showNavigation="false">
+<graph fixAxes>
   $A
   $B
   <point x="4" y="-4" />
 </graph>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 By default, points can be dragged around, which updates their coordinates throughout your document. In particular: if you move the second point, $B$, its coordinates are updated above the graph.
 
 A key feature of DoenetML is that these kinds of updates are *bidrectional*, as demonstrated below. In the following example, you can use the `<mathInput/>` to adjust the coordinates of $P$, and the point will move. But if you drag $P$ to a new location in the graph, the contents of the `<mathInput/>` object will also update!
 
-```doenet
+```doenet-editor-horiz
 <p>
   <m>P = </m> 
   <mathInput name="Pcoords" 
@@ -42,25 +41,24 @@ A key feature of DoenetML is that these kinds of updates are *bidrectional*, as 
              displayDigits="3" />
 </p>
 
-<graph showNavigation="false" size="small">
+<graph fixAxes size="small">
   <point>$Pcoords</point>
 </graph>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 You can see another neat feature of Doenet in the above example, although it's more relevant when using Doenet activities than authoring them. Use the input box to change the coordinates of $P$ to something which is outside of the grid -- say, $(20,2)$. The point will disappear, but Doenet will draw a small arrow on the side of the graph to let you know there's a point beyond the border. You can click and drag on that arrow to bring $P$ back into view! (If you don't want those arrows when a point is off-screen, you can include the `hideOffGraphIndicator` attribute in the definition of your point.)
 
 ### Point Labels
 Similar to `<slider> `and `<graph>` objects, you can provide a label for a point with a nested `<label>` tag. Labels are placed above and to the right of a point, but you can adjust the location using the `labelPosition` attribute. The valid positions are: `top`, `left`, `right`, `bottom`, `upperleft`, `upperright`, `lowerleft`, and `lowerright`.
 
-Often, you want the name and label of your point to be the same. To avoid the hassle of typing nested tags,
+Often, you want the name and label of your point to be the same. You can code the information redundantly with nested tags as in this example:
 ```doenet
      <point name="P" coords="(4,5)"><label>P</label></point>
 ```
 
-DoenetML provides a shortcut attribute called `labelIsName` which uses the name of the point as its label:
-```doenet
-<graph showNavigation="false">
+But, DoenetML also provides a shortcut attribute called `labelIsName` which uses the name of the point as its label:
+```doenet-editor-horiz
+<graph fixAxes>
   
   <point name="A" labelPosition="right" labelIsName>
     (-8,2)
@@ -75,7 +73,6 @@ DoenetML provides a shortcut attribute called `labelIsName` which uses the name 
   
 </graph>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 Labels are printed in plain text, unless you use `<m>` or `<math>` inside of a `<label>` child. If you look carefully at the three points above, you'll notice that $A$ was rendered with MathJax, in a different font than $B$ and $C$.
 
@@ -84,28 +81,27 @@ Earlier, you learned how to use `styleNumber` to distinguish between function gr
 
 ```doenet-example
 <graph xmin="0" xmax="7" ymin="-1" ymax="1" 
-           showNavigation="false" identicalAxisScales
+           fixAxes identicalAxisScales
            displayXAxis="false" displayYAxis="false" >  
 
-      <map>
-        <template><point labelPosition="bottom" styleNumber="$i">
-          ($i,0)
-          <label>$i</label>
-        </point></template>
-        <sources alias="i"><sequence from="1" to="6" /></sources>
-      </map>
+  <repeatForSequence from="1" to="6" valueName="i">
+    <point labelPosition="bottom" styleNumber="$i">
+      ($i,0)
+      <label>$i</label>
+    </point>
+  </repeatForSequence>
 
-    </graph>
+</graph>
 ```
 
-Before continuing, try adjusting the `styleNumber` of a point in one of the examples above. Click "update" and make sure the point's style changes.
+Before continuing, try adjusting the `styleNumber` of a point in one of the examples above. Click *Update* and make sure the point's style changes.
 
 ### Point Arithmetic
 DoenetML supports some basic arithmetic operations with points, essentially treating them like vectors. By combining scalar multiplication and addition, you can easily find and plot the midpoint of two points. (Normally we'd refer to the midpoint of a line segment, but we haven't learned how to graph line segments yet!)
 
 *Reminder: In DoenetML you can refer to an object before it is defined, as long as it is defined somewhere in your document. In the following code, the computations with $P$ and $Q$ are done at the beginning, even though those points are defined in the `<graph>` below.*
 
-```doenet
+```doenet-editor-horiz
 <p><m>3\cdot P = 
   <math simplify>3*$P</math></m>
 </p>
@@ -117,7 +113,7 @@ DoenetML supports some basic arithmetic operations with points, essentially trea
 <p><m>\dfrac{P+Q}{2} = 
   <math simplify name="midpt">(1/2)*($P+$Q)</math></m></p>
 
-<graph showNavigation="false" size="small"
+<graph fixAxes size="small"
        xmin="-1" ymin="-1">
 
   <point name="P" coords="(2,8)" labelIsName />
@@ -129,7 +125,6 @@ DoenetML supports some basic arithmetic operations with points, essentially trea
         
 </graph>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 Notice that you can drag $P$ and $Q$ around in the graph, and everything else updates appropriately. However, you can't click on the midpoint $M$ and drag it around. That's because it's a *dependent* object; in other words, its coordinates depend on both $P$ and $Q$. Changing $M$ would require changing $P$, or $Q$, or both. Since Doenet isn't sure which of those three options you want, it doesn't let you move $M$ at all.
 
@@ -138,8 +133,7 @@ Now go back and add the attribute `fixed` to the definition of $Q$,
 <point name="Q" coords="(6,3)" labelisName fixed/>
 ```
 
-and then click "update." As you can guess, the `fixed` attribute tells Doenet that the coordinates of $Q$ are fixed, i.e. can't be changed by the user. Verify that you can drag $P$ but not $Q$. Here's the surprise: you can now click and drag on the midpoint $M$-- try it to be sure! Now that $Q$ is fixed, Doenet knows the only way $M$ can change is if $P$ moves, so it will go ahead and make that change when you drag the midpoint.
+and then click *Update*. As you can guess, the `fixed` attribute tells Doenet that the coordinates of $Q$ are fixed, i.e. can't be changed by the user. Verify that you can drag $P$ but not $Q$. Here's the surprise: you can now click and drag on the midpoint $M$-- try it to be sure! Now that $Q$ is fixed, Doenet knows the only way $M$ can change is if $P$ moves, so it will go ahead and make that change when you drag the midpoint.
 
 ### Next Steps
 In the next section, we'll move up from points to line segments, rays, and lines. Then we'll learn about so-called "properties" in Doenet, before moving on to more complicated shapes like polygons.
-import { DoenetExample } from "../../../components"

--- a/packages/docs-nextra/pages/tutorials/intermediateTutorial/iT2-3-lines.mdx
+++ b/packages/docs-nextra/pages/tutorials/intermediateTutorial/iT2-3-lines.mdx
@@ -37,10 +37,10 @@ All of these approaches are possible in DoenetML as well, using various attribut
 We already could graph a line in slope-intercept form $y = mx + b$
 by graphing the function $f(x) = mx + b$. This approach is more general, though; for example, a vertical line $x = c$ doesn't have a valid slope-intercept equation! We can graph a vertical line using `<line>`, but not as a `<function>`.
 
-All three methods are illustrated in the example below. Try adjusting the attributes and clicking "update," to make sure you know how to use each type of definition. Notice how, similar to the `<point>` tag, you can adjust the appearances of lines using styleNumber.
+All three methods are illustrated in the example below. Try adjusting the attributes and clicking *Update*, to make sure you know how to use each type of definition. Notice how, similar to the `<point>` tag, you can adjust the appearances of lines using styleNumber.
 
-```doenet
-<graph showNavigation="false">
+```doenet-editor-horiz
+<graph fixAxes>
 
   <line through="(-8,8) (9,6)" />
   <line through="(0,4)" slope="1/2" styleNumber="2" />
@@ -50,11 +50,10 @@ All three methods are illustrated in the example below. Try adjusting the attrib
   
 </graph>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 Also similar to `<point>`, you can define a line outside of a `<graph>` object, either in a `<setup>` block or in your regular text. If you define a line (or reference it using `$lineName`) within regular text, Doenet will print an equation of the line.
 
-```doenet
+```doenet-editor-horiz
 <setup>
   <line name="line1" equation="y=6-x" />
 </setup>
@@ -62,12 +61,11 @@ Also similar to `<point>`, you can define a line outside of a `<graph>` object, 
 <p>$line1</p>
 <p><line name="line2" equation="y=x" /></p>
 
-<graph showNavigation="false" size="small">
+<graph fixAxes size="small">
   $line1
   $line2
 </graph>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 Finally, and again like points, lines can be dragged around in Doenet. Try dragging one of the lines in the previous example, and notice that Doenet will automatically update the equation of the line as it moves. (If you want to prevent this behavior, the `fixed` attribute you learned about in the previous section will prevent a line from moving.)
 
@@ -75,14 +73,13 @@ Finally, and again like points, lines can be dragged around in Doenet. Try dragg
 
 In geometry, we frequently want to define a line $l$ which goes through a point $P$ and is either parallel or perpendicular to some other line $k$. For these applications, the `parallelTo` and `perpendicularTo` attributes can be useful, as shown in the following example.
 
-```doenet
+```doenet-editor-horiz
 <graph>
   <line name="k">y = 3x + 4</line>
   <line through="(1,2)" parallelTo="$k"  styleNumber="2"/>
   <line through="(-1,-2)" perpendicularTo="$k"  styleNumber="3"/>
 </graph>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 ### Line Segments and Rays
 The ray $\overrightarrow{PQ}$ starts at its endpoint $P$ (sometimes called its vertex) and goes through $Q$. DoenetML has a `<ray>` tag with attributes that match those terms:
@@ -101,8 +98,8 @@ Similar to defining a `<line>` through two points, the endpoints are separated b
 
 In the example below, you can adjust $\overrightarrow{PQ}$ and $\overline{RS}$ by dragging the four labeled points. You can also drag the ray or line segments themselves, and the labeled points will translate accordingly.
 
-```doenet
-<graph showNavigation="false">
+```doenet-editor-horiz
+<graph fixAxes>
   <point name="P" coords="(-8,8)"  labelIsName />
   <point name="Q" coords="(6,4)"   labelIsName />
   <point name="R" coords="(-6,2)"  labelIsName />
@@ -113,27 +110,24 @@ In the example below, you can adjust $\overrightarrow{PQ}$ and $\overline{RS}$ b
   <lineSegment endpoints="(2,-5) (8,-5)" />
 </graph>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 ### Stylish Segments
 As with lines, you can change how rays and segments are displayed on screen using the `styleNumber` attributes. You've already seen how points are displayed with each `styleNumber`. Below you can see points combined with a line segment.
 
 ```doenet-example
 <graph xmin="0" xmax="7.5" ymin="-1" ymax="2" 
-           showNavigation="false" identicalAxisScales
+           fixAxes identicalAxisScales
            displayXAxis="false" displayYAxis="false" >  
 
-      <map>
-        <template><point labelPosition="bottom" styleNumber="$i">
-          ($i,0)
-          <label>$i</label>
-        </point>
-        <lineSegment endpoints="($i,0) ($i+0.5,1)" styleNumber="$i"/>
-        </template>
-        <sources alias="i"><sequence from="1" to="6" /></sources>
-      </map>
+  <repeatForSequence from="1" to="6" valueName="i">
+    <point labelPosition="bottom" styleNumber="$i">
+      ($i,0)
+      <label>$i</label>
+    </point>
+    <lineSegment endpoints="($i,0) ($i+0.5,1)" styleNumber="$i"/>
+  </repeatForSequence>
 
-    </graph>
+</graph>
 ```
 
 ### Geometry Example
@@ -151,8 +145,8 @@ Now that we have points, segments, and rays, we can use DoenetML to create an in
 
     (Note, currently, `<intersection>` works with lines, line segments, rays, polygons and circles.)
 
-```doenet
-<graph showNavigation="false" displayXAxis="false" displayYAxis="false">
+```doenet-editor-horiz
+<graph fixAxes displayXAxis="false" displayYAxis="false">
   <point name="A" coords="(-6,6)" labelIsName />
   <point name="B" coords="(7,4)"  labelIsName />
   <point name="C" coords="(0,-5)" labelIsName labelPosition="bottom"/>
@@ -172,7 +166,6 @@ Now that we have points, segments, and rays, we can use DoenetML to create an in
   <intersection styleNumber="5">$AD $BE</intersection>
 </graph>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 ### Next Steps
 There are many more geometric objects you can display in Doenet, including polygons and circles. Before we get to those shapes, however, it's time to take a step back and learn about another DoenetML feature. The next section will cover **properties**, which are an important tool for interacting with DoenetML ccmponents.

--- a/packages/docs-nextra/pages/tutorials/intermediateTutorial/iT2-4-properties.mdx
+++ b/packages/docs-nextra/pages/tutorials/intermediateTutorial/iT2-4-properties.mdx
@@ -35,7 +35,7 @@ The documentation page for each DoenetML component, as found in either the [Alph
 
 As a basic example, the following code uses the $x$ and $y$-coordinates of points $P$ and $Q$ to compute the length of $\overline{PQ}$, via the distance formula. However, it turns out DoenetML already computes that distance; we can access it using the `length` property of the line segment.
 
-```doenet
+```doenet-editor-horiz
 <graph showNavigation="false" size="small">
 
   <point name="P" x="-8" y="-2" />
@@ -54,7 +54,6 @@ As a basic example, the following code uses the $x$ and $y$-coordinates of point
 <p>Using the <c>length</c> property:
 <m>PQ = $PQ.length</m></p> 
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 Drag the endpoints around and double check that the distances are updated correctly. Also notice that we can refer to `$Q.x` and `$Q.y`, even though we defined Q without using the `x` and `y` attributes.
 
@@ -75,29 +74,28 @@ Later in this tutorial we'll cover sequences and other lists of objects in Doene
 
 * Some properties return a list of objects instead of one specific value.
 
-* To refer to the $n^{th}$ object in a list, use the following "array" notation: First, enter the name of the component, followed by the type of object or property that is being accessed, followed by square brackets enclosing the index value desired. The following example shows this notation for three different types of lists; `<mathList>`, `<textList>`, and `<booleanList>`.
+* To refer to the $n^{th}$ object in a list, use the following "array" notation: First, enter the name of the object followed by square brackets enclosing the index value desired. The following example shows this notation for three different types of lists; `<mathList>`, `<textList>`, and `<booleanList>`.
 
-```doenet {2,5,8} 
+```doenet-editor-horiz
 <p>A mathlist: <mathList name="ml">x xy pi^2 sqrt(2)</mathList></p>
-<p>The third "math" in the <tag>mathList</tag> is: $ml.maths[3]</p>
+<p>The third "math" in the <tag>mathList</tag> is: $ml[3]</p>
 
 <p>A textlist: <textList name="tl">red orange yellow green</textList></p>
-<p>The third "text" in the <tag>textList</tag> is: $tl.texts[3]</p>
+<p>The third "text" in the <tag>textList</tag> is: $tl[3]</p>
 
 <p>A booleanlist: <booleanList name="bl">true 1 0 true</booleanList></p>
-<p>The third "boolean" in the <tag>booleanList</tag> is: $bl.booleans[3]</p>
+<p>The third "boolean" in the <tag>booleanList</tag> is: $bl[3]</p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 ### Doenet Indexes from 1
 
-In some languages, `$listName.prop[0]` would be the first element, but DoenetML starts counting at $1$; the first item in any list (or vector, or map, etc...) is `$listName.prop[1]`.
+In some languages, `$listName[0]` would be the first element, but DoenetML starts counting at $1$; the first item in any list is `$listName[1]`.
 
 ### Array Notation with Graphical Components
 
 The following code demonstrates the use of array notation and properties with graphical components. Two line segments are defined using the `endpoints` attribute; as we saw in the previous section, these endpoints are not drawn by default. However, the reference to `$line2.endpoints` (line 5) is nested within the `<graph>` component. That's why the endpoints of `line2` are displayed, and those of `line1` are not.
 
-Below the graph, you'll find references to the `endpoints` property of both line segements, as well as individual references to specific data from the `endpoints` property list (see lines 10-11).
+Below the graph, you'll find references to the `endpoints` property of both line segments, as well as individual references to specific data from the `endpoints` property list (see lines 10-11).
 
 
 ```doenet-editor-horiz
@@ -115,7 +113,6 @@ Below the graph, you'll find references to the `endpoints` property of both line
 ```
 
 
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 As usual, if you drag either of the line segments or the endpoints, all of the coordinates in the text below the graph will be updated.
 

--- a/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-1-writing-mathematics.mdx
+++ b/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-1-writing-mathematics.mdx
@@ -19,63 +19,58 @@ but you have no control over where the line breaks occur, how far the bullet poi
 
 If you've created a webpage with HTML, you'll feel right at home writing in DoenetML. (And if you haven't, don't worry -- there's not too much to learn!) Content is always contained between opening and closing tags. Just like HTML, tags are denoted with angle brackets, < and >. The closing tag includes an extra slash.
 
-For example, the following text would create a new paragraph:
-```doenet
-     <p>Write the paragraph text here!</p>
+For example, the following text would create a new paragraph.
+```doenet-editor-horiz
+<p>Write the paragraph text here!</p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
+Try adding a second paragraph in the first panel above and clicking the *Update* button; the second panel will display the two paragraphs.
 
 Similarly, the `<em>` tag tells Doenet that the surrounded text should be emphasized, which typically means your web browser will italicize the text.
 
-Below this paragraph, you'll see an example with one line of code using `<p>` and `<em>` tags. To test the code in a live editor, click on the "Test Code" button at the bottom of the example.
+Below, you'll see an example using `<p>` and `<em>` tags.  You can click on the blank line at the bottom and add a new paragraph, surrounded by `<p>` and `</p>`. Then click *Update* to see the results. If you get an error, make sure you've included both the opening tag `<p>` and the closing tags `</p>`.
 
-In your test editor, you can click on the blank line at the bottom and add a new paragraph, surrounded by `<p>` and `</p>`. Then click "update" to see the results. If you get an error, make sure you've included both the opening and ending tags,
-
-```doenet
+```doenet-editor-horiz
 <p>This is a short paragraph, which includes some <em>emphasized</em> text. Similar to other markup languages, DoenetML ignores    extra    spaces
 
 and blank lines.</p>
+
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 As demonstrated above, tags can be nested; the text between `<p>` and `</p>` includes emphasized text, using the `<em>` tag. If you nest tags, you must always close the most "recent" tag before closing any others. For example, once you use an `<em>` inside of a paragraph, you **must** include the closing `</em>` before finishing the paragraph with `</p>`.
 
-In your test editor, try swapping the `</em>` and `</p>` tags, and then click "update." DoenetML will complain that it expected `</em>`, but found something else instead.
+Try swapping the `</em>` and `</p>` tags, and then click <em>Update</em>. DoenetML will complain that it expected `</em>`, but found something else instead.
 
-Similar to HTML, tags in DoenetML are **case-insensitive**. In other words, you could replace any `<em> `tag above with `<EM>`, `<eM>`, or `<Em>`, and the emphasized text will still render correctly.
+Tags in DoenetML are **case-sensitive**. In other words, if replace an `<em> `tag with `<EM>`, `<eM>`, or `<Em>`, you will get an error.
 
 ### Math Expressions in DoenetML
 
 In DoenetML, mathematical expressions are denoted with the `<m>` tag, and are rendered with [MathJax](https://www.mathjax.org/). If an expression or equation is important enough to be centered on a line by itself, use the `<me>` tag instead.
 
-```doenet
+```doenet-editor-horiz
 <p>Consider the function</p>
 
 <me>f(x) = x^2-3x-10.</me>
 
 <p>Then <m>f(x)=0</m> when <m>x=5</m> or <m>x=-2</m>.</p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 For those familiar with LaTeX, the difference between `<m>` and `<me>` is essentially the same as "inline" and "display" mode in LaTeX. Speaking of LaTeX: you can use nearly any valid LaTeX code in `<m>` and `<me>` tags. (You can see the full list of [commands supported by MathJax](https://docs.mathjax.org/en/latest/input/tex/macros/index.html); although you can't embed full text environments in an `<m>`, essentially any code you would use to typeset mathematics should work.) See below for some examples.
 
-```doenet
+```doenet-editor-horiz
 <me>x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}</me>
 
 <me>F(x) = \int_a^x f(t) \, dt</me>
 
 <me>| \angle ABC | = 30^\circ</me>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 The `<m>` and `<me>` tags do not recognize strings such as "sqrt" or "sin" as mathematical functions. To render those functions correctly, use the appropriate LaTeX code:
 
-```doenet
+```doenet-editor-horiz
 <me>\sqrt{a^2+b^2}</me>
 
 <me>\sin{(a+b)}</me>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 A full LaTeX introduction is beyond the scope of this tutorial. If you're not familiar with LaTeX, we highly encourage you to search online for an introduction to typing mathematics in LaTeX, such as [this guide](https://overleaf.com/learn/latex/Mathematical_expressions) from Overleaf.
 
@@ -83,7 +78,7 @@ A full LaTeX introduction is beyond the scope of this tutorial. If you're not fa
 
 Many of the basic HTML tags for formatting text carry over to DoenetML. The code sample below demonstrates paragraphs, lists, and alert (bold) text.
 
-```doenet
+```doenet-editor-horiz
 <p>You've already seen paragraphs and <em>emphasized</em> text.  Although DoenetML does not have a tag for bold text, it does have a tag for <alert>alert text</alert>.</p>
   
 <p>Lists come in two flavors: ordered and unordered.</p>
@@ -101,9 +96,8 @@ Many of the basic HTML tags for formatting text carry over to DoenetML. The code
   <li>code, but with bullet points, not numbers.</li>
 </ul>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
-  Lists can be nexted as well, but be sure the second list is entirely contained between a pair of `<li>` and `</li>` tags in the "parent" list. See the editor below. Try turning one or both of the lists into an ordered list in the test editor and click update to see the results.
+  Lists can be nested as well, but be sure the second list is entirely contained between a pair of `<li>` and `</li>` tags in the "parent" list. See the editor below. Try turning one or both of the lists into an ordered list in the test editor and click update to see the results.
 
 ### Comments
 Occasionally you might want to "comment out" part of your document, i.e. prevent it from being processed by Doenet and displayed on screen. (Perhaps something isn't working correctly, or you're working on a long document and only want a portion of it to render on screen.). DoenetML uses the same comment tag as HTML; anything between `<!-- and -->` will be ignored:
@@ -112,12 +106,11 @@ Occasionally you might want to "comment out" part of your document, i.e. prevent
 ```
 
 You can see a DoenetML comment in action in the following sample:
-```doenet
+```doenet-editor-horiz
 <!-- <p>This paragraph will be ignored by Doenet</p> -->
 
 <p>This text will be displayed.</p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 ### For Experienced HTML Users Only
 *(If that doesn't describe you, feel free to skip right over this section!)*
@@ -131,9 +124,7 @@ If you've written a lot of HTML in your life, you'll feel comfortable with the s
 `<code>`: use `<c>` instead.
 
 `<a href="https://doenet.org">link text</a>`:
-Use `<ref uri="https://doenet.org">link text</ref>` instead. Make sure to include `https://` at the beginning of the link.
-
-`<hr/>`: will cause an error.
+Use `<ref to="https://doenet.org">link text</ref>` instead. Make sure to include `https://` at the beginning of the link.
 
 `<h1>` through `<h6>`: will cause an error.
 Instead, you can create headers by including the appropriate text within `<section>` tags. This will create an automatically numbered section in your document (or subsection, if you nest the `<section>` tags). If you wish to give the section a specific name instead, use the `<title>` within the section. 

--- a/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-10-advice.mdx
+++ b/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-10-advice.mdx
@@ -18,7 +18,7 @@ More generally, there are some fairly serious errors that would immediately caus
 
 Along the same lines: if you give Doenet an invalid attribute value, it will generally just ignore the attribute instead of crashing with an error message. In the following code, we made a typo and used a curly bracket in the domain, writing $[0,2\}$ instead of $[0,2]$. Notice that Doenet still defines the function, and does not restrict its domain at all; $f(-1)$ and $f(3)$ are both defined.
 
-```doenet
+```doenet-editor-horiz
 <function name="f" domain="[0,2}">
   x^2
 </function>
@@ -29,19 +29,18 @@ Along the same lines: if you give Doenet an invalid attribute value, it will gen
 <p>$$f(2)</p>
 <p>$$f(3)</p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 On one hand this is very forgiving and helpful, but it can be surprising as well. Suppose you notice that $f(10)$ is defined even though the domain of $f$ is supposed to be $[0,2]$. You might think there's a bug in Doenet's code regarding domains, but in fact (at least in this case) it's author error. For this example, Doenet will issue several warnings that look like this : 
-    *Line #5 Insufficient dimensions for domain for function. Domain has 0 intervals but the function has 1 input.*
+    *Insufficient dimensions for domain for function. Domain has 0 intervals but the function has 1 input.*
 
-(Note - to view warnings look for the yellow button in the bottom left corner of the text editor.)
+(Note - to view warnings look for the *Warnings* in the bottom left corner of the text editor.)
 
 ### Avoiding Crashes
 There are relatively few reasons why a Doenet document will fail to load, and display an error message instead. The most common are:
 
 * **Omitting a closing tag.** If you omit a closing `</p>`, for example, Doenet will give you an error message similar to
 
-  ***Error:** Invalid DoenetML. Missing closing tag. Expected `</p>`. Found on line 8*
+  **Error:** Invalid DoenetML: The tag `<p>` has no closing tag. Expected a self-closing tag or a `</p>` tag. Found on line 8.
 
     The displayed line number tells you the location of the error in the document.
 
@@ -55,9 +54,7 @@ There are relatively few reasons why a Doenet document will fail to load, and di
 
     * Names cannot begin with a number or an underscore.
 
-    Unlike attributes and tags, names are case-sensitive in DoenetML. A name can match the same text as an attribute; for example,`<math name="domain">4</math>` is valid DoenetML. But we encourage you to avoid this so that you don't cause any confusion.
-
-* **Duplicate component name.** You cannot give two components the same name.
+    Unlike attributes, names are case-sensitive in DoenetML. A name can match the same text as an attribute; for example,`<math name="domain">4</math>` is valid DoenetML. But we encourage you to avoid this so that you don't cause any confusion.
 
 ### Attributes vs. Children
 

--- a/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-3-variables-numbers.mdx
+++ b/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-3-variables-numbers.mdx
@@ -9,7 +9,7 @@ This section will also introduce attributes, which are an important way to defin
 ### The `<math>` Tag
 In DoenetML, `<math>` denotes a mathematical expression that can be rendered on screen and used in computations.
 
-```doenet
+```doenet-editor-horiz
 <p>
   <math>1-2</math>
 </p>
@@ -18,7 +18,6 @@ In DoenetML, `<math>` denotes a mathematical expression that can be rendered on 
   <math>sqrt(3^2+4^2)</math>
 </p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 Notice that the contents of a `<math>` tag are rendered in standard mathematical notation, just like `<m>` or `<me>` tags. The difference is that `<math>` can include arithmetic and algebraic operations. Unlike the `<m>` tag, common mathematical functions like "sqrt" and "sin" are recognized and rendered correctly.
 
@@ -26,7 +25,7 @@ By default, DoenetML does not perform any simplifications on the contents of a `
 
 In the following examples, we've added `simplify="true"` to each opening `<math>` tag. Notice how Doenet now simplifies each expression, by computing $1 - 2 = -1$ and $\sqrt{3^2 + 4^2} = 5$.
 
-```doenet
+```doenet-editor-horiz
 <p>
   <math simplify="true">1-2</math>
 </p>
@@ -35,13 +34,12 @@ In the following examples, we've added `simplify="true"` to each opening `<math>
   <math simplify="true">sqrt(3^2+4^2)</math>
 </p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
-**Pro tip #1:** the expression `attribute="true"` can always be replaced with just `attribute`. In the test editor, try deleting `="true"` from the attributes above, click update, and verify that Doenet still simplifies the expressions.
+**Pro tip #1:** the expression `attribute="true"` can always be replaced with just `attribute`. Try deleting `="true"` from the attributes above, click *Update*, and verify that Doenet still simplifies the expressions.
 
 **Pro tip #2:** the `simplify` attribute has other possible settings, such as `simplify="numbers"`, which will combine constants but not group other variables together. See the following code sample for an example.
 
-```doenet
+```doenet-editor-horiz
 <p> This expression will be fully simplified:
   <math simplify>3x^2 - 2x^2 + 3x + 5x + 7 + 9</math>
 </p>
@@ -50,7 +48,6 @@ Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_
   <math simplify="numbers">3x^2 - 2x^2 + 3x + 5x + 7 + 9</math>
 </p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 ### The name Attribute
 Perhaps the most commonly used attribute in DoenetML is `name`, which allows you to create a reference to an object (which could be *any* component, such as a `<p>`, an `<ol>`, or a `<math>`) so that you can refer to it later. (If you have a programing background, think: creating variables.) For example, the following code essentially amounts to "Let $x = 3$" in DoenetML:
@@ -62,16 +59,15 @@ Once we've defined a reference for $x$ with the `name` attribute, we can refer t
 
 When you want to refer to an object (or an object property, which we will discuss in later tutorials), use the `$` symbol, followed by the `name` of the object. The following example illustrates one common use for an object reference: repeating back to the user a value they've entered in a `<textInput/>` component.
 
-```doenet
+```doenet-editor-horiz
 <p>What is your name? <textInput name="userName"/></p>
 
 <p>Hello, $userName!</p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 Here is another example, where the original `<math>` component is used to define a value, and then later referenced to perform an algebraic substitution.
 
-```doenet
+```doenet-editor-horiz
 <p>Define the value of <m>x</m> here:
   <math name="x">3</math>
 </p>
@@ -83,16 +79,15 @@ Here is another example, where the original `<math>` component is used to define
 
 <p>Now simplify that value: <math simplify>$y</math>.</p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 Did you notice that $x$ was used to define a new `<math>` object named $y$, which was later used to create a third `<math>`, which was the simplified value of $y$? We could have also included the simplify attribute when defining $y$:
 ```doenet
      <math name="y" simplify>1+$x+$x^2+$x^3</math>
 ```
 
-You can use the `$` symbol to refer to any number of Doenet objects. The following example uses multiple references to solve the equation $a x - b = 10$. In the test editor, try changing the values of $a$ and $b$ and click update to solve the new equation.
+You can use the `$` symbol to refer to any number of Doenet objects. The following example uses multiple references to solve the equation $a x - b = 10$. Try changing the values of $a$ and $b$ and click *Update* to solve the new equation.
 
-```doenet
+```doenet-editor-horiz
 <p>Define <m>a</m> and <m>b</m> :
   <math name="a">3</math>, 
   <math name="b">8</math>
@@ -100,28 +95,25 @@ You can use the `$` symbol to refer to any number of Doenet objects. The followi
 
 <p>Solution: <math simplify>(10+$b)/$a</math></p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 ### The `<number>` Tag
 The `<math>` tag can be used for symbolic or numerical expressions. If you just want to store a numerical value, you can use the `<number>` instead. Although you can use arithmetic and functions to define a `<number>`, only the resulting value will be stored. Compare how Doenet treats the expression $\sin(\frac{\pi}{4})$ inside `<math>` or `<number>` tags.
 
-```doenet
+```doenet-editor-horiz
 <p><math>sin(pi/4)</math></p>
 
 <p><number>sin(pi/4)</number></p>  
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 Unlike the contents of a `<math>` object, the value of a `<number>` is rendered as plain text, instead of using [MathJax](https://www.mathjax.org/). The difference can be visually jarring if it's next to other rendered mathematics or numbers. In some cases you might want to wrap your `<number>` between `<m>` and `</m>`:
 
-```doenet
+```doenet-editor-horiz
 <p><math>0.707</math></p>
 
 <p><m>\sin(\pi/4)=</m> <number>sin(pi/4)</number></p>  
 
 <p><m>\sin(\pi/4) = <number>sin(pi/4)</number></m></p>  
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 **Pro tip #3:** As you learn DoenetML, it's usually easiest to deal with `<math>` objects and not use `<number>`, unless you really want to display a decimal approximation. The difference between the tags becomes more important later on, once you're writing more advanced DoenetML code. If you have to do hundreds of computations, for example, it's much faster to work with `<number>` than to do symbolic computations with `<math>` objects.
 

--- a/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-4-comparison-math.mdx
+++ b/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-4-comparison-math.mdx
@@ -15,7 +15,7 @@ To start, here's a review of the two tags:
 In practice, the behavior of `<m>` and `<math>` can look very similar. Consider the following example.
 
 
-```doenet {5,11}
+```doenet-editor-horiz
 <p>Define two numbers:
   <m name="a">1</m>,
   <m name="b">2</m></p>
@@ -28,13 +28,12 @@ In practice, the behavior of `<m>` and `<math>` can look very similar. Consider 
 <p>Add them together:
   <math name="xySum">$x+$y</math></p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 Although using `<m> `or `<math>` results in the same display: there's a crucial, invisible difference. As described above, `$abSum` is just a string of characters, with no mathematical meaning or value. Conversely, `$xySum` is a mathematical object, with a value which could be simplified, and used in later computations.
 
 To drive this point home: the following code adds simplify to the definition of `xySum`, and also uses the result in a subsequent calculation.
 
-```doenet {5-6}
+```doenet-editor-horiz
 <p>Define two numbers:
   <math name="x">1</math>,
   <math name="y">2</math></p>
@@ -42,11 +41,10 @@ To drive this point home: the following code adds simplify to the definition of 
   <math name="xySum" simplify>$x+$y</math></p>
 <p>Square the result: <math simplify>$xySum^2</math></p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 Those calculations would not be possible with the `<m>` tag. In the following code, `$abSum^2` results in $_^2$, which is Doenet-speak for "the square of some unknown value." Because `$abSum` is a string of characters, not a number or mathematical expression, Doenet does not know how to square it.
 
-```doenet {5-6}
+```doenet-editor-horiz
 <p>Define two numbers:
   <m name="a">1</m>,
   <m name="b">2</m></p>
@@ -54,7 +52,6 @@ Those calculations would not be possible with the `<m>` tag. In the following co
   <m name="abSum">$a+$b</m></p>
 <p>Square the result: <math simplify>$abSum^2</math></p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 With the above example in mind, it's tempting to "play it safe" and use `<math>` tags everywhere. But the extra "internal machinery" associated with `<math>` objects means that `<m>` tags are more efficient with resources, and it's a good idea to use them when possible.
 
@@ -64,7 +61,7 @@ Sometimes it seems like `<m>` will suffice for your purposes, but it's worth pla
 
 Consider the following example, which uses three numbers to create and solve a quadratic equation. (Later in this tutorial you'll learn how to let the user provide these coefficients; for now we'll just define them in the code.)
 
-```doenet {7}
+```doenet-editor-horiz
 <p>Define the coefficients for a quadratic function here: 
   <math name="a">2</math>,
   <math name="b">8</math>,
@@ -76,13 +73,12 @@ Consider the following example, which uses three numbers to create and solve a q
   <math simplify>(-$b - sqrt($b^2- 4*$a*$c))/(2*$a)</math>.
 </p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
-Everything seems to be working! We've used `<m>` tags to display the quadratic equation, because we're not doing any computations there; we're just copying the coefficients into the expression. By contrast, we used `<math>` tags to do the computations with the quadratic formula. (To verify that Doenet is doing the computations, try removing simplify from one of the `<math>` tags and click "Update.")
+Everything seems to be working! We've used `<m>` tags to display the quadratic equation, because we're not doing any computations there; we're just copying the coefficients into the expression. By contrast, we used `<math>` tags to do the computations with the quadratic formula. (To verify that Doenet is doing the computations, try removing simplify from one of the `<math>` tags and click *Update*.)
 
 As it turns out, however, there's a subtle issue with our code. Check out what happens with the `<m>` tag with different coefficients:
 
-```doenet {7}
+```doenet-editor-horiz
 <p>Define the coefficients for a quadratic function here: 
   <math name="a">1</math>,
   <math name="b">-3</math>,
@@ -94,7 +90,6 @@ As it turns out, however, there's a subtle issue with our code. Check out what h
   <math simplify>(-$b - sqrt($b^2- 4*$a*$c))/(2*$a)</math>.
 </p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 Why does the quadratic equation look so strange? The `<m>` tag does no simplifications. It doesn't know (or care) about mathematical conventions such as:
 
@@ -103,7 +98,7 @@ Why does the quadratic equation look so strange? The `<m>` tag does no simplific
 
 How can we ensure that the quadratic equation will always be rendered nicely? It turns out to be trickier than expected. A natural first thought is to use `<math>` instead of `<m>`:
 
-```doenet {7}
+```doenet-editor-horiz
 <p>Define the coefficients for a quadratic function here: 
   <math name="a">1</math>,
   <math name="b">-3</math>,
@@ -113,11 +108,10 @@ How can we ensure that the quadratic equation will always be rendered nicely? It
 <p>Equation: <math>$a x^2 + $b x + $c = 0</math>
 </p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 That's an improvement; when displaying a `<math>` object, Doenet makes some straightforward adjustments such as writing $-3 x$ instead of $+ -3x$, but we still have $1x^2$ at the beginning of the equation. Perhaps we can fix that issue by adding `simplify` to the tag defining the equation?
 
-```doenet {7}
+```doenet-editor-horiz
 <p>Define the coefficients for a quadratic function here: 
   <math name="a">1</math>,
   <math name="b">-3</math>,
@@ -127,13 +121,12 @@ That's an improvement; when displaying a `<math>` object, Doenet makes some stra
 <p>Equation: <math simplify>$a x^2 + $b x + $c = 0</math>
 </p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 We're definitely getting closer! Doenet now displays $x^2 - 3x + 2$ as expected, but the equation still looks a little odd, with $0 = $ at the beginning. That happened because we asked Doenet to simplify the *entire equation*, and not just the quadratic polynomial. Doenet's simplification routines decided that the simpler, constant side of the equation should come first. Mathematically that's fine, but it looks odd to our eyes.
 
 To fix that remaining issue, we should use `<math>` to simplify just the quadratic polynomial, and display the rest of the equation with `<m>`. We could use side-by-side `<math>` and `<m>` tags, or nest them, as shown below. Nesting the tags is preferred, because it ensures the spacing is correct throughout the equation. (In the side-by-side example below, $=$ is too close to the $2$. You could manually leave a space between the side-by-side tags, but experienced HTML users know that it's dicey to expect that blank spaces or lines will be preserved.)
 
-```doenet
+```doenet-editor-horiz
 <p>Define the coefficients for a quadratic function here: 
   <math name="a">1</math>,
   <math name="b">-3</math>,
@@ -146,7 +139,6 @@ To fix that remaining issue, we should use `<math>` to simplify just the quadrat
 <p>Nested: <m><math simplify>$a x^2 + $b x + $c</math>=0</m>
 </p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 The moral of the story: when choosing between `<m>` and `<math>`, it's worth thinking about all the possible values your code might have to deal with, and whether simplifications will ever be necessary!
 

--- a/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-5-setup-blocks.mdx
+++ b/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-5-setup-blocks.mdx
@@ -8,7 +8,7 @@ In the following example, the numbers $a$, $b$, and $c$ are defined as `<math>` 
 $b^2 - 4 a c$
 . None of those definitions and computation are displayed on screen, but all four numbers are used later on.
 
-```doenet {1,9}
+```doenet-editor-horiz
 <setup>  
   <math name="a">2</math>
   <math name="b">8</math>
@@ -25,11 +25,10 @@ $b^2 - 4 a c$
 
 <p>Discriminant: $discr</p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 For comparison, here's the same code with `<setup>` and `</setup>` removed. The four numbers from the `<setup>` block are all displayed on screen, which is confusing to the user!
 
-```doenet
+```doenet-editor-horiz
 <math name="a">2</math>
 <math name="b">8</math>
 <math name="c">6</math>
@@ -44,7 +43,6 @@ For comparison, here's the same code with `<setup>` and `</setup>` removed. The 
 
 <p>Discriminant: $discr</p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 Throughout the rest of this tutorial, we'll frequently use `<setup>` for definitions and computations that don't need to appear on screen.
 

--- a/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-6-user-input.mdx
+++ b/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-6-user-input.mdx
@@ -13,18 +13,17 @@ The simplest way to have the user enter a number or mathematical expression is u
 
 In the example below, enter a number in the input box, and press return.
 
-```doenet {2}
+```doenet-editor-horiz
 <p>
   Enter a value for <m>x</m>: <mathInput name="userNumber" />
 </p>
 
 <p><m>x^2 = <math simplify>$userNumber^2</math></m></p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 In that example, Doenet displays $\_  ^2$ until you have entered a number; when the `<mathInput>` is blank, Doenet does not have a number to square. Although this makes logical sense, it looks very odd on the screen. You can avoid this by providing a default value for the `<mathInput>` object, using the `prefill` attribute. In the following code, `userNumber` is assigned a default value of $3$, but you can type a new number in the input box.
 
-```doenet {3}
+```doenet-editor-horiz
 <p>
   Enter a value for <m>x</m>: 
   <mathInput name="userNumber" prefill="3" />
@@ -32,7 +31,6 @@ In that example, Doenet displays $\_  ^2$ until you have entered a number; when 
 
 <p><m>x^2 = <math simplify>$userNumber^2</math></m></p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 **Note #1:** The value of a `<mathInput>` does not have to be a number. Try replacing $3$ with an expression like $a + b$ in the previous example.
 
@@ -44,7 +42,7 @@ Similar to [Desmos](https://desmos.com/) and other websites, input in a `<mathIn
 
 DoenetML documents can have multiple `<mathInput>` tags. The following code is a modification of our earlier quadratic formula example; now that we've learned about user input, the reader can change the values of $a$, $b$, or $c$, and Doenet will solve the resulting equation.
 
-```doenet {2-4}
+```doenet-editor-horiz
 <p>Enter the coefficients for <m>ax^2+bx+c</m>:</p> 
  <p><m>a = </m> <mathInput name="a" prefill="1"/></p>
  <p><m>b = </m> <mathInput name="b" prefill="-3"/></p>
@@ -58,13 +56,12 @@ DoenetML documents can have multiple `<mathInput>` tags. The following code is a
 <me>x = <math simplify>(-$b + sqrt($b^2- 4*$a*$c))/(2*$a)</math></me> 
 <me>x = <math simplify>(-$b - sqrt($b^2- 4*$a*$c))/(2*$a)</math></me> 
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 ### Component Order
 
 Although it's not specific to `<mathInput>` components, this is a good moment to point out an important feature of Doenet. The following example is almost identical to the previous one; the only difference is that the quadratic formula calculations have been moved to a `<setup>` block, and then are referred to later on as `$solution1` and `$solution2`.
 
-```doenet {1,4}
+```doenet-editor-horiz
 <setup>
    <math simplify name="solution1">(-$b + sqrt($b^2- 4*$a*$c))/(2*$a)</math>
    <math simplify name="solution2">(-$b - sqrt($b^2- 4*$a*$c))/(2*$a)</math>
@@ -82,7 +79,6 @@ Although it's not specific to `<mathInput>` components, this is a good moment to
 <me>x = $solution1</me> 
 <me>x = $solution2</me> 
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 The surprising thing about this new version is that $a$, $b$, and $c$ are used in lines 2--3 of the setup block... even though they're not defined until lines 7--9 of the code! This can be confusing to people who are used to sequential programming languages, in which you have to define the variable a before you can use it in computations. In Doenet, by contrast, you can refer to `$a` at any point, as long as `a` is defined somewhere in the document.
 
@@ -92,14 +88,13 @@ Often we want to pose a question to a user, have them type some input, and then 
 
 The `<answer>` component provides visual feedback, with a blue "Enter" button that changes to a red X or green check mark, depending on whether the submitted answer is wrong or right.
 
-```doenet
+```doenet-editor-horiz
 <p>Enter <m>5x^2-3</m>: <answer>5x^2-3</answer></p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
-The contents of an `<answer>` can depend on other objects. In the code below, you can enter constants to modify the linear equation, and then in the test editor check that you can correctly find the solution to the equation.
+The contents of an `<answer>` can depend on other objects. Below, you can enter constants to modify the linear equation, and then check that you can correctly find the solution to the equation.
 
-```doenet {13}
+```doenet-editor-horiz
 <setup>
   <math simplify name="solution">($c-$b)/$a</math>
 </setup>
@@ -114,12 +109,11 @@ The contents of an `<answer>` can depend on other objects. In the code below, yo
 
  <p><m>x = </m> <answer>$solution</answer></p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 ### Multiple Answers and `<mathList>`
 Often a question has more than one answer; a quadratic equation could have two solutions, for example. The following code combines a few of our previous examples. You can adjust the coefficients of a quadratic equation, and then check whether you can correctly compute the solutions. You can enter both solutions, separated by a comma, and then check your answer.
 
-```doenet {16-18}
+```doenet-editor-horiz
 <setup>
   <math simplify name="solution1">(-$b + sqrt($b^2- 4*$a*$c))/(2*$a)</math>
   <math simplify name="solution2">(-$b - sqrt($b^2- 4*$a*$c))/(2*$a)</math>
@@ -140,7 +134,6 @@ Often a question has more than one answer; a quadratic equation could have two s
   </answer>
 </p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 As you can see in the code, the correct response is defined as a `<mathList>`, which is a list of `<math>` objects:
 

--- a/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-7-functions.mdx
+++ b/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-7-functions.mdx
@@ -17,7 +17,7 @@ To evaluate your function, use the self-closing `<evaluate>` tag as follows:
 
 The following code shows this in action, with both numeric and symbolic input.
 
-```doenet
+```doenet-editor-horiz
 <setup>  
   <function name="f">x^2+1</function>
 </setup>
@@ -25,16 +25,14 @@ The following code shows this in action, with both numeric and symbolic input.
 <p><m>f(4) = <evaluate function="$f" input="4"/></m> </p>
 <p><m>f(a+b) = <evaluate function="$f" input="a+b"/> </m> </p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 In the above example, the function $f$ was defined in the `<setup>` block. If you include a `<function>` within the main text of your document, outside of a setup block, Doenet will render the formula for the function, but not the function name. In that situation, you probably want to include code such as `<m>g(x) = ... </m>` to avoid having a random, "floating" formula in your document:
 
-```doenet
+```doenet-editor-horiz
 <p><function name="f">x^2+1</function></p>
 
 <p><m>g(x) = <function name="g">sin( pi x)</function></m></p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 ### The `$$` Macro
 In mathematics we spend a lot of time evaluating functions. It would be time consuming and awkward to write `<evaluate function="$functionName" input="inputValue" />` every time you want to plug a value into a function. Fortunately, DoenetML provides a time-saving macro:
@@ -45,7 +43,7 @@ In mathematics we spend a lot of time evaluating functions. It would be time con
 
 The syntax shown above is equivalent to the longer `<evaluate>` tag. Frequently you want to evaluate a function at some number which was provided in a `<mathInput/>` box or defined as a `<math>`, so expressions like `$$f($a)` are extremely common in DoenetML; essentially that expression means "evaluate $f(x)$ at $x = a$."
 
-```doenet
+```doenet-editor-horiz
 <p><m>f(x) = 
   <function name="func">2x+3</function>
 </m>, and <m>f(0) = $$func(0)</m>.</p>
@@ -55,7 +53,6 @@ The syntax shown above is equivalent to the longer `<evaluate>` tag. Frequently 
 
 <p><m>f($a) = $$func($a)</m></p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 ### `$` vs. `$$`
 It can be confusing for new DoenetML users to remember when to use `$` or `$$`. The key is to remember what they stand for.
@@ -68,7 +65,7 @@ The most common mistake with `$` and `$$` is to define a function named $f$ and 
 
 These behaviors are illustrated in the following example.
 
-```doenet
+```doenet-editor-horiz
 <p>The next two lines are functionally equivalent.  (Pun intended!)</p>
 <p><function name="f">x^2</function></p>
 <p>$f</p>
@@ -78,12 +75,11 @@ These behaviors are illustrated in the following example.
 <p>This will compute <m>f(2)</m>:</p>
 <p>$$f(2)</p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 ### User-Defined Functions
 In DoenetML documents, we sometimes want to evaluate a function which is provided by the student. (See this [Arclength demonstration](https://www.doenet.org/portfolioviewer/_GreyYWRKHtWjTGfgI8axS), for example.) One way to accomplish this is by having the user enter a formula in a `<mathInput/>`, and then use the value of that input to define a function. See the example below for an example.
 
-```doenet
+```doenet-editor-horiz
 <setup>
   <function name="f">$userFormula</function>
 </setup>
@@ -98,7 +94,6 @@ In DoenetML documents, we sometimes want to evaluate a function which is provide
 
 <p><m>f($x) = $$f($x)</m></p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 ### Numeric Functions
 *This section is a bit technical and could be skipped if you're just starting to learn DoenetML. It's included for later reference, because the feature described here could be very important to you as you learn to write more complicated DoenetML documents.*
@@ -112,7 +107,7 @@ then you can evaluate f with numeric or symbolic inputs: `$$f(2)` returns 5, and
 
 Sometimes, you might know ahead of time that you will only evaluate a function with numeric inputs. In that case, you can create a "numeric function" (as opposed to "symbolic function") by including the attribute `symbolic="false"` in the function definition. Check out the following example to see how this affects function evaluation.
 
-```doenet
+```doenet-editor-horiz
 <p>Symbolic: <m>f(x) = <function name="f">1/x</function></m></p>
 <p><m> f(2) = $$f(2)</m></p>
 <p><m> f(\pi) = $$f(pi)</m></p>
@@ -125,7 +120,6 @@ Sometimes, you might know ahead of time that you will only evaluate a function w
 <p><m> g(3.1) = $$g(3.1)</m></p>
 <p><m> g(a+b) = $$g(a+b)</m></p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 At the very bottom of the results window (you may have to scroll!), $g(a + b) = NaN$, which is Doenet-speak for "Not a Number." The function $g$ can only handle numeric input; when we try to evaluate $g$ with symbolic input, the evaluation fails.
 

--- a/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-8-domains.mdx
+++ b/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-8-domains.mdx
@@ -7,7 +7,7 @@ In this section we'll explore additional options and operations with functions i
 ### Specifying the Domain of a Function
 So far the functions we've used have been defined for all real numbers. If you want to restrict the domain of a function, you can use the domain attribute in the `<function>` tag. Any attempt to evaluate the function outside of its specified domain will return an empty result. In the example below, this happens for $f(3)$.
 
-```doenet
+```doenet-editor-horiz
 <setup>
   <function name="f" domain="[0,2]">
     x^2
@@ -19,7 +19,6 @@ So far the functions we've used have been defined for all real numbers. If you w
 <p><m>f(2) = $$f(2)</m></p>
 <p><m>f(3) = $$f(3)</m></p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 As of this writing, DoenetML supports any interval (open, closed, half open / half closed) as the domain of a single variable function. This includes intervals which stretch to infinity, e.g.
 
@@ -36,7 +35,7 @@ In DoenetML, we can compute the derivative of an elementary function using the `
 
 creates a new DoenetML function named `fPrime` which is the derivative of $f$. The new function `fPrime` can be used in all the same ways as the original function, including evaluation using the `$$` macro. Here's an example.
 
-```doenet
+```doenet-editor-horiz
 <setup>
   <function name="f">$userFormula</function>
 </setup>
@@ -53,7 +52,6 @@ creates a new DoenetML function named `fPrime` which is the derivative of $f$. T
 <p>Symbolic evaluation: <m>f'($x) = $$fPrime($x)</m></p>
 <p>Numeric evaluation: <m>f'($x) = <number>$$fPrime($x)</number></m></p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 If your original function has a specified `domain`, its derivative will have the same `domain`.
 
@@ -61,7 +59,7 @@ If your original function has a specified `domain`, its derivative will have the
 The default variable in a DoenetML function is 
 $x$, but we can switch to a different variable using the `variable` attribute. This affects how the function is rendered on screen, and the `<derivative>` tag will use the correct variable as well.
 
-```doenet
+```doenet-editor-horiz
 <p><m>f(u) = </m>
   <function name="f" variable="u">cos(u)</function>
 </p>
@@ -70,7 +68,6 @@ $x$, but we can switch to a different variable using the `variable` attribute. T
 
 <p><m>f'(u) = <derivative name="fPrime">$f</derivative></m></p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 ### Higher Order Derivatives
 You can compute higher order derivatives through repeated use of `<derivative>` tags. For example, the following code defines a function along with its first and second derivatives.
@@ -85,7 +82,7 @@ You can compute higher order derivatives through repeated use of `<derivative>` 
 
 However, if you don't need $f'(x)$, you can jump straight to the second (or higher) derivative using the `derivVariables` attribute, as demonstrated in the following example.
 
-```doenet
+```doenet-editor-horiz
 <p><m>f(x) = </m>
   <function name="f">x sin(x)</function>
 </p>
@@ -100,7 +97,6 @@ However, if you don't need $f'(x)$, you can jump straight to the second (or high
    </m>
 </p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 ### Multivariable Functions and Partial Derivatives
 For those familiar with multivariable calculus: now it's time to tie all of the concepts in this section together! We can define a multivariable function using the `variables` attribute with `<function>`. For example,
@@ -111,7 +107,7 @@ For those familiar with multivariable calculus: now it's time to tie all of the 
 
 defines the function $f(x,y) = x^2 \cos (y)$ in DoenetML. The input variables should be listed (in order) in the variables attribute, separated by spaces. "In order" means that, if we evaluate `$$f(1,2)`, Doenet will set $x = 1$ and $y = 2$ because $x$ was listed first in the variables attribute, and $y$ second.
 
-```doenet
+```doenet-editor-horiz
 <p><m>f(x,y) = </m>
   <function name="f" variables="x y">x^2 cos(y)</function>
 </p>
@@ -120,11 +116,10 @@ defines the function $f(x,y) = x^2 \cos (y)$ in DoenetML. The input variables sh
 <p><m>f(x,5) = $$f(x,5)</m></p>
 <p><m>f(3,4) = $$f(3,4)</m></p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 To compute partial derivatives, we'll use the same `derivVariables` attribute from above. We can list one variable to specify which partial derivative to take. We can provide a list of variables to compute higher order (and mixed) partial derivatives.
 
-```doenet
+```doenet-editor-horiz
 <p><m>f(x,y) = </m>
   <function name="f" variables="x y">x^2 cos(y)</function>
 </p>
@@ -142,7 +137,6 @@ To compute partial derivatives, we'll use the same `derivVariables` attribute fr
 </p>
 
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 Although it's not demonstrated in these examples, you can also define a `domain` for multivariable functions. In the following definition,
 

--- a/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-9-sliders.mdx
+++ b/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-9-sliders.mdx
@@ -2,7 +2,7 @@ import { DoenetViewer, DoenetEditor, DoenetExample } from "../../../components"
 
 # Sliders
 
-Earlier you learned how to use `<mathInput>` to allow users to input text. Sliders are another common way for readers to input values or control an on-screen activity. By default, the (self-closing) tag `<slider/>` creates the following generic slider:
+Earlier you learned how to use `<mathInput>` to allow users to input math expressions. Sliders are another common way for readers to input values or control an on-screen activity. By default, the (self-closing) tag `<slider/>` creates the following generic slider:
 
 ```doenet-example
 <slider />
@@ -12,16 +12,15 @@ You can drag the point right and left to choose a value from 0 to 10. The defaul
 
 ### Common Slider Options
 
-The following example illustrates how to adjust the minimum and maximum values of a slider, the step size, and more. In the test editor, be sure to experiment with the code and click "update" to see how these attributes work.
+The following example illustrates how to adjust the minimum and maximum values of a slider, the step size, and more. Be sure to experiment with the code and click *Update* to see how these attributes work.
 
-```doenet
+```doenet-editor-horiz
 <slider showValue="false" />
 
 <slider from="5" to="20" step="3" initialValue="8"/>
 
 <slider from="0" to="1" step="0.001" showTicks="false" />
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 For completeness, here's a rundown of the attributes in those examples:
 
@@ -40,7 +39,7 @@ For completeness, here's a rundown of the attributes in those examples:
 ### Customized Slider Labels
 We can adjust the label on a slider using the `<label>` tag. This is a separate tag, not an attribute, and it must be nested between `<slider>` and `</slider>`; we can't use the "self-closing" style tag in this situation. This is demonstrated in the code below. We've also given the slider a name attribute, so that we can use its value in a calculation.
 
-```doenet
+```doenet-editor-horiz
 <slider from="-40" to="40" step="1" 
   initialValue="0" name="tempC">
   <label>Temp (<m>{}^{\circ}C</m>)</label>
@@ -52,14 +51,13 @@ We can adjust the label on a slider using the `<label>` tag. This is a separate 
   </m>
 </p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 *(For those who don't live in a climate where the Celsius and Fahrenheit temperatures can be the same: the from and to values were chosen to reflect common temperatures in Minnesota. Yes, it gets cold. Yes, we're ok with that. No, we don't want to move!)*
 
 ### Binding Sliders and Inputs
 Sometimes you want to provide your readers with maximum flexibility, and allow them to change a value using an input box *or* a slider! We can do that with the following code. The `<mathInput/>` is named $x$, and its value is used in the computation of `$$f($x)`. But we've used the `bindValueTo` attribute to ensure that the value of $x$ will always match the value of `xSlider`.
 
-```doenet
+```doenet-editor-horiz
 <p>Let <m>f(x) = <function name="f">x^2+1</function></m>.</p>
 
 <p>Choose a value of <m>x</m> (or adjust slider):</p>
@@ -69,18 +67,16 @@ Sometimes you want to provide your readers with maximum flexibility, and allow t
 
 <p><m>f($x) = $$f($x)</m></p>
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 Try adjusting the slider, and notice that the value in the `<mathInput/>` box is updated as well. Conversely, if you enter a number like $3$ or $4$ in the box, the value of the slider will be updated. Finally, try entering some numbers in the box which are not possible values for the slider (e.g. $1.7$, $\frac{3}{2}$, or $2 \pi$). Notice that DoenetML will choose the closest valid value of the slider, and update both the slider and input box accordingly.
 
 **Warning!** You can also bind the value of a slider to an input box... but you shouldn't! That approach leads to the following unexpected behavior. In the code below, instead of including the `bindValueTo="$xSlider"` attribute in the `<mathInput/>` tag, we've bound the slider to the input box instead:
 
-```doenet
+```doenet-editor-horiz
 <p><m>x = </m> <mathInput name="x" /></p>
 
 <slider from="0" to="5" step="1" name="xSlider" bindValueTo="$x" /> 
 ```
-Test code [here](https://www.doenet.org/portfolioeditor/_J1J2N530LyIvVWx64xB8V/_AgzWwqGV6Yy9DfqMyGlFm).
 
 If you adjust the slider, you'll see that the value of the input box is updated as well. Similarly, if you enter $1$ or $2$ in the input box, the slider will be updated. But now enter $3.8$ in the input box. You'll see that the slider will choose the closest valid value, but the input box will not update to $4$. Its value stays at $3.8$. At best this would be confusing to your readers, because two values which are supposed to be the same are actually different. At worst it could cause other parts of your code to break!
 

--- a/packages/docs-nextra/theme.config.tsx
+++ b/packages/docs-nextra/theme.config.tsx
@@ -5,20 +5,6 @@ export default {
     project: {
         link: "https://github.com/shuding/nextra",
     },
-    head: (
-        <>
-            <script
-                type="module"
-                src="https://dev.doenet.org/cdn/doenet-standalone.js"
-            >
-                {" "}
-            </script>
-            <link
-                rel="stylesheet"
-                href="https://dev.doenet.org/cdn/style.css"
-            />
-        </>
-    ),
     sidebar: {
         defaultMenuCollapseLevel: "1",
         "auto collapse": true,


### PR DESCRIPTION
This PR converts the introductory and intermediate tutorials to the conventions of version 0.7 and the embedded doenet editor in nextra.

The section "A Comparison of Mathematics Tags" still needs some conversions, as the `<m>` tag no longer works exactly as described.