### PR TITLE
Avoid intermittent vite static-copy ENOENT in test-cypress

### DIFF
--- a/packages/test-cypress/vite.config.ts
+++ b/packages/test-cypress/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
                         "../*",
                     ),
                     dest: "doenetml-worker/",
+                    overwrite: false,
                 },
                 {
                     src: path.join(
@@ -25,6 +26,7 @@ export default defineConfig({
                         "../fonts/*",
                     ),
                     dest: "fonts/",
+                    overwrite: false,
                 },
             ],
         }),


### PR DESCRIPTION
## Summary
- Prevent intermittent vite-plugin-static-copy ENOENT unlink races seen during Cypress bundling.
- Set overwrite: false on static copy targets in packages/test-cypress/vite.config.ts.

## Changes
- doenetml-worker copy target: added overwrite: false
- fonts copy target: added overwrite: false

## Why
vite-plugin-static-copy can call fs.cp with overwrite behavior that occasionally races in Cypress cache/bundle directories, causing transient ENOENT errors on unlink. Skipping overwrite avoids that race for these stable copied assets.

## Validation
- Rebuilt @doenet/test-cypress successfully after the config change.
