### PR TITLE
doNotSave flag means don't ever save

### DIFF
--- a/packages/doenetml-worker-javascript/src/Core.js
+++ b/packages/doenetml-worker-javascript/src/Core.js
@@ -11798,35 +11798,40 @@ export default class Core {
             this.essentialValuesSavedInDefinition = {};
         }
 
-        // merge in new state variables set in update
-        for (let newValuesProcessed of newStateVariableValuesProcessed) {
-            for (const componentIdxStr in newValuesProcessed) {
-                const componentIdx = Number(componentIdxStr);
-                const stateId = this._components[componentIdx].stateId;
-                if (!this.cumulativeStateVariableChanges[stateId]) {
-                    this.cumulativeStateVariableChanges[stateId] = {};
-                }
-                for (let varName in newValuesProcessed[componentIdx]) {
-                    let cumValues =
-                        this.cumulativeStateVariableChanges[stateId][varName];
-                    // if cumValues is an object with mergeObject = true,
-                    // then merge attributes from newStateVariableValues into cumValues
-                    if (
-                        typeof cumValues === "object" &&
-                        cumValues !== null &&
-                        cumValues.mergeObject
-                    ) {
-                        Object.assign(
-                            cumValues,
-                            removeFunctionsMathExpressionClass(
-                                newValuesProcessed[componentIdx][varName],
-                            ),
-                        );
-                    } else {
-                        this.cumulativeStateVariableChanges[stateId][varName] =
-                            removeFunctionsMathExpressionClass(
+        if (!doNotSave) {
+            // merge in new state variables set in update
+            for (let newValuesProcessed of newStateVariableValuesProcessed) {
+                for (const componentIdxStr in newValuesProcessed) {
+                    const componentIdx = Number(componentIdxStr);
+                    const stateId = this._components[componentIdx].stateId;
+                    if (!this.cumulativeStateVariableChanges[stateId]) {
+                        this.cumulativeStateVariableChanges[stateId] = {};
+                    }
+                    for (let varName in newValuesProcessed[componentIdx]) {
+                        let cumValues =
+                            this.cumulativeStateVariableChanges[stateId][
+                                varName
+                            ];
+                        // if cumValues is an object with mergeObject = true,
+                        // then merge attributes from newStateVariableValues into cumValues
+                        if (
+                            typeof cumValues === "object" &&
+                            cumValues !== null &&
+                            cumValues.mergeObject
+                        ) {
+                            Object.assign(
+                                cumValues,
+                                removeFunctionsMathExpressionClass(
+                                    newValuesProcessed[componentIdx][varName],
+                                ),
+                            );
+                        } else {
+                            this.cumulativeStateVariableChanges[stateId][
+                                varName
+                            ] = removeFunctionsMathExpressionClass(
                                 newValuesProcessed[componentIdx][varName],
                             );
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This PR makes the `doNotSave` flag sent with `performUpdate` prevent the change from ever being saved to the database.

Previously, the flag meant that the particular state variable change set was not saved with that action, but the change set was added to the `cumulativeStateVariableChanges` object. With this setup, even though saving was not immediately triggered, the change set would be saved whenever the next change set ocured. Now, such change sets are not added to the `cumulativeStateVariableChanges` object so they are never saved to the database.