### PR TITLE
Electron configuration is rendered

### DIFF
--- a/packages/doenetml-worker-javascript/src/components/chemistry/ElectronConfiguration.js
+++ b/packages/doenetml-worker-javascript/src/components/chemistry/ElectronConfiguration.js
@@ -10,6 +10,7 @@ export default class ElectronConfiguration extends MathComponent {
 
         stateVariableDefinitions.latex = {
             public: true,
+            forRenderer: true,
             shadowingInstructions: {
                 createComponentOfType: "latex",
             },

--- a/packages/test-cypress/cypress/e2e/chemistry/atom.cy.js
+++ b/packages/test-cypress/cypress/e2e/chemistry/atom.cy.js
@@ -1,0 +1,28 @@
+import { cesc } from "@doenet/utils";
+import { toMathJaxString } from "../../../src/util/mathDisplay";
+
+describe("Atom tests", function () {
+    beforeEach(() => {
+        cy.clearIndexedDB();
+        cy.visit("");
+    });
+
+    it("Electron configuration displays correctly", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+<atom name="helium" atomicNumber="2"/>
+<p name="p">The electron configuration for helium is $helium.electronConfiguration.</p>
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#p").should(
+            "have.text",
+            `The electron configuration for helium is ${toMathJaxString("1s2")}.`,
+        );
+    });
+});


### PR DESCRIPTION
This PR fixes a bug where the electron configuration of an atom wasn't rendered.

Fixes #494 