### PR TITLE
coprimeCombinations option for <selectFromSequence>

### DIFF
--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/selectfromsequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/selectfromsequence.test.ts
@@ -1790,4 +1790,288 @@ describe("SelectFromSequence tag tests", async () => {
 
         expect(n === 1 || n === 3).eq(true);
     });
+
+    it("select two coprime numbers from 1 to 4", async () => {
+        const doenetML = `<selectFromSequence name="s" numToSelect="2" from="1" to="4" coprimeCombinations />`;
+        const valid_combinations = [
+            [1, 2],
+            [1, 3],
+            [1, 4],
+            [2, 1],
+            [2, 3],
+            [3, 1],
+            [3, 2],
+            [3, 4],
+            [4, 1],
+            [4, 3],
+        ];
+        const componentName = "s";
+
+        await test_combined_values({
+            doenetML,
+            valid_combinations,
+            componentName,
+            num_samples: 20,
+            num_to_select: 2,
+        });
+    });
+
+    it("select two odd coprime numbers from 15 to 21, sort results", async () => {
+        const doenetML = `<selectFromSequence name="s" numToSelect="2" from="15" to="21" step="2" coprimeCombinations sortResults />`;
+        const valid_combinations = [
+            [15, 17],
+            [15, 19],
+            [17, 19],
+            [17, 21],
+            [19, 21],
+        ];
+        const componentName = "s";
+
+        await test_combined_values({
+            doenetML,
+            valid_combinations,
+            componentName,
+            num_samples: 10,
+            num_to_select: 2,
+        });
+    });
+
+    it("select two odd coprime numbers from 15 to 21, sort results, with negative step", async () => {
+        const doenetML = `<selectFromSequence name="s" numToSelect="2" from="21" to="15" step="-2" coprimeCombinations sortResults />`;
+        const valid_combinations = [
+            [15, 17],
+            [15, 19],
+            [17, 19],
+            [17, 21],
+            [19, 21],
+        ];
+        const componentName = "s";
+
+        await test_combined_values({
+            doenetML,
+            valid_combinations,
+            componentName,
+            num_samples: 10,
+            num_to_select: 2,
+        });
+    });
+
+    it("select two coprime numbers from 21 to 27, excluding 23 and 25, sort results", async () => {
+        const doenetML = `<selectFromSequence name="s" numToSelect="2" from="21" to="27" exclude="23 25" coprimeCombinations sortResults />`;
+        const valid_combinations = [
+            [21, 22],
+            [21, 26],
+            [22, 27],
+            [26, 27],
+        ];
+        const componentName = "s";
+
+        await test_combined_values({
+            doenetML,
+            valid_combinations,
+            componentName,
+            num_samples: 8,
+            num_to_select: 2,
+        });
+    });
+
+    it("select four coprime numbers from 22 to 28, excluding 23 and 25, sort results", async () => {
+        const doenetML = `<selectFromSequence name="s" numToSelect="4" from="22" to="27" exclude="23 25" coprimeCombinations sortResults />`;
+        const valid_combinations = [
+            [22, 24, 26, 27],
+            [22, 24, 27, 28],
+            [22, 26, 27, 28],
+            [24, 26, 27, 28],
+        ];
+        const componentName = "s";
+
+        await test_combined_values({
+            doenetML,
+            valid_combinations,
+            componentName,
+            num_samples: 8,
+            num_to_select: 4,
+        });
+    });
+
+    it("select three coprime numbers from 4 to 6, with replacement, sort results", async () => {
+        const doenetML = `<selectFromSequence name="s" numToSelect="3" from="4" to="6" coprimeCombinations  withReplacement sortResults />`;
+        const valid_combinations = [
+            [4, 5, 6],
+            [4, 4, 5],
+            [4, 5, 5],
+            [5, 5, 6],
+            [5, 6, 6],
+            [5, 6, 6],
+        ];
+        const componentName = "s";
+
+        await test_combined_values({
+            doenetML,
+            valid_combinations,
+            componentName,
+            num_samples: 12,
+            num_to_select: 3,
+        });
+    });
+
+    it("excludeCombinations overrides coprimeCombinations", async () => {
+        const doenetML = `<selectFromSequence name="s" numToSelect="2" from="2" to="4" coprimeCombinations excludeCombinations="(2 3) (3 4)" />`;
+        const valid_combinations = [
+            [2, 4],
+            [3, 2],
+            [4, 2],
+            [4, 3],
+        ];
+        const componentName = "s";
+
+        await test_combined_values({
+            doenetML,
+            valid_combinations,
+            componentName,
+            num_samples: 20,
+            num_to_select: 2,
+        });
+
+        let { core } = await createTestCore({ doenetML });
+
+        let errorWarnings = core.core!.errorWarnings;
+
+        expect(errorWarnings.errors.length).eq(0);
+        expect(errorWarnings.warnings.length).eq(1);
+
+        expect(errorWarnings.warnings[0].message).contain(
+            "coprimeCombinations ignored since excludeCombinations specified",
+        );
+        expect(errorWarnings.warnings[0].position.start.line).eq(1);
+        expect(errorWarnings.warnings[0].position.start.column).eq(1);
+        expect(errorWarnings.warnings[0].position.end.line).eq(1);
+        expect(errorWarnings.warnings[0].position.end.column).eq(118);
+    });
+
+    it("coprimeCombinations ignored when not selecting numbers", async () => {
+        const doenetML = `<selectFromSequence name="s" type="letters" numToSelect="2" from="a" to="b" coprimeCombinations />`;
+        const valid_combinations = [
+            ["a", "b"],
+            ["b", "a"],
+        ];
+        const componentName = "s";
+
+        await test_combined_values({
+            doenetML,
+            valid_combinations,
+            componentName,
+            num_samples: 2,
+            num_to_select: 2,
+        });
+
+        let { core } = await createTestCore({ doenetML });
+
+        let errorWarnings = core.core!.errorWarnings;
+
+        expect(errorWarnings.errors.length).eq(0);
+        expect(errorWarnings.warnings.length).eq(1);
+
+        expect(errorWarnings.warnings[0].message).contain(
+            "coprimeCombinations ignored since not selecting numbers",
+        );
+        expect(errorWarnings.warnings[0].position.start.line).eq(1);
+        expect(errorWarnings.warnings[0].position.start.column).eq(1);
+        expect(errorWarnings.warnings[0].position.end.line).eq(1);
+        expect(errorWarnings.warnings[0].position.end.column).eq(99);
+    });
+
+    it("excludeCombinations gives error when not selecting integers", async () => {
+        const errorMessage =
+            "Cannot select coprime combinations as not selecting positive integers";
+
+        const doenetMLs = [
+            `<selectFromSequence name="s" numToSelect="2" from="2.5" to="4" coprimeCombinations />`,
+            `<selectFromSequence name="s" numToSelect="2" from="2" step="4.4" coprimeCombinations />`,
+            `<selectFromSequence name="s" numToSelect="2" from="-2" step="3" coprimeCombinations />`,
+            `<selectFromSequence name="s" numToSelect="2" to="4" step="3" length="3" coprimeCombinations />`,
+            `<selectFromSequence name="s" numToSelect="2" from="4" step="-3" coprimeCombinations />`,
+        ];
+
+        for (const doenetML of doenetMLs) {
+            const { core } = await createTestCore({
+                doenetML,
+            });
+            const errorWarnings = core.core!.errorWarnings;
+            expect(errorWarnings.errors.length).eq(1);
+            expect(errorWarnings.warnings.length).eq(0);
+            expect(errorWarnings.errors[0].message).contain(errorMessage);
+        }
+    });
+
+    it("excludeCombinations gives error if from/to and step are not coprime", async () => {
+        const errorMessage = `Cannot select coprime numbers. All possible values share a common factor. (Specified values of "from" or "to" must be coprime with "step".)`;
+
+        const doenetMLs = [
+            `<selectFromSequence name="s" numToSelect="2" from="2" step="4" coprimeCombinations />`,
+            `<selectFromSequence name="s" numToSelect="2" to="8" step="2" coprimeCombinations />`,
+        ];
+
+        for (const doenetML of doenetMLs) {
+            const { core } = await createTestCore({
+                doenetML,
+            });
+            const errorWarnings = core.core!.errorWarnings;
+            expect(errorWarnings.errors.length).eq(1);
+            expect(errorWarnings.warnings.length).eq(0);
+            expect(errorWarnings.errors[0].message).contain(errorMessage);
+        }
+    });
+
+    it("can select two coprime numbers when only option is 1", async () => {
+        const doenetML = `<selectFromSequence name="s" numToSelect="2" from="1" to="1" coprimeCombinations withReplacement />`;
+        const valid_combinations = [[1, 1]];
+        const componentName = "s";
+
+        await test_combined_values({
+            doenetML,
+            valid_combinations,
+            componentName,
+            num_samples: 4,
+            num_to_select: 2,
+        });
+    });
+
+    it("excludeCombinations gives error if one option that isn't 1", async () => {
+        const errorMessage =
+            "Cannot select coprime combinations from a single number that is not 1.";
+        const doenetMLs = [
+            `<selectFromSequence name="s" numToSelect="2" from="2" to="2" coprimeCombinations withReplacement />`,
+            `<selectFromSequence name="s" numToSelect="2" from="2" to="4" exclude="3 4" coprimeCombinations withReplacement />`,
+        ];
+
+        for (const doenetML of doenetMLs) {
+            const { core } = await createTestCore({
+                doenetML,
+            });
+            const errorWarnings = core.core!.errorWarnings;
+            expect(errorWarnings.errors.length).eq(1);
+            expect(errorWarnings.warnings.length).eq(0);
+            expect(errorWarnings.errors[0].message).contain(errorMessage);
+        }
+    });
+
+    it("excludeCombinations gives error if all possible values share factor due to exclude", async () => {
+        const errorMessage =
+            "Could not select coprime numbers. All possible values share a common factor.";
+        const doenetMLs = [
+            `<selectFromSequence name="s" numToSelect="2" from="2" to="4" exclude="3" coprimeCombinations />`,
+            `<selectFromSequence name="s" numToSelect="3" from="2" to="6" exclude="3 5" coprimeCombinations />`,
+        ];
+
+        for (const doenetML of doenetMLs) {
+            const { core } = await createTestCore({
+                doenetML,
+            });
+            const errorWarnings = core.core!.errorWarnings;
+            expect(errorWarnings.errors.length).eq(1);
+            expect(errorWarnings.warnings.length).eq(0);
+            expect(errorWarnings.errors[0].message).contain(errorMessage);
+        }
+    });
 });

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -58208,6 +58208,13 @@
                         "string"
                     ]
                 },
