### PR TITLE
add aria labels to check work buttons

### DIFF
--- a/packages/doenetml-worker-javascript/src/components/abstract/Input.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/Input.js
@@ -34,6 +34,8 @@ export default class Input extends InlineComponent {
                         "justSubmitted",
                         "creditAchieved",
                         "showCorrectness",
+                        "submitLabel",
+                        "submitLabelNoCorrectness",
                         "numAttemptsLeft",
                         "creditIsReducedByAttempt",
                         "numIncorrectSubmissions",
@@ -184,6 +186,47 @@ export default class Input extends InlineComponent {
                         dependencyValues.showCorrectnessFlag !== false;
                 }
                 return { setValue: { showCorrectness } };
+            },
+        };
+
+        stateVariableDefinitions.submitLabel = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                answerAncestor: {
+                    dependencyType: "stateVariable",
+                    variableName: "answerAncestor",
+                },
+            }),
+            definition({ dependencyValues }) {
+                let submitLabel;
+                if (dependencyValues.answerAncestor) {
+                    submitLabel =
+                        dependencyValues.answerAncestor.stateValues.submitLabel;
+                } else {
+                    submitLabel = "";
+                }
+                return { setValue: { submitLabel } };
+            },
+        };
+
+        stateVariableDefinitions.submitLabelNoCorrectness = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                answerAncestor: {
+                    dependencyType: "stateVariable",
+                    variableName: "answerAncestor",
+                },
+            }),
+            definition({ dependencyValues }) {
+                let submitLabelNoCorrectness;
+                if (dependencyValues.answerAncestor) {
+                    submitLabelNoCorrectness =
+                        dependencyValues.answerAncestor.stateValues
+                            .submitLabelNoCorrectness;
+                } else {
+                    submitLabelNoCorrectness = "";
+                }
+                return { setValue: { submitLabelNoCorrectness } };
             },
         };
 

