### PR TITLE
Migrate lsp tools/lsp to current DAST types

### DIFF
--- a/packages/lsp-tools/src/auto-completer/index.ts
+++ b/packages/lsp-tools/src/auto-completer/index.ts
@@ -2,7 +2,7 @@ import { DoenetSourceObject, RowCol } from "../doenet-source-object";
 import { doenetSchema } from "@doenet/static-assets/schema";
 import { COMPLETION_SNIPPETS } from "@doenet/static-assets/completion-snippets";
 import type { CompletionSnippetCursor } from "@doenet/static-assets/completion-snippet-protocol";
-import { DastAttributeV6, DastElementV6 } from "@doenet/parser";
+import { DastAttribute, DastElement } from "@doenet/parser";
 import { getCompletionItems } from "./methods/get-completion-items";
 import { getSchemaViolations } from "./methods/get-schema-violations";
 import { getCompletionContext } from "./methods/get-completion-context";
@@ -35,7 +35,7 @@ export type ResolveRefMemberContainerArgs = {
 };
 
 export type RefMemberContainerResolution = {
-    node: DastElementV6 | null;
+    node: DastElement | null;
     unresolvedPathParts: string[];
 };
 
@@ -273,9 +273,9 @@ export class AutoCompleter {
      * Gets the attribute where offset is between its start and end position, if one exists.
      */
     _getAttributeContainsOffset(
-        node: DastElementV6,
+        node: DastElement,
         offset: number,
-    ): DastAttributeV6 | null {
+    ): DastAttribute | null {
         const candidate = Object.values(node.attributes).find((attr) => {
             const start = attr.position?.start.offset;
             const end = attr.position?.end.offset;

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-context.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-context.ts
@@ -1,8 +1,8 @@
 import { RowCol } from "../../doenet-source-object";
-import type { DastMacro, DastMacroV6 } from "@doenet/parser";
+import type { DastMacro } from "@doenet/parser";
 import { AutoCompleter } from "../index";
 
-type MacroNode = DastMacro | DastMacroV6;
+type MacroNode = DastMacro;
 
 // Keep these aligned with parser grammar in `packages/parser/src/macros/macros.peggy`:
 // - SimpleIdent = [a-zA-Z_][a-zA-Z0-9_]*

--- a/packages/lsp-tools/src/auto-completer/methods/get-schema-violations.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-schema-violations.ts
@@ -5,10 +5,10 @@ import {
     DiagnosticSeverity,
 } from "vscode-languageserver/browser";
 import {
-    DastAttributeV6,
-    DastElementV6,
-    DastNodesV6,
-    DastRootV6,
+    DastAttribute,
+    DastElement,
+    DastNodes,
+    DastRoot,
     showCursor,
     toXml,
     visit,
@@ -23,8 +23,8 @@ export function getSchemaViolations(this: AutoCompleter): Diagnostic[] {
      * Get all pairs of elements and their parent.
      */
     function getElementPairs(
-        node: DastElementV6 | DastRootV6,
-    ): { node: DastElementV6; parent: DastElementV6 | DastRootV6 }[] {
+        node: DastElement | DastRoot,
+    ): { node: DastElement; parent: DastElement | DastRoot }[] {
         return node.children.flatMap((child) => {
             if (child.type === "element") {
                 return [
@@ -191,7 +191,7 @@ export function getSchemaViolations(this: AutoCompleter): Diagnostic[] {
 /**
  * Determine if the list of nodes contains a macro or function descendant.
  */
-function hasMacroOrFunctionChild(nodes: DastNodesV6[]): boolean {
+function hasMacroOrFunctionChild(nodes: DastNodes[]): boolean {
     let ret = false;
     visit(nodes, (node) => {
         if (node.type === "macro" || node.type === "function") {
@@ -205,7 +205,7 @@ function hasMacroOrFunctionChild(nodes: DastNodesV6[]): boolean {
 /**
  * Get the offset of the start and end of the attribute value.
  */
-function getAttributeValueRange(node: DastAttributeV6): {
+function getAttributeValueRange(node: DastAttribute): {
     start: number;
     end: number;
 } {
@@ -217,9 +217,17 @@ function getAttributeValueRange(node: DastAttributeV6): {
     }
     const first = node.children[0];
     const last = node.children[node.children.length - 1];
+    const firstStart = first.position?.start.offset || 0;
+    const lastEnd = last.position?.end.offset || 0;
+    const attrStart = node.position?.start.offset;
+    const attrEnd = node.position?.end.offset;
 
     return {
-        start: first.position?.start.offset || 0,
-        end: last.position?.end.offset || 0,
+        // Include the surrounding quote characters when present.
+        start:
+            attrStart == null
+                ? Math.max(0, firstStart - 1)
+                : Math.max(attrStart, firstStart - 1),
+        end: attrEnd == null ? lastEnd + 1 : Math.min(attrEnd, lastEnd + 1),
     };
 }

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -1,4 +1,4 @@
-import type { DastElementV6, DastNodesV6 } from "@doenet/parser";
+import type { DastElement, DastNodes } from "@doenet/parser";
 import type { DoenetSourceObject } from "../doenet-source-object";
 import type {
     ResolveRefMemberContainer,
@@ -61,9 +61,9 @@ export class RustResolverAdapter {
     private enabled = false;
 
     /** Rust flat index → JS DAST element (matched by source position). */
-    private rustIndexToDastElement: Map<number, DastElementV6> = new Map();
+    private rustIndexToDastElement: Map<number, DastElement> = new Map();
     /** JS DAST element → Rust flat index. */
-    private dastElementToRustIndex: Map<DastElementV6, number> = new Map();
+    private dastElementToRustIndex: Map<DastElement, number> = new Map();
 
     constructor(
         sourceObj: DoenetSourceObject,
@@ -109,20 +109,20 @@ export class RustResolverAdapter {
         this.dastElementToRustIndex.clear();
 
         // Collect JS DAST elements keyed by start offset.
-        const dastByStartOffset = new Map<number, DastElementV6>();
-        const collectElements = (node: DastNodesV6) => {
+        const dastByStartOffset = new Map<number, DastElement>();
+        const collectElements = (node: DastNodes) => {
             if (node.type === "element") {
                 const off = node.position?.start?.offset;
                 if (off != null) {
                     dastByStartOffset.set(off, node);
                 }
                 for (const child of node.children) {
-                    collectElements(child as DastNodesV6);
+                    collectElements(child as DastNodes);
                 }
             }
         };
         for (const child of this.sourceObj.dast.children) {
-            collectElements(child as DastNodesV6);
+            collectElements(child as DastNodes);
         }
 
         // Match flat DAST elements to JS DAST elements by start offset.

--- a/packages/lsp-tools/src/dev-site.tsx
+++ b/packages/lsp-tools/src/dev-site.tsx
@@ -7,7 +7,6 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { CodeMirror } from "@doenet/codemirror";
 import { lezerToDast, parse, filterPositionInfo } from "@doenet/parser";
-import { lezerToDastV6 } from "@doenet/parser/v06";
 import JsonView from "react18-json-view";
 import "react18-json-view/src/style.css";
 import { DoenetSourceObject } from "./doenet-source-object";
@@ -69,17 +68,14 @@ function App() {
     const [omitPosition, setOmitPosition] = React.useState(false);
     const [rawJson, setRawJson] = React.useState(false);
     const [currentPos, setCurrentPos] = React.useState(0);
-    const [dastV6, setDastV6] = React.useState(true);
 
     React.useEffect(() => {
-        let dast = dastV6
-            ? lezerToDastV6(doenetSource)
-            : lezerToDast(doenetSource);
+        let dast = lezerToDast(doenetSource);
         if (omitPosition) {
             dast = filterPositionInfo(dast as any) as any;
         }
         setDast(dast);
-    }, [doenetSource, omitPosition, dastV6]);
+    }, [doenetSource, omitPosition]);
     React.useEffect(() => {
         sourceObj.setSource(doenetSource);
         console.log(
@@ -117,20 +113,6 @@ function App() {
                     }}
                 />
                 <label htmlFor="raw-json">Show raw JSON</label>
-                <input
-                    type="checkbox"
-                    id="dast-v6"
-                    checked={dastV6}
-                    onChange={(e) => {
-                        setDastV6(e.target.checked);
-                    }}
-                />
-                <label
-                    htmlFor="dast-v6"
-                    title="DAST v0.6 is the old version of DAST that accepts old-style macros."
-                >
-                    Use DAST v0.6
-                </label>
             </div>
             <div
                 style={{ display: "flex", overflow: "hidden", height: "100%" }}

--- a/packages/lsp-tools/src/doenet-source-object/index.ts
+++ b/packages/lsp-tools/src/doenet-source-object/index.ts
@@ -136,6 +136,11 @@ export class DoenetSourceObject extends LazyDataObject {
      * Returns the index of the nearest containing element (or root),
      * or `null` if no node exists at that position.
      *
+     * Offsets are cursor positions, so `offset === source.length` is valid
+     * (cursor at end-of-file). For that case we use left-of-cursor semantics
+     * and return the same index as `source.length - 1` when the source is
+     * non-empty.
+     *
      * This mapping is used for Rust resolver integration to identify nodes by stable indices
      * rather than object references.
      *
@@ -144,6 +149,15 @@ export class DoenetSourceObject extends LazyDataObject {
      */
     getNodeIndexAtOffset(offset: number): number | null {
         const offsetToIndexMap = this._offsetToNodeIndexMap();
+        if (offset < 0 || offset > this.source.length) {
+            return null;
+        }
+        if (offset === this.source.length) {
+            if (this.source.length === 0) {
+                return null;
+            }
+            return offsetToIndexMap[this.source.length - 1] ?? null;
+        }
         return offsetToIndexMap[offset] ?? null;
     }
 

--- a/packages/lsp-tools/src/doenet-source-object/index.ts
+++ b/packages/lsp-tools/src/doenet-source-object/index.ts
@@ -1,12 +1,10 @@
 import {
     DastElement,
-    DastFunctionMacro,
     DastNodes,
     DastRoot,
     LezerSyntaxNodeName,
     Position,
     toXml,
-    DastMacro,
 } from "@doenet/parser";
 import {
     initDast,
@@ -441,25 +439,3 @@ export type OffsetToPositionMap = {
     rowMap: Uint32Array;
     columnMap: Uint32Array;
 };
-
-/**
- * Returns `true` if the macro is an "old-style" macro with slashes
- * in its path.
- */
-export function isOldMacro(macro: DastMacro | DastFunctionMacro): boolean {
-    if (!("version" in macro) || macro.version !== "0.6") {
-        return false;
-    }
-    switch (macro.type) {
-        case "macro": {
-            return macro.path.length !== 1;
-        }
-        case "function": {
-            const innerMacro =
-                "macro" in macro && typeof macro.macro === "object"
-                    ? macro.macro
-                    : null;
-            return innerMacro ? isOldMacro(innerMacro as any) : false;
-        }
-    }
-}

--- a/packages/lsp-tools/src/doenet-source-object/index.ts
+++ b/packages/lsp-tools/src/doenet-source-object/index.ts
@@ -1,13 +1,12 @@
 import {
     DastElement,
-    DastElementV6,
-    DastFunctionMacroV6,
-    DastMacroV6,
-    DastNodesV6,
-    DastRootV6,
+    DastFunctionMacro,
+    DastNodes,
+    DastRoot,
     LezerSyntaxNodeName,
     Position,
     toXml,
+    DastMacro,
 } from "@doenet/parser";
 import {
     initDast,
@@ -27,7 +26,6 @@ import {
     getAddressableNamesAtOffset,
     getMacroReferentAtOffset,
 } from "./methods/macro-resolvers";
-import { DastMacro } from "@doenet/parser";
 import type {
     Position as LSPPosition,
     Range as LSPRange,
@@ -205,7 +203,7 @@ export class DoenetSourceObject extends LazyDataObject {
      * partially complete (`false`). Complete elements are valid xml.
      * Incomplete elements are `<abc` or `<abc>`.
      */
-    isCompleteElement(node: DastElementV6): {
+    isCompleteElement(node: DastElement): {
         tagComplete: boolean;
         closed: boolean;
     } {
@@ -265,9 +263,7 @@ export class DoenetSourceObject extends LazyDataObject {
      *
      * Note: these values are given as **offsets**.
      */
-    getElementTagRanges(
-        node: DastElementV6 | DastElement,
-    ): { start: number; end: number }[] {
+    getElementTagRanges(node: DastElement): { start: number; end: number }[] {
         const start = node.position?.start?.offset || 0;
         const end = node.position?.end?.offset || 0;
         const childrenStart = node.children[0]?.position?.start?.offset;
@@ -285,7 +281,7 @@ export class DoenetSourceObject extends LazyDataObject {
     /**
      * Get the parent of `node`. Node must be in `this.dast`.
      */
-    getParent(node: DastNodesV6): DastElementV6 | DastRootV6 | null {
+    getParent(node: DastNodes): DastElement | DastRoot | null {
         const parentMap = this._parentMap();
         return parentMap.get(node) || null;
     }
@@ -296,8 +292,8 @@ export class DoenetSourceObject extends LazyDataObject {
      *
      * Node must be in `this.dast`.
      */
-    getParents(node: DastNodesV6): (DastElementV6 | DastRootV6)[] {
-        const ret: (DastElementV6 | DastRootV6)[] = [];
+    getParents(node: DastNodes): (DastElement | DastRoot)[] {
+        const ret: (DastElement | DastRoot)[] = [];
 
         let parent = this.getParent(node);
         while (parent && parent.type !== "root") {
@@ -312,7 +308,7 @@ export class DoenetSourceObject extends LazyDataObject {
      * Get the unique descendant of `node` with name `name`.
      */
     getNamedDescendant(
-        node: DastElementV6 | DastRootV6 | undefined | null,
+        node: DastElement | DastRoot | undefined | null,
         name: string,
     ) {
         if (!node) {
@@ -332,7 +328,7 @@ export class DoenetSourceObject extends LazyDataObject {
      * Get all descendant names directly addressable from `node`.
      */
     getDescendantNamesForNode(
-        node: DastElementV6 | DastRootV6 | undefined | null,
+        node: DastElement | DastRoot | undefined | null,
     ): string[] {
         if (!node) {
             return [];
@@ -349,7 +345,7 @@ export class DoenetSourceObject extends LazyDataObject {
      * once under the same node are excluded.
      */
     getUniqueDescendantNamesForNode(
-        node: DastElementV6 | DastRootV6 | undefined | null,
+        node: DastElement | DastRoot | undefined | null,
     ): string[] {
         const names = this.getDescendantNamesForNode(node);
         const counts = new Map<string, number>();
@@ -364,7 +360,7 @@ export class DoenetSourceObject extends LazyDataObject {
      */
     getReferentAtOffset(offset: number | RowCol, name: string) {
         const { node } = this.elementAtOffsetWithContext(offset);
-        let parent: DastElementV6 | DastRootV6 | undefined | null = node;
+        let parent: DastElement | DastRoot | undefined | null = node;
         let referent = this.getNamedDescendant(parent, name);
         while (parent && parent.type !== "root" && !referent) {
             parent = this._parentMap().get(parent);
@@ -395,7 +391,7 @@ export class DoenetSourceObject extends LazyDataObject {
      * Return the smallest range that contains all of the nodes in `nodes`.
      */
     getNodeRange<Style extends "default" | "lsp">(
-        nodes: DastNodesV6 | DastNodesV6[],
+        nodes: DastNodes | DastNodes[],
         style?: Style,
     ): Style extends "lsp" ? LSPRange : Position {
         if (!Array.isArray(nodes)) {
@@ -429,7 +425,7 @@ export class DoenetSourceObject extends LazyDataObject {
     /**
      * The DAST representation of `source`.
      */
-    get dast(): DastRootV6 {
+    get dast(): DastRoot {
         return this._dast();
     }
 
@@ -450,24 +446,20 @@ export type OffsetToPositionMap = {
  * Returns `true` if the macro is an "old-style" macro with slashes
  * in its path.
  */
-export function isOldMacro(
-    macro: DastMacro | DastFunctionMacroV6 | DastMacroV6 | DastFunctionMacroV6,
-): boolean {
+export function isOldMacro(macro: DastMacro | DastFunctionMacro): boolean {
     if (!("version" in macro) || macro.version !== "0.6") {
         return false;
     }
     switch (macro.type) {
         case "macro": {
-            if (macro.path.length !== 1) {
-                return true;
-            }
-            if ("accessedProp" in macro && macro.accessedProp) {
-                return isOldMacro(macro.accessedProp);
-            }
-            return false;
+            return macro.path.length !== 1;
         }
         case "function": {
-            return "macro" in macro && isOldMacro(macro.macro);
+            const innerMacro =
+                "macro" in macro && typeof macro.macro === "object"
+                    ? macro.macro
+                    : null;
+            return innerMacro ? isOldMacro(innerMacro as any) : false;
         }
     }
 }

--- a/packages/lsp-tools/src/doenet-source-object/initializers.ts
+++ b/packages/lsp-tools/src/doenet-source-object/initializers.ts
@@ -1,12 +1,12 @@
 import {
-    DastElementV6,
-    DastNodesV6,
-    DastRootV6,
+    DastElement,
+    DastNodes,
+    DastRoot,
     stringToLezer,
+    lezerToDast,
     toXml,
     visit,
 } from "@doenet/parser";
-import { lezerToDastV6 } from "@doenet/parser/v06";
 import type { TreeCursor } from "@lezer/common";
 import { DoenetSourceObject, OffsetToPositionMap } from "./index";
 
@@ -41,16 +41,16 @@ export function initLezerCursor(this: DoenetSourceObject): TreeCursor {
 }
 
 export function initDast(this: DoenetSourceObject) {
-    return lezerToDastV6(this._lezer(), this.source);
+    return lezerToDast(this._lezer(), this.source);
 }
 
 export function initParentMap(this: DoenetSourceObject) {
-    const parentMap = new Map<DastNodesV6, DastElementV6 | DastRootV6>();
+    const parentMap = new Map<DastNodes, DastElement | DastRoot>();
     for (const node of this.dast.children) {
         parentMap.set(node, this.dast);
     }
     visit(this.dast, (_node) => {
-        const node = _node as DastNodesV6;
+        const node = _node as DastNodes;
         if (node.type === "element") {
             for (const child of node.children) {
                 parentMap.set(child, node);
@@ -67,11 +67,11 @@ export function initParentMap(this: DoenetSourceObject) {
  */
 export function initOffsetToNodeMapRight(this: DoenetSourceObject) {
     const dast = this.dast;
-    const offsetToNodeMap: (DastNodesV6 | null)[] = Array.from(this.source).map(
+    const offsetToNodeMap: (DastNodes | null)[] = Array.from(this.source).map(
         () => null,
     );
     visit(dast, (_node) => {
-        const node = _node as DastNodesV6;
+        const node = _node as DastNodes;
         if (node.type === "error") {
             return;
         }
@@ -115,18 +115,15 @@ export function initOffsetToNodeMapLeft(this: DoenetSourceObject) {
  * Returns array where `map[offset]` = root/element index or `null` if no node.
  */
 export function initOffsetToNodeIndexMap(this: DoenetSourceObject) {
-    const nodeToIndexMap = new Map<DastRootV6 | DastElementV6, number>();
-    const containingElementMap = new Map<
-        DastNodesV6,
-        DastRootV6 | DastElementV6
-    >();
+    const nodeToIndexMap = new Map<DastRoot | DastElement, number>();
+    const containingElementMap = new Map<DastNodes, DastRoot | DastElement>();
     const dast = this.dast;
     let nextIndex = 0;
 
     // Build root/element -> index mapping and record containing element for each node.
     const assignIndices = (
-        node: DastNodesV6,
-        containingElement: DastRootV6 | DastElementV6,
+        node: DastNodes,
+        containingElement: DastRoot | DastElement,
     ) => {
         const nextContaining =
             node.type === "element" ? node : containingElement;
@@ -135,14 +132,14 @@ export function initOffsetToNodeIndexMap(this: DoenetSourceObject) {
         if (node.type === "element") {
             nodeToIndexMap.set(node, nextIndex++);
             for (const child of node.children) {
-                assignIndices(child as DastNodesV6, node);
+                assignIndices(child as DastNodes, node);
             }
         }
     };
 
     nodeToIndexMap.set(dast, nextIndex++);
     for (const child of dast.children) {
-        assignIndices(child as DastNodesV6, dast);
+        assignIndices(child as DastNodes, dast);
     }
 
     // Map offsets to indices using existing right-biased offset→node map.
@@ -161,14 +158,14 @@ export function initOffsetToNodeIndexMap(this: DoenetSourceObject) {
     return offsetToIndexMap;
 }
 
-export type AccessList = { name: string; element: DastElementV6 }[];
+export type AccessList = { name: string; element: DastElement }[];
 export function initDescendantNamesMap(this: DoenetSourceObject) {
     const dast = this.dast;
-    const namesInScope: Map<DastElementV6 | DastRootV6, AccessList> = new Map();
+    const namesInScope: Map<DastElement | DastRoot, AccessList> = new Map();
     const rootAccessList: AccessList = [];
     namesInScope.set(dast, rootAccessList);
     visit(dast, (_node, info) => {
-        const node = _node as DastNodesV6;
+        const node = _node as DastNodes;
         if (!(node.type === "element")) {
             return;
         }
@@ -182,7 +179,7 @@ export function initDescendantNamesMap(this: DoenetSourceObject) {
         const name = toXml(nameAttr.children);
         // We have a name. Push our name to all of our parents.
         for (const _parent of info.parents) {
-            const parent = _parent as DastElementV6 | DastRootV6;
+            const parent = _parent as DastElement | DastRoot;
             if (!namesInScope.has(parent)) {
                 namesInScope.set(parent, []);
             }

--- a/packages/lsp-tools/src/doenet-source-object/initializers.ts
+++ b/packages/lsp-tools/src/doenet-source-object/initializers.ts
@@ -67,9 +67,9 @@ export function initParentMap(this: DoenetSourceObject) {
  */
 export function initOffsetToNodeMapRight(this: DoenetSourceObject) {
     const dast = this.dast;
-    const offsetToNodeMap: (DastNodes | null)[] = Array.from(this.source).map(
-        () => null,
-    );
+    const offsetToNodeMap: (DastNodes | null)[] = new Array(
+        this.source.length,
+    ).fill(null);
     visit(dast, (_node) => {
         const node = _node as DastNodes;
         if (node.type === "error") {

--- a/packages/lsp-tools/src/doenet-source-object/methods/at-offset.ts
+++ b/packages/lsp-tools/src/doenet-source-object/methods/at-offset.ts
@@ -2,7 +2,6 @@ import { CursorPosition, DoenetSourceObject, RowCol } from "../index";
 import {
     DastElement,
     DastNodes,
-    DastNodesV6,
     DastRoot,
     LezerSyntaxNodeName,
 } from "@doenet/parser";
@@ -21,7 +20,7 @@ export function nodeAtOffset<const T extends DastNodes["type"]>(
     this: DoenetSourceObject,
     offset: number | RowCol,
     options?: { type?: T; side?: "left" | "right" },
-): Extract<DastNodesV6, { type: T }> | null {
+): Extract<DastNodes, { type: T }> | null {
     let { type, side = "right" } = options || {};
     if (typeof offset !== "number") {
         offset = this.rowColToOffset(offset);

--- a/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
+++ b/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
@@ -1,5 +1,5 @@
 import { CursorPosition, DoenetSourceObject, RowCol } from "../index";
-import { DastElementV6, LezerSyntaxNodeName } from "@doenet/parser";
+import { DastElement, LezerSyntaxNodeName } from "@doenet/parser";
 
 /**
  * Get the element containing the position `offset`. `null` is returned if the position is not
@@ -12,7 +12,7 @@ export function elementAtOffsetWithContext(
     this: DoenetSourceObject,
     offset: number | RowCol,
 ): {
-    node: DastElementV6 | null;
+    node: DastElement | null;
     cursorPosition: CursorPosition;
 } {
     if (typeof offset !== "number") {
@@ -68,7 +68,7 @@ export function elementAtOffsetWithContext(
             lezerNode = leftNode;
             node = this.nodeAtOffset(lezerNode.from, {
                 type: "element",
-            }) as DastElementV6 | null;
+            }) as DastElement | null;
         }
 
         const lezerNodeType = lezerNode.type.name as LezerSyntaxNodeName;

--- a/packages/lsp-tools/src/doenet-source-object/methods/macro-resolvers.ts
+++ b/packages/lsp-tools/src/doenet-source-object/methods/macro-resolvers.ts
@@ -1,12 +1,11 @@
 import {
     DastElement,
-    DastElementV6,
-    DastMacroV6,
+    DastMacro,
+    DastMacroPathPart,
     DastRoot,
-    DastRootV6,
     toXml,
 } from "@doenet/parser";
-import { DoenetSourceObject, RowCol, isOldMacro } from "../index";
+import { DoenetSourceObject, RowCol } from "../index";
 import { AccessList } from "../initializers";
 
 /**
@@ -18,12 +17,12 @@ import { AccessList } from "../initializers";
 export function getMacroReferentAtOffset(
     this: DoenetSourceObject,
     offset: number | RowCol,
-    macro: DastMacroV6,
+    macro: DastMacro,
 ) {
-    if (isOldMacro(macro)) {
-        throw new Error(`Cannot resolve v0.6 style macro "${toXml(macro)}"`);
+    const [pathPart, ...restPath] = macro.path;
+    if (!pathPart) {
+        return null;
     }
-    let pathPart = macro.path[0];
     if (pathPart.index.length > 0) {
         throw new Error(
             `The first part of a macro path must be just a name without an index. Failed to resolve "${toXml(
@@ -36,40 +35,38 @@ export function getMacroReferentAtOffset(
     if (!referent) {
         return null;
     }
-    // If there are no ".foo" accesses, the referent gets returned.
-    if (!macro.accessedProp) {
+    // If there are no member accesses, the referent gets returned.
+    if (restPath.length === 0) {
         return {
             node: referent,
-            accessedProp: null,
+            unresolvedPath: [] as DastMacroPathPart[],
         };
     }
-    // Otherwise, we walk down the tree trying to
-    // resolve whatever `accessedProp` refers to until we find something
-    // that doesn't exist.
-    let prop: DastMacroV6 | null = macro.accessedProp;
-    let propReferent: DastElementV6 | null = referent;
-    while (prop) {
-        if (prop.path[0].index.length > 0) {
+    // Otherwise, walk down member path until unresolved.
+    let currReferent = referent;
+    for (let i = 0; i < restPath.length; i++) {
+        const part = restPath[i];
+        if (part.index.length > 0) {
             // Indexing can only be used on synthetic nodes.
             return {
                 node: referent,
-                accessedProp: prop,
+                unresolvedPath: restPath.slice(i),
             };
         }
-        propReferent = this.getNamedDescendant(referent, prop.path[0].name);
+        const propReferent = this.getNamedDescendant(currReferent, part.name);
         if (!propReferent) {
             return {
                 node: referent,
-                accessedProp: prop,
+                unresolvedPath: restPath.slice(i),
             };
         }
         // Step down one level
         referent = propReferent;
-        prop = prop.accessedProp;
+        currReferent = propReferent;
     }
     return {
         node: referent,
-        accessedProp: null,
+        unresolvedPath: [] as DastMacroPathPart[],
     };
 }
 
@@ -103,8 +100,8 @@ export function getAddressableNamesAtOffset(
  * ensures that addresses are unique.
  */
 export function getMacroAddressableChildrenAtElement(
-    currElement: DastElementV6 | DastRootV6,
-    descendantNamesMap: Map<DastElementV6 | DastRootV6, AccessList>,
+    currElement: DastElement | DastRoot,
+    descendantNamesMap: Map<DastElement | DastRoot, AccessList>,
 ): string[][] {
     const accessList = descendantNamesMap.get(currElement);
     if (!accessList) {

--- a/packages/lsp-tools/src/doenet-to-markdown/index.ts
+++ b/packages/lsp-tools/src/doenet-to-markdown/index.ts
@@ -1,4 +1,4 @@
-import { DastNodes, DastNodesV6, DastRoot, toXml } from "@doenet/parser";
+import { DastNodes, DastRoot, toXml } from "@doenet/parser";
 import type {
     Root as MdastRoot,
     Nodes as MdastNodes,
@@ -198,7 +198,7 @@ function doenetToMdast(
                 case "title": {
                     const depth = sum(
                         sourceObj
-                            .getParents(node as DastNodesV6)
+                            .getParents(node)
                             .map((n) =>
                                 n.type === "element" &&
                                 DIVISIONS.includes(n.name)

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -3,7 +3,7 @@ import util from "util";
 import { CompletionItemKind } from "vscode-languageserver/browser";
 
 import { filterPositionInfo, DastMacro, DastElement } from "@doenet/parser";
-import { DoenetSourceObject, isOldMacro } from "../src/doenet-source-object";
+import { DoenetSourceObject } from "../src/doenet-source-object";
 import { doenetSchema } from "@doenet/static-assets/schema";
 import { AutoCompleter, RustResolverAdapter } from "../src";
 import type { RustResolverCore } from "../src";

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -1085,6 +1085,19 @@ describe("AutoCompleter", () => {
             expect(index1).toBe(index2);
         });
 
+        it("Uses left-of-cursor semantics at EOF", () => {
+            const source = `<aa><b></b></aa>`;
+            const sourceObj = new DoenetSourceObject(source);
+
+            const eofIndex = sourceObj.getNodeIndexAtOffset(source.length);
+            const lastCharIndex = sourceObj.getNodeIndexAtOffset(
+                source.length - 1,
+            );
+
+            expect(eofIndex).toBe(lastCharIndex);
+            expect(eofIndex).not.toBeNull();
+        });
+
         it("Differentiates nested nodes with different indices", () => {
             const source = `<aa><b></b></aa>`;
             const sourceObj = new DoenetSourceObject(source);

--- a/packages/lsp-tools/test/doenet-source-object.test.ts
+++ b/packages/lsp-tools/test/doenet-source-object.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import util from "util";
 
 import { filterPositionInfo, DastMacro, DastElement } from "@doenet/parser";
-import { DoenetSourceObject, isOldMacro } from "../src/doenet-source-object";
+import { DoenetSourceObject } from "../src/doenet-source-object";
 
 const origLog = console.log;
 console.log = (...args) => {

--- a/packages/lsp-tools/test/macro-resolution.test.ts
+++ b/packages/lsp-tools/test/macro-resolution.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import util from "util";
 
 import { DastMacro, DastElement } from "@doenet/parser";
-import { DoenetSourceObject, isOldMacro } from "../src/doenet-source-object";
+import { DoenetSourceObject } from "../src/doenet-source-object";
 import {
     getPrefixes,
     mergeLeftUniquePrefixes,
@@ -78,27 +78,6 @@ describe("DoenetSourceObject", () => {
             expect(elm?.node).toMatchObject({ type: "element", name: "c" });
             expect(elm?.unresolvedPath).toEqual([]);
         }
-    });
-
-    it("Can determine if a macro is an old-style macro with slashes in the path", () => {
-        let source: string;
-        let sourceObj: DoenetSourceObject;
-        let macro: DastMacro;
-
-        source = `$foo.bar[2].baz`;
-        sourceObj = new DoenetSourceObject(source);
-        macro = sourceObj.dast.children[0] as any as DastMacro;
-        expect(isOldMacro(macro)).toEqual(false);
-
-        source = `$(foo.bar[2].baz)`;
-        sourceObj = new DoenetSourceObject(source);
-        macro = sourceObj.dast.children[0] as any as DastMacro;
-        expect(isOldMacro(macro)).toEqual(false);
-
-        source = `$(foo/x.bar[2].baz)`;
-        sourceObj = new DoenetSourceObject(source);
-        macro = sourceObj.dast.children[0] as any as DastMacro;
-        expect(isOldMacro(macro)).toEqual(false);
     });
 
     it("Can uniquely merge prefixes", () => {

--- a/packages/lsp-tools/test/macro-resolution.test.ts
+++ b/packages/lsp-tools/test/macro-resolution.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import util from "util";
 
-import { DastMacro, DastElement, DastMacroV6 } from "@doenet/parser";
+import { DastMacro, DastElement } from "@doenet/parser";
 import { DoenetSourceObject, isOldMacro } from "../src/doenet-source-object";
 import {
     getPrefixes,
@@ -46,7 +46,7 @@ describe("DoenetSourceObject", () => {
     it("Can find named referents from macros", () => {
         let source: string;
         let sourceObj: DoenetSourceObject;
-        let macro: DastMacroV6;
+        let macro: DastMacro;
 
         source = `<a name="x">
             <b name="y">
@@ -58,26 +58,25 @@ describe("DoenetSourceObject", () => {
         {
             let offset = source.indexOf("<d") + 1;
             macro = new DoenetSourceObject("$x.y").dast
-                .children[0] as any as DastMacroV6;
+                .children[0] as any as DastMacro;
             let elm = sourceObj.getMacroReferentAtOffset(offset, macro);
             expect(elm?.node).toMatchObject({ type: "element", name: "b" });
         }
         {
             let offset = source.indexOf("<d") + 1;
             macro = new DoenetSourceObject("$x.y.w").dast
-                .children[0] as any as DastMacroV6;
+                .children[0] as any as DastMacro;
             let elm = sourceObj.getMacroReferentAtOffset(offset, macro);
             expect(elm?.node).toMatchObject({ type: "element", name: "b" });
-            expect(elm?.accessedProp).toMatchObject(
-                macro.accessedProp!.accessedProp!,
-            );
+            expect(elm?.unresolvedPath.map((p) => p.name)).toEqual(["w"]);
         }
         {
             let offset = source.indexOf("<d") + 1;
             macro = new DoenetSourceObject("$x.y.z").dast
-                .children[0] as any as DastMacroV6;
+                .children[0] as any as DastMacro;
             let elm = sourceObj.getMacroReferentAtOffset(offset, macro);
             expect(elm?.node).toMatchObject({ type: "element", name: "c" });
+            expect(elm?.unresolvedPath).toEqual([]);
         }
     });
 
@@ -99,7 +98,7 @@ describe("DoenetSourceObject", () => {
         source = `$(foo/x.bar[2].baz)`;
         sourceObj = new DoenetSourceObject(source);
         macro = sourceObj.dast.children[0] as any as DastMacro;
-        expect(isOldMacro(macro)).toEqual(true);
+        expect(isOldMacro(macro)).toEqual(false);
     });
 
     it("Can uniquely merge prefixes", () => {

--- a/packages/lsp-tools/test/resolver-parity.test.ts
+++ b/packages/lsp-tools/test/resolver-parity.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { DoenetSourceObject } from "../src/doenet-source-object";
 import { AutoCompleter } from "../src";
-import { DastElementV6 } from "@doenet/parser";
+import { DastElement } from "@doenet/parser";
 
 /**
  * Resolver parity tests verify that member completion resolution behavior
@@ -223,7 +223,7 @@ describe("Resolver Parity - Member Completion Resolution", () => {
                         type: "element",
                         attributes: {},
                         children: [],
-                    } as DastElementV6,
+                    } as DastElement,
                     unresolvedPathParts: [],
                 }),
             });

--- a/packages/lsp/src/features/document-symbols.ts
+++ b/packages/lsp/src/features/document-symbols.ts
@@ -3,7 +3,7 @@ import {
     DocumentSymbol,
     SymbolKind,
 } from "vscode-languageserver/browser";
-import { DastNodesV6, toXml } from "@doenet/parser";
+import { DastNodes, toXml } from "@doenet/parser";
 import { DocumentInfo } from "../globals";
 import { DoenetSourceObject } from "@doenet/lsp-tools";
 
@@ -28,7 +28,7 @@ export function addDocumentSymbolsSupport(
  * Get a document symbol for the given node.
  */
 function nodeToSymbol(
-    node: DastNodesV6,
+    node: DastNodes,
     sourceObj: DoenetSourceObject,
 ): DocumentSymbol | undefined {
     switch (node.type) {
@@ -73,7 +73,7 @@ function nodeToSymbol(
  * Recursively get all symbols for the given node's children.
  */
 function getChildrenSymbols(
-    node: DastNodesV6,
+    node: DastNodes,
     sourceObj: DoenetSourceObject,
 ): DocumentSymbol[] {
     const ret: DocumentSymbol[] = [];


### PR DESCRIPTION
## Summary
- switch lsp-tools DoenetSourceObject from lezerToDastV6 to lezerToDast
- replace DAST V6 types with current DAST types across lsp-tools and lsp consumers
- rewrite macro referent resolution to use flat macro path arrays and unresolved path parts
- update affected tests for new resolver return shape and types
- keep JS fallback behavior intact in autocomplete resolver paths

## Validation
- npm run build -w @doenet/lsp-tools
- npm run test -w @doenet/lsp-tools -- --run
- npm run build -w @doenet/lsp
- manual local check confirmed by author
