### PR TITLE
Fix bug where line segment label was repeated at endpoints

### DIFF
--- a/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
+++ b/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
@@ -147,7 +147,7 @@ export default React.memo(function LineSegment(props) {
 
         let jsxPointAttributes = Object.assign({}, jsxSegmentAttributes);
         Object.assign(jsxPointAttributes, {
-            withLabel: false,
+            withlabel: false,
             fixed: false,
             highlight: true,
             fillColor: "none",


### PR DESCRIPTION
This PR fixes a bug where `withlabel` was not correctly set to `false` on the line segment endpoints, leading to the line segment label being repeated at the endpoints.