### PR TITLE
move pretzel input to question line

### DIFF
--- a/packages/doenetml/src/Viewer/renderers/pretzel.css
+++ b/packages/doenetml/src/Viewer/renderers/pretzel.css
@@ -41,16 +41,15 @@
         /* padding: 5px; */
     }
 
-    .pretzelAnswerInput {
-        display: flex;
-        justify-content: space-between;
-        /* border-bottom: 1px solid #333; */
-        background-color: #ddd;
+    .pretzelAnswer {
         padding: 10px;
+        background-color: #ddd;
     }
 
-    .pretzelStatement {
+    .pretzelInputStatement {
+        display: flex;
         padding: 10px;
+        gap: 10px;
     }
 
     .pretzelWrapper {

--- a/packages/doenetml/src/Viewer/renderers/pretzel.tsx
+++ b/packages/doenetml/src/Viewer/renderers/pretzel.tsx
@@ -77,15 +77,15 @@ export default React.memo(function Pretzel(props: UseDoenetRendererProps) {
                     className={`pretzel${gridIdx + 1} pretzelProblem`}
                     key={prob}
                 >
-                    <div className="pretzelAnswerInput">
+                    <div className="pretzelAnswer">
+                        <b>Answer</b>: {answer}
+                    </div>
+                    <div className="pretzelInputStatement">
                         <div>
                             <span>{input}</span>
                         </div>
-                        <div>
-                            <b>Answer</b>: {answer}
-                        </div>
+                        <div>{statement}</div>
                     </div>
-                    <div className="pretzelStatement">{statement}</div>
                 </div>
             );
 


### PR DESCRIPTION
This PR move the input boxes from the right of the answer line to the left of the question line.

Fixes #867 