### PR TITLE
make sure scroll bar appears in CodeMirror

### DIFF
--- a/packages/codemirror/src/CodeMirror.tsx
+++ b/packages/codemirror/src/CodeMirror.tsx
@@ -77,7 +77,7 @@ export function CodeMirror({
     }, [documentId, readOnly]);
 
     return (
-        <div className="mathjax_ignore">
+        <div className="mathjax_ignore" style={{ height: "100%" }}>
             <ReactCodeMirror
                 style={{ height: "100%" }}
                 value={value}


### PR DESCRIPTION
This PR fixes a regression in #703, where adding a `<div>` with no height specified around CodeMirror caused the vertical scrollbar to disappear. Specifying the height to be 100% restores the scrollbar.