+                "allowReflection": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "displayDigits": {
                     "optional": true,
                     "type": [
@@ -58358,6 +58365,11 @@
                 },
                 {
                     "name": "allowTranslation",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "allowReflection",
                     "type": "boolean",
                     "isArray": false
                 },
@@ -79403,6 +79415,13 @@
                         "string"
                     ]
                 },
+                "allowReflection": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "displayDigits": {
                     "optional": true,
                     "type": [
@@ -79504,6 +79523,11 @@
                 },
                 {
                     "name": "allowTranslation",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "allowReflection",
                     "type": "boolean",
                     "isArray": false
                 },
@@ -79793,6 +79817,13 @@
                         "string"
                     ]
                 },
+                "allowReflection": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "displayDigits": {
                     "optional": true,
                     "type": [
@@ -79901,6 +79932,11 @@
                 },
                 {
                     "name": "allowTranslation",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "allowReflection",
                     "type": "boolean",
                     "isArray": false
                 },
@@ -80215,6 +80251,13 @@
                         "string"
                     ]
                 },
+                "allowReflection": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "displayDigits": {
                     "optional": true,
                     "type": [
@@ -80323,6 +80366,11 @@
                 },
                 {
                     "name": "allowTranslation",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "allowReflection",
                     "type": "boolean",
                     "isArray": false
                 },
@@ -80637,6 +80685,13 @@
                         "string"
                     ]
                 },
