### PR TITLE
run javascript worker tests as separate job

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -40,7 +40,7 @@ jobs:
 
             - name: Debug Build Artifacts
               run: |
-                  ls -la ./packages/*/.wireit/ || echo "No .wireit directory in parser"
+                  ls -la ./packages/*/.wireit/ || echo "No .wireit directory found"
                   du -sh ./packages/*/.wireit/*/
 
             # upload all the .wireit directories so that the test job can use them.
@@ -78,7 +78,7 @@ jobs:
 
             - name: Debug Build Artifacts
               run: |
-                  ls -la ./packages/*/.wireit/ || echo "No .wireit directory in parser"
+                  ls -la ./packages/*/.wireit/ || echo "No .wireit directory found"
 
             # with the wireit cache saved, this build step should be fast.
             - name: Build (cached)
@@ -114,13 +114,13 @@ jobs:
 
             - name: Debug Build Artifacts
               run: |
-                  ls -la ./packages/*/.wireit/ || echo "No .wireit directory in parser"
+                  ls -la ./packages/*/.wireit/ || echo "No .wireit directory found"
 
             # with the wireit cache saved, this build step should be fast.
             - name: Build (cached)
               run: |
                   export NODE_OPTIONS="--max_old_space_size=6114"
-                  npm run build
+                  npm run build -w packages/doenetml-worker
               env:
                   WIREIT_CACHE: "local"
 
@@ -150,7 +150,7 @@ jobs:
 
             - name: Debug Build Artifacts
               run: |
-                  ls -la ./packages/*/.wireit/ || echo "No .wireit directory in parser"
+                  ls -la ./packages/*/.wireit/ || echo "No .wireit directory found"
 
             # with the wireit cache saved, this build step should be fast.
             - name: Build (cached)
@@ -284,7 +284,7 @@ jobs:
 
             - name: Debug Build Artifacts
               run: |
-                  ls -la ./packages/*/.wireit/ || echo "No .wireit directory in parser"
+                  ls -la ./packages/*/.wireit/ || echo "No .wireit directory found"
 
             - name: Update versions
               run: |

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "prettier:format": "prettier --write .",
         "publish": "npm run publish -w packages/doenetml -w packages/standalone -w packages/doenetml-iframe -w packages/v06-to-v07",
         "test": "npm run test -ws --if-present -- run",
-        "test:all-no-worker-js": "npm --if-present run test -w packages/codemirror -w packages/debug-hooks -w packages/docs-nextra -w packages/doenetml -w packages/doenetml-iframe -w packages/doenetml-prototype -w packages/doenetml-to-pretext -w packages/doenetml-worker -w packages/doenetml-worker-rust -w packages/lsp -w packages/lsp-tools -w packages/parser -w packages/standalone -w packages/static-assets -w packages/test-cypress -w packages/test-viewer -w packages/ui-components -w packages/utils -w packages/v06-to-v07 -w packages/virtual-keyboard -w packages/vscode-extension -- run",
+        "test:all-no-worker-js": "echo \"NOTE: 'test:all-no-worker-js' uses a hard-coded workspace list; update this list when adding or removing workspaces.\" && npm --if-present run test -w packages/codemirror -w packages/debug-hooks -w packages/docs-nextra -w packages/doenetml -w packages/doenetml-iframe -w packages/doenetml-prototype -w packages/doenetml-to-pretext -w packages/doenetml-worker -w packages/doenetml-worker-rust -w packages/lsp -w packages/lsp-tools -w packages/parser -w packages/standalone -w packages/static-assets -w packages/test-cypress -w packages/test-viewer -w packages/ui-components -w packages/utils -w packages/v06-to-v07 -w packages/virtual-keyboard -w packages/vscode-extension -- run",
         "version": "npm version -w packages/doenetml -w packages/standalone -w packages/doenetml-iframe -w packages/v06-to-v07"
     },
     "prettier": {


### PR DESCRIPTION
This PR runs the doenetml-worker-javascript as a separate CI job , since they take a long time to run.