### PR TITLE
fix reference attributes in examples and documentation

### DIFF
--- a/packages/docs-nextra/pages/reference/award2b.mdx
+++ b/packages/docs-nextra/pages/reference/award2b.mdx
@@ -206,7 +206,7 @@ render the `feedbacks` property of the ` <answer>{:dn}`.
 </graph>
 
 <answer name="ans">
-  <award referencesAreResponses="P">
+  <award referencesAreResponses="$P">
     <when>
       $P.x > $threshold
       and $P.y > $threshold

--- a/packages/docs-nextra/pages/reference/bestFitLine.mdx
+++ b/packages/docs-nextra/pages/reference/bestFitLine.mdx
@@ -71,7 +71,7 @@ Coordinates for the points are provided by the user with the ` <mathInput/>{:dn}
 
 ```doenet-editor-horiz
  <p>Add your data points to the graph, approximated to the nearest <m>0.5</m> units.</p>
-  <callAction actionName="addChildren" target="dataGraph">
+  <callAction actionName="addChildren" target="$dataGraph">
     <point>(0,0)
       <constraints>
         <constrainToGrid dx="0.5" dy="0.5"/>
@@ -81,7 +81,7 @@ Coordinates for the points are provided by the user with the ` <mathInput/>{:dn}
   </callAction>
   <p>Data: 
     <asList>
-      <collect name="dataPoints" componentTypes="point" source="dataGraph"/>
+      <collect name="dataPoints" componentType="point" from="$dataGraph"/>
     </asList></p>
   <graph name="dataGraph" grid>
     <bestFitLine name="linearFit" data="$dataPoints"/>

--- a/packages/docs-nextra/pages/reference/count.mdx
+++ b/packages/docs-nextra/pages/reference/count.mdx
@@ -35,14 +35,14 @@ The ` <count>{:dn}` component renders the length of a named ` <mathList>{:dn}`.
 
 
 ```doenet-editor-horiz
-<callAction actionName="addChildren" target="g">
+<callAction actionName="addChildren" target="$g">
   <point/>
   <label>Add Point</label>
 </callAction>
 <graph name="g" size="small"/>
 <p>Number of points = 
   <count>
-    <collect name="collectedPoints" componentTypes="point" source="g"/>
+    <collect name="collectedPoints" componentType="point" from="$g"/>
   </count>
 </p>
 $collectedPoints

--- a/packages/docs-nextra/pages/reference/point.mdx
+++ b/packages/docs-nextra/pages/reference/point.mdx
@@ -212,7 +212,7 @@ Points can take ` <constraints>{:dn}` as children. Several different types of co
     <label>Animate point</label>
   </booleanInput>
 </graph>
