### PR TITLE
fix schema for pretzel so only children are problems

### DIFF
--- a/packages/doenetml-worker-javascript/src/components/Pretzel.js
+++ b/packages/doenetml-worker-javascript/src/components/Pretzel.js
@@ -14,6 +14,9 @@ export default class Pretzel extends BlockScoredComponent {
     static renderChildren = true;
     static canDisplayChildErrors = true;
 
+    static additionalSchemaChildren = ["problem"];
+    static additionalSchemaChildrenDoNotInherit = true;
+
     static createAttributesObject() {
         const attributes = super.createAttributesObject();
 
@@ -34,14 +37,17 @@ export default class Pretzel extends BlockScoredComponent {
             {
                 group: "problems",
                 componentTypes: ["statement"],
+                excludeFromSchema: true,
             },
             {
                 group: "textInputs",
                 componentTypes: ["textInput"],
+                excludeFromSchema: true,
             },
             {
                 group: "givenAnswers",
                 componentTypes: ["span"],
+                excludeFromSchema: true,
             },
         ];
     }

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -32,6 +32,7 @@ type ComponentClass = {
     getAdapterComponentType: (...args: any[]) => string;
     numAdapters: number;
     additionalSchemaChildren?: string[];
+    additionalSchemaChildrenDoNotInherit?: boolean;
 };
 
 interface ComponentInfoObjects extends ReturnType<
@@ -215,14 +216,18 @@ export function getSchema() {
         // The static variable additionalSchemaChildren on a component class
         // can be used to add children to the schema that wouldn't show up otherwise.
         // Two uses are:
-        // 1. to include children that are accepted by sugar but are in a child group
+        // 1. to include children that are accepted by sugar but are not in a child group
         //    because the sugar moves them to no longer be children
         // 2. to add composite children to the schema even though they should be expanded,
         //    (as adding a composite child to a child group will prevent it from being expanded)
         if (cClass.additionalSchemaChildren) {
             for (let type2 of cClass.additionalSchemaChildren) {
                 if (type2 in inheritedOrAdaptedTypes) {
-                    children.push(...inheritedOrAdaptedTypes[type2]);
+                    if (cClass.additionalSchemaChildrenDoNotInherit) {
+                        children.push(type2);
+                    } else {
+                        children.push(...inheritedOrAdaptedTypes[type2]);
+                    }
                 }
                 if (
                     type2 === "string" ||

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -64405,6 +64405,30 @@
                         "string"
                     ]
                 },
+                "highContrastColor": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "highContrastColorWord": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "highContrastColorDarkMode": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
+                "highContrastColorWordDarkMode": {
+                    "optional": true,
+                    "type": [
+                        "string"
+                    ]
+                },
                 "backgroundColor": {
                     "optional": true,
                     "type": [
@@ -132262,13 +132286,7 @@
             },
             "children": [
                 {
-                    "ref": "statement"
-                },
-                {
-                    "ref": "textInput"
-                },
-                {
-                    "ref": "span"
+                    "ref": "problem"
                 }
             ],
             "textChildrenAllowed": false,

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -39745,6 +39745,18 @@
                     "name": "textColorWordDarkMode"
                 },
                 {
+                    "name": "highContrastColor"
+                },
+                {
+                    "name": "highContrastColorWord"
+                },
+                {
+                    "name": "highContrastColorDarkMode"
+                },
+                {
+                    "name": "highContrastColorWordDarkMode"
+                },
+                {
                     "name": "backgroundColor"
                 },
                 {
@@ -80822,9 +80834,7 @@
         {
             "name": "pretzel",
             "children": [
-                "statement",
-                "textInput",
-                "span"
+                "problem"
             ],
             "attributes": [
                 {


### PR DESCRIPTION
This PR fixes the schema for `<pretzel>` so that it matches the children actually authored, rather than the children the component actually receives after the sugared-in pretzel arranger does its work.

Fixes #766 