--- a/packages/doenetml/src/utils/checkWork.tsx
+++ b/packages/doenetml/src/utils/checkWork.tsx
@@ -105,7 +105,7 @@ export function createCheckWorkComponent(
             ? SVs.submitLabel
             : SVs.submitLabelNoCorrectness;
         const checkWorkLabel = showText ? <>&nbsp; {checkWorkText}</> : "";
-        const title = showText ? undefined : checkWorkText;
+        const additionalLabel = showText ? undefined : checkWorkText;
 
         checkWorkComponent = (
             <Button
@@ -114,13 +114,13 @@ export function createCheckWorkComponent(
                 disabled={disabled}
                 style={checkWorkStyle}
                 onClick={submitAnswer}
-                aria-label={checkWorkText}
+                aria-label={additionalLabel}
             >
                 <FontAwesomeIcon
                     icon={faLevelDownAlt as IconProp}
                     transform={{ rotate: 90 }}
                     aria-hidden={true}
-                    title={title}
+                    title={additionalLabel}
                 />
                 {checkWorkLabel}
             </Button>
@@ -132,18 +132,18 @@ export function createCheckWorkComponent(
             ).getPropertyValue("--mainGreen");
 
             const correctLabel = showText ? <>&nbsp; Correct</> : "";
-            const title = showText ? undefined : "Correct";
+            const additionalLabel = showText ? undefined : "Correct";
 
             checkWorkComponent = (
                 <span
                     id={id + "_correct"}
                     style={statusStyle}
-                    aria-label="Correct"
+                    aria-label={additionalLabel}
                 >
                     <FontAwesomeIcon
                         icon={faCheck as IconProp}
                         aria-hidden={true}
-                        title={title}
+                        title={additionalLabel}
                     />
                     {correctLabel}
                 </span>
@@ -153,17 +153,17 @@ export function createCheckWorkComponent(
                 document.documentElement,
             ).getPropertyValue("--mainRed");
             const incorrectLabel = showText ? <>&nbsp; Incorrect</> : "";
-            const title = showText ? undefined : "Incorrect";
+            const additionalLabel = showText ? undefined : "Incorrect";
             checkWorkComponent = (
                 <span
                     id={id + "_incorrect"}
                     style={statusStyle}
-                    aria-label="Incorrect"
+                    aria-label={additionalLabel}
                 >
                     <FontAwesomeIcon
                         icon={faTimes as IconProp}
                         aria-hidden={true}
-                        title={title}
+                        title={additionalLabel}
                     />
                     {incorrectLabel}
                 </span>
@@ -176,12 +176,13 @@ export function createCheckWorkComponent(
                 ? `${percent}% Credit`
                 : `${percent}% Correct`;
             const partialLabel = showText ? partialText : `${percent} %`;
+            const additionalLabel = showText ? undefined : partialText;
 
             checkWorkComponent = (
                 <span
                     id={id + "_partial"}
                     style={statusStyle}
-                    aria-label={partialText}
+                    aria-label={additionalLabel}
                 >
                     {partialLabel}
                 </span>
@@ -191,7 +192,7 @@ export function createCheckWorkComponent(
         // showCorrectness is false
         statusStyle.backgroundColor = "rgb(74, 3, 217)";
         const responseSavedText = showText ? <>&nbsp; Response Saved</> : "";
-        const title = showText ? undefined : "Response Saved";
+        const additionalLabel = showText ? undefined : "Response Saved";
 
         if (!showText) {
             statusStyle.padding = "1px 8px 1px 4px"; // To center the faCloud icon
@@ -200,12 +201,12 @@ export function createCheckWorkComponent(
             <span
                 id={id + "_saved"}
                 style={statusStyle}
-                aria-label="Response Saved"
+                aria-label={additionalLabel}
             >
                 <FontAwesomeIcon
                     icon={faCloud as IconProp}
                     aria-hidden={true}
-                    title={title}
+                    title={additionalLabel}
                 />
                 {responseSavedText}
             </span>

--- a/packages/doenetml/src/utils/checkWork.tsx
+++ b/packages/doenetml/src/utils/checkWork.tsx
@@ -93,16 +93,12 @@ export function createCheckWorkComponent(
     let checkWorkComponent;
 
     if (validationState === "unvalidated") {
-        const checkWorkText = showText ? (
-            <>
-                &nbsp;{" "}
-                {SVs.showCorrectness
-                    ? SVs.submitLabel
-                    : SVs.submitLabelNoCorrectness}
-            </>
-        ) : (
-            ""
-        );
+        const checkWorkText = SVs.showCorrectness
+            ? SVs.submitLabel
+            : SVs.submitLabelNoCorrectness;
+        const checkWorkLabel = showText ? <>&nbsp; {checkWorkText}</> : "";
+
+        console.log({ checkWorkText });
 
         checkWorkComponent = (
             <Button
@@ -111,12 +107,13 @@ export function createCheckWorkComponent(
                 disabled={disabled}
                 style={checkWorkStyle}
                 onClick={submitAnswer}
+                aria-label={checkWorkText}
             >
                 <FontAwesomeIcon
                     icon={faLevelDownAlt as IconProp}
                     transform={{ rotate: 90 }}
                 />
-                {checkWorkText}
+                {checkWorkLabel}
             </Button>
         );
     } else if (SVs.showCorrectness) {
@@ -125,50 +122,52 @@ export function createCheckWorkComponent(
                 document.documentElement,
             ).getPropertyValue("--mainGreen");
 
-            const checkWorkText = showText ? <>&nbsp; Correct</> : "";
+            const correctLabel = showText ? <>&nbsp; Correct</> : "";
 
             checkWorkComponent = (
                 <Button
                     id={id + "_correct"}
                     style={checkWorkStyle}
                     tabIndex={checkWorkTabIndex}
+                    aria-label="Correct"
                 >
                     <FontAwesomeIcon icon={faCheck as IconProp} />
-                    {checkWorkText}
+                    {correctLabel}
                 </Button>
             );
         } else if (validationState === "incorrect") {
             checkWorkStyle.backgroundColor = getComputedStyle(
                 document.documentElement,
             ).getPropertyValue("--mainRed");
-            const checkWorkText = showText ? <>&nbsp; Incorrect</> : "";
+            const incorrectLabel = showText ? <>&nbsp; Incorrect</> : "";
             checkWorkComponent = (
                 <Button
                     id={id + "_incorrect"}
                     style={checkWorkStyle}
                     tabIndex={checkWorkTabIndex}
+                    aria-label="Incorrect"
                 >
                     <FontAwesomeIcon icon={faTimes as IconProp} />
-                    {checkWorkText}
+                    {incorrectLabel}
                 </Button>
             );
         } else {
             // partialcorrect
             checkWorkStyle.backgroundColor = "#efab34";
             const percent = Math.round(SVs.creditAchieved * 100);
-            const checkWorkText = showText
-                ? SVs.creditIsReducedByAttempt
-                    ? `${percent}% Credit`
-                    : `${percent}% Correct`
-                : `${percent} %`;
+            const partialText = SVs.creditIsReducedByAttempt
+                ? `${percent}% Credit`
+                : `${percent}% Correct`;
+            const partialLabel = showText ? partialText : `${percent} %`;
 
             checkWorkComponent = (
                 <Button
                     id={id + "_partial"}
                     style={checkWorkStyle}
                     tabIndex={checkWorkTabIndex}
+                    aria-label={partialText}
                 >
-                    {checkWorkText}
+                    {partialLabel}
                 </Button>
             );
         }
@@ -185,6 +184,7 @@ export function createCheckWorkComponent(
                 id={id + "_saved"}
                 style={checkWorkStyle}
                 tabIndex={checkWorkTabIndex}
+                aria-label="Response Saved"
             >
                 <FontAwesomeIcon icon={faCloud as IconProp} />
                 &nbsp; Response Saved

--- a/packages/doenetml/src/utils/checkWork.tsx
+++ b/packages/doenetml/src/utils/checkWork.tsx
@@ -15,7 +15,7 @@ const Button = styled.button`
     display: inline-block;
     color: white;
     background-color: var(--mainBlue);
-    padding: 2px;
+    padding: "1px 6px 1px 6px";
     /* border: var(--mainBorder); */
     border: none;
     border-radius: var(--mainBorderRadius);
@@ -75,9 +75,17 @@ export function createCheckWorkComponent(
 
     const disabled = SVs.disabled;
 
-    let checkWorkStyle: React.CSSProperties = {
+    const checkWorkStyle: React.CSSProperties = {
         cursor: "pointer",
-        padding: "1px 6px 1px 6px",
+    };
+
+    const statusStyle: React.CSSProperties = {
+        padding: "1px 4px 1px 4px",
+        marginRight: "4px",
+        borderRadius: "5px",
+        height: "22px",
+        display: "inline-block",
+        verticalAlign: "middle",
     };
 
     let checkWorkTabIndex = 0;
@@ -97,6 +105,7 @@ export function createCheckWorkComponent(
             ? SVs.submitLabel
             : SVs.submitLabelNoCorrectness;
         const checkWorkLabel = showText ? <>&nbsp; {checkWorkText}</> : "";
+        const title = showText ? undefined : checkWorkText;
 
         checkWorkComponent = (
             <Button
@@ -110,48 +119,58 @@ export function createCheckWorkComponent(
                 <FontAwesomeIcon
                     icon={faLevelDownAlt as IconProp}
                     transform={{ rotate: 90 }}
+                    aria-hidden={true}
+                    title={title}
                 />
                 {checkWorkLabel}
             </Button>
         );
     } else if (SVs.showCorrectness) {
         if (validationState === "correct") {
-            checkWorkStyle.backgroundColor = getComputedStyle(
+            statusStyle.backgroundColor = getComputedStyle(
                 document.documentElement,
             ).getPropertyValue("--mainGreen");
 
             const correctLabel = showText ? <>&nbsp; Correct</> : "";
+            const title = showText ? undefined : "Correct";
 
             checkWorkComponent = (
-                <Button
+                <span
                     id={id + "_correct"}
-                    style={checkWorkStyle}
-                    tabIndex={checkWorkTabIndex}
+                    style={statusStyle}
                     aria-label="Correct"
                 >
-                    <FontAwesomeIcon icon={faCheck as IconProp} />
+                    <FontAwesomeIcon
+                        icon={faCheck as IconProp}
+                        aria-hidden={true}
+                        title={title}
+                    />
                     {correctLabel}
-                </Button>
+                </span>
             );
         } else if (validationState === "incorrect") {
-            checkWorkStyle.backgroundColor = getComputedStyle(
+            statusStyle.backgroundColor = getComputedStyle(
                 document.documentElement,
             ).getPropertyValue("--mainRed");
             const incorrectLabel = showText ? <>&nbsp; Incorrect</> : "";
+            const title = showText ? undefined : "Incorrect";
             checkWorkComponent = (
-                <Button
+                <span
                     id={id + "_incorrect"}
-                    style={checkWorkStyle}
-                    tabIndex={checkWorkTabIndex}
+                    style={statusStyle}
                     aria-label="Incorrect"
                 >
-                    <FontAwesomeIcon icon={faTimes as IconProp} />
+                    <FontAwesomeIcon
+                        icon={faTimes as IconProp}
+                        aria-hidden={true}
+                        title={title}
+                    />
                     {incorrectLabel}
-                </Button>
+                </span>
             );
         } else {
-            // partialcorrect
-            checkWorkStyle.backgroundColor = "#efab34";
+            // partial correct
+            statusStyle.backgroundColor = "#efab34";
             const percent = Math.round(SVs.creditAchieved * 100);
             const partialText = SVs.creditIsReducedByAttempt
                 ? `${percent}% Credit`
@@ -159,34 +178,37 @@ export function createCheckWorkComponent(
             const partialLabel = showText ? partialText : `${percent} %`;
 
             checkWorkComponent = (
-                <Button
+                <span
                     id={id + "_partial"}
-                    style={checkWorkStyle}
-                    tabIndex={checkWorkTabIndex}
+                    style={statusStyle}
                     aria-label={partialText}
                 >
                     {partialLabel}
-                </Button>
+                </span>
             );
         }
     } else {
         // showCorrectness is false
-        checkWorkStyle.backgroundColor = "rgb(74, 3, 217)";
-        const checkWorkText = showText ? <>&nbsp; Response Saved</> : "";
+        statusStyle.backgroundColor = "rgb(74, 3, 217)";
+        const responseSavedText = showText ? <>&nbsp; Response Saved</> : "";
+        const title = showText ? undefined : "Response Saved";
 
         if (!showText) {
-            checkWorkStyle.padding = "1px 8px 1px 4px"; // To center the faCloud icon
+            statusStyle.padding = "1px 8px 1px 4px"; // To center the faCloud icon
         }
         checkWorkComponent = (
-            <Button
+            <span
                 id={id + "_saved"}
-                style={checkWorkStyle}
-                tabIndex={checkWorkTabIndex}
+                style={statusStyle}
                 aria-label="Response Saved"
             >
-                <FontAwesomeIcon icon={faCloud as IconProp} />
-                &nbsp; Response Saved
-            </Button>
+                <FontAwesomeIcon
+                    icon={faCloud as IconProp}
+                    aria-hidden={true}
+                    title={title}
+                />
+                {responseSavedText}
+            </span>
         );
     }
 

--- a/packages/doenetml/src/utils/checkWork.tsx
+++ b/packages/doenetml/src/utils/checkWork.tsx
@@ -98,8 +98,6 @@ export function createCheckWorkComponent(
             : SVs.submitLabelNoCorrectness;
         const checkWorkLabel = showText ? <>&nbsp; {checkWorkText}</> : "";
 
-        console.log({ checkWorkText });
-
         checkWorkComponent = (
             <Button
                 id={id + "_submit"}

--- a/packages/test-cypress/cypress/e2e/tagSpecific/answer.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/answer.cy.js
@@ -38,7 +38,11 @@ describe("Answer Tag Tests", function () {
             let mathInputPartialAnchor = cesc("#" + mathInputName + "_partial");
 
             // cy.get(mathInputAnchor).should('have.value', '');
-            cy.get(mathInputSubmitAnchor).should("be.visible");
+            cy.get(mathInputSubmitAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Check Work",
+            );
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
@@ -46,7 +50,11 @@ describe("Answer Tag Tests", function () {
             cy.log("Type correct answer in");
             cy.get(mathInputAnchor).type(`x+y`, { force: true });
             // cy.get(mathInputAnchor).should('have.value', 'x+y');
-            cy.get(mathInputSubmitAnchor).should("be.visible");
+            cy.get(mathInputSubmitAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Check Work",
+            );
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
@@ -55,14 +63,22 @@ describe("Answer Tag Tests", function () {
             cy.get(mathInputAnchor).type(`{enter}`, { force: true });
             // cy.get(mathInputAnchor).should('have.value', 'x+y');
             cy.get(mathInputSubmitAnchor).should("not.exist");
-            cy.get(mathInputCorrectAnchor).should("be.visible");
+            cy.get(mathInputCorrectAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Correct",
+            );
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
 
             cy.log("Add space");
             cy.get(mathInputAnchor).type(`{end} `, { force: true });
             // cy.get(mathInputAnchor).should('have.value', 'x+yz');
-            cy.get(mathInputSubmitAnchor).should("be.visible");
+            cy.get(mathInputSubmitAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Check Work",
+            );
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
@@ -71,14 +87,22 @@ describe("Answer Tag Tests", function () {
             cy.get(mathInputAnchor).type(`{enter}`, { force: true });
             // cy.get(mathInputAnchor).should('have.value', 'x+y');
             cy.get(mathInputSubmitAnchor).should("not.exist");
-            cy.get(mathInputCorrectAnchor).should("be.visible");
+            cy.get(mathInputCorrectAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Correct",
+            );
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
 
             cy.log("Delete space");
             cy.get(mathInputAnchor).type(`{end}{backspace}`, { force: true });
             // cy.get(mathInputAnchor).should('have.value', 'x+yz');
-            cy.get(mathInputSubmitAnchor).should("be.visible");
+            cy.get(mathInputSubmitAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Check Work",
+            );
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
@@ -87,14 +111,22 @@ describe("Answer Tag Tests", function () {
             cy.get(mathInputAnchor).type(`{enter}`, { force: true });
             // cy.get(mathInputAnchor).should('have.value', 'x+y');
             cy.get(mathInputSubmitAnchor).should("not.exist");
-            cy.get(mathInputCorrectAnchor).should("be.visible");
+            cy.get(mathInputCorrectAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Correct",
+            );
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
 
             cy.log("Add letter");
             cy.get(mathInputAnchor).type(`{end}z`, { force: true });
             // cy.get(mathInputAnchor).should('have.value', 'x+yz');
-            cy.get(mathInputSubmitAnchor).should("be.visible");
+            cy.get(mathInputSubmitAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Check Work",
+            );
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
@@ -102,7 +134,11 @@ describe("Answer Tag Tests", function () {
             cy.log("Delete letter (no longer goes back to saying correct)");
             cy.get(mathInputAnchor).type(`{end}{backspace}`, { force: true });
             // cy.get(mathInputAnchor).should('have.value', 'x+y');
-            cy.get(mathInputSubmitAnchor).should("be.visible");
+            cy.get(mathInputSubmitAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Check Work",
+            );
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
@@ -112,7 +148,11 @@ describe("Answer Tag Tests", function () {
                 force: true,
             });
             // cy.get(mathInputAnchor).should('have.value', 'x');
-            cy.get(mathInputSubmitAnchor).should("be.visible");
+            cy.get(mathInputSubmitAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Check Work",
+            );
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
@@ -120,7 +160,11 @@ describe("Answer Tag Tests", function () {
             cy.log("Back to correct (no longer goes back to saying correct)");
             cy.get(mathInputAnchor).type(`{end}+y`, { force: true });
             // cy.get(mathInputAnchor).should('have.value', 'x+y');
-            cy.get(mathInputSubmitAnchor).should("be.visible");
+            cy.get(mathInputSubmitAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Check Work",
+            );
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
@@ -129,7 +173,11 @@ describe("Answer Tag Tests", function () {
             cy.get(mathInputAnchor).type(`{enter}`, { force: true });
             // cy.get(mathInputAnchor).should('have.value', 'x+y');
             cy.get(mathInputSubmitAnchor).should("not.exist");
-            cy.get(mathInputCorrectAnchor).should("be.visible");
+            cy.get(mathInputCorrectAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Correct",
+            );
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
 
@@ -138,7 +186,11 @@ describe("Answer Tag Tests", function () {
                 force: true,
             });
             // cy.get(mathInputAnchor).should('have.value', 'x');
-            cy.get(mathInputSubmitAnchor).should("be.visible");
+            cy.get(mathInputSubmitAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Check Work",
+            );
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
@@ -148,13 +200,21 @@ describe("Answer Tag Tests", function () {
             // cy.get(mathInputAnchor).should('have.value', 'x');
             cy.get(mathInputSubmitAnchor).should("not.exist");
             cy.get(mathInputCorrectAnchor).should("not.exist");
-            cy.get(mathInputIncorrectAnchor).should("be.visible");
+            cy.get(mathInputIncorrectAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Incorrect",
+            );
             cy.get(mathInputPartialAnchor).should("not.exist");
 
             cy.log("Add letter");
             cy.get(mathInputAnchor).type(`{end}a`, { force: true });
             // cy.get(mathInputAnchor).should('have.value', 'xa');
-            cy.get(mathInputSubmitAnchor).should("be.visible");
+            cy.get(mathInputSubmitAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Check Work",
+            );
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
@@ -162,7 +222,11 @@ describe("Answer Tag Tests", function () {
             cy.log("Delete letter (no longer goes back to saying incorrect)");
             cy.get(mathInputAnchor).type(`{end}{backspace}`, { force: true });
             // cy.get(mathInputAnchor).should('have.value', 'x');
-            cy.get(mathInputSubmitAnchor).should("be.visible");
+            cy.get(mathInputSubmitAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Check Work",
+            );
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
@@ -170,7 +234,11 @@ describe("Answer Tag Tests", function () {
             cy.log("Delete all");
             cy.get(mathInputAnchor).type(`{end}{backspace}`, { force: true });
             // cy.get(mathInputAnchor).should('have.value', '');
-            cy.get(mathInputSubmitAnchor).should("be.visible");
+            cy.get(mathInputSubmitAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Check Work",
+            );
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
@@ -180,7 +248,11 @@ describe("Answer Tag Tests", function () {
             );
             cy.get(mathInputAnchor).type(`x`, { force: true });
             // cy.get(mathInputAnchor).should('have.value', 'x');
-            cy.get(mathInputSubmitAnchor).should("be.visible");
+            cy.get(mathInputSubmitAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Check Work",
+            );
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
@@ -190,13 +262,21 @@ describe("Answer Tag Tests", function () {
             // cy.get(mathInputAnchor).should('have.value', 'x');
             cy.get(mathInputSubmitAnchor).should("not.exist");
             cy.get(mathInputCorrectAnchor).should("not.exist");
-            cy.get(mathInputIncorrectAnchor).should("be.visible");
+            cy.get(mathInputIncorrectAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Incorrect",
+            );
             cy.get(mathInputPartialAnchor).should("not.exist");
 
             cy.log("Enter partially correct answer");
             cy.get(mathInputAnchor).type(`{end}+z`, { force: true });
             // cy.get(mathInputAnchor).should('have.value', 'x+z');
-            cy.get(mathInputSubmitAnchor).should("be.visible");
+            cy.get(mathInputSubmitAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Check Work",
+            );
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
@@ -207,12 +287,18 @@ describe("Answer Tag Tests", function () {
             cy.get(mathInputSubmitAnchor).should("not.exist");
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
-            cy.get(mathInputPartialAnchor).should("have.text", "32 %");
+            cy.get(mathInputPartialAnchor)
+                .should("have.text", "32 %")
+                .should("have.attr", "aria-label", "32% Correct");
 
             cy.log("Add letter");
             cy.get(mathInputAnchor).type(`{end}z`, { force: true });
             // cy.get(mathInputAnchor).should('have.value', 'x+zz');
-            cy.get(mathInputSubmitAnchor).should("be.visible");
+            cy.get(mathInputSubmitAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Check Work",
+            );
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
@@ -222,7 +308,11 @@ describe("Answer Tag Tests", function () {
             );
             cy.get(mathInputAnchor).type(`{end}{backspace}`, { force: true });
             // cy.get(mathInputAnchor).should('have.value', 'x+z');
-            cy.get(mathInputSubmitAnchor).should("be.visible");
+            cy.get(mathInputSubmitAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Check Work",
+            );
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
@@ -232,7 +322,11 @@ describe("Answer Tag Tests", function () {
                 force: true,
             });
             // cy.get(mathInputAnchor).should('have.value', 'x');
-            cy.get(mathInputSubmitAnchor).should("be.visible");
+            cy.get(mathInputSubmitAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Check Work",
+            );
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
@@ -242,7 +336,11 @@ describe("Answer Tag Tests", function () {
             );
             cy.get(mathInputAnchor).type(`{end}+z`, { force: true });
             // cy.get(mathInputAnchor).should('have.value', 'x+z');
-            cy.get(mathInputSubmitAnchor).should("be.visible");
+            cy.get(mathInputSubmitAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Check Work",
+            );
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
@@ -253,12 +351,18 @@ describe("Answer Tag Tests", function () {
             cy.get(mathInputSubmitAnchor).should("not.exist");
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
-            cy.get(mathInputPartialAnchor).should("have.text", "32 %");
+            cy.get(mathInputPartialAnchor)
+                .should("have.text", "32 %")
+                .should("have.attr", "aria-label", "32% Correct");
 
             cy.log("Enter invalid answer");
             cy.get(mathInputAnchor).type(`{end}/`, { force: true });
             // cy.get(mathInputAnchor).should('have.value', 'x+z');
-            cy.get(mathInputSubmitAnchor).should("be.visible");
+            cy.get(mathInputSubmitAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Check Work",
+            );
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
@@ -268,13 +372,21 @@ describe("Answer Tag Tests", function () {
             // cy.get(mathInputAnchor).should('have.value', 'x+z/');
             cy.get(mathInputSubmitAnchor).should("not.exist");
             cy.get(mathInputCorrectAnchor).should("not.exist");
-            cy.get(mathInputIncorrectAnchor).should("be.visible");
+            cy.get(mathInputIncorrectAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Incorrect",
+            );
             cy.get(mathInputPartialAnchor).should("not.exist");
 
             cy.log("Another invalid answer shows submit button again");
             cy.get(mathInputAnchor).type(`{end}^`, { force: true });
             // cy.get(mathInputAnchor).should('have.value', 'x+z/^');
-            cy.get(mathInputSubmitAnchor).should("be.visible");
+            cy.get(mathInputSubmitAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Check Work",
+            );
             cy.get(mathInputCorrectAnchor).should("not.exist");
             cy.get(mathInputIncorrectAnchor).should("not.exist");
             cy.get(mathInputPartialAnchor).should("not.exist");
@@ -284,7 +396,11 @@ describe("Answer Tag Tests", function () {
             // cy.get(mathInputAnchor).should('have.value', 'x+z/^');
             cy.get(mathInputSubmitAnchor).should("not.exist");
             cy.get(mathInputCorrectAnchor).should("not.exist");
-            cy.get(mathInputIncorrectAnchor).should("be.visible");
+            cy.get(mathInputIncorrectAnchor).should(
+                "have.attr",
+                "aria-label",
+                "Incorrect",
+            );
             cy.get(mathInputPartialAnchor).should("not.exist");
         });
     });


### PR DESCRIPTION
This PR makes check work buttons accessible by adding aria-labels that explain their function. It also changes the answer messages to be spans rather than buttons, as they don't have an action.

Fixes #597 