### PR TITLE
fix feedback styling

### DIFF
--- a/packages/doenetml/src/Viewer/renderers/feedback.css
+++ b/packages/doenetml/src/Viewer/renderers/feedback.css
@@ -1,4 +1,4 @@
-.doenet-viewer .feedback aside {
+.doenet-viewer .feedback > aside {
     background-color: var(--canvas);
     margin: 0px 4px 12px 4px;
     padding: 1em;
@@ -8,7 +8,7 @@
     border-bottom-right-radius: 5px;
 }
 
-.doenet-viewer .feedback span {
+.doenet-viewer .feedback > span {
     display: block;
     margin: 12px 4px 0px 4px;
     padding: 6px;

--- a/packages/doenetml/src/Viewer/renderers/feedback.tsx
+++ b/packages/doenetml/src/Viewer/renderers/feedback.tsx
@@ -34,10 +34,7 @@ export default React.memo(function Feedback(props: UseDoenetRendererProps) {
     return (
         <div ref={ref} className="feedback">
             <span tabIndex={0}>{icon} Feedback</span>
-            <aside
-                id={id}
-                // tabIndex="0"
-            >
+            <aside id={id}>
                 {SVs.feedbackText}
                 {children}
             </aside>


### PR DESCRIPTION
This PR fixes a bug introduced in #723, where the css selector for the feedback heading was too lax and would apply the styling to spans inside the feedback itself.