### PR TITLE
disableAfterCorrect adjusts with creditByAttempt

### DIFF
--- a/packages/doenetml-worker-javascript/src/utils/answer.js
+++ b/packages/doenetml-worker-javascript/src/utils/answer.js
@@ -436,9 +436,19 @@ export function returnStandardAnswerStateVariableDefinition() {
                 dependencyType: "stateVariable",
                 variableName: "creditAchieved",
             },
+            nextCreditFactor: {
+                dependencyType: "stateVariable",
+                variableName: "nextCreditFactor",
+                variablesOptional: true,
+            },
         }),
         definition({ dependencyValues }) {
-            if (dependencyValues.creditAchieved === 1) {
+            const creditAchieved = dependencyValues.creditAchieved;
+            if (
+                creditAchieved === 1 ||
+                (creditAchieved > 0 &&
+                    creditAchieved === dependencyValues.nextCreditFactor)
+            ) {
                 return {
                     setValue: { hasBeenCorrect: true },
                     setEssentialValue: { hasBeenCorrect: true },


### PR DESCRIPTION
This PR factors in the reduced credit possible from `creditByAttempt` when determining the criterion for disabling when `disableAfterCorrect` is enabled. In particular, when the maximum credit possible is reduced, the answer will become disabled when that maximum is achieved.

Fixes #630.