### PR TITLE
track if loaded initial renderer state

### DIFF
--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -142,7 +142,7 @@ export function DocViewer({
 
     const rendererClasses = useRef<Record<string, any>>({});
     const coreInfo = useRef<Record<string, any> | null>(null);
-    const loadedInitialState = useRef(false);
+    const loadedInitialRendererState = useRef(false);
     const coreCreated = useRef(false);
     const coreCreationInProgress = useRef(false);
     const coreId = useRef<string>("");
@@ -240,7 +240,7 @@ export function DocViewer({
                         setDocumentRenderer(null);
                         coreCreated.current = false;
                         coreCreationInProgress.current = false;
-                        loadedInitialState.current = false;
+                        loadedInitialRendererState.current = false;
 
                         processLoadedDocState(e.data.state);
 
@@ -759,7 +759,7 @@ export function DocViewer({
 
         if (
             init &&
-            loadedInitialState.current &&
+            loadedInitialRendererState.current &&
             !errorInitializingRenderers.current &&
             !errorInsideRenderers.current &&
             !hidden
@@ -902,8 +902,8 @@ export function DocViewer({
                     serializedComponentsReviver,
                 );
 
-                // Record the fact that we loaded the state before starting core
-                loadedInitialState.current = true;
+                // Record whether or not we loaded the renderer state before starting core
+                loadedInitialRendererState.current = Boolean(rendererState);
 
                 initializeRenderers({
                     rendererState,
@@ -1004,8 +1004,8 @@ export function DocViewer({
             data.rendererState &&
             JSON.parse(data.rendererState, serializedComponentsReviver);
 
-        // Record the fact that we loaded the state before starting core
-        loadedInitialState.current = true;
+        // Record whether or not we loaded the renderer state before starting core
+        loadedInitialRendererState.current = Boolean(rendererState);
 
         initializeRenderers({
             rendererState,
@@ -1341,7 +1341,7 @@ export function DocViewer({
         setDocumentRenderer(null);
         coreCreated.current = false;
         coreCreationInProgress.current = false;
-        loadedInitialState.current = false;
+        loadedInitialRendererState.current = false;
 
         setStage("wait");
 


### PR DESCRIPTION
If renderer state is loaded, then we initialize the renderers right away, and we don't initialize them again after core is initialized. We previously just checked if we loaded state to determine if we need to initialize the renderers after core is initialized.

With the ability to load core state without renderer state (#706), simply loading state does not give enough information. With this PR, we now correctly check if *renderer* state was loaded, and initialize the renderers after core if it was not loaded.