### PR TITLE
remove invisible times, function operator symbol when normalize latex

### DIFF
--- a/packages/doenetml-worker-javascript/src/test/math/normalizeLatexString.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/math/normalizeLatexString.test.ts
@@ -89,9 +89,17 @@ describe("normalizeLatexString unicode substitutions @group4", () => {
         expect(output).toContain("\\rho");
         expect(output).toContain("\\pi");
     });
+
+    it("removes invisible times and function operators", () => {
+        const input = "f\u2061(x\u2062y)";
+        const output = normalizeLatexString(input);
+        expect(output).toContain("f (x y)");
+        expect(output).not.toContain("\u2061");
+        expect(output).not.toContain("\u2062");
+    });
 });
 
-describe("normalizeLatexString double script handling", () => {
+describe("normalizeLatexString double script handling @group4", () => {
     it("collapses double exponents", () => {
         const input = "x^{^{8}}";
         const output = normalizeLatexString(input);

--- a/packages/doenetml-worker-javascript/src/utils/math.ts
+++ b/packages/doenetml-worker-javascript/src/utils/math.ts
@@ -425,6 +425,8 @@ export function normalizeLatexString(
         ["\u221E", " \\infty "], // ∞
         ["\u2205", " \\emptyset "], // ∅
         ["\u2032", "'"], // ′
+        ["\u2061", " "], // function application
+        ["\u2062", " "], // invisible times
     ];
 
     for (let sub of substitutions) {


### PR DESCRIPTION
This PR removes the invisible times and function operator symbols when normalizing a latex string. In this way, having those characters in a math input will not prevent the expression from parsing correctly.