+                "allowReflection": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "displayDigits": {
                     "optional": true,
                     "type": [
@@ -80763,6 +80818,11 @@
                 },
                 {
                     "name": "allowTranslation",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "allowReflection",
                     "type": "boolean",
                     "isArray": false
                 },
@@ -81092,6 +81152,13 @@
                         "string"
                     ]
                 },
+                "allowReflection": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
+                },
                 "displayDigits": {
                     "optional": true,
                     "type": [
@@ -81260,6 +81327,11 @@
                 },
                 {
                     "name": "allowTranslation",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "allowReflection",
                     "type": "boolean",
                     "isArray": false
                 },
@@ -104652,6 +104724,13 @@
                     "type": [
                         "string"
                     ]
+                },
+                "coprimeCombinations": {
+                    "optional": true,
+                    "type": [
+                        "true",
+                        "false"
+                    ]
                 }
             },
             "children": [],
@@ -104694,6 +104773,11 @@
                 },
                 {
                     "name": "sortResults",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "coprimeCombinations",
                     "type": "boolean",
                     "isArray": false
                 },

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -35404,6 +35404,13 @@
                     "name": "minShrink"
                 },
                 {
+                    "name": "allowReflection",
+                    "values": [
+                        "true",
+                        "false"
+                    ]
+                },
+                {
                     "name": "displayDigits"
                 },
                 {
@@ -35511,6 +35518,11 @@
                 },
                 {
                     "name": "allowTranslation",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "allowReflection",
                     "type": "boolean",
                     "isArray": false
                 },
