### PR TITLE
pretzel can handle problems with missing statement or answer

### DIFF
--- a/packages/doenetml-worker-javascript/src/components/PretzelArranger.js
+++ b/packages/doenetml-worker-javascript/src/components/PretzelArranger.js
@@ -211,10 +211,6 @@ export default class PretzelArranger extends CompositeComponent {
         stateVariableDefinitions.statements = {
             additionalStateVariablesDefined: ["givenAnswers", "validProblems"],
             returnDependencies: () => ({
-                numProblems: {
-                    dependencyType: "stateVariable",
-                    variableName: "numProblems",
-                },
                 serializedProblemChildren: {
                     dependencyType: "stateVariable",
                     variableName: "serializedProblemChildren",
@@ -306,7 +302,19 @@ export default class PretzelArranger extends CompositeComponent {
             const prevAnswer =
                 givenAnswers[(problemIdx - 1 + numProblems) % numProblems];
 
-            replacements.push(prevAnswer);
+            if (prevAnswer === null) {
+                replacements.push({
+                    type: "serialized",
+                    componentType: "span",
+                    componentIdx: nComponents++,
+                    attributes: {},
+                    doenetAttributes: {},
+                    state: {},
+                    children: [],
+                });
+            } else {
+                replacements.push(prevAnswer);
+            }
             replacements.push({
                 type: "serialized",
                 componentType: "textInput",
@@ -332,7 +340,19 @@ export default class PretzelArranger extends CompositeComponent {
                 state: {},
                 children: [],
             });
-            replacements.push(thisStatement);
+            if (thisStatement === null) {
+                replacements.push({
+                    type: "serialized",
+                    componentType: "statement",
+                    componentIdx: nComponents++,
+                    attributes: {},
+                    doenetAttributes: {},
+                    state: {},
+                    children: [],
+                });
+            } else {
+                replacements.push(thisStatement);
+            }
         }
 
         return {

--- a/packages/parser/src/dast-normalize/component-sugar/pretzel.ts
+++ b/packages/parser/src/dast-normalize/component-sugar/pretzel.ts
@@ -16,6 +16,7 @@ export function pretzelSugar(node: DastElement) {
             children: node.children,
             attributes: {},
             source_doc: node.source_doc,
+            position: node.position,
         },
     ];
 }


### PR DESCRIPTION
If a `<pretzel>` contains a `<problem>` that is missing a `<statement>` or `<givenAnswer>`, a warning is given and the document doesn't crash. Instead, it displays the pretzel with no content for the missing pieces.