### PR TITLE
Play or pause video programmatically only if state changed

### DIFF
--- a/packages/doenetml/src/Viewer/renderers/video.tsx
+++ b/packages/doenetml/src/Viewer/renderers/video.tsx
@@ -29,6 +29,8 @@ export default React.memo(function Video(props) {
     let pollIntervalId = useRef(null);
     let lastSetTimeAction = useRef(null);
 
+    let lastSVsState = useRef(null);
+
     const ref = useRef(null);
 
     useRecordVisibilityChanges(ref, callAction, actions);
@@ -379,19 +381,22 @@ export default React.memo(function Video(props) {
 
     if (player.current?.getPlayerState) {
         let playerState = player.current.getPlayerState();
-        if (SVs.state === "playing") {
-            if (
-                playerState === window.YT.PlayerState.UNSTARTED ||
-                playerState === window.YT.PlayerState.PAUSED ||
-                playerState === window.YT.PlayerState.CUED ||
-                playerState === window.YT.PlayerState.ENDED
-            ) {
-                player.current.playVideo();
+        if (SVs.state !== lastSVsState.current) {
+            if (SVs.state === "playing") {
+                if (
+                    playerState === window.YT.PlayerState.UNSTARTED ||
+                    playerState === window.YT.PlayerState.PAUSED ||
+                    playerState === window.YT.PlayerState.CUED ||
+                    playerState === window.YT.PlayerState.ENDED
+                ) {
+                    player.current.playVideo();
+                }
+            } else if (SVs.state === "stopped") {
+                if (playerState === window.YT.PlayerState.PLAYING) {
+                    player.current.pauseVideo();
+                }
             }
-        } else if (SVs.state === "stopped") {
-            if (playerState === window.YT.PlayerState.PLAYING) {
-                player.current.pauseVideo();
-            }
+            lastSVsState.current = SVs.state;
         }
 
         if (SVs.time !== Number(lastSetTimeAction.current)) {


### PR DESCRIPTION
This PR fixes a bug where a video could restart even after it was paused. The bug could be invoked if the change in the video `state` state variable was delayed due to calculations triggered on video state change. In this delayed case, the `state` state variable could still be reported as "playing" even the video player itself stopped, which triggered a command to play the video.

To fix the bug, the command to play or pause the video is invoked only if the video `state` state variable has changed.

Fixes #624.