### PR TITLE
messageParent flag for sending events to iframe parent

### DIFF
--- a/packages/doenetml-iframe/src/iframe-viewer-index.ts
+++ b/packages/doenetml-iframe/src/iframe-viewer-index.ts
@@ -82,25 +82,6 @@ function renderViewerWithFunctionProps(...args: (string | Function)[]) {
 
 messageParentFromViewer({ iframeReady: true });
 
-// The iframe forwards all SPLICE messages that aren't a response to its parent.
-// Exception: SPLICE.submitAllAnswers is initiated by the app, so the logic is reversed.
-// Do forward SPLICE.submitAllAnswers.response but don't forward SPLICE.submitAllAnswers
-window.addEventListener("message", (e) => {
-    if (e.origin !== window.parent.location.origin) {
-        return;
-    }
-    if (
-        e.data.subject?.startsWith("SPLICE") &&
-        (!e.data.subject?.endsWith("response") ||
-            e.data.subject.endsWith("submitAllAnswers.response")) &&
-        !e.data.subject.endsWith("submitAllAnswers")
-    ) {
-        window.parent.postMessage(e.data);
-    } else if (e.data.subject === "requestAnswerResponses") {
-        window.parent.postMessage(e.data);
-    }
-});
-
 /**
  * Send a message to the parent React component.
  * @param data

--- a/packages/doenetml-iframe/src/utils.ts
+++ b/packages/doenetml-iframe/src/utils.ts
@@ -51,7 +51,7 @@ export function createHtmlForDoenetViewer(
             // It assumes that viewerId, doenetViewerProps, doenetViewerPropsSpecified, and ComlinkViewer are defined in the global scope.
             ${viewerIframeJsSource}
         </script>
-        <div id="root">
+        <div id="root" data-doenet-message-parent="true">
             <script type="text/doenetml">${doenetML}</script>
         </div>
     </body>
@@ -96,7 +96,7 @@ export function createHtmlForDoenetEditor(
             // It assumes that editorId, doenetEditorProps, doenetEditorPropsSpecified, and ComlinkEditor are defined in the global scope.
             ${editorIframeJsSource}
         </script>
-        <div id="root">
+        <div id="root" data-doenet-message-parent="true">
             <script type="text/doenetml">${doenetML}</script>
         </div>
     </body>

--- a/packages/doenetml-prototype/src/DoenetML.tsx
+++ b/packages/doenetml-prototype/src/DoenetML.tsx
@@ -14,6 +14,7 @@ export type DoenetMLFlags = {
     allowSaveState: boolean;
     allowLocalState: boolean;
     allowSaveEvents: boolean;
+    messageParent: boolean;
     autoSubmit: boolean;
 };
 
@@ -29,6 +30,7 @@ export const defaultFlags: DoenetMLFlags = {
     allowSaveState: true,
     allowLocalState: false,
     allowSaveEvents: true,
+    messageParent: false,
     autoSubmit: false,
 };
 

--- a/packages/doenetml-to-pretext/src/index.ts
+++ b/packages/doenetml-to-pretext/src/index.ts
@@ -17,6 +17,7 @@ const defaultFlags = {
     allowSaveState: true,
     allowLocalState: false,
     allowSaveEvents: true,
+    messageParent: false,
     autoSubmit: false,
 };
 

--- a/packages/doenetml-worker-javascript/src/test/utils/test-core.ts
+++ b/packages/doenetml-worker-javascript/src/test/utils/test-core.ts
@@ -42,6 +42,7 @@ type DoenetMLFlags = {
     allowSaveState: boolean;
     allowLocalState: boolean;
     allowSaveEvents: boolean;
+    messageParent: boolean;
     autoSubmit: boolean;
 };
 
@@ -57,6 +58,7 @@ const defaultFlags: DoenetMLFlags = {
     allowSaveState: true,
     allowLocalState: false,
     allowSaveEvents: true,
+    messageParent: false,
     autoSubmit: false,
 };
 

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -508,6 +508,7 @@ export function EditorViewer({
                         allowSaveState: false,
                         allowLocalState: false,
                         allowSaveEvents: showResponses,
+                        messageParent: false,
                         readOnly: false,
                     }}
                     activityId={activityId}

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -261,10 +261,16 @@ export function DocViewer({
                         args: {},
                     });
 
-                    window.postMessage({
+                    const message = {
                         subject: "SPLICE.submitAllAnswers.response",
                         success: actionResult,
-                    });
+                    };
+
+                    if (flags.messageParent && window.parent) {
+                        window.parent.postMessage(message);
+                    } else {
+                        window.postMessage(message);
+                    }
                 }
             }
         };
@@ -807,17 +813,20 @@ export function DocViewer({
                 docId,
             });
         } else {
-            console.log("SPLICE.reportScoreAndState", {
-                data,
-                activityId,
-                docId,
-            });
-            window.postMessage({
+            const message = {
                 data,
                 subject: "SPLICE.reportScoreAndState",
                 activityId,
                 docId,
-            });
+            };
+
+            console.log(message);
+
+            if (flags.messageParent && window.parent) {
+                window.parent.postMessage(message);
+            } else {
+                window.postMessage(message);
+            }
         }
     }
 
@@ -951,15 +960,8 @@ export function DocViewer({
             (resolve, reject) => {
                 getStatePromiseResolve = resolve;
                 getStatePromiseReject = reject;
-                console.log("SPLICE.getState", {
-                    messageId,
-                    cid,
-                    activityId,
-                    docId,
-                    attemptNumber,
-                    userId,
-                });
-                window.postMessage({
+
+                const message = {
                     subject: "SPLICE.getState",
                     messageId,
                     cid,
@@ -967,7 +969,15 @@ export function DocViewer({
                     docId,
                     attemptNumber,
                     userId,
-                });
+                };
+
+                console.log(message);
+
+                if (flags.messageParent && window.parent) {
+                    window.parent.postMessage(message);
+                } else {
+                    window.postMessage(message);
+                }
             },
         );
 
@@ -1188,12 +1198,20 @@ export function DocViewer({
     }
 
     function sendEvent(data: any) {
-        window.postMessage({
+        const message = {
             ...data,
             subject: "SPLICE.sendEvent",
             activityId,
             docId,
-        });
+        };
+
+        console.log(message);
+
+        if (flags.messageParent && window.parent) {
+            window.parent.postMessage(message);
+        } else {
+            window.postMessage(message);
+        }
     }
 
     /**
@@ -1218,7 +1236,8 @@ export function DocViewer({
             (resolve, reject) => {
                 requestSolutionPromiseResolve = resolve;
                 requestSolutionPromiseReject = reject;
-                window.postMessage({
+
+                const message = {
                     subject: "SPLICE.requestSolutionView",
                     messageId,
                     activityId,
@@ -1226,7 +1245,15 @@ export function DocViewer({
                     attemptNumber,
                     userId,
                     componentIdx,
-                });
+                };
+
+                console.log(message);
+
+                if (flags.messageParent && window.parent) {
+                    window.parent.postMessage(message);
+                } else {
+                    window.postMessage(message);
+                }
             },
         );
 

--- a/packages/doenetml/src/Viewer/renderers/utils/AnswerResponseButton.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/AnswerResponseButton.tsx
@@ -6,6 +6,7 @@ import {
     TooltipAnchor,
 } from "@ariakit/react";
 import "./AnswerResponseButton.css";
+import { DoenetMLFlags } from "../../../doenetml";
 
 export function AnswerResponseButton({
     answerId,
@@ -13,12 +14,14 @@ export function AnswerResponseButton({
     activityId,
     docId,
     numResponses = 0,
+    flags,
 }: {
     answerId: string;
     answerComponentIdx: number;
     activityId: string;
     docId: string;
     numResponses?: number;
+    flags: DoenetMLFlags;
 }) {
     return (
         <TooltipProvider>
@@ -26,13 +29,18 @@ export function AnswerResponseButton({
                 <Button
                     className="doenet-button action-button answer-response-button"
                     onClick={() => {
-                        window.postMessage({
+                        const message = {
                             subject: "requestAnswerResponses",
                             answerComponentIdx,
                             answerId,
                             activityId,
                             docId,
-                        });
+                        };
+                        if (flags.messageParent && window.parent) {
+                            window.parent.postMessage(message);
+                        } else {
+                            window.postMessage(message);
+                        }
                     }}
                 >
                     {numResponses}

--- a/packages/doenetml/src/Viewer/useDoenetRenderer.tsx
+++ b/packages/doenetml/src/Viewer/useDoenetRenderer.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { renderersLoadComponent } from "./DocViewer";
 import { ComponentInfo, mainSlice, useAppSelector } from "../state";
+import { DoenetMLFlags } from "../doenetml";
 
 export type UseDoenetRendererProps = {
     coreId: string;
@@ -19,6 +20,7 @@ export type UseDoenetRendererProps = {
     doenetViewerUrl?: string;
     fetchExternalDoenetML?: (arg: string) => Promise<string>;
     requestScrollTo?: (offset: number) => void;
+    flags: DoenetMLFlags;
 };
 
 // TODO: potentially remove initializeChildrenOnConstruction
@@ -98,6 +100,7 @@ export default function useDoenetRenderer(
             callAction: props.callAction,
             fetchExternalDoenetML: props.fetchExternalDoenetML,
             requestScrollTo: props.requestScrollTo,
+            flags: props.flags,
         };
 
         let rendererClass =
@@ -154,5 +157,6 @@ export default function useDoenetRenderer(
         doenetViewerUrl: props.doenetViewerUrl,
         fetchExternalDoenetML: props.fetchExternalDoenetML,
         requestScrollTo: props.requestScrollTo,
+        flags: props.flags,
     };
 }

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -31,6 +31,7 @@ export type DoenetMLFlags = {
     allowSaveState: boolean;
     allowLocalState: boolean;
     allowSaveEvents: boolean;
+    messageParent: boolean;
     autoSubmit: boolean;
 };
 
@@ -46,6 +47,7 @@ export const defaultFlags: DoenetMLFlags = {
     allowSaveState: true,
     allowLocalState: false,
     allowSaveEvents: true,
+    messageParent: false,
     autoSubmit: false,
 };
 

--- a/packages/test-viewer/src/test/testViewer.tsx
+++ b/packages/test-viewer/src/test/testViewer.tsx
@@ -217,6 +217,7 @@ export default function TestViewer() {
                 allowSaveState: false,
                 allowLocalState: false,
                 allowSaveEvents: false,
+                messageParent: false,
                 autoSubmit: false,
             }}
             activityId=""

--- a/packages/v06-to-v07/src/core-info/core.ts
+++ b/packages/v06-to-v07/src/core-info/core.ts
@@ -25,6 +25,7 @@ type DoenetMLFlags = {
     allowSaveState: boolean;
     allowLocalState: boolean;
     allowSaveEvents: boolean;
+    messageParent: boolean;
     autoSubmit: boolean;
 };
 
@@ -40,6 +41,7 @@ const defaultFlags: DoenetMLFlags = {
     allowSaveState: true,
     allowLocalState: false,
     allowSaveEvents: true,
+    messageParent: false,
     autoSubmit: false,
 };
 


### PR DESCRIPTION
This PR adds a `messageParent` flag, which, if true, posts messages, such as `SPLICE` messages to `window.parent`, if it exists. In this way, if Doenet is embedded in an iframe, messages can be directly posted to the iframe parent.