### PR TITLE
Blur active element on point down

### DIFF
--- a/packages/doenetml/src/Viewer/renderers/booleanInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/booleanInput.tsx
@@ -154,6 +154,8 @@ export default React.memo(function BooleanInput(props: UseDoenetRendererProps) {
         newInputJXG.isDraggable = !fixLocation.current;
 
         newInputJXG.on("down", function (e: JXGEvent) {
+            (document.activeElement as HTMLElement | null)?.blur();
+
             pointerAtDown.current = [e.x, e.y];
             pointAtDown.current = [
                 ...(newAnchorPointJXG.coords.scrCoords as [

--- a/packages/doenetml/src/Viewer/renderers/button.tsx
+++ b/packages/doenetml/src/Viewer/renderers/button.tsx
@@ -120,6 +120,8 @@ export default React.memo(function ButtonComponent(
         newButtonJXG.isDraggable = !fixLocation.current;
 
         newButtonJXG.on("down", function (e: JXGEvent) {
+            (document.activeElement as HTMLElement | null)?.blur();
+
             pointerAtDown.current = [e.x, e.y];
             pointAtDown.current = [
                 ...(newAnchorPointJXG.coords.scrCoords as [

--- a/packages/doenetml/src/Viewer/renderers/circle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/circle.tsx
@@ -324,6 +324,8 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
         });
 
         circleJXG.current.on("down", function (e) {
+            (document.activeElement as HTMLElement | null)?.blur();
+
             dragged.current = false;
             pointerAtDown.current = [e.x, e.y];
             centerAtDown.current = [

--- a/packages/doenetml/src/Viewer/renderers/curve.tsx
+++ b/packages/doenetml/src/Viewer/renderers/curve.tsx
@@ -257,6 +257,8 @@ export default React.memo(function Curve(props) {
             board.on("up", upBoard);
 
             newCurveJXG.on("down", (e) => {
+                (document.activeElement as HTMLElement | null)?.blur();
+
                 pointerAtDown.current = [e.x, e.y];
                 pointerIsDown.current = true;
                 pointerMovedSinceDown.current = false;
@@ -345,6 +347,8 @@ export default React.memo(function Curve(props) {
             }
         } else {
             newCurveJXG.on("down", function (e) {
+                (document.activeElement as HTMLElement | null)?.blur();
+
                 pointerAtDown.current = [e.x, e.y];
                 pointerIsDown.current = true;
                 pointerMovedSinceDown.current = false;
@@ -480,6 +484,8 @@ export default React.memo(function Curve(props) {
     }
 
     function downThroughPoint(i, e) {
+        (document.activeElement as HTMLElement | null)?.blur();
+
         // console.log(`down through point: ${i}`)
 
         // also called when navigate to point using keyboard

--- a/packages/doenetml/src/Viewer/renderers/image.tsx
+++ b/packages/doenetml/src/Viewer/renderers/image.tsx
@@ -190,6 +190,8 @@ export default React.memo(function Image(props) {
         lastRotate.current = SVs.rotate;
 
         newImageJXG.on("down", function (e) {
+            (document.activeElement as HTMLElement | null)?.blur();
+
             pointerAtDown.current = [e.x, e.y];
             pointAtDown.current = [...newAnchorPointJXG.coords.scrCoords];
             dragged.current = false;

--- a/packages/doenetml/src/Viewer/renderers/label.tsx
+++ b/packages/doenetml/src/Viewer/renderers/label.tsx
@@ -138,6 +138,8 @@ export default React.memo(function Label(props) {
         newLabelJXG.isDraggable = !fixLocation.current;
 
         newLabelJXG.on("down", function (e) {
+            (document.activeElement as HTMLElement | null)?.blur();
+
             pointerAtDown.current = [e.x, e.y];
             pointAtDown.current = [...newAnchorPointJXG.coords.scrCoords];
             dragged.current = false;

--- a/packages/doenetml/src/Viewer/renderers/line.tsx
+++ b/packages/doenetml/src/Viewer/renderers/line.tsx
@@ -262,6 +262,8 @@ export default React.memo(function Line(props) {
         });
 
         newLineJXG.on("down", function (e) {
+            (document.activeElement as HTMLElement | null)?.blur();
+
             dragged.current = false;
             pointerAtDown.current = [e.x, e.y];
             pointsAtDown.current = [

--- a/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
+++ b/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
@@ -282,6 +282,8 @@ export default React.memo(function LineSegment(props) {
         });
 
         point1JXG.current.on("down", (e) => {
+            (document.activeElement as HTMLElement | null)?.blur();
+
             draggedPoint.current = null;
             pointerAtDown.current = [e.x, e.y];
             downOnPoint.current = 1;
@@ -302,6 +304,8 @@ export default React.memo(function LineSegment(props) {
             });
         });
         point2JXG.current.on("down", (e) => {
+            (document.activeElement as HTMLElement | null)?.blur();
+
             draggedPoint.current = null;
             pointerAtDown.current = [e.x, e.y];
             downOnPoint.current = 2;
@@ -322,6 +326,8 @@ export default React.memo(function LineSegment(props) {
             });
         });
         lineSegmentJXG.current.on("down", function (e) {
+            (document.activeElement as HTMLElement | null)?.blur();
+
             draggedPoint.current = null;
             pointerAtDown.current = [e.x, e.y];
             pointsAtDown.current = [

--- a/packages/doenetml/src/Viewer/renderers/math.tsx
+++ b/packages/doenetml/src/Viewer/renderers/math.tsx
@@ -163,6 +163,8 @@ export default React.memo(function MathComponent(
         newMathJXG.isDraggable = !fixLocation.current;
 
         newMathJXG.on("down", function (e) {
+            (document.activeElement as HTMLElement | null)?.blur();
+
             pointerAtDown.current = [e.x, e.y];
             pointAtDown.current = [
                 ...(newAnchorPointJXG.coords.scrCoords as [

--- a/packages/doenetml/src/Viewer/renderers/number.tsx
+++ b/packages/doenetml/src/Viewer/renderers/number.tsx
@@ -137,6 +137,8 @@ export default React.memo(function NumberComponent(props) {
         newNumberJXG.isDraggable = !fixLocation.current;
 
         newNumberJXG.on("down", function (e) {
+            (document.activeElement as HTMLElement | null)?.blur();
+
             pointerAtDown.current = [e.x, e.y];
             pointAtDown.current = [...newAnchorPointJXG.coords.scrCoords];
             dragged.current = false;

--- a/packages/doenetml/src/Viewer/renderers/point.tsx
+++ b/packages/doenetml/src/Viewer/renderers/point.tsx
@@ -197,6 +197,8 @@ export default React.memo(function Point(props: UseDoenetRendererProps) {
         let newPointJXG = board.create("point", coords, jsxPointAttributes);
 
         newShadowPointJXG.on("down", function (e: { x: number; y: number }) {
+            (document.activeElement as HTMLElement | null)?.blur();
+
             pointerAtDown.current = [e.x, e.y];
             pointAtDown.current = [
                 ...(newShadowPointJXG.coords.scrCoords as [

--- a/packages/doenetml/src/Viewer/renderers/polygon.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polygon.tsx
@@ -320,6 +320,8 @@ export default React.memo(function Polygon(props) {
     }
 
     function downHandler(i, e) {
+        (document.activeElement as HTMLElement | null)?.blur();
+
         draggedPoint.current = null;
         pointerAtDown.current = [e.x, e.y];
 

--- a/packages/doenetml/src/Viewer/renderers/polyline.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polyline.tsx
@@ -314,6 +314,8 @@ export default React.memo(function Polyline(props) {
     }
 
     function downHandler(i, e) {
+        (document.activeElement as HTMLElement | null)?.blur();
+
         draggedPoint.current = null;
         pointerAtDown.current = [e.x, e.y];
 

--- a/packages/doenetml/src/Viewer/renderers/ray.tsx
+++ b/packages/doenetml/src/Viewer/renderers/ray.tsx
@@ -213,6 +213,8 @@ export default React.memo(function Ray(props) {
         });
 
         newRayJXG.on("down", function (e) {
+            (document.activeElement as HTMLElement | null)?.blur();
+
             dragged.current = false;
             pointerAtDown.current = [e.x, e.y];
             pointsAtDown.current = [

--- a/packages/doenetml/src/Viewer/renderers/text.tsx
+++ b/packages/doenetml/src/Viewer/renderers/text.tsx
@@ -136,6 +136,8 @@ export default React.memo(function Text(props) {
         newTextJXG.isDraggable = !fixLocation.current;
 
         newTextJXG.on("down", function (e) {
+            (document.activeElement as HTMLElement | null)?.blur();
+
             pointerAtDown.current = [e.x, e.y];
             pointAtDown.current = [...newAnchorPointJXG.coords.scrCoords];
             dragged.current = false;

--- a/packages/doenetml/src/Viewer/renderers/textInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/textInput.tsx
@@ -246,6 +246,8 @@ export default function TextInput(props: UseDoenetRendererProps) {
         newInputJXG.rendNodeLabel.style.marginRight = "2px";
 
         newInputJXG.on("down", function (e) {
+            (document.activeElement as HTMLElement | null)?.blur();
+
             pointerAtDown.current = [e.x, e.y];
             pointAtDown.current = [...newAnchorPointJXG.coords.scrCoords];
             dragged.current = false;

--- a/packages/doenetml/src/Viewer/renderers/vector.tsx
+++ b/packages/doenetml/src/Viewer/renderers/vector.tsx
@@ -253,6 +253,8 @@ export default React.memo(function Vector(props) {
         });
 
         newPoint1JXG.on("down", function (e) {
+            (document.activeElement as HTMLElement | null)?.blur();
+
             headBeingDragged.current = false;
             tailBeingDragged.current = false;
             pointerAtDown.current = [e.x, e.y];
@@ -277,6 +279,8 @@ export default React.memo(function Vector(props) {
         });
 
         newPoint2JXG.on("down", function (e) {
+            (document.activeElement as HTMLElement | null)?.blur();
+
             headBeingDragged.current = false;
             tailBeingDragged.current = false;
             pointerAtDown.current = [e.x, e.y];
@@ -303,6 +307,8 @@ export default React.memo(function Vector(props) {
         // if drag vector, need to keep track of original point positions
         // so that they won't get stuck in an attractor
         newVectorJXG.on("down", function (e) {
+            (document.activeElement as HTMLElement | null)?.blur();
+
             headBeingDragged.current = false;
             tailBeingDragged.current = false;
             pointerAtDown.current = [e.x, e.y];


### PR DESCRIPTION
For draggable graphical objects, blur the currently active element in the pointer down event.

Without this blur, a focused mathInput does not lose focus when dragging the element. If one clicks back on the mathInput, it does not accept additional input (unless one removes its focus and reenters the mathInput).

Resolves #457 