### PR TITLE
update SPLICE messages to more closely match spec

### DIFF
--- a/packages/doenetml-worker-javascript/src/CoreWorker.ts
+++ b/packages/doenetml-worker-javascript/src/CoreWorker.ts
@@ -22,7 +22,10 @@ export type UpdateRenderersCallback = (arg: {
     errorWarnings?: { errors: any[]; warnings: any[] };
     init?: boolean;
 }) => void;
-export type ReportScoreAndStateCallback = (data: unknown) => void;
+export type ReportScoreAndStateCallback = (data: {
+    score: number;
+    state: unknown;
+}) => void;
 export type RequestAnimationFrame = (args: {
     action: { actionName: string; componentIdx?: string };
     actionArgs: Record<string, any>;

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -110,7 +110,12 @@ export function DoenetViewer({
     render?: boolean;
     requestedVariantIndex?: number;
     initialState?: Record<string, any> | null;
-    reportScoreAndStateCallback?: Function;
+    reportScoreAndStateCallback?: (data: {
+        score: number;
+        state: unknown;
+        activityId: string;
+        docId: string;
+    }) => void;
     setIsInErrorState?: Function;
     generatedVariantCallback?: Function;
     documentStructureCallback?: Function;

--- a/packages/test-viewer/src/main.jsx
+++ b/packages/test-viewer/src/main.jsx
@@ -11,7 +11,6 @@ window.addEventListener("message", (event) => {
         console.log(event.data.score);
         console.log(event.data.state);
     } else if (event.data.subject == "SPLICE.sendEvent") {
-        console.log(event.data.location);
         console.log(event.data.name);
         console.log(event.data.data);
     }

--- a/packages/test-viewer/src/test/testViewer.tsx
+++ b/packages/test-viewer/src/test/testViewer.tsx
@@ -213,10 +213,6 @@ export default function TestViewer() {
                 showFeedback,
                 showHints,
                 solutionDisplayMode: "button",
-                allowLoadState: false,
-                allowSaveState: false,
-                allowLocalState: false,
-                allowSaveEvents: false,
                 messageParent: false,
                 autoSubmit: false,
             }}


### PR DESCRIPTION
This PR changes the format of some SPLICE messages to better match the [SPLICE protocol](https://docs.google.com/document/d/1X6Vx6Em67t8Vp4Vecnmc-7OblVewJJKDFIJUrvRAvdc/edit?pli=1&tab=t.0#heading=h.r0syp685x130).

This new format is a BREAKING CHANGE.

Messages with new formats
- SPLICE.getState: parameters are now in kebab case
- SPLICE.reportScoreAndState: `score` and `state` are no longer nested in an additional `data` object. Parameters are in kebab case
- SPLICE.sendEvent: most parameters are now nested in an additional `data` object.
- SPLICE.requestSolutionView: parameters are now in kebab case