### PR TITLE
display answer as block component if have block input child

### DIFF
--- a/packages/doenetml-worker-javascript/src/components/Answer.js
+++ b/packages/doenetml-worker-javascript/src/components/Answer.js
@@ -48,6 +48,7 @@ export default class Answer extends InlineComponent {
         attributes.inline = {
             createComponentOfType: "boolean",
             createStateVariable: "inline",
+            forRenderer: true,
             defaultValue: false,
             public: true,
         };

--- a/packages/doenetml/src/Viewer/renderers/answer.tsx
+++ b/packages/doenetml/src/Viewer/renderers/answer.tsx
@@ -122,7 +122,10 @@ export default React.memo(function Answer(props: UseDoenetRendererProps) {
             id={id}
             style={{
                 marginBottom: "4px",
-                display: SVs.haveBlockInputChild ? "flex" : "inline-flex",
+                display:
+                    SVs.inline || !SVs.haveBlockInputChild
+                        ? "inline-flex"
+                        : "flex",
                 alignItems: "start",
             }}
         >

--- a/packages/test-cypress/cypress/e2e/tagSpecific/answer.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/answer.cy.js
@@ -3285,7 +3285,13 @@ d
             <choice>n</choice>
         </choiceInput>
     </answer>
-    <answer name="ans5">x</answer>
+    <answer name="ans5" inline>
+        <choiceInput inline="false">
+            <choice>m</choice>
+            <choice>n</choice>
+        </choiceInput>
+    </answer>
+    <answer name="ans6">x</answer>
 
     `,
                 },
@@ -3298,5 +3304,6 @@ d
         cy.get("#ans3").should("have.css", "display", "inline-flex");
         cy.get("#ans4").should("have.css", "display", "flex");
         cy.get("#ans5").should("have.css", "display", "inline-flex");
+        cy.get("#ans6").should("have.css", "display", "inline-flex");
     });
 });


### PR DESCRIPTION
This PR fixes a regression where an answer with a block choice input was display in inline mode.

For example, for the following DoenetML,
```xml
hello
<answer>
   <choice credit="1">a</choice>
   <choice>b</choice>
</answer>
bye
```
and answer is once again displayed on its own line.