### PR TITLE
upgrade @doenet/prefigure to 0.5.13

### DIFF
--- a/packages/doenetml/src/Viewer/renderers/utils/prefigureConfig.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/prefigureConfig.ts
@@ -5,7 +5,7 @@ const DEFAULT_PREFIGURE_DIAGCESS_SCRIPT_URL =
 // It is intentionally managed independently from the wheel/runtime version
 // metadata in packages/prefigure/src/worker/compiler-metadata.ts.
 const DEFAULT_PREFIGURE_MODULE_URL =
-    "https://cdn.jsdelivr.net/npm/@doenet/prefigure@0.5.11-doenet.6/prefigure.js";
+    "https://cdn.jsdelivr.net/npm/@doenet/prefigure@0.5.13/prefigure.js";
 
 const env = (
     import.meta as ImportMeta & {

--- a/packages/prefigure/package.json
+++ b/packages/prefigure/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/prefigure",
     "type": "module",
     "description": "Standalone PreFigure WASM compiler for browser and CDN usage",
-    "version": "0.5.11-doenet.6",
+    "version": "0.5.13",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": false,


### PR DESCRIPTION
This PR upgrades the @doenet/prefigure to version 0.5.13. This is the version of the WASM package that we load off the jsdelivr CDN in production.