### PR TITLE
Paginator controls can handle bad paginator attribute

### DIFF
--- a/packages/doenetml-worker-javascript/src/components/Paginator.js
+++ b/packages/doenetml-worker-javascript/src/components/Paginator.js
@@ -309,12 +309,16 @@ export class PaginatorControls extends BlockComponent {
                             dependencyType: "stateVariable",
                             componentIdx: stateValues.paginatorComponentIdx,
                             variableName: "currentPage",
+                            variablesOptional: true,
                         },
                     };
                 }
             },
             definition({ dependencyValues }) {
-                if ("paginatorPage" in dependencyValues) {
+                if (
+                    "paginatorPage" in dependencyValues &&
+                    Number.isInteger(dependencyValues.paginatorPage)
+                ) {
                     return {
                         setValue: {
                             currentPage: dependencyValues.paginatorPage,
@@ -338,12 +342,16 @@ export class PaginatorControls extends BlockComponent {
                             dependencyType: "stateVariable",
                             componentIdx: stateValues.paginatorComponentIdx,
                             variableName: "numPages",
+                            variablesOptional: true,
                         },
                     };
                 }
             },
             definition({ dependencyValues }) {
-                if ("paginatorNPages" in dependencyValues) {
+                if (
+                    "paginatorNPages" in dependencyValues &&
+                    Number.isInteger(dependencyValues.paginatorNPages)
+                ) {
                     return {
                         setValue: {
                             numPages: dependencyValues.paginatorNPages,

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/paginator.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/paginator.test.ts
@@ -427,4 +427,27 @@ describe("Paginator tag tests", async () => {
                 .childIndicesToRender,
         ).eqls([1]);
     });
+
+    it("Paginator controls can handle bad paginator attribute", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <paginatorControls paginator="$section1" name="pcontrols" />
+  
+    <section name="section1">
+      <title name="title1">Page 1</title>
+      <p>What is 1+1? <answer name="answer1">$two</answer></p>
+    </section>
+    `,
+        });
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("pcontrols")].stateValues
+                .currentPage,
+        ).eq(1);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("pcontrols")].stateValues
+                .numPages,
+        ).eq(1);
+    });
 });


### PR DESCRIPTION
This PR makes sure that `<paginatorControls>` doesn't crash when its `paginator` attribute references a component that isn't a paginator.