@@ -48321,6 +48333,13 @@
                     "name": "minShrink"
                 },
                 {
+                    "name": "allowReflection",
+                    "values": [
+                        "true",
+                        "false"
+                    ]
+                },
+                {
                     "name": "displayDigits"
                 },
                 {
@@ -48400,6 +48419,11 @@
                 },
                 {
                     "name": "allowTranslation",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "allowReflection",
                     "type": "boolean",
                     "isArray": false
                 },
@@ -48666,6 +48690,13 @@
                     "name": "minShrink"
                 },
                 {
+                    "name": "allowReflection",
+                    "values": [
+                        "true",
+                        "false"
+                    ]
+                },
+                {
                     "name": "displayDigits"
                 },
                 {
@@ -48752,6 +48783,11 @@
                 },
                 {
                     "name": "allowTranslation",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "allowReflection",
                     "type": "boolean",
                     "isArray": false
                 },
@@ -49043,6 +49079,13 @@
                     "name": "minShrink"
                 },
                 {
+                    "name": "allowReflection",
+                    "values": [
+                        "true",
+                        "false"
+                    ]
+                },
+                {
                     "name": "displayDigits"
                 },
                 {
@@ -49129,6 +49172,11 @@
                 },
                 {
                     "name": "allowTranslation",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "allowReflection",
                     "type": "boolean",
                     "isArray": false
                 },
@@ -49420,6 +49468,13 @@
                     "name": "minShrink"
                 },
                 {
+                    "name": "allowReflection",
+                    "values": [
+                        "true",
+                        "false"
+                    ]
+                },
+                {
                     "name": "displayDigits"
                 },
                 {
@@ -49515,6 +49570,11 @@
                 },
                 {
                     "name": "allowTranslation",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "allowReflection",
                     "type": "boolean",
                     "isArray": false
                 },
@@ -49821,6 +49881,13 @@
                     "name": "minShrink"
                 },
                 {
+                    "name": "allowReflection",
+                    "values": [
+                        "true",
+                        "false"
+                    ]
+                },
+                {
                     "name": "displayDigits"
                 },
                 {
@@ -49937,6 +50004,11 @@
                 },
                 {
                     "name": "allowTranslation",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "allowReflection",
                     "type": "boolean",
                     "isArray": false
                 },
@@ -64826,6 +64898,13 @@
                 },
                 {
                     "name": "excludeCombinations"
+                },
+                {
+                    "name": "coprimeCombinations",
+                    "values": [
+                        "true",
+                        "false"
+                    ]
                 }
             ],
             "properties": [
@@ -64866,6 +64945,11 @@
                 },
                 {
                     "name": "sortResults",
+                    "type": "boolean",
+                    "isArray": false
+                },
+                {
+                    "name": "coprimeCombinations",
                     "type": "boolean",
                     "isArray": false
                 },


### PR DESCRIPTION
This PR adds a `coprimeCombinations` attribute to `<selectFromSequence>`. If selecting multiple positive integers, specifying `coprimeCombinations` restricts the selection to results were the integers are coprime.

Resolves #654