### PR TITLE
add publish and version scripts to publish 4 workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
         "docs": "npm run build --workspace packages/docs-nextra & npm run dev --workspace packages/docs-nextra",
         "prettier:check": "prettier --check .",
         "prettier:format": "prettier --write .",
-        "test": "npm run test -ws --if-present -- run"
+        "publish": "npm run publish -w packages/doenetml -w packages/standalone -w packages/doenetml-iframe -w packages/v06-to-v07",
+        "test": "npm run test -ws --if-present -- run",
+        "version": "npm version -w packages/doenetml -w packages/standalone -w packages/doenetml-iframe -w packages/v06-to-v07"
     },
     "prettier": {
         "tabWidth": 4


### PR DESCRIPTION
This PR creates two new npm scripts:

1. `version`: run `npm version` on the four workspace we publish together: `doeneml`, `standalone`, `doenet-iframe`, and `v06-to-07`. For example, `npm run version -- patch` will increment each package to the next patch level.
2. `publish`: run `npm  run publish` on the same four workspaces.