### PR TITLE
add `overflow-x: auto` style to doenet-viewer

### DIFF
--- a/packages/doenetml/src/DoenetML.css
+++ b/packages/doenetml/src/DoenetML.css
@@ -107,6 +107,7 @@ html {
 .doenet-viewer {
     font-family: "Open Sans" !important;
     color: var(--canvasText);
+    overflow-x: auto;
 }
 .doenet-viewer h1 {
     font-size: 2em;


### PR DESCRIPTION
This PR adds the style `overflow-x: auto` to the `doenet-viewer` class.

The purpose of this change is to fix [a bug reported](https://community.doenet.org/t/width-of-doenet-in-pretext/54) where an answer blank with a long answer typed into it extended beyond the width of the iframe (that was embedded into a PreTeXt document). As a result, the right side of the answer blank, along with the check work button, was hidden and could not be accessed. With `overflow-x: auto` set on the `doenet-viewer` class, a horizontal scroll bar should appear in this situation, allowing the user to scroll to the right side of the answer and access the check work button.