### PR TITLE
Increase node memory in dev containers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
             "version": "latest"
         }
     },
-    "postCreateCommand": "export NODE_OPTIONS='--max_old_space_size=6144' && npm install && npm run build",
+    "postCreateCommand": "export NODE_OPTIONS='--max-old-space-size=6144' && npm install && npm run build",
     "customizations": {
         "vscode": {
             "extensions": [


### PR DESCRIPTION
If you try to build the docs in a dev container, it crashes.
I added the same Node memory flag from Github actions to our devcontainer setup.