### PR TITLE
prefigure centered labels have more alignment options

### DIFF
--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
@@ -608,6 +608,19 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         expect(prefigureXML).toContain(`alignment="n"`);
     });
 
+    it("renderer=prefigure center lineSegment mostly off graph shifts anchor/alignment to keep label visible", async () => {
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph(
+                '<lineSegment endpoints="(8,9.7) (100,9.7)" labelPosition="center"><label>this is a long center label</label></lineSegment>',
+                { attrs: 'xMin="-10" yMin="-10" xMax="10" yMax="10"' },
+            ),
+        );
+
+        expect(prefigureXML).toContain(`endpoints="((8,9.7),(100,9.7))"`);
+        expectLabelLocationNearStart(prefigureXML, 0.1);
+        expect(prefigureXML).toContain(`alignment="sw"`);
+    });
+
     it("renderer=prefigure segment with both endpoints off-screen but crossing graph uses clipped line-mode remap", async () => {
         const prefigureXML = await getPrefigureXML(
             prefigureGraph(

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/label.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/label.ts
@@ -329,6 +329,9 @@ function estimateLabelMetrics(
  *
  * `preferNorth` determines whether the graph-direction intent lies on the
  * local north (`n`) or south (`s`) side of the segment.
+ * For `center`, we still prefer centered `n`/`s` placements first, but also
+ * include diagonal fallbacks so labels can stay visible when the centered
+ * cardinals would clip at the graph boundary.
  * Candidate order matters: earlier entries are preferred, later entries are
  * only considered when overflow forces a fallback.
  */
@@ -342,14 +345,14 @@ function getLineAlignmentCandidates(
         return null;
     }
 
-    if (pos === "center") {
-        return ["n", "s"];
-    }
-
     const h = location >= 0.5 ? "w" : "e";
     const oppositeH = h === "w" ? "e" : "w";
     const primary = preferNorth ? "n" : "s";
     const secondary = preferNorth ? "s" : "n";
+
+    if (pos === "center") {
+        return ["n", "s", `n${h}`, `s${h}`, `n${oppositeH}`, `s${oppositeH}`];
+    }
 
     return [
         primary,


### PR DESCRIPTION
This PR adds the diagonal alignment options even for the "center" label location for PreFigure labels. These options allow the label to be placed off the edge of a line segment if needed to stay fully visible on the graph.