### PR TITLE
line segment renderer does not crash with complex endpoints

### DIFF
--- a/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
+++ b/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
@@ -63,7 +63,9 @@ export default React.memo(function LineSegment(props) {
     function createLineSegmentJXG() {
         if (
             SVs.numericalEndpoints.length !== 2 ||
-            SVs.numericalEndpoints.some((x) => x.length !== 2)
+            SVs.numericalEndpoints.some(
+                (x) => x.length !== 2 || x.some((v) => !Number.isFinite(v)),
+            )
         ) {
             lineSegmentJXG.current = null;
             point1JXG.current = null;
@@ -560,7 +562,9 @@ export default React.memo(function LineSegment(props) {
             createLineSegmentJXG();
         } else if (
             SVs.numericalEndpoints.length !== 2 ||
-            SVs.numericalEndpoints.some((x) => x.length !== 2)
+            SVs.numericalEndpoints.some(
+                (x) => x.length !== 2 || x.some((v) => !Number.isFinite(v)),
+            )
         ) {
             deleteLineSegmentJXG();
         } else {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/linesegment.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/linesegment.cy.js
@@ -1,0 +1,29 @@
+import { cesc } from "@doenet/utils";
+
+describe("Line Tag Tests", function () {
+    beforeEach(() => {
+        cy.clearIndexedDB();
+        cy.visit("/");
+    });
+
+    it("complex endpoint doesn't crash renderer", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <graph>
+        <lineSegment name="ls" endpoints="(1,0) (1,2i)"  />
+    </graph>
+    <p name="p">Endpoints: <point name="P1" extend="$ls.endpoint1" />, <point name="P2" extend="$ls.endpoint2" /></p>
+    `,
+                },
+                "*",
+            );
+        });
+
+        cy.get(cesc("#P1")).should("have.text", "(1,0)");
+        cy.get(cesc("#P2")).should("have.text", "(1,2i)");
+
+
+    });
+});


### PR DESCRIPTION
Add check to line segment renderer to skip attempting to create the line segment if there is an endpoint that doesn't have finite real coordinates.