### PR TITLE
ignore initial blank string children in answer sugar

### DIFF
--- a/packages/doenetml-worker-javascript/src/components/Answer.js
+++ b/packages/doenetml-worker-javascript/src/components/Answer.js
@@ -311,6 +311,18 @@ export default class Answer extends InlineComponent {
                 (child) => !componentIsSpecifiedType(child, "label"),
             );
 
+            // remove beginning and ending blank strings from matchedChildren
+            const firstNonBlankInd = matchedChildren.findIndex(
+                (child) => typeof child !== "string" || child.trim() !== "",
+            );
+            const lastNonBlankInd = matchedChildren.findLastIndex(
+                (child) => typeof child !== "string" || child.trim() !== "",
+            );
+            matchedChildren = matchedChildren.slice(
+                firstNonBlankInd,
+                lastNonBlankInd + 1,
+            );
+
             let childIsWrappable = [];
             for (let child of matchedChildren) {
                 if (typeof child !== "object") {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/answer.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/answer.test.ts
@@ -6946,4 +6946,36 @@ What is the derivative of <function name="f">x^2</function>?
         expect(errorWarnings.errors.length).eq(0);
         expect(errorWarnings.warnings.length).eq(0);
     });
+
+    it("ignore initial blank string in answer sugar", async () => {
+        // Fix bug where the initial blank string child of the answer
+        // prevented the sugar from wrapping the text after the mathInput correctly.
+        const doenetML = `
+    <p><answer name="ans">
+    <mathInput name="mi"><label>x</label></mathInput>
+    x    
+    </answer></p>
+  `;
+
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML,
+        });
+
+        await updateMathInputValue({
+            latex: "x",
+            componentIdx: await resolvePathToNodeIdx("mi"),
+            core,
+        });
+
+        await submitAnswer({
+            componentIdx: await resolvePathToNodeIdx("ans"),
+            core,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("ans")].stateValues
+                .creditAchieved,
+        ).eq(1);
+    });
 });


### PR DESCRIPTION
This PR fixes a bug where the answer sugar did not correctly wrap the `x` for this DoenetML:
```
<answer name="ans">
    <mathInput name="mi"><label>x</label></mathInput>
    x
</answer>
```
The blank string between the `<answer>` and `<mathInput>` prevented the `x` from getting wrapped by an award.