### PR TITLE
move `__componentNeedingUpdateValue` to core state

### DIFF
--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -646,7 +646,6 @@ export function DocViewer({
 
     function initializeRenderers(args: Record<string, any>) {
         if (args.rendererState) {
-            delete args.rendererState.__componentNeedingUpdateValue;
             if (
                 forceDisable ||
                 forceShowCorrectness ||
@@ -903,17 +902,6 @@ export function DocViewer({
                     serializedComponentsReviver,
                 );
 
-                if (rendererState?.__componentNeedingUpdateValue) {
-                    callAction({
-                        action: {
-                            actionName: "updateValue",
-                            componentIdx:
-                                rendererState.__componentNeedingUpdateValue,
-                        },
-                        args: { doNotIgnore: true },
-                    });
-                }
-
                 // Record the fact that we loaded the state before starting core
                 loadedInitialState.current = true;
 
@@ -1015,16 +1003,6 @@ export function DocViewer({
         let rendererState =
             data.rendererState &&
             JSON.parse(data.rendererState, serializedComponentsReviver);
-
-        if (rendererState?.__componentNeedingUpdateValue) {
-            callAction({
-                action: {
-                    actionName: "updateValue",
-                    componentIdx: rendererState.__componentNeedingUpdateValue,
-                },
-                args: { doNotIgnore: true },
-            });
-        }
 
         // Record the fact that we loaded the state before starting core
         loadedInitialState.current = true;


### PR DESCRIPTION
This PR fixes a reversion caused by allowing one to save core state but not renderer state (#706).

The `__componentNeedingUpdateValue` variable catches the edge case of the document state being saved (and a document closed) while the cursor is inside a changed input. In such a state, the `immediateValue` state variable contains the new value of the input, but the `value` state variable has not been update due to no blur event. When reloading such a state into a document, one must run `updateValue` on that input because the cursor is no longer in that input. Otherwise, the state of that input is inconsistent and does not match the value (`immediateValue`) displayed in the document.

Previously, we used the renderer state to store  `__componentNeedingUpdateValue`, and we called an action to update the value when it was encountered. In order to always have  `__componentNeedingUpdateValue` even if the renderer state is not being saved, this PR moves  `__componentNeedingUpdateValue` to being saved in core state.