-<animateFromSequence target="t" from="-4pi" to="4pi" step="pi/16" animationInterval="100" animationOn="$on"/>
+<animateFromSequence target="$t" from="-4pi" to="4pi" step="pi/16" animationInterval="100" animationOn="$on"/>
 ```
 
 

--- a/packages/doenetml-worker-javascript/src/components/Legend.js
+++ b/packages/doenetml-worker-javascript/src/components/Legend.js
@@ -145,7 +145,7 @@ export default class Legend extends GraphicalComponent {
                         // XXX: this is not a perfect solution to the fact that we cannot tell
                         // if we are from a reference by looking that the name starts with "__".
                         // Really, we should use the shadow source only if we have reference like $P
-                        // but not if we extend such <point extend="P" name="P2" styleNumber="4" />!!!
+                        // but not if we extend such <point extend="$P" name="P2" styleNumber="4" />!!!
                         // Adding both an imperfect stopgap
                         let shadowSource =
                             dependencyValues[

--- a/packages/doenetml-worker-javascript/src/test/answerValidation/matchPartial.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/answerValidation/matchPartial.test.ts
@@ -609,7 +609,7 @@ describe("match partial validation tests", async () => {
         doenetML,
         type,
     }: {
-        doenetML;
+        doenetML: string;
         type: "math" | "text";
     }) {
         await run_tests({
@@ -1271,14 +1271,14 @@ describe("match partial validation tests", async () => {
   <p>
   <mathInput name="mi" />
   <answer name="ans1">
-    <award referencesAreResponses="mi">
+    <award referencesAreResponses="$mi">
       <when matchPartial>
         $mi = <mathList><math>(1,2)</math><math>(3,4)</math></mathList>
       </when>
     </award>
   </answer>
   <answer name="ans2">
-    <award referencesAreResponses="mi">
+    <award referencesAreResponses="$mi">
       <when matchPartial>
         <mathList><math>(1,2)</math><math>(3,4)</math></mathList> = $mi
       </when>
@@ -1294,14 +1294,14 @@ describe("match partial validation tests", async () => {
   <p>
   <mathInput name="mi" />
   <answer name="ans1">
-    <award referencesAreResponses="mi">
+    <award referencesAreResponses="$mi">
       <when matchPartial>
         $mi = <mathList><math createVectors>(1,2)</math><math createVectors>(3,4)</math></mathList>
       </when>
     </award>
   </answer>
   <answer name="ans2">
-    <award referencesAreResponses="mi">
+    <award referencesAreResponses="$mi">
       <when matchPartial>
         <mathList><math createVectors>(1,2)</math><math createVectors>(3,4)</math></mathList> = $mi
       </when>
@@ -1317,14 +1317,14 @@ describe("match partial validation tests", async () => {
   <p>
   <mathInput name="mi" />
   <answer name="ans1">
-    <award referencesAreResponses="mi">
+    <award referencesAreResponses="$mi">
       <when matchPartial>
         <math createVectors>$mi</math> = <mathList><math>(1,2)</math><math>(3,4)</math></mathList>
       </when>
     </award>
   </answer>
   <answer name="ans2">
-    <award referencesAreResponses="mi">
+    <award referencesAreResponses="$mi">
       <when matchPartial>
         <mathList><math>(1,2)</math><math>(3,4)</math></mathList> = <math createVectors>$mi</math>
       </when>
@@ -1340,14 +1340,14 @@ describe("match partial validation tests", async () => {
   <p>
   <mathInput name="mi" />
   <answer name="ans1">
-    <award referencesAreResponses="mi">
+    <award referencesAreResponses="$mi">
       <when matchPartial>
         <math createVectors>$mi</math> = <mathList><math createVectors>(1,2)</math><math createVectors>(3,4)</math></mathList>
       </when>
     </award>
   </answer>
   <answer name="ans2">
-    <award referencesAreResponses="mi">
+    <award referencesAreResponses="$mi">
       <when matchPartial>
         <mathList><math createVectors>(1,2)</math><math createVectors>(3,4)</math></mathList> = <math createVectors>$mi</math>
       </when>
@@ -1363,14 +1363,14 @@ describe("match partial validation tests", async () => {
   <p>
   <mathInput name="mi" />
   <answer name="ans1">
-    <award referencesAreResponses="mi">
+    <award referencesAreResponses="$mi">
       <when matchPartial>
         $mi = <mathList><math>[1,2)</math><math>(3,4]</math></mathList>
       </when>
     </award>
   </answer>
   <answer name="ans2">
-    <award referencesAreResponses="mi">
+    <award referencesAreResponses="$mi">
       <when matchPartial>
         <mathList><math>[1,2)</math><math>(3,4]</math></mathList> = $mi
       </when>
@@ -1396,14 +1396,14 @@ describe("match partial validation tests", async () => {
   <p>
   <mathInput name="mi" />
   <answer name="ans1">
-    <award referencesAreResponses="mi">
+    <award referencesAreResponses="$mi">
       <when matchPartial>
         $mi = <mathList><math>[1,2]</math><math>[3,4]</math></mathList>
       </when>
     </award>
   </answer>
   <answer name="ans2">
-    <award referencesAreResponses="mi">
+    <award referencesAreResponses="$mi">
       <when matchPartial>
         <mathList><math>[1,2]</math><math>[3,4]</math></mathList> = $mi
       </when>
@@ -1429,14 +1429,14 @@ describe("match partial validation tests", async () => {
   <p>
   <mathInput name="mi" />
   <answer name="ansP">
-    <award referencesAreResponses="mi">
+    <award referencesAreResponses="$mi">
       <when matchPartial>
         $mi = <mathList>(1,2) (3,4)</mathList>
       </when>
     </award>
   </answer>
   <answer name="ansPU">
-    <award referencesAreResponses="mi">
+    <award referencesAreResponses="$mi">
       <when matchPartial unorderedCompare>
         $mi = <mathList>(1,2) (3,4)</mathList>
       </when>

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/problem.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/problem.test.ts
@@ -690,7 +690,7 @@ describe("Problem tag tests", async () => {
       
         <p>Numbers that add to 3: <mathInput name="n1" /> <mathInput name="n2" />
         <answer name="sum3">
-          <award referencesAreResponses="n1 n2">
+          <award referencesAreResponses="$n1 $n2">
             <when>$n1+$n2=3</when>
           </award>
         </answer></p>
@@ -725,7 +725,7 @@ describe("Problem tag tests", async () => {
       
         <p>Numbers that add to 3: <mathInput name="n1" /> <mathInput name="n2" />
         <answer name="sum3">
-          <award referencesAreResponses="n1 n2">
+          <award referencesAreResponses="$n1 $n2">
             <when>$n1+$n2=3</when>
           </award>
         </answer></p>
@@ -761,7 +761,7 @@ describe("Problem tag tests", async () => {
       
         <p>Numbers that add to 3: <mathInput name="n1" /> <mathInput name="n2" />
         <answer name="sum3">
-          <award referencesAreResponses="n1 n2">
+          <award referencesAreResponses="$n1 $n2">
             <when>$n1+$n2=3</when>
           </award>
         </answer></p>
@@ -799,7 +799,7 @@ describe("Problem tag tests", async () => {
       
         <p>Numbers that add to 3: <mathInput name="n1" /> <mathInput name="n2" />
         <answer name="sum3">
-          <award referencesAreResponses="n1 n2">
+          <award referencesAreResponses="$n1 $n2">
             <when>$n1+$n2=3</when>
           </award>
         </answer></p>
@@ -840,7 +840,7 @@ describe("Problem tag tests", async () => {
       
         <p>Numbers that add to 3: <mathInput name="n1" /> <mathInput name="n2" />
         <answer name="sum3">
-          <award referencesAreResponses="n1 n2">
+          <award referencesAreResponses="$n1 $n2">
             <when>$n1+$n2=3</when>
           </award>
         </answer></p>
@@ -1156,7 +1156,7 @@ describe("Problem tag tests", async () => {
       
           <p>Numbers that add to 3: <mathInput name="n1" /> <mathInput name="n2" />
           <answer name="sum3">
-            <award referencesAreResponses="n1 n2">
+            <award referencesAreResponses="$n1 $n2">
               <when>$n1+$n2=3</when>
             </award>
           </answer></p>
@@ -1195,7 +1195,7 @@ describe("Problem tag tests", async () => {
       
           <p>Numbers that add to 3: <mathInput name="n1" /> <mathInput name="n2" />
           <answer name="sum3">
-            <award referencesAreResponses="n1 n2">
+            <award referencesAreResponses="$n1 $n2">
               <when>$n1+$n2=3</when>
             </award>
           </answer></p>

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/dast/ref_expand.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/dast/ref_expand.rs
@@ -18,9 +18,9 @@ use super::{
 /// expands to
 /// ```xml
 /// <point name="p" />
-/// <point extend="p" />
+/// <point extend="$p" />
 /// ```
-/// Care is taken to preserve the tag name of the referent. (E.g., a `<point />` maps to a `<point extends="..." />`,
+/// Care is taken to preserve the tag name of the referent. (E.g., a `<point />` maps to a `<point extend="..." />`,
 /// a `<line />` maps to a `<line extend="..." />`, etc.)
 pub struct Expander {}
 
@@ -42,8 +42,8 @@ impl Expander {
             // which will prevent the borrow checker from complaining if we mutate `flat_root` during processing.
             flat_root.nodes[idx] = match mem::take(&mut flat_root.nodes[idx]) {
                 FlatNode::Ref(ref_) => {
-                    // A ref `$f` gets replaced with `<foo extend="f" />` where `foo` is the tag name of the referent.
-                    // e.g. `<point name="p" />$p` becomes `<point name="p" /><point extend="p" />`
+                    // A ref `$f` gets replaced with `<foo extend="$f" />` where `foo` is the tag name of the referent.
+                    // e.g. `<point name="p" />$p` becomes `<point name="p" /><point extend="$p" />`
                     // Expanding a ref is can be done with a single replacement.
 
                     //flat_root.nodes[idx] = resolved
@@ -82,7 +82,7 @@ impl Expander {
                     }
                 }
                 FlatNode::FunctionRef(function_ref) => {
-                    // A function ref `$$f(x)` becomes `<evaluate extend="f"><ol><li>x</li></ol></evaluate>`
+                    // A function ref `$$f(x)` becomes `<evaluate extend="$f"><ol><li>x</li></ol></evaluate>`
                     // This involves creating multiple new nodes and setting them as children of the `evaluate` node.
                     let resolved =
                         match resolver.resolve(&function_ref.path, function_ref.idx, false) {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/problem.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/problem.cy.js
@@ -31,7 +31,7 @@ describe("Problem Tag Tests", function () {
       
         <p>Numbers that add to 3: <mathInput name="n1" /> <mathInput name="n2" />
         <answer name="sum3">
-          <award referencesAreResponses="n1 n2">
+          <award referencesAreResponses="$n1 $n2">
             <when>$n1+$n2=3</when>
           </award>
         </answer></p>
@@ -247,7 +247,7 @@ describe("Problem Tag Tests", function () {
       
         <p>Numbers that add to 3: <mathInput name="n1" /> <mathInput name="n2" />
         <answer name="sum3">
-          <award referencesAreResponses="n1 n2">
+          <award referencesAreResponses="$n1 $n2">
             <when>$n1+$n2=3</when>
           </award>
         </answer></p>
@@ -464,7 +464,7 @@ describe("Problem Tag Tests", function () {
       
         <p>Numbers that add to 3: <mathInput name="n1" /> <mathInput name="n2" />
         <answer name="sum3">
-          <award referencesAreResponses="n1 n2">
+          <award referencesAreResponses="$n1 $n2">
             <when>$n1+$n2=3</when>
           </award>
         </answer></p>
@@ -681,7 +681,7 @@ describe("Problem Tag Tests", function () {
       
           <p>Numbers that add to 3: <mathInput name="n1" /> <mathInput name="n2" />
           <answer name="sum3">
-            <award referencesAreResponses="n1 n2">
+            <award referencesAreResponses="$n1 $n2">
               <when>$n1+$n2=3</when>
             </award>
           </answer></p>
@@ -922,7 +922,7 @@ describe("Problem Tag Tests", function () {
       
           <p>Numbers that add to 3: <mathInput name="n1" /> <mathInput name="n2" />
           <answer name="sum3">
-            <award referencesAreResponses="n1 n2">
+            <award referencesAreResponses="$n1 $n2">
               <when>$n1+$n2=3</when>
             </award>
           </answer></p>

--- a/packages/test-cypress/cypress/e2e/tagSpecific/ref.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/ref.cy.js
@@ -445,7 +445,7 @@ describe("ref Tag Tests", function () {
     <callAction target="$refCountAside" actionName="navigateToTarget" name="startCount">
       <label>Start counting</label>
     </callAction>
-    <callAction target="$count" actionName="startAnimation" triggerWith="startCount" />
+    <callAction target="$count" actionName="startAnimation" triggerWith="$startCount" />
     <ref name="toAside" to="$aside" hide>Aside</ref>
     <p>
     <callAction target="$toAside" actionName="navigateToTarget" name="go"><label>Go to aside</label></callAction>

--- a/packages/test-viewer/src/test/testCode.doenet
+++ b/packages/test-viewer/src/test/testCode.doenet
@@ -1,9 +1,12 @@
 <graph>
-    <point name="P" x="3" y="1" />
-    <rectangle width="40" height="40" center="(0,0)" filled name="R" />
+  <point name="P" x="3" y="1" />
+  <rectangle width="40" height="40" center="(0,0)" filled name="R" />
 </graph>
-<number name="n">1</number>
-<updateValue triggerWhenObjectsClicked="P R" newValue="$n+1" target="n" />
+<number name="n">1</number> <updateValue
+  triggerWhenObjectsClicked="$P $R"
+  newValue="$n+1"
+  target="$n"
+/>
 <p>Use this to <m>a < b</m>test DoenetML</p>
 <p>A second paragraph!</p>
 <!-- <graph showNavigation>


### PR DESCRIPTION
This PR fixes the documentation and examples in comments where reference attributes were missing dollar signs.