### PR TITLE
fix graph horizontal align

### DIFF
--- a/packages/doenetml/src/Viewer/renderers/graph.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graph.tsx
@@ -220,7 +220,7 @@ export default React.memo(function Graph(props) {
         };
     } else {
         outerStyle = { display: "flex", justifyContent: SVs.horizontalAlign };
-        innerStyle = { width: "100%" };
+        innerStyle = { maxWidth: "100%" };
     }
 
     if (SVs.showBorder) {
@@ -251,7 +251,7 @@ export default React.memo(function Graph(props) {
                         aria-label={ariaLabel}
                         role={role}
                         aria-hidden={ariaHidden}
-                        style={{ width: "100%", display: "block" }}
+                        style={{ maxWidth: "100%", display: "block" }}
                     >
                         <div id={id} className="jxgbox" style={divStyle} />
                     </div>
@@ -497,7 +497,7 @@ export default React.memo(function Graph(props) {
                     aria-label={ariaLabel}
                     role={role}
                     aria-hidden={ariaHidden}
-                    style={{ width: "100%" }}
+                    style={{ maxWidth: "100%" }}
                     aria-details={descriptionId}
                 >
                     <div id={id} className="jxgbox" style={divStyle} />


### PR DESCRIPTION
The PR fixes a bug in the graph renderer, where the `horizontalAlign` attribute was having no effect. Now graphs with the default `displayMode` of "block" and the default `horizontalAlign` of "center" are correctly center aligned.

Fixes #808