### PR TITLE
restore ability of Format DoenetML button in editor

### DIFF
--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -412,6 +412,7 @@ export function EditorViewer({
                                 sameWidth
                                 gutter={2}
                                 className="popover"
+                                data-test="Format As Select Popover"
                             >
                                 <SelectItem
                                     className="select-item"

--- a/packages/test-cypress/cypress/e2e/EditorViewer/editorViewer.cy.js
+++ b/packages/test-cypress/cypress/e2e/EditorViewer/editorViewer.cy.js
@@ -159,7 +159,10 @@ describe("EditorViewer Tests", function () {
 
         cy.log("Format as DoenetML");
         cy.get("[data-test='Format As Select']").click();
-        cy.contains(".select-item", "DoenetML").click();
+        cy.contains(
+            "[data-test='Format As Select Popover'] .select-item",
+            "DoenetML",
+        ).click();
 
         cy.contains("[data-test='Format DoenetML Button']", "Format").click();
 


### PR DESCRIPTION
This PR restores the ability of the "Format As" button in the editor, so that it formats contents into either DoenetML or XML format.

This regression was introduced in #739, where we memoized the code editor to prevent the search panel from closing prematurely.