### PR TITLE
add guard to attributePrimitive dependency for other attribute types

### DIFF
--- a/packages/doenetml-worker-javascript/src/Dependencies.js
+++ b/packages/doenetml-worker-javascript/src/Dependencies.js
@@ -9421,7 +9421,7 @@ class AttributePrimitiveDependency extends StateVariableDependency {
 
             if (parent) {
                 value = parent.attributes[this.attributeName];
-                if (value) {
+                if (value && value.type === "primitive") {
                     value = value.primitive.value;
                 } else {
                     value = null;


### PR DESCRIPTION
This PR fixes a bug, encountered when a `<sort>` is in an answer, where the `attributePrimitive` dependency crashed due to receiving an attribute of type "unresolved".  We now properly check for the attribute primitive type.