### PR TITLE
derive default for DivisionType

### DIFF
--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/core/state/types/division_type.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/core/state/types/division_type.rs
@@ -52,4 +52,3 @@ impl Display for DivisionType {
         write!(f, "{display_name}")
     }
 }
-


### PR DESCRIPTION
Follow new linting rule of rust 1.91.