### PR TITLE
purge jsdelivr cache of standalone after publishing

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -268,8 +268,23 @@ jobs:
 
             - name: Purge jsDelivr cache
               run: |
-                  # Purge package-level cache for standalone package
-                  curl -f https://purge.jsdelivr.net/npm/@doenet/standalone@dev
-                  # Purge critical standalone files explicitly
-                  curl -f https://purge.jsdelivr.net/npm/@doenet/standalone@dev/doenet-standalone.js
-                  curl -f https://purge.jsdelivr.net/npm/@doenet/standalone@dev/style.css
+                  echo "Waiting for npm package propagation before purging jsDelivr cache..."
+                  sleep 15
+
+                  echo "Purging jsDelivr cache for @doenet/standalone@dev (package-level)..."
+                  if ! curl -fv https://purge.jsdelivr.net/npm/@doenet/standalone@dev; then
+                      echo "Error: Failed to purge package-level cache for @doenet/standalone@dev" >&2
+                      exit 1
+                  fi
+
+                  echo "Purging jsDelivr cache for @doenet/standalone@dev/doenet-standalone.js..."
+                  if ! curl -fv https://purge.jsdelivr.net/npm/@doenet/standalone@dev/doenet-standalone.js; then
+                      echo "Error: Failed to purge cache for doenet-standalone.js" >&2
+                      exit 1
+                  fi
+
+                  echo "Purging jsDelivr cache for @doenet/standalone@dev/style.css..."
+                  if ! curl -fv https://purge.jsdelivr.net/npm/@doenet/standalone@dev/style.css; then
+                      echo "Error: Failed to purge cache for style.css" >&2
+                      exit 1
+                  fi


### PR DESCRIPTION
After publishing to the dev tag, purge the jsdelivr cache for the standalone files so that users obtaining the software via @dev can get the new version right away.