### PR TITLE
derivatives of all forms of inverse trig functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
                 "jszip": "^3.10.1",
                 "katex": "^0.16.27",
                 "lorem-ipsum": "^2.0.8",
-                "math-expressions": "^2.0.0-alpha83",
+                "math-expressions": "^2.0.0-alpha84",
                 "micromark": "^4.0.2",
                 "nanoid": "^5.1.6",
                 "nextra": "^3.3.1",
@@ -14251,9 +14251,9 @@
             }
         },
         "node_modules/math-expressions": {
-            "version": "2.0.0-alpha83",
-            "resolved": "https://registry.npmjs.org/math-expressions/-/math-expressions-2.0.0-alpha83.tgz",
-            "integrity": "sha512-cz4zZEke2jlhKdkGDutqOrGNigiJZlNzyQCCOp+txwmKQitAc1nX7jWJWkdpJhMWsp1FgOAO3wk86FuJOxvHlw==",
+            "version": "2.0.0-alpha84",
+            "resolved": "https://registry.npmjs.org/math-expressions/-/math-expressions-2.0.0-alpha84.tgz",
+            "integrity": "sha512-kOb/4itQsBq3RlO/yXTnvJx6+E8KmH1uF8wsP0YFLpS0G4Fi+fxNF8CfWx0Ks50i3lP812BYQ943aybQoLOIfg==",
             "dev": true,
             "license": "(GPL-3.0 OR Apache-2.0)",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
         "jszip": "^3.10.1",
         "katex": "^0.16.27",
         "lorem-ipsum": "^2.0.8",
-        "math-expressions": "^2.0.0-alpha83",
+        "math-expressions": "^2.0.0-alpha84",
         "micromark": "^4.0.2",
         "nanoid": "^5.1.6",
         "nextra": "^3.3.1",

--- a/packages/doenetml-worker-javascript/src/components/FunctionOperators.js
+++ b/packages/doenetml-worker-javascript/src/components/FunctionOperators.js
@@ -600,10 +600,12 @@ export class Derivative extends FunctionBaseOperator {
                                 for (let comp = 0; comp < nComponents; comp++) {
                                     let valComp = value.get_component(comp);
                                     for (let variable of dependencyValues.derivVariables) {
-                                        valComp = valComp.derivative(
-                                            variable.subscripts_to_strings()
-                                                .tree,
-                                        );
+                                        valComp = valComp
+                                            .normalize_applied_functions()
+                                            .derivative(
+                                                variable.subscripts_to_strings()
+                                                    .tree,
+                                            );
                                     }
                                     derivComps.push(valComp.tree);
                                 }

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/functionoperators.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/functionoperators.test.ts
@@ -699,6 +699,99 @@ describe("Function Operator tag tests @group1", async () => {
         ).be.true;
     });
 
+    it("derivative of inverse trig functions", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <function name="f1">arcsin(x)</function>
+    <function name="f1a">asin(x)</function>
+    <function name="f2">arccos(x)</function>
+    <function name="f2a">acos(x)</function>
+    <function name="f3">arctan(x)</function>
+    <function name="f3a">atan(x)</function>
+    <function name="f4">arccot(x)</function>
+    <function name="f4a">acot(x)</function>
+    <function name="f5">arcsec(x)</function>
+    <function name="f5a">asec(x)</function>
+    <function name="f6">arccsc(x)</function>
+    <function name="f6a">acsc(x)</function>
+    <derivative name="d1">$f1</derivative>
+    <derivative name="d1a">$f1a</derivative>
+    <derivative name="d2">$f2</derivative>
+    <derivative name="d2a">$f2a</derivative>
+    <derivative name="d3">$f3</derivative>
+    <derivative name="d3a">$f3a</derivative>
+    <derivative name="d4">$f4</derivative>
+    <derivative name="d4a">$f4a</derivative>
+    <derivative name="d5">$f5</derivative>
+    <derivative name="d5a">$f5a</derivative>
+    <derivative name="d6">$f6</derivative>
+    <derivative name="d6a">$f6a</derivative>
+    `,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[
+                await resolvePathToNodeIdx("d1")
+            ].stateValues.formula.equals(me.fromText("1/sqrt(1-x^2)")),
+        ).be.true;
+        expect(
+            stateVariables[
+                await resolvePathToNodeIdx("d1a")
+            ].stateValues.formula.equals(me.fromText("1/sqrt(1-x^2)")),
+        ).be.true;
+        expect(
+            stateVariables[
+                await resolvePathToNodeIdx("d2")
+            ].stateValues.formula.equals(me.fromText("-1/sqrt(1-x^2)")),
+        ).be.true;
+        expect(
+            stateVariables[
+                await resolvePathToNodeIdx("d2a")
+            ].stateValues.formula.equals(me.fromText("-1/sqrt(1-x^2)")),
+        ).be.true;
+        expect(
+            stateVariables[
+                await resolvePathToNodeIdx("d3")
+            ].stateValues.formula.equals(me.fromText("1/(1+x^2)")),
+        ).be.true;
+        expect(
+            stateVariables[
+                await resolvePathToNodeIdx("d3a")
+            ].stateValues.formula.equals(me.fromText("1/(1+x^2)")),
+        ).be.true;
+        expect(
+            stateVariables[
+                await resolvePathToNodeIdx("d4")
+            ].stateValues.formula.equals(me.fromText("-1/(1+x^2)")),
+        ).be.true;
+        expect(
+            stateVariables[
+                await resolvePathToNodeIdx("d4a")
+            ].stateValues.formula.equals(me.fromText("-1/(1+x^2)")),
+        ).be.true;
+        expect(
+            stateVariables[
+                await resolvePathToNodeIdx("d5")
+            ].stateValues.formula.equals(me.fromText("1/(x sqrt(x^2-1))")),
+        ).be.true;
+        expect(
+            stateVariables[
+                await resolvePathToNodeIdx("d5a")
+            ].stateValues.formula.equals(me.fromText("1/(x sqrt(x^2-1))")),
+        ).be.true;
+        expect(
+            stateVariables[
+                await resolvePathToNodeIdx("d6")
+            ].stateValues.formula.equals(me.fromText("-1/(x sqrt(x^2-1))")),
+        ).be.true;
+        expect(
+            stateVariables[
+                await resolvePathToNodeIdx("d6a")
+            ].stateValues.formula.equals(me.fromText("-1/(x sqrt(x^2-1))")),
+        ).be.true;
+    });
+
     it("specifying derivative variables of a function", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `


### PR DESCRIPTION
This PR upgrades math-expression so that the derivative of both forms (e.g., acos and arccos) of inverse trigonometric functions work. Previously acos and family did not work.

The PR also make sure that `normalize_applied_functions` is always called before taking a derivative, even for vector-valued functions.