### PR TITLE
upgrade better-react-mathjax to support MathJax 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
                 "@vitest/web-worker": "^3.2.4",
                 "@vscode/test-web": "^0.0.70",
                 "autoprefixer": "^10.4.21",
-                "better-react-mathjax": "^2.3.0",
+                "better-react-mathjax": "^2.4.0-beta-1",
                 "bootstrap": "^5.3.6",
                 "chalk": "^5.4.1",
                 "classnames": "^2.5.1",
@@ -2097,6 +2097,58 @@
             "version": "1.0.2",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@mathjax/mathjax-newcm-font": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@mathjax/mathjax-newcm-font/-/mathjax-newcm-font-4.0.0.tgz",
+            "integrity": "sha512-kpsJgIF4FpWiwIkFgOPmWwy5GXfL25spmJJNg27HQxPddmEL8Blx0jn2BuU/nlwjM/9SnYpEfDrWiAMgLPlB8Q==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/@mathjax/src": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@mathjax/src/-/src-4.0.0.tgz",
+            "integrity": "sha512-i7oYVLkHTskfTqxBzrbvcJN8ptGChWb6bx2LZsCySk7QWf61JqaMYX5N7M0qr8tnYqRmN5DDedkRda7wDuTdBA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@mathjax/mathjax-newcm-font": "4.0.0",
+                "mhchemparser": "^4.2.1",
+                "mj-context-menu": "^0.9.1",
+                "speech-rule-engine": "5.0.0-beta.1"
+            }
+        },
+        "node_modules/@mathjax/src/node_modules/commander": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+            "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@mathjax/src/node_modules/mj-context-menu": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.9.1.tgz",
+            "integrity": "sha512-ECPcVXZFRfeYOxb1MWGzctAtnQcZ6nRucE3orfkKX7t/KE2mlXO2K/bq4BcCGOuhdz3Wg2BZDy2S8ECK73/iIw==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/@mathjax/src/node_modules/speech-rule-engine": {
+            "version": "5.0.0-beta.1",
+            "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-5.0.0-beta.1.tgz",
+            "integrity": "sha512-arqcJpXEYRG9mQMxRCNd2xFERGvIvwvuhcnoXDw/SyeYNyJ5I9SUU5ft+BPw0M1rPpwl3Q+6ZeeYAcwGXTa6oQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@xmldom/xmldom": "0.9.8",
+                "commander": "14.0.0",
+                "wicked-good-xpath": "1.3.0"
+            },
+            "bin": {
+                "sre": "bin/sre"
+            }
         },
         "node_modules/@mdx-js/mdx": {
             "version": "3.0.1",
@@ -4701,6 +4753,16 @@
                 "node": ">=18.20.0"
             }
         },
+        "node_modules/@xmldom/xmldom": {
+            "version": "0.9.8",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
+            "integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.6"
+            }
+        },
         "node_modules/@zip.js/zip.js": {
             "version": "2.7.63",
             "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.63.tgz",
@@ -5616,10 +5678,13 @@
             }
         },
         "node_modules/better-react-mathjax": {
-            "version": "2.3.0",
+            "version": "2.4.0-beta-1",
+            "resolved": "https://registry.npmjs.org/better-react-mathjax/-/better-react-mathjax-2.4.0-beta-1.tgz",
+            "integrity": "sha512-idLyXS//8ESuZl2gVSHWx57EbkzX23rjG40RejXUp7V0Yfm5EQMRng6FEx6opk0vP5BuHNIulCoB7Qf6NELiXQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "@mathjax/src": "^4.0.0",
                 "mathjax-full": "^3.2.2"
             },
             "peerDependencies": {
@@ -13613,6 +13678,19 @@
             },
             "peerDependencies": {
                 "react": "^18.2.0"
+            }
+        },
+        "node_modules/nextra/node_modules/better-react-mathjax": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/better-react-mathjax/-/better-react-mathjax-2.3.0.tgz",
+            "integrity": "sha512-K0ceQC+jQmB+NLDogO5HCpqmYf18AU2FxDbLdduYgkHYWZApFggkHE4dIaXCV1NqeoscESYXXo1GSkY6fA295w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mathjax-full": "^3.2.2"
+            },
+            "peerDependencies": {
+                "react": ">=16.8"
             }
         },
         "node_modules/nextra/node_modules/negotiator": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "@vitest/web-worker": "^3.2.4",
         "@vscode/test-web": "^0.0.70",
         "autoprefixer": "^10.4.21",
-        "better-react-mathjax": "^2.3.0",
+        "better-react-mathjax": "^2.4.0-beta-1",
         "bootstrap": "^5.3.6",
         "chalk": "^5.4.1",
         "classnames": "^2.5.1",


### PR DESCRIPTION
This PR upgrades better-react-mathjax to version 2.4.0-beta-1 as that supports MathJax 4. Previously, we just tried pointing it to the new version of MathJax, which mostly worked, but had some odd behavior.

Fixes #674