### PR TITLE
Fix GitHub Actions deprecation warnings for Node 20 runtime

### DIFF
--- a/.github/workflows/gh-pages-docs.yml
+++ b/.github/workflows/gh-pages-docs.yml
@@ -21,6 +21,9 @@ concurrency:
     group: "pages"
     cancel-in-progress: false
 
+env:
+    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
     build-docs:
         runs-on: ubuntu-latest

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -11,6 +11,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
     cancel-in-progress: true
 
+env:
+    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
     changes:
         name: Detect Changed Paths
@@ -255,12 +258,10 @@ jobs:
               uses: actions/checkout@v3
 
             - name: Install toolchain
-              uses: actions-rs/toolchain@v1
-              with:
-                  profile: minimal
-                  toolchain: stable
-                  override: true
-                  components: rustfmt, clippy
+              run: |
+                  rustup set profile minimal
+                  rustup toolchain install stable --component rustfmt --component clippy
+                  rustup default stable
 
             - name: Cargo fmt
               working-directory: ./packages/doenetml-worker-rust


### PR DESCRIPTION
## Summary
- opt workflows into Node 24 for JavaScript-based actions via FORCE_JAVASCRIPT_ACTIONS_TO_NODE24="true"
- replace deprecated actions-rs/toolchain@v1 usage in Rust lint job with equivalent rustup commands

## Files changed
- .github/workflows/on-pull-request.yml
- .github/workflows/gh-pages-docs.yml