### PR TITLE
Wire Rust resolver into LSP autocomplete and fix completion bugs

### DIFF
--- a/.changeset/solid-radios-laugh.md
+++ b/.changeset/solid-radios-laugh.md
@@ -1,0 +1,9 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Improve reference autocomplete behavior by wiring Rust-backed resolver logic and fixing completion visibility/index handling.
+
+This includes better scope filtering for names, indexed reference completions for takesIndex components, and repeat synthetic name support in autocomplete flows.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,13 @@ Agents working in this repository should read [TEST_RUN_INSTRUCTIONS_FOR_AGENTS.
 - Do not rely on an old build or an already-running preview server after source edits.
 - The runbook includes non-interactive test commands, Cypress preview-server workflow, fail-fast Cypress commands, and stale-asset troubleshooting.
 
+## Coding Conventions for Agents
+
+- Avoid `private` class fields and methods; use an underscore prefix for internal members.
+- Avoid fire-and-forget calls via `void`; if a Promise is intentionally not awaited, attach an explicit `.catch(...)` handler.
+- Prefer function declarations over function-valued variables, unless reassignment or dynamic replacement is required.
+- Prefer `async`/`await` over old-style Promise chains (`.then(...)` / `.catch(...)`) when writing asynchronous code.
+
 ## Commit Hygiene Requirements
 
 - Format changed files with Prettier before committing.

--- a/packages/codemirror/cypress.config.ts
+++ b/packages/codemirror/cypress.config.ts
@@ -1,11 +1,46 @@
 import { defineConfig } from "cypress";
 import vitePreprocessor from "cypress-vite";
+import fs from "fs";
 
 export default defineConfig({
     component: {
         devServer: {
             framework: "react",
             bundler: "vite",
+            viteConfig: {
+                plugins: [
+                    {
+                        // The LSP IIFE bundle (≈7 MB, with inlined WASM)
+                        // triggers a parse error in Vite's import-analysis
+                        // when imported with `?raw`.  This plugin intercepts
+                        // the load and returns a plain string export.
+                        name: "raw-lsp-bundle",
+                        enforce: "pre" as const,
+                        load(id: string) {
+                            if (
+                                /[?&]raw\b/.test(id) &&
+                                (id.includes("@doenet/lsp") ||
+                                    id.includes("/packages/lsp/"))
+                            ) {
+                                const filePath = id.replace(/[?#].*$/, "");
+                                const content = fs.readFileSync(
+                                    filePath,
+                                    "utf-8",
+                                );
+                                // Convert to base64 and decode at runtime to
+                                // avoid a multi-MB string literal that
+                                // es-module-lexer cannot parse.
+                                const b64 =
+                                    Buffer.from(content).toString("base64");
+                                return `export default atob(${JSON.stringify(b64)});`;
+                            }
+                        },
+                    },
+                ],
+                optimizeDeps: {
+                    exclude: ["@doenet/lsp"],
+                },
+            },
         },
         specPattern: "test/cypress/component/**/*.cy.{js,jsx,ts,tsx}",
         supportFile: "test/cypress/support/component.ts",

--- a/packages/codemirror/cypress.config.ts
+++ b/packages/codemirror/cypress.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
             viteConfig: {
                 plugins: [
                     {
-                        // The LSP IIFE bundle (≈7 MB, with inlined WASM)
+                        // April 7, 2026: The LSP IIFE bundle (≈7 MB, with inlined WASM)
                         // triggers a parse error in Vite's import-analysis
                         // when imported with `?raw`.  This plugin intercepts
                         // the load and returns a plain string export.

--- a/packages/codemirror/src/extensions/lsp/plugin.ts
+++ b/packages/codemirror/src/extensions/lsp/plugin.ts
@@ -225,9 +225,7 @@ export class LSPPlugin implements PluginValue {
 
     destroy() {
         this.unsubscribeDiagnostics?.();
-        void uniqueLanguageServerInstance
-            .closeDocument(this.uri)
-            .catch(() => {});
+        uniqueLanguageServerInstance.closeDocument(this.uri).catch(() => {});
     }
 
     processDiagnostics() {

--- a/packages/codemirror/src/extensions/lsp/plugin.ts
+++ b/packages/codemirror/src/extensions/lsp/plugin.ts
@@ -225,6 +225,9 @@ export class LSPPlugin implements PluginValue {
 
     destroy() {
         this.unsubscribeDiagnostics?.();
+        void uniqueLanguageServerInstance
+            .closeDocument(this.uri)
+            .catch(() => {});
     }
 
     processDiagnostics() {

--- a/packages/codemirror/src/extensions/lsp/worker.ts
+++ b/packages/codemirror/src/extensions/lsp/worker.ts
@@ -1,5 +1,12 @@
-// @ts-ignore
-import LSPWorker from "@doenet/lsp/language-server.js?worker";
+// @ts-ignore — ?raw loads the pre-built IIFE as a string so we can create
+// a blob: URL Worker.  This avoids the double-base64 encoding that Vite's
+// ?worker inline produces (data: URL of the entire IIFE), which bloated
+// downstream bundles and broke WASM loading inside the worker.
+import lspSource from "@doenet/lsp/language-server.js?raw";
+
+const lspWorkerBlobUrl = URL.createObjectURL(
+    new Blob([lspSource], { type: "application/javascript" }),
+);
 import { initWorker } from "./utils/init-message-connection";
 import {
     Diagnostic,
@@ -60,7 +67,7 @@ export class LSP {
         }
         if (this.initStatus === "uninitialized") {
             this.initStatus = "initializing";
-            this.worker = new LSPWorker();
+            this.worker = new Worker(lspWorkerBlobUrl);
             const { lspConn, workerConn } = await initWorker(this.worker!);
             this.lspConn = lspConn;
             this.workerConn = workerConn;

--- a/packages/codemirror/src/extensions/lsp/worker.ts
+++ b/packages/codemirror/src/extensions/lsp/worker.ts
@@ -4,9 +4,11 @@
 // downstream bundles and broke WASM loading inside the worker.
 import lspSource from "@doenet/lsp/language-server.js?raw";
 
-const lspWorkerBlobUrl = URL.createObjectURL(
-    new Blob([lspSource], { type: "application/javascript" }),
-);
+function createLspWorkerBlobUrl() {
+    return URL.createObjectURL(
+        new Blob([lspSource], { type: "application/javascript" }),
+    );
+}
 import { initWorker } from "./utils/init-message-connection";
 import {
     Diagnostic,
@@ -67,7 +69,18 @@ export class LSP {
         }
         if (this.initStatus === "uninitialized") {
             this.initStatus = "initializing";
-            this.worker = new Worker(lspWorkerBlobUrl);
+            let workerBlobUrl: string | null = null;
+            try {
+                workerBlobUrl = createLspWorkerBlobUrl();
+                this.worker = new Worker(workerBlobUrl);
+            } finally {
+                if (workerBlobUrl) {
+                    const urlToRevoke = workerBlobUrl;
+                    // Revoke after construction to avoid accumulating blob URLs
+                    // across long sessions and hot-reload cycles.
+                    queueMicrotask(() => URL.revokeObjectURL(urlToRevoke));
+                }
+            }
             const { lspConn, workerConn } = await initWorker(this.worker!);
             this.lspConn = lspConn;
             this.workerConn = workerConn;

--- a/packages/codemirror/src/extensions/lsp/worker.ts
+++ b/packages/codemirror/src/extensions/lsp/worker.ts
@@ -1,6 +1,6 @@
 // @ts-ignore — ?raw loads the pre-built IIFE as a string so we can create
 // a blob: URL Worker.  This avoids the double-base64 encoding that Vite's
-// ?worker inline produces (data: URL of the entire IIFE), which bloated
+// ?worker inline produces (data: URL of the entire IIFE), which increased
 // downstream bundles and broke WASM loading inside the worker.
 import lspSource from "@doenet/lsp/language-server.js?raw";
 

--- a/packages/codemirror/test/cypress/component/autocomplete.cy.tsx
+++ b/packages/codemirror/test/cypress/component/autocomplete.cy.tsx
@@ -534,4 +534,41 @@ describe("CodeMirror LSP Autocomplete Plugin", () => {
         cy.wait(300);
         cy.get(".cm-tooltip-autocomplete").should("not.exist");
     });
+
+    it("inserts $name[] snippet with cursor between brackets for takesIndex elements", () => {
+        cy.mount(
+            <AutocompleteTestHarness
+                initialValue={
+                    '<repeat name="rep" numRepetitions="3"><math>x</math></repeat>\n'
+                }
+            />,
+        );
+
+        cy.get(".cm-content").click().type("{ctrl}{end}", { force: true });
+        cy.get(".cm-content").type("$re", { force: true });
+        openAutocomplete();
+
+        // Select the "rep[]" indexed completion item
+        cy.get(".cm-tooltip-autocomplete .cm-completionLabel")
+            .contains("rep[]")
+            .click();
+
+        cy.get(".cm-content")
+            .invoke("text")
+            .then((text) => {
+                // Should insert $rep[], NOT $rep[$1]
+                expect(text).to.contain("$rep[");
+                expect(text).to.contain("]");
+                expect(text).to.not.contain("$1");
+            });
+
+        // The cursor should be between the brackets, so typing inserts there.
+        cy.get(".cm-content").type("1", { force: true });
+
+        cy.get(".cm-content")
+            .invoke("text")
+            .then((text) => {
+                expect(text).to.contain("$rep[1]");
+            });
+    });
 });

--- a/packages/codemirror/vite.config.ts
+++ b/packages/codemirror/vite.config.ts
@@ -1,38 +1,11 @@
 import { visualizer } from "rollup-plugin-visualizer";
 import { PluginOption, defineConfig } from "vite";
 import dts from "vite-plugin-dts";
-import fs from "fs";
-
-/**
- * Vite plugin that ensures `?raw` imports of the LSP IIFE bundle work in the
- * dev server.  The built LSP bundle (≈7 MB, with inlined WASM data URL) can
- * trip Vite's `import-analysis` transform when the normal `vite:asset` `load`
- * handler doesn't claim the file (e.g. inside Cypress component-test dev
- * server).  This plugin intercepts the load early and returns the file as a
- * plain string export, matching what `?raw` should produce.
- */
-function rawLspBundlePlugin(): PluginOption {
-    return {
-        name: "raw-lsp-bundle",
-        enforce: "pre",
-        load(id) {
-            if (/[?&]raw\b/.test(id) && id.includes("@doenet/lsp")) {
-                const filePath = id.replace(/[?#].*$/, "");
-                const content = fs.readFileSync(filePath, "utf-8");
-                return `export default ${JSON.stringify(content)}`;
-            }
-        },
-    };
-}
 
 // https://vitejs.dev/config/
 export default defineConfig({
     base: "./",
-    plugins: [
-        rawLspBundlePlugin(),
-        dts({ rollupTypes: true }),
-        visualizer() as PluginOption,
-    ],
+    plugins: [dts({ rollupTypes: true }), visualizer() as PluginOption],
     build: {
         minify: false,
         sourcemap: true,

--- a/packages/codemirror/vite.config.ts
+++ b/packages/codemirror/vite.config.ts
@@ -1,11 +1,38 @@
 import { visualizer } from "rollup-plugin-visualizer";
 import { PluginOption, defineConfig } from "vite";
 import dts from "vite-plugin-dts";
+import fs from "fs";
+
+/**
+ * Vite plugin that ensures `?raw` imports of the LSP IIFE bundle work in the
+ * dev server.  The built LSP bundle (≈7 MB, with inlined WASM data URL) can
+ * trip Vite's `import-analysis` transform when the normal `vite:asset` `load`
+ * handler doesn't claim the file (e.g. inside Cypress component-test dev
+ * server).  This plugin intercepts the load early and returns the file as a
+ * plain string export, matching what `?raw` should produce.
+ */
+function rawLspBundlePlugin(): PluginOption {
+    return {
+        name: "raw-lsp-bundle",
+        enforce: "pre",
+        load(id) {
+            if (/[?&]raw\b/.test(id) && id.includes("@doenet/lsp")) {
+                const filePath = id.replace(/[?#].*$/, "");
+                const content = fs.readFileSync(filePath, "utf-8");
+                return `export default ${JSON.stringify(content)}`;
+            }
+        },
+    };
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
     base: "./",
-    plugins: [dts({ rollupTypes: true }), visualizer() as PluginOption],
+    plugins: [
+        rawLspBundlePlugin(),
+        dts({ rollupTypes: true }),
+        visualizer() as PluginOption,
+    ],
     build: {
         minify: false,
         sourcemap: true,
@@ -17,5 +44,11 @@ export default defineConfig({
         rollupOptions: {
             external: ["react", "react-dom", "react-dom/server"],
         },
+    },
+    // The LSP bundle is a large IIFE with inlined WASM (≈7 MB).  It is
+    // imported with `?raw` to create a blob-URL Worker.  Prevent Vite's
+    // dev server from trying to pre-bundle it.
+    optimizeDeps: {
+        exclude: ["@doenet/lsp"],
     },
 });

--- a/packages/doenetml-worker-javascript/src/components/BooleanList.js
+++ b/packages/doenetml-worker-javascript/src/components/BooleanList.js
@@ -6,6 +6,8 @@ import { convertUnresolvedAttributesForComponentType } from "../utils/dast/conve
 export default class BooleanList extends CompositeComponent {
     static componentType = "booleanList";
 
+    static takesIndex = true;
+
     static stateVariableToEvaluateAfterReplacements =
         "readyToExpandWhenResolved";
 

--- a/packages/doenetml-worker-javascript/src/components/Collect.js
+++ b/packages/doenetml-worker-javascript/src/components/Collect.js
@@ -5,6 +5,8 @@ import { createNewComponentIndices } from "../utils/componentIndices";
 export default class Collect extends CompositeComponent {
     static componentType = "collect";
 
+    static takesIndex = true;
+
     static allowInSchemaAsComponent = ["_inline", "_block", "_graphical"];
 
     static acceptAnyAttribute = true;

--- a/packages/doenetml-worker-javascript/src/components/MathList.js
+++ b/packages/doenetml-worker-javascript/src/components/MathList.js
@@ -14,6 +14,8 @@ import { returnUnorderedListStateVariableDefinitions } from "../utils/unorderedL
 export default class MathList extends CompositeComponent {
     static componentType = "mathList";
 
+    static takesIndex = true;
+
     static stateVariableToEvaluateAfterReplacements =
         "readyToExpandWhenResolved";
 

--- a/packages/doenetml-worker-javascript/src/components/NumberList.js
+++ b/packages/doenetml-worker-javascript/src/components/NumberList.js
@@ -13,6 +13,8 @@ import { returnUnorderedListStateVariableDefinitions } from "../utils/unorderedL
 export default class NumberList extends CompositeComponent {
     static componentType = "numberList";
 
+    static takesIndex = true;
+
     static stateVariableToEvaluateAfterReplacements =
         "readyToExpandWhenResolved";
 

--- a/packages/doenetml-worker-javascript/src/components/Repeat.js
+++ b/packages/doenetml-worker-javascript/src/components/Repeat.js
@@ -13,6 +13,8 @@ import { createNewComponentIndices } from "../utils/componentIndices";
 export default class Repeat extends CompositeComponent {
     static componentType = "repeat";
 
+    static takesIndex = true;
+
     static allowInSchemaAsComponent = ["_inline", "_block", "_graphical"];
 
     static createsVariants = true;

--- a/packages/doenetml-worker-javascript/src/components/RepeatForSequence.js
+++ b/packages/doenetml-worker-javascript/src/components/RepeatForSequence.js
@@ -15,6 +15,8 @@ import { copyStateFromUnlinkedSource, remapExtendIndices } from "./Repeat";
 export default class RepeatForSequence extends CompositeComponent {
     static componentType = "repeatForSequence";
 
+    static takesIndex = true;
+
     static allowInSchemaAsComponent = ["_inline", "_block", "_graphical"];
 
     static createsVariants = true;

--- a/packages/doenetml-worker-javascript/src/components/SamplePrimeNumbers.js
+++ b/packages/doenetml-worker-javascript/src/components/SamplePrimeNumbers.js
@@ -13,6 +13,8 @@ export default class SamplePrimeNumbers extends CompositeComponent {
     }
     static componentType = "samplePrimeNumbers";
 
+    static takesIndex = true;
+
     static allowInSchemaAsComponent = ["integer"];
 
     static createsVariants = true;

--- a/packages/doenetml-worker-javascript/src/components/SampleRandomNumbers.js
+++ b/packages/doenetml-worker-javascript/src/components/SampleRandomNumbers.js
@@ -13,6 +13,8 @@ export default class SampleRandomNumbers extends CompositeComponent {
     }
     static componentType = "sampleRandomNumbers";
 
+    static takesIndex = true;
+
     static allowInSchemaAsComponent = ["number"];
 
     static createsVariants = true;

--- a/packages/doenetml-worker-javascript/src/components/Select.js
+++ b/packages/doenetml-worker-javascript/src/components/Select.js
@@ -10,6 +10,8 @@ import { createNewComponentIndices } from "../utils/componentIndices";
 export default class Select extends CompositeComponent {
     static componentType = "select";
 
+    static takesIndex = true;
+
     static allowInSchemaAsComponent = ["_inline", "_block", "_graphical"];
 
     static createsVariants = true;

--- a/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
@@ -20,6 +20,8 @@ import me from "math-expressions";
 export default class SelectFromSequence extends Sequence {
     static componentType = "selectFromSequence";
 
+    static takesIndex = true;
+
     static createsVariants = true;
 
     static createAttributesObject() {

--- a/packages/doenetml-worker-javascript/src/components/SelectPrimeNumbers.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectPrimeNumbers.js
@@ -12,6 +12,8 @@ import CompositeComponent from "./abstract/CompositeComponent";
 export default class SelectPrimeNumbers extends CompositeComponent {
     static componentType = "selectPrimeNumbers";
 
+    static takesIndex = true;
+
     static allowInSchemaAsComponent = ["integer"];
 
     static createsVariants = true;

--- a/packages/doenetml-worker-javascript/src/components/SelectRandomNumbers.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectRandomNumbers.js
@@ -5,6 +5,8 @@ import { convertUnresolvedAttributesForComponentType } from "../utils/dast/conve
 export default class SelectRandomNumbers extends SampleRandomNumbers {
     static componentType = "selectRandomNumbers";
 
+    static takesIndex = true;
+
     static allowInSchemaAsComponent = ["number"];
 
     static createsVariants = true;

--- a/packages/doenetml-worker-javascript/src/components/Sequence.js
+++ b/packages/doenetml-worker-javascript/src/components/Sequence.js
@@ -11,6 +11,8 @@ import { convertUnresolvedAttributesForComponentType } from "../utils/dast/conve
 export default class Sequence extends CompositeComponent {
     static componentType = "sequence";
 
+    static takesIndex = true;
+
     static stateVariableToEvaluateAfterReplacements =
         "readyToExpandWhenResolved";
 

--- a/packages/doenetml-worker-javascript/src/components/Shuffle.js
+++ b/packages/doenetml-worker-javascript/src/components/Shuffle.js
@@ -8,6 +8,8 @@ import { createNewComponentIndices } from "../utils/componentIndices";
 export default class Shuffle extends CompositeComponent {
     static componentType = "shuffle";
 
+    static takesIndex = true;
+
     static allowInSchemaAsComponent = ["_inline", "_block", "_graphical"];
 
     static createsVariants = true;

--- a/packages/doenetml-worker-javascript/src/components/Sort.js
+++ b/packages/doenetml-worker-javascript/src/components/Sort.js
@@ -6,6 +6,8 @@ import { createNewComponentIndices } from "../utils/componentIndices";
 export default class Sort extends CompositeComponent {
     static componentType = "sort";
 
+    static takesIndex = true;
+
     static allowInSchemaAsComponent = ["_inline", "_block", "_graphical"];
 
     static stateVariableToEvaluateAfterReplacements =

--- a/packages/doenetml-worker-javascript/src/components/Substitute.js
+++ b/packages/doenetml-worker-javascript/src/components/Substitute.js
@@ -8,6 +8,8 @@ import {
 export default class Substitute extends CompositeComponent {
     static componentType = "substitute";
 
+    static takesIndex = true;
+
     static allowInSchemaAsComponent = ["math", "text"];
 
     static stateVariableToEvaluateAfterReplacements =

--- a/packages/doenetml-worker-javascript/src/components/TextList.js
+++ b/packages/doenetml-worker-javascript/src/components/TextList.js
@@ -6,6 +6,8 @@ import { convertUnresolvedAttributesForComponentType } from "../utils/dast/conve
 export default class TextList extends CompositeComponent {
     static componentType = "textList";
 
+    static takesIndex = true;
+
     static stateVariableToEvaluateAfterReplacements =
         "readyToExpandWhenResolved";
 

--- a/packages/doenetml-worker-rust/lib-doenetml-core/src/dast/ref_resolve/resolve.rs
+++ b/packages/doenetml-worker-rust/lib-doenetml-core/src/dast/ref_resolve/resolve.rs
@@ -61,7 +61,8 @@ pub(super) enum Visibility {
     ChildrenInvisibleToTheirGrandparents,
 }
 
-const CHILDREN_INVISIBLE_TO_THEIR_GRANDPARENTS: [&str; 3] = ["repeat", "option", "case"];
+const CHILDREN_INVISIBLE_TO_THEIR_GRANDPARENTS: [&str; 5] =
+    ["repeat", "repeatForSequence", "option", "case", "else"];
 
 impl Visibility {
     fn lookup_by_name(name: &str) -> Self {

--- a/packages/lsp-tools/src/auto-completer/index.ts
+++ b/packages/lsp-tools/src/auto-completer/index.ts
@@ -14,6 +14,7 @@ type ElementSchema = {
     properties?: { name: string }[];
     children: string[];
     acceptsStringChildren: boolean;
+    takesIndex?: boolean;
 };
 
 type ProcessedSnippet = {
@@ -32,6 +33,11 @@ export type ResolveRefMemberContainerArgs = {
     pathParts: string[];
     /** Optional flat-tree node index at the given offset, for Rust-backed resolution */
     nodeIndex?: number | null;
+    /**
+     * Whether any resolved path part used a bracket index (e.g. `$sel[1].`).
+     * When true, `takesIndex` elements should expose descendant names.
+     */
+    hasIndex?: boolean;
 };
 
 export type RefMemberContainerResolution = {
@@ -96,6 +102,7 @@ export class AutoCompleter {
     schema: ElementSchema[] = [];
     private resolveRefMemberContainerAtOffsetImpl?: ResolveRefMemberContainer;
     private isNameAddressableImpl?: (offset: number, name: string) => boolean;
+    private getAdditionalRefNamesImpl?: (offset: number) => string[];
     /**
      * A map of element names (in lower case) to their canonical capitalization.
      */
@@ -153,6 +160,23 @@ export class AutoCompleter {
     }
 
     /**
+     * Set a callback that returns additional ref names (e.g. repeat
+     * `valueName`/`indexName`) that should appear in `$name` completions
+     * at the given offset even though they are not in the raw DAST.
+     */
+    setGetAdditionalRefNames(fn?: (offset: number) => string[]) {
+        this.getAdditionalRefNamesImpl = fn;
+        return this;
+    }
+
+    /**
+     * Return any additional ref names injected for this offset.
+     */
+    getAdditionalRefNames(offset: number): string[] {
+        return this.getAdditionalRefNamesImpl?.(offset) ?? [];
+    }
+
+    /**
      * Test whether `name` is addressable from `offset`.
      * Falls back to `true` when no checker is set.
      */
@@ -173,6 +197,7 @@ export class AutoCompleter {
     resolveRefMemberContainerAtOffset(
         offset: number,
         pathParts: string[],
+        hasIndex?: boolean,
     ): RefMemberContainerResolution {
         if (this.resolveRefMemberContainerAtOffsetImpl) {
             const nodeIndex = this.sourceObj.getNodeIndexAtOffset(offset);
@@ -180,6 +205,7 @@ export class AutoCompleter {
                 offset,
                 pathParts,
                 nodeIndex,
+                hasIndex,
             });
             if (resolved) {
                 return resolved;
@@ -228,9 +254,18 @@ export class AutoCompleter {
                 ? []
                 : lookupPathParts.slice(firstUnresolvedPartIndex);
 
+        // When there are unresolved parts, the path is invalid —
+        // return null so the caller offers no completions.
+        if (unresolvedPathParts.length > 0) {
+            return {
+                node: null,
+                unresolvedPathParts,
+            };
+        }
+
         return {
-            node: unresolvedPathParts.length > 0 ? null : referent,
-            unresolvedPathParts,
+            node: referent,
+            unresolvedPathParts: [],
         };
     }
 

--- a/packages/lsp-tools/src/auto-completer/index.ts
+++ b/packages/lsp-tools/src/auto-completer/index.ts
@@ -6,6 +6,7 @@ import { DastAttribute, DastElement } from "@doenet/parser";
 import { getCompletionItems } from "./methods/get-completion-items";
 import { getSchemaViolations } from "./methods/get-schema-violations";
 import { getCompletionContext } from "./methods/get-completion-context";
+import type { RustResolverAdapter } from "./rust-resolver-adapter";
 
 type ElementSchema = {
     name: string;
@@ -47,7 +48,7 @@ export type RefMemberContainerResolution = {
      * When provided by the resolver, this is the list of descendant names
      * that are actually visible from the resolved node (respecting
      * visibility rules like `ChildrenInvisibleToTheirGrandparents`).
-     * If absent, the caller falls back to the JS descendant name walk.
+     * The completion pipeline expects this to be provided by the resolver.
      */
     visibleDescendantNames?: string[];
 };
@@ -57,13 +58,7 @@ export type ResolveRefMemberContainer = (
 ) => RefMemberContainerResolution | null;
 
 export type AutoCompleterOptions = {
-    resolveRefMemberContainerAtOffset?: ResolveRefMemberContainer;
-    /**
-     * Optional callback that tests whether a given name is addressable
-     * (visible) from the cursor position.  Used to filter `$name`
-     * completions according to Rust resolver visibility rules.
-     */
-    isNameAddressable?: (offset: number, name: string) => boolean;
+    rustResolverAdapter?: RustResolverAdapter;
 };
 
 /**
@@ -100,8 +95,7 @@ function adjustCursorForTrimStart(
 export class AutoCompleter {
     sourceObj: DoenetSourceObject = new DoenetSourceObject();
     schema: ElementSchema[] = [];
-    private resolveRefMemberContainerAtOffsetImpl?: ResolveRefMemberContainer;
-    private isNameAddressableImpl?: (offset: number, name: string) => boolean;
+    private rustResolverAdapter?: RustResolverAdapter;
     private getAdditionalRefNamesImpl?: (offset: number) => string[];
     /**
      * A map of element names (in lower case) to their canonical capitalization.
@@ -133,29 +127,17 @@ export class AutoCompleter {
             // will be parsed as a text "<" rather than an invalid element.
             this.sourceObj.setSource(source + " ");
         }
-        this.resolveRefMemberContainerAtOffsetImpl =
-            options?.resolveRefMemberContainerAtOffset;
-        this.isNameAddressableImpl = options?.isNameAddressable;
+        this.rustResolverAdapter = options?.rustResolverAdapter;
         if (schema) {
             this.setSchema(schema);
         }
     }
 
     /**
-     * Replace the ref-member container resolver used during completion.
-     * Pass `undefined` to restore default in-process resolution.
+     * Set the Rust resolver adapter used for `$name` visibility filtering.
      */
-    setResolveRefMemberContainerAtOffset(resolver?: ResolveRefMemberContainer) {
-        this.resolveRefMemberContainerAtOffsetImpl = resolver;
-        return this;
-    }
-
-    /**
-     * Replace the name-addressability checker used during `$name` completion.
-     * Pass `undefined` to restore default (allow all names).
-     */
-    setIsNameAddressable(fn?: (offset: number, name: string) => boolean) {
-        this.isNameAddressableImpl = fn;
+    setRustResolverAdapter(adapter?: RustResolverAdapter) {
+        this.rustResolverAdapter = adapter;
         return this;
     }
 
@@ -178,13 +160,16 @@ export class AutoCompleter {
 
     /**
      * Test whether `name` is addressable from `offset`.
-     * Falls back to `true` when no checker is set.
+     * Returns `false` when no Rust resolver adapter is set.
      */
     isNameAddressable(offset: number, name: string): boolean {
-        if (this.isNameAddressableImpl) {
-            return this.isNameAddressableImpl(offset, name);
+        if (this.rustResolverAdapter) {
+            return this.rustResolverAdapter.isNameAddressableFromOffset(
+                offset,
+                name,
+            );
         }
-        return true;
+        return false;
     }
 
     /**
@@ -199,73 +184,22 @@ export class AutoCompleter {
         pathParts: string[],
         hasIndex?: boolean,
     ): RefMemberContainerResolution {
-        if (this.resolveRefMemberContainerAtOffsetImpl) {
-            const nodeIndex = this.sourceObj.getNodeIndexAtOffset(offset);
-            const resolved = this.resolveRefMemberContainerAtOffsetImpl({
-                offset,
-                pathParts,
-                nodeIndex,
-                hasIndex,
-            });
+        if (this.rustResolverAdapter) {
+            const resolved =
+                this.rustResolverAdapter.resolveRefMemberContainerAtOffset(
+                    offset,
+                    pathParts,
+                    hasIndex,
+                );
             if (resolved) {
                 return resolved;
             }
         }
-
-        if (pathParts.length === 0) {
-            return {
-                node: null,
-                unresolvedPathParts: [],
-            };
-        }
-
-        const lookupPathParts = pathParts.slice(0, -1);
-        if (lookupPathParts.length === 0) {
-            return {
-                node: null,
-                unresolvedPathParts: [],
-            };
-        }
-
-        let referent = this.sourceObj.getReferentAtOffset(
-            offset,
-            lookupPathParts[0],
-        );
-        if (!referent) {
-            return {
-                node: null,
-                unresolvedPathParts: lookupPathParts,
-            };
-        }
-
-        let firstUnresolvedPartIndex = -1;
-        for (let i = 1; i < lookupPathParts.length; i++) {
-            const part = lookupPathParts[i];
-            const child = this.sourceObj.getNamedDescendant(referent, part);
-            if (!child) {
-                firstUnresolvedPartIndex = i;
-                break;
-            }
-            referent = child;
-        }
-
         const unresolvedPathParts =
-            firstUnresolvedPartIndex === -1
-                ? []
-                : lookupPathParts.slice(firstUnresolvedPartIndex);
-
-        // When there are unresolved parts, the path is invalid —
-        // return null so the caller offers no completions.
-        if (unresolvedPathParts.length > 0) {
-            return {
-                node: null,
-                unresolvedPathParts,
-            };
-        }
-
+            pathParts.length > 0 ? pathParts.slice(0, -1) : [];
         return {
-            node: referent,
-            unresolvedPathParts: [],
+            node: null,
+            unresolvedPathParts,
         };
     }
 

--- a/packages/lsp-tools/src/auto-completer/index.ts
+++ b/packages/lsp-tools/src/auto-completer/index.ts
@@ -5,7 +5,10 @@ import type { CompletionSnippetCursor } from "@doenet/static-assets/completion-s
 import { DastAttribute, DastElement } from "@doenet/parser";
 import { getCompletionItems } from "./methods/get-completion-items";
 import { getSchemaViolations } from "./methods/get-schema-violations";
-import { getCompletionContext } from "./methods/get-completion-context";
+import {
+    getCompletionContext,
+    type CompletionContext,
+} from "./methods/get-completion-context";
 import type { RustResolverAdapter } from "./rust-resolver-adapter";
 
 type ElementSchema = {
@@ -234,7 +237,10 @@ export class AutoCompleter {
      * Get completion items at the given offset, including XML, snippet, and
      * ref-specific completions.
      */
-    getCompletionItems = getCompletionItems;
+    getCompletionItems = (
+        offset: number | RowCol,
+        cachedContext?: CompletionContext,
+    ) => getCompletionItems.call(this, offset, cachedContext);
 
     /**
      * Get a list of LSP `Diagnostic`s for schema violations.

--- a/packages/lsp-tools/src/auto-completer/index.ts
+++ b/packages/lsp-tools/src/auto-completer/index.ts
@@ -37,6 +37,13 @@ export type ResolveRefMemberContainerArgs = {
 export type RefMemberContainerResolution = {
     node: DastElement | null;
     unresolvedPathParts: string[];
+    /**
+     * When provided by the resolver, this is the list of descendant names
+     * that are actually visible from the resolved node (respecting
+     * visibility rules like `ChildrenInvisibleToTheirGrandparents`).
+     * If absent, the caller falls back to the JS descendant name walk.
+     */
+    visibleDescendantNames?: string[];
 };
 
 export type ResolveRefMemberContainer = (
@@ -45,6 +52,12 @@ export type ResolveRefMemberContainer = (
 
 export type AutoCompleterOptions = {
     resolveRefMemberContainerAtOffset?: ResolveRefMemberContainer;
+    /**
+     * Optional callback that tests whether a given name is addressable
+     * (visible) from the cursor position.  Used to filter `$name`
+     * completions according to Rust resolver visibility rules.
+     */
+    isNameAddressable?: (offset: number, name: string) => boolean;
 };
 
 /**
@@ -82,6 +95,7 @@ export class AutoCompleter {
     sourceObj: DoenetSourceObject = new DoenetSourceObject();
     schema: ElementSchema[] = [];
     private resolveRefMemberContainerAtOffsetImpl?: ResolveRefMemberContainer;
+    private isNameAddressableImpl?: (offset: number, name: string) => boolean;
     /**
      * A map of element names (in lower case) to their canonical capitalization.
      */
@@ -114,6 +128,7 @@ export class AutoCompleter {
         }
         this.resolveRefMemberContainerAtOffsetImpl =
             options?.resolveRefMemberContainerAtOffset;
+        this.isNameAddressableImpl = options?.isNameAddressable;
         if (schema) {
             this.setSchema(schema);
         }
@@ -126,6 +141,26 @@ export class AutoCompleter {
     setResolveRefMemberContainerAtOffset(resolver?: ResolveRefMemberContainer) {
         this.resolveRefMemberContainerAtOffsetImpl = resolver;
         return this;
+    }
+
+    /**
+     * Replace the name-addressability checker used during `$name` completion.
+     * Pass `undefined` to restore default (allow all names).
+     */
+    setIsNameAddressable(fn?: (offset: number, name: string) => boolean) {
+        this.isNameAddressableImpl = fn;
+        return this;
+    }
+
+    /**
+     * Test whether `name` is addressable from `offset`.
+     * Falls back to `true` when no checker is set.
+     */
+    isNameAddressable(offset: number, name: string): boolean {
+        if (this.isNameAddressableImpl) {
+            return this.isNameAddressableImpl(offset, name);
+        }
+        return true;
     }
 
     /**

--- a/packages/lsp-tools/src/auto-completer/index.ts
+++ b/packages/lsp-tools/src/auto-completer/index.ts
@@ -32,13 +32,10 @@ export type ResolveRefMemberContainerArgs = {
     offset: number;
     /** Path segments to resolve (e.g., ["foo", "bar"] for $foo.bar) */
     pathParts: string[];
+    /** Per-path-part index flags aligned with pathParts. */
+    pathPartHasIndex?: boolean[];
     /** Optional flat-tree node index at the given offset, for Rust-backed resolution */
     nodeIndex?: number | null;
-    /**
-     * Whether any resolved path part used a bracket index (e.g. `$sel[1].`).
-     * When true, `takesIndex` elements should expose descendant names.
-     */
-    hasIndex?: boolean;
 };
 
 export type RefMemberContainerResolution = {
@@ -168,14 +165,14 @@ export class AutoCompleter {
     resolveRefMemberContainerAtOffset(
         offset: number,
         pathParts: string[],
-        hasIndex?: boolean,
+        pathPartHasIndex?: boolean[],
     ): RefMemberContainerResolution {
         if (this._rustResolverAdapter) {
             const resolved =
                 this._rustResolverAdapter.resolveRefMemberContainerAtOffset(
                     offset,
                     pathParts,
-                    hasIndex,
+                    pathPartHasIndex,
                 );
             if (resolved) {
                 return resolved;
@@ -362,7 +359,7 @@ export class AutoCompleter {
      * Initialize snippets map after schema is set.
      * Processes all snippets and indexes them by their normalized element name for quick lookup.
      */
-    private _initializeSnippets() {
+    _initializeSnippets() {
         this.snippetsByNormalizedElement.clear();
 
         Object.entries(COMPLETION_SNIPPETS).forEach(([key, snippet]) => {

--- a/packages/lsp-tools/src/auto-completer/index.ts
+++ b/packages/lsp-tools/src/auto-completer/index.ts
@@ -45,12 +45,11 @@ export type RefMemberContainerResolution = {
     node: DastElement | null;
     unresolvedPathParts: string[];
     /**
-     * When provided by the resolver, this is the list of descendant names
-     * that are actually visible from the resolved node (respecting
+     * Descendant names that are actually visible from the resolved node (respecting
      * visibility rules like `ChildrenInvisibleToTheirGrandparents`).
-     * The completion pipeline expects this to be provided by the resolver.
+     * Resolvers must always provide this field.
      */
-    visibleDescendantNames?: string[];
+    visibleDescendantNames: string[];
 };
 
 export type ResolveRefMemberContainer = (
@@ -186,6 +185,7 @@ export class AutoCompleter {
         return {
             node: null,
             unresolvedPathParts,
+            visibleDescendantNames: [],
         };
     }
 

--- a/packages/lsp-tools/src/auto-completer/index.ts
+++ b/packages/lsp-tools/src/auto-completer/index.ts
@@ -97,8 +97,8 @@ function adjustCursorForTrimStart(
 export class AutoCompleter {
     sourceObj: DoenetSourceObject = new DoenetSourceObject();
     schema: ElementSchema[] = [];
-    private rustResolverAdapter?: RustResolverAdapter;
-    private getAdditionalRefNamesImpl?: (offset: number) => string[];
+    _rustResolverAdapter?: RustResolverAdapter;
+    _getAdditionalRefNamesImpl?: (offset: number) => string[];
     /**
      * A map of element names (in lower case) to their canonical capitalization.
      */
@@ -130,8 +130,8 @@ export class AutoCompleter {
             // will be parsed as a text "<" rather than an invalid element.
             this.sourceObj.setSource(source + " ");
         }
-        this.rustResolverAdapter = options?.rustResolverAdapter;
-        this.getAdditionalRefNamesImpl = options?.getAdditionalRefNames;
+        this._rustResolverAdapter = options?.rustResolverAdapter;
+        this._getAdditionalRefNamesImpl = options?.getAdditionalRefNames;
         if (schema) {
             this.setSchema(schema);
         }
@@ -141,7 +141,7 @@ export class AutoCompleter {
      * Return any additional ref names injected for this offset.
      */
     getAdditionalRefNames(offset: number): string[] {
-        return this.getAdditionalRefNamesImpl?.(offset) ?? [];
+        return this._getAdditionalRefNamesImpl?.(offset) ?? [];
     }
 
     /**
@@ -149,8 +149,8 @@ export class AutoCompleter {
      * Returns `false` when no Rust resolver adapter is set.
      */
     isNameAddressable(offset: number, name: string): boolean {
-        if (this.rustResolverAdapter) {
-            return this.rustResolverAdapter.isNameAddressableFromOffset(
+        if (this._rustResolverAdapter) {
+            return this._rustResolverAdapter.isNameAddressableFromOffset(
                 offset,
                 name,
             );
@@ -170,9 +170,9 @@ export class AutoCompleter {
         pathParts: string[],
         hasIndex?: boolean,
     ): RefMemberContainerResolution {
-        if (this.rustResolverAdapter) {
+        if (this._rustResolverAdapter) {
             const resolved =
-                this.rustResolverAdapter.resolveRefMemberContainerAtOffset(
+                this._rustResolverAdapter.resolveRefMemberContainerAtOffset(
                     offset,
                     pathParts,
                     hasIndex,

--- a/packages/lsp-tools/src/auto-completer/index.ts
+++ b/packages/lsp-tools/src/auto-completer/index.ts
@@ -58,7 +58,9 @@ export type ResolveRefMemberContainer = (
 ) => RefMemberContainerResolution | null;
 
 export type AutoCompleterOptions = {
+    sourceObj?: DoenetSourceObject;
     rustResolverAdapter?: RustResolverAdapter;
+    getAdditionalRefNames?: (offset: number) => string[];
 };
 
 /**
@@ -122,33 +124,17 @@ export class AutoCompleter {
         schema: ElementSchema[] = doenetSchema.elements,
         options?: AutoCompleterOptions,
     ) {
+        this.sourceObj = options?.sourceObj ?? new DoenetSourceObject();
         if (source != null) {
             // Adding a space at the end of the source so that a final "<"
             // will be parsed as a text "<" rather than an invalid element.
             this.sourceObj.setSource(source + " ");
         }
         this.rustResolverAdapter = options?.rustResolverAdapter;
+        this.getAdditionalRefNamesImpl = options?.getAdditionalRefNames;
         if (schema) {
             this.setSchema(schema);
         }
-    }
-
-    /**
-     * Set the Rust resolver adapter used for `$name` visibility filtering.
-     */
-    setRustResolverAdapter(adapter?: RustResolverAdapter) {
-        this.rustResolverAdapter = adapter;
-        return this;
-    }
-
-    /**
-     * Set a callback that returns additional ref names (e.g. repeat
-     * `valueName`/`indexName`) that should appear in `$name` completions
-     * at the given offset even though they are not in the raw DAST.
-     */
-    setGetAdditionalRefNames(fn?: (offset: number) => string[]) {
-        this.getAdditionalRefNamesImpl = fn;
-        return this;
     }
 
     /**
@@ -292,15 +278,6 @@ export class AutoCompleter {
         });
 
         return candidate || null;
-    }
-
-    /**
-     * Set the internal DoenetSourceObject. This should not normally be used,
-     * but may be used if you want to pool DoenetSourceObjects over multiple
-     * instances.
-     */
-    setDoenetSourceObject(sourceObj: DoenetSourceObject) {
-        this.sourceObj = sourceObj;
     }
 
     /**

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-context.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-context.ts
@@ -10,7 +10,29 @@ type MacroNode = DastMacro;
 const SIMPLE_IDENTIFIER_CHAR_REGEX = /[A-Za-z0-9_]/;
 const SIMPLE_IDENTIFIER_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const MACRO_IDENTIFIER_CHAR_REGEX = /[A-Za-z0-9_-]/;
-const MACRO_PATH_CHAR_REGEX = /[A-Za-z0-9_.-]/;
+const MACRO_PATH_CHAR_REGEX = /[A-Za-z0-9_.[\]-]/;
+
+/** Regex matching one or more bracket indices at the end, e.g. `[1]`, `[2][3]`. */
+const BRACKET_INDEX_SUFFIX_REGEX = /(\[[^\]]*\])+$/;
+
+/**
+ * Strip bracket indices from path parts and report whether any were present.
+ * For example: `["sel[1]", "member", ""]` → `{ parts: ["sel", "member", ""], hasIndex: true }`.
+ */
+function stripIndicesFromPathParts(parts: string[]): {
+    parts: string[];
+    hasIndex: boolean;
+} {
+    let hasIndex = false;
+    const stripped = parts.map((p) => {
+        if (BRACKET_INDEX_SUFFIX_REGEX.test(p)) {
+            hasIndex = true;
+            return p.replace(BRACKET_INDEX_SUFFIX_REGEX, "");
+        }
+        return p;
+    });
+    return { parts: stripped, hasIndex };
+}
 
 /**
  * High-level cursor contexts used to choose between XML completions and
@@ -35,7 +57,31 @@ export type CompletionContext =
           typedPrefix: string;
           replaceFromOffset: number;
           pathParts: string[];
+          /**
+           * Whether any path part (before the currently-typed segment)
+           * contained a bracket index, e.g. `$sel[1].`.  When true,
+           * `takesIndex` elements should expose descendant names.
+           */
+          hasIndex: boolean;
       };
+
+/**
+ * Build a `refMember` context, stripping bracket indices from path parts.
+ */
+function makeRefMemberContext(
+    typedPrefix: string,
+    replaceFromOffset: number,
+    rawPathParts: string[],
+): CompletionContext & { cursorPos: "refMember" } {
+    const { parts, hasIndex } = stripIndicesFromPathParts(rawPathParts);
+    return {
+        cursorPos: "refMember",
+        typedPrefix,
+        replaceFromOffset,
+        pathParts: parts,
+        hasIndex,
+    };
+}
 
 /**
  * Walk left from `offset` capturing a continuous identifier fragment.
@@ -136,12 +182,11 @@ export function getCompletionContext(
                     offset,
                 ),
             );
-            return {
-                cursorPos: "refMember",
-                typedPrefix: activeTypedPrefix,
-                replaceFromOffset: activeTokenStart,
-                pathParts: pathSource.split("."),
-            };
+            return makeRefMemberContext(
+                activeTypedPrefix,
+                activeTokenStart,
+                pathSource.split("."),
+            );
         }
 
         if (
@@ -199,12 +244,11 @@ export function getCompletionContext(
 
         // Pattern: `$identifier.member`
         if (source.charAt(pathStart - 1) === "$") {
-            return {
-                cursorPos: "refMember",
-                typedPrefix: macroTypedPrefix,
-                replaceFromOffset: macroTokenStart,
-                pathParts: source.slice(pathStart, offset).split("."),
-            };
+            return makeRefMemberContext(
+                macroTypedPrefix,
+                macroTokenStart,
+                source.slice(pathStart, offset).split("."),
+            );
         }
 
         // Pattern: `$(identifier.member` or `$(identifier).member`
@@ -212,12 +256,11 @@ export function getCompletionContext(
             source.charAt(pathStart - 1) === "(" &&
             source.charAt(pathStart - 2) === "$"
         ) {
-            return {
-                cursorPos: "refMember",
-                typedPrefix: macroTypedPrefix,
-                replaceFromOffset: macroTokenStart,
-                pathParts: source.slice(pathStart, offset).split("."),
-            };
+            return makeRefMemberContext(
+                macroTypedPrefix,
+                macroTokenStart,
+                source.slice(pathStart, offset).split("."),
+            );
         }
 
         // Pattern: `$(identifier).member`
@@ -232,12 +275,11 @@ export function getCompletionContext(
                     pathStart - 1,
                 );
                 const suffix = source.slice(pathStart, offset);
-                return {
-                    cursorPos: "refMember",
-                    typedPrefix: macroTypedPrefix,
-                    replaceFromOffset: macroTokenStart,
-                    pathParts: `${basePath}${suffix}`.split("."),
-                };
+                return makeRefMemberContext(
+                    macroTypedPrefix,
+                    macroTokenStart,
+                    `${basePath}${suffix}`.split("."),
+                );
             }
         }
 
@@ -256,14 +298,13 @@ export function getCompletionContext(
             }
             if (source.charAt(baseStart - 1) === "$") {
                 const basePath = source.slice(baseStart, pathStart - 2);
-                return {
-                    cursorPos: "refMember",
-                    typedPrefix: macroTypedPrefix,
-                    replaceFromOffset: macroTokenStart,
-                    pathParts: `${basePath}.${source
+                return makeRefMemberContext(
+                    macroTypedPrefix,
+                    macroTokenStart,
+                    `${basePath}.${source
                         .slice(pathStart, offset)
                         .replace(/^\(/, "")}`.split("."),
-                };
+                );
             }
 
             // Parenthesized base: `$(identifier).(member`
@@ -277,14 +318,13 @@ export function getCompletionContext(
                         macroOpenParen + 1,
                         baseStart - 1,
                     );
-                    return {
-                        cursorPos: "refMember",
-                        typedPrefix: macroTypedPrefix,
-                        replaceFromOffset: macroTokenStart,
-                        pathParts: `${basePath}.${source
+                    return makeRefMemberContext(
+                        macroTypedPrefix,
+                        macroTokenStart,
+                        `${basePath}.${source
                             .slice(pathStart, offset)
                             .replace(/^\(/, "")}`.split("."),
-                    };
+                    );
                 }
             }
         }
@@ -311,7 +351,7 @@ export function getCompletionContext(
         let dollarPos = tokenStart - 2;
         while (
             dollarPos > 0 &&
-            /[A-Za-z0-9_.]/.test(source.charAt(dollarPos - 1))
+            /[A-Za-z0-9_.[\]$-]/.test(source.charAt(dollarPos - 1))
         ) {
             dollarPos--;
         }
@@ -320,12 +360,7 @@ export function getCompletionContext(
             const pathStr = source.slice(pathStart, offset).trim();
             const pathParts = pathStr.split(".").filter((p) => p.length > 0);
             if (pathParts.length > 0 && /^[A-Za-z0-9_]/.test(pathStr)) {
-                return {
-                    cursorPos: "refMember",
-                    typedPrefix,
-                    replaceFromOffset: tokenStart,
-                    pathParts,
-                };
+                return makeRefMemberContext(typedPrefix, tokenStart, pathParts);
             }
         }
     }

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-context.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-context.ts
@@ -86,6 +86,38 @@ function makeRefMemberContext(
 }
 
 /**
+ * Validate raw path parts before converting to a `refMember` context.
+ * Whitespace around any non-final segment indicates invalid syntax
+ * (for example, `$foo .bar` or `$foo[1] .`).
+ */
+function hasValidRefMemberPathSyntax(rawPathParts: string[]): boolean {
+    if (rawPathParts.length === 0) {
+        return false;
+    }
+
+    for (let i = 0; i < rawPathParts.length - 1; i++) {
+        const part = rawPathParts[i];
+        if (part.length === 0 || part.trim() !== part) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function makeValidatedRefMemberContext(
+    typedPrefix: string,
+    replaceFromOffset: number,
+    rawPathParts: string[],
+): CompletionContext {
+    if (!hasValidRefMemberPathSyntax(rawPathParts)) {
+        return { cursorPos: "body" };
+    }
+
+    return makeRefMemberContext(typedPrefix, replaceFromOffset, rawPathParts);
+}
+
+/**
  * Walk left from `offset` capturing a continuous identifier fragment.
  * Uses the specified regex to match identifier characters.
  */
@@ -184,7 +216,7 @@ export function getCompletionContext(
                     offset,
                 ),
             );
-            return makeRefMemberContext(
+            return makeValidatedRefMemberContext(
                 activeTypedPrefix,
                 activeTokenStart,
                 pathSource.split("."),
@@ -246,7 +278,7 @@ export function getCompletionContext(
 
         // Pattern: `$identifier.member`
         if (source.charAt(pathStart - 1) === "$") {
-            return makeRefMemberContext(
+            return makeValidatedRefMemberContext(
                 macroTypedPrefix,
                 macroTokenStart,
                 source.slice(pathStart, offset).split("."),
@@ -258,7 +290,7 @@ export function getCompletionContext(
             source.charAt(pathStart - 1) === "(" &&
             source.charAt(pathStart - 2) === "$"
         ) {
-            return makeRefMemberContext(
+            return makeValidatedRefMemberContext(
                 macroTypedPrefix,
                 macroTokenStart,
                 source.slice(pathStart, offset).split("."),
@@ -277,7 +309,7 @@ export function getCompletionContext(
                     pathStart - 1,
                 );
                 const suffix = source.slice(pathStart, offset);
-                return makeRefMemberContext(
+                return makeValidatedRefMemberContext(
                     macroTypedPrefix,
                     macroTokenStart,
                     `${basePath}${suffix}`.split("."),
@@ -300,7 +332,7 @@ export function getCompletionContext(
             }
             if (source.charAt(baseStart - 1) === "$") {
                 const basePath = source.slice(baseStart, pathStart - 2);
-                return makeRefMemberContext(
+                return makeValidatedRefMemberContext(
                     macroTypedPrefix,
                     macroTokenStart,
                     `${basePath}.${source
@@ -320,7 +352,7 @@ export function getCompletionContext(
                         macroOpenParen + 1,
                         baseStart - 1,
                     );
-                    return makeRefMemberContext(
+                    return makeValidatedRefMemberContext(
                         macroTypedPrefix,
                         macroTokenStart,
                         `${basePath}.${source
@@ -362,7 +394,11 @@ export function getCompletionContext(
             const pathStr = source.slice(pathStart, offset).trim();
             const pathParts = pathStr.split(".");
             if (pathParts.length > 0 && /^[A-Za-z0-9_]/.test(pathStr)) {
-                return makeRefMemberContext(typedPrefix, tokenStart, pathParts);
+                return makeValidatedRefMemberContext(
+                    typedPrefix,
+                    tokenStart,
+                    pathParts,
+                );
             }
         }
     }

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-context.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-context.ts
@@ -16,22 +16,25 @@ const MACRO_PATH_CHAR_REGEX = /[A-Za-z0-9_.[\]-]/;
 const BRACKET_INDEX_SUFFIX_REGEX = /(\[[^\]]*\])+$/;
 
 /**
- * Strip bracket indices from path parts and report whether any were present.
- * For example: `["sel[1]", "member", ""]` → `{ parts: ["sel", "member", ""], hasIndex: true }`.
+ * Strip bracket indices from path parts and report index usage per segment.
+ * For example:
+ * `["sel[1]", "member", ""]` →
+ * `{ parts: ["sel", "member", ""], pathPartHasIndex: [true, false, false] }`.
  */
 function stripIndicesFromPathParts(parts: string[]): {
     parts: string[];
-    hasIndex: boolean;
+    pathPartHasIndex: boolean[];
 } {
-    let hasIndex = false;
+    const pathPartHasIndex: boolean[] = [];
     const stripped = parts.map((p) => {
-        if (BRACKET_INDEX_SUFFIX_REGEX.test(p)) {
-            hasIndex = true;
+        const indexed = BRACKET_INDEX_SUFFIX_REGEX.test(p);
+        pathPartHasIndex.push(indexed);
+        if (indexed) {
             return p.replace(BRACKET_INDEX_SUFFIX_REGEX, "");
         }
         return p;
     });
-    return { parts: stripped, hasIndex };
+    return { parts: stripped, pathPartHasIndex };
 }
 
 /**
@@ -58,11 +61,10 @@ export type CompletionContext =
           replaceFromOffset: number;
           pathParts: string[];
           /**
-           * Whether any path part (before the currently-typed segment)
-           * contained a bracket index, e.g. `$sel[1].`.  When true,
-           * `takesIndex` elements should expose descendant names.
+           * Per-segment index flags aligned with `pathParts`.
+           * Example: `$rep[1].myMath.` -> pathPartHasIndex `[true, false, false]`.
            */
-          hasIndex: boolean;
+          pathPartHasIndex: boolean[];
       };
 
 /**
@@ -73,13 +75,13 @@ function makeRefMemberContext(
     replaceFromOffset: number,
     rawPathParts: string[],
 ): CompletionContext & { cursorPos: "refMember" } {
-    const { parts, hasIndex } = stripIndicesFromPathParts(rawPathParts);
+    const { parts, pathPartHasIndex } = stripIndicesFromPathParts(rawPathParts);
     return {
         cursorPos: "refMember",
         typedPrefix,
         replaceFromOffset,
         pathParts: parts,
-        hasIndex,
+        pathPartHasIndex,
     };
 }
 

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-context.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-context.ts
@@ -360,7 +360,7 @@ export function getCompletionContext(
         if (source.charAt(dollarPos - 1) === "$") {
             const pathStart = dollarPos;
             const pathStr = source.slice(pathStart, offset).trim();
-            const pathParts = pathStr.split(".").filter((p) => p.length > 0);
+            const pathParts = pathStr.split(".");
             if (pathParts.length > 0 && /^[A-Za-z0-9_]/.test(pathStr)) {
                 return makeRefMemberContext(typedPrefix, tokenStart, pathParts);
             }

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-context.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-context.ts
@@ -351,7 +351,7 @@ export function getCompletionContext(
         let dollarPos = tokenStart - 2;
         while (
             dollarPos > 0 &&
-            /[A-Za-z0-9_.[\]$-]/.test(source.charAt(dollarPos - 1))
+            /[A-Za-z0-9_.[\]-]/.test(source.charAt(dollarPos - 1))
         ) {
             dollarPos--;
         }

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -279,7 +279,7 @@ function toRefSegmentInsertText(label: string) {
 function determineVisibleNames(
     takesIndex: boolean,
     resolvedPartHasIndex: boolean,
-    visibleDescendantNames: string[] | undefined,
+    visibleDescendantNames: string[],
     schema: { properties?: { name: string }[] } | undefined,
 ): { descendantNames: Set<string>; propertyNames: string[] } {
     // For a takesIndex composite:
@@ -292,7 +292,7 @@ function determineVisibleNames(
     const descendantNames =
         takesIndex && !resolvedPartHasIndex
             ? new Set<string>()
-            : new Set(visibleDescendantNames ?? []);
+            : new Set(visibleDescendantNames);
 
     const propertyNames =
         takesIndex && resolvedPartHasIndex

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -309,6 +309,41 @@ function buildNameToElementTypeMap(
 }
 
 /**
+ * Determine which descendant and property names should be visible for a resolved
+ * element, respecting takesIndex and hasIndex semantics.
+ *
+ * - For `takesIndex` composites without a bracket index: descendants are hidden,
+ *   only properties are shown.
+ * - For `takesIndex` composites with a bracket index: descendants are shown
+ *   (replacement child names), properties are hidden (unknown type).
+ * - For regular elements: both descendants and properties are shown.
+ * - For invalid access (element doesn't take index but has one): both are empty.
+ */
+function determineVisibleNames(
+    isDirectRef: boolean,
+    takesIndex: boolean,
+    hasIndex: boolean,
+    visibleDescendantNames: string[] | undefined,
+    schema: { properties?: { name: string }[] } | undefined,
+): { descendantNames: Set<string>; propertyNames: string[] } {
+    // When the user has provided an index on a takesIndex composite
+    // (e.g. $rep[1].), the referent is a replacement child — not the
+    // composite itself. We don't know the replacement's component type,
+    // so we can only offer descendant name completions, not properties.
+    const descendantNames =
+        isDirectRef && takesIndex && !hasIndex
+            ? new Set<string>()
+            : new Set(visibleDescendantNames ?? []);
+
+    const propertyNames =
+        isDirectRef && takesIndex && hasIndex
+            ? []
+            : schema?.properties?.map((property) => property.name) || [];
+
+    return { descendantNames, propertyNames };
+}
+
+/**
  * Build schema-property completions for the currently resolved ref target.
  * These are shown only after descendant-name candidates so concrete named
  * children win label collisions.
@@ -505,6 +540,8 @@ export function getCompletionItems(
 
         const componentType = this.normalizeElementName(resolvedNode.name);
         const schema = this.schemaElementsByName[componentType];
+        const isDirectRef = completionContext.pathParts.length <= 2;
+        const takesIndex = schema?.takesIndex ?? false;
 
         // When the resolved element has `takesIndex: true` AND the user has
         // NOT entered a bracket index, descendants are accessible only via
@@ -518,26 +555,17 @@ export function getCompletionItems(
         // For deeper paths like $rep[1].myMath., the index was consumed at
         // the first segment and the final resolved node is a concrete
         // descendant that should be treated normally.
-        const isDirectRef = completionContext.pathParts.length <= 2;
-        const takesIndex = schema?.takesIndex ?? false;
-
         if (isDirectRef && !takesIndex && completionContext.hasIndex) {
             return [];
         }
 
-        const descendantNames =
-            isDirectRef && takesIndex && !completionContext.hasIndex
-                ? new Set<string>()
-                : new Set(resolved.visibleDescendantNames ?? []);
-
-        // When the user has provided an index on a takesIndex composite
-        // (e.g. $rep[1].), the referent is a replacement child — not the
-        // composite itself.  We don't know the replacement's component type,
-        // so we can only offer descendant name completions, not properties.
-        const propertyNames =
-            isDirectRef && takesIndex && completionContext.hasIndex
-                ? []
-                : schema?.properties?.map((property) => property.name) || [];
+        const { descendantNames, propertyNames } = determineVisibleNames(
+            isDirectRef,
+            takesIndex,
+            completionContext.hasIndex,
+            resolved.visibleDescendantNames,
+            schema,
+        );
 
         const prefix = completionContext.typedPrefix.toLowerCase();
         const filteredDescendantNames = [...descendantNames].filter((name) =>

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -1,6 +1,7 @@
 import { DoenetSourceObject, RowCol } from "../../doenet-source-object";
 import type { CompletionItem, Range } from "vscode-languageserver/browser";
 import { CompletionItemKind } from "vscode-languageserver/browser";
+import type { DastElement, DastRoot } from "@doenet/parser";
 import type {
     CompletionSnippetCompletionItemData,
     CompletionSnippetCursor,
@@ -10,6 +11,10 @@ import { AutoCompleter } from "../index";
 // Keep these aligned with parser grammar in `packages/parser/src/macros/macros.peggy`:
 // - SimpleIdent = [a-zA-Z_][a-zA-Z0-9_]*
 const SIMPLE_IDENTIFIER_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const NAME_TO_ELEMENT_TYPE_MAP_CACHE = new WeakMap<
+    DastRoot | DastElement,
+    Map<string, string>
+>();
 
 /**
  * Create an LSP Range from source offset positions.
@@ -263,6 +268,47 @@ function toRefSegmentInsertText(label: string) {
 }
 
 /**
+ * Walk the DAST and build a map from user-assigned `name` attribute values
+ * to the element's tag name (component type).  Used to look up whether
+ * a named element has `takesIndex`.
+ */
+function buildNameToElementTypeMap(
+    root: DastRoot | DastElement,
+): Map<string, string> {
+    const cachedMap = NAME_TO_ELEMENT_TYPE_MAP_CACHE.get(root);
+    if (cachedMap) {
+        return cachedMap;
+    }
+
+    const map = new Map<string, string>();
+    function walk(node: DastRoot | DastElement) {
+        if (node.type === "element") {
+            const nameAttr = node.attributes?.name;
+            if (nameAttr) {
+                const nameVal =
+                    nameAttr.children.length === 1 &&
+                    nameAttr.children[0].type === "text"
+                        ? nameAttr.children[0].value
+                        : undefined;
+                if (nameVal) {
+                    map.set(nameVal, node.name);
+                }
+            }
+        }
+        if ("children" in node) {
+            for (const child of node.children) {
+                if (child.type === "element") {
+                    walk(child);
+                }
+            }
+        }
+    }
+    walk(root);
+    NAME_TO_ELEMENT_TYPE_MAP_CACHE.set(root, map);
+    return map;
+}
+
+/**
  * Build schema-property completions for the currently resolved ref target.
  * These are shown only after descendant-name candidates so concrete named
  * children win label collisions.
@@ -375,7 +421,12 @@ export function getCompletionItems(
             .getAddressableNamesAtOffset(offset)
             .filter((parts) => parts.length === 1)
             .map((parts) => parts[0]);
-        const uniqueNames = [...new Set(addressableNames)];
+        // Inject additional names (e.g. repeat valueName/indexName) that
+        // don't exist in the raw DAST but are valid at runtime.
+        const additionalNames = this.getAdditionalRefNames(offset);
+        const uniqueNames = [
+            ...new Set([...addressableNames, ...additionalNames]),
+        ];
         const visibleNames = uniqueNames.filter((name) =>
             this.isNameAddressable(offset, name),
         );
@@ -383,7 +434,7 @@ export function getCompletionItems(
             prefix ? name.toLowerCase().startsWith(prefix) : true,
         );
 
-        return createReferenceCompletionItems(
+        const baseItems = createReferenceCompletionItems(
             this,
             filteredNames,
             completionContext.replaceFromOffset,
@@ -391,6 +442,44 @@ export function getCompletionItems(
             "Reference name",
             toRefNameInsertText,
         );
+
+        // For names that refer to takesIndex elements (repeat, select, …),
+        // offer an additional "$name[]" snippet with cursor between the
+        // brackets so the user can type the index directly.
+        const nameToElementType = buildNameToElementTypeMap(
+            this.sourceObj.dast,
+        );
+        const replaceRange = createTextEditRange(
+            this.sourceObj,
+            completionContext.replaceFromOffset,
+            offset,
+        );
+        for (const name of filteredNames) {
+            const elementType = nameToElementType.get(name);
+            if (!elementType) continue;
+            const normalized = this.normalizeElementName(elementType);
+            const schema = this.schemaElementsByName[normalized];
+            if (!schema?.takesIndex) continue;
+            const insertText = isParenthesizedContext
+                ? `${name}[]`
+                : `${toRefSegmentInsertText(name)}[]`;
+            baseItems.push({
+                label: `${name}[]`,
+                kind: CompletionItemKind.Reference,
+                detail: "Indexed reference",
+                textEdit: {
+                    range: replaceRange,
+                    newText: insertText,
+                },
+                data: {
+                    snippetCursor: {
+                        caretOffset: insertText.length - 1,
+                    },
+                } satisfies CompletionSnippetCompletionItemData,
+            });
+        }
+
+        return baseItems;
     }
 
     if (allowRefCompletion && completionContext.cursorPos === "refMember") {
@@ -406,6 +495,7 @@ export function getCompletionItems(
         const resolved = this.resolveRefMemberContainerAtOffset(
             offset,
             completionContext.pathParts,
+            completionContext.hasIndex,
         );
         const resolvedNode = resolved.node;
 
@@ -413,16 +503,46 @@ export function getCompletionItems(
             return [];
         }
 
-        const descendantNames = new Set(
-            resolved.visibleDescendantNames ??
-                this.sourceObj.getUniqueDescendantNamesForNode(resolvedNode),
-        );
-
         const componentType = this.normalizeElementName(resolvedNode.name);
+        const schema = this.schemaElementsByName[componentType];
+
+        // When the resolved element has `takesIndex: true` AND the user has
+        // NOT entered a bracket index, descendants are accessible only via
+        // index (e.g. $name[1].member), not via bare $name.member.
+        // Offer only property completions in that case.
+        // Conversely, if the element does NOT take an index but the user
+        // wrote one (e.g. $sec[1].), the access is invalid — return nothing.
+        //
+        // These checks only apply to direct references (pathParts has two
+        // entries: the root name and the empty segment being typed).
+        // For deeper paths like $rep[1].myMath., the index was consumed at
+        // the first segment and the final resolved node is a concrete
+        // descendant that should be treated normally.
+        const isDirectRef = completionContext.pathParts.length <= 2;
+        const takesIndex = schema?.takesIndex ?? false;
+
+        if (isDirectRef && !takesIndex && completionContext.hasIndex) {
+            return [];
+        }
+
+        const descendantNames =
+            isDirectRef && takesIndex && !completionContext.hasIndex
+                ? new Set<string>()
+                : new Set(
+                      resolved.visibleDescendantNames ??
+                          this.sourceObj.getUniqueDescendantNamesForNode(
+                              resolvedNode,
+                          ),
+                  );
+
+        // When the user has provided an index on a takesIndex composite
+        // (e.g. $rep[1].), the referent is a replacement child — not the
+        // composite itself.  We don't know the replacement's component type,
+        // so we can only offer descendant name completions, not properties.
         const propertyNames =
-            this.schemaElementsByName[componentType]?.properties?.map(
-                (property) => property.name,
-            ) || [];
+            isDirectRef && takesIndex && completionContext.hasIndex
+                ? []
+                : schema?.properties?.map((property) => property.name) || [];
 
         const prefix = completionContext.typedPrefix.toLowerCase();
         const filteredDescendantNames = [...descendantNames].filter((name) =>

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -275,23 +275,25 @@ function toRefSegmentInsertText(label: string) {
  * - For invalid access (element doesn't take index but has one): both are empty.
  */
 function determineVisibleNames(
-    isDirectRef: boolean,
     takesIndex: boolean,
-    directPartHasIndex: boolean,
+    resolvedPartHasIndex: boolean,
     visibleDescendantNames: string[] | undefined,
     schema: { properties?: { name: string }[] } | undefined,
 ): { descendantNames: Set<string>; propertyNames: string[] } {
-    // When the user has provided an index on a takesIndex composite
-    // (e.g. $rep[1].), the referent is a replacement child — not the
-    // composite itself. We don't know the replacement's component type,
-    // so we can only offer descendant name completions, not properties.
+    // For a takesIndex composite:
+    //   - Without an index ($rep.): descendants are inaccessible via bare dot
+    //     access, so hide them and show only schema properties.
+    //   - With an index ($rep[1]. or $sec.rep[1].): the cursor is after a
+    //     replacement child of unknown component type, so show descendant
+    //     names but hide schema properties (they describe the composite, not
+    //     the replacement).
     const descendantNames =
-        isDirectRef && takesIndex && !directPartHasIndex
+        takesIndex && !resolvedPartHasIndex
             ? new Set<string>()
             : new Set(visibleDescendantNames ?? []);
 
     const propertyNames =
-        isDirectRef && takesIndex && directPartHasIndex
+        takesIndex && resolvedPartHasIndex
             ? []
             : schema?.properties?.map((property) => property.name) || [];
 
@@ -493,31 +495,27 @@ export function getCompletionItems(
 
         const componentType = this.normalizeElementName(resolvedNode.name);
         const schema = this.schemaElementsByName[componentType];
-        const isDirectRef = completionContext.pathParts.length <= 2;
         const takesIndex = schema?.takesIndex ?? false;
-        const directPartHasIndex =
-            (completionContext.pathPartHasIndex?.[0] ?? false) || false;
+        // Read the index flag for the resolved segment — always the
+        // second-to-last entry in pathParts (the last entry is always the
+        // empty typed-prefix).  Examples:
+        //   $rep[1].   → pathParts=["rep",""]          → index 0 (direct ref)
+        //   $sec.rep[1]. → pathParts=["sec","rep",""]  → index 1 (indirect)
+        //   $rep[1].myMath. → pathParts=["rep","myMath",""] → index 1 (resolved is myMath, not rep)
+        const resolvedPartHasIndex =
+            completionContext.pathPartHasIndex?.[
+                completionContext.pathParts.length - 2
+            ] ?? false;
 
-        // When the resolved element has `takesIndex: true` AND the user has
-        // NOT entered a bracket index, descendants are accessible only via
-        // index (e.g. $name[1].member), not via bare $name.member.
-        // Offer only property completions in that case.
-        // Conversely, if the element does NOT take an index but the user
+        // When the resolved element does NOT take an index but the user
         // wrote one (e.g. $sec[1].), the access is invalid — return nothing.
-        //
-        // These checks only apply to direct references (pathParts has two
-        // entries: the root name and the empty segment being typed).
-        // For deeper paths like $rep[1].myMath., the index was consumed at
-        // the first segment and the final resolved node is a concrete
-        // descendant that should be treated normally.
-        if (isDirectRef && !takesIndex && directPartHasIndex) {
+        if (!takesIndex && resolvedPartHasIndex) {
             return [];
         }
 
         const { descendantNames, propertyNames } = determineVisibleNames(
-            isDirectRef,
             takesIndex,
-            directPartHasIndex,
+            resolvedPartHasIndex,
             resolved.visibleDescendantNames,
             schema,
         );

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -312,7 +312,7 @@ function buildNameToElementTypeMap(
 
 /**
  * Determine which descendant and property names should be visible for a resolved
- * element, respecting takesIndex and hasIndex semantics.
+ * element, respecting takesIndex and per-segment index semantics.
  *
  * - For `takesIndex` composites without a bracket index: descendants are hidden,
  *   only properties are shown.
@@ -324,7 +324,7 @@ function buildNameToElementTypeMap(
 function determineVisibleNames(
     isDirectRef: boolean,
     takesIndex: boolean,
-    hasIndex: boolean,
+    directPartHasIndex: boolean,
     visibleDescendantNames: string[] | undefined,
     schema: { properties?: { name: string }[] } | undefined,
 ): { descendantNames: Set<string>; propertyNames: string[] } {
@@ -333,12 +333,12 @@ function determineVisibleNames(
     // composite itself. We don't know the replacement's component type,
     // so we can only offer descendant name completions, not properties.
     const descendantNames =
-        isDirectRef && takesIndex && !hasIndex
+        isDirectRef && takesIndex && !directPartHasIndex
             ? new Set<string>()
             : new Set(visibleDescendantNames ?? []);
 
     const propertyNames =
-        isDirectRef && takesIndex && hasIndex
+        isDirectRef && takesIndex && directPartHasIndex
             ? []
             : schema?.properties?.map((property) => property.name) || [];
 
@@ -531,7 +531,7 @@ export function getCompletionItems(
         const resolved = this.resolveRefMemberContainerAtOffset(
             offset,
             completionContext.pathParts,
-            completionContext.hasIndex,
+            completionContext.pathPartHasIndex,
         );
         const resolvedNode = resolved.node;
 
@@ -543,6 +543,8 @@ export function getCompletionItems(
         const schema = this.schemaElementsByName[componentType];
         const isDirectRef = completionContext.pathParts.length <= 2;
         const takesIndex = schema?.takesIndex ?? false;
+        const directPartHasIndex =
+            (completionContext.pathPartHasIndex?.[0] ?? false) || false;
 
         // When the resolved element has `takesIndex: true` AND the user has
         // NOT entered a bracket index, descendants are accessible only via
@@ -556,14 +558,14 @@ export function getCompletionItems(
         // For deeper paths like $rep[1].myMath., the index was consumed at
         // the first segment and the final resolved node is a concrete
         // descendant that should be treated normally.
-        if (isDirectRef && !takesIndex && completionContext.hasIndex) {
+        if (isDirectRef && !takesIndex && directPartHasIndex) {
             return [];
         }
 
         const { descendantNames, propertyNames } = determineVisibleNames(
             isDirectRef,
             takesIndex,
-            completionContext.hasIndex,
+            directPartHasIndex,
             resolved.visibleDescendantNames,
             schema,
         );

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -431,8 +431,8 @@ export function getCompletionItems(
         ];
         const filteredNames = uniqueNames.filter(
             (name) =>
-                this.isNameAddressable(offset, name) &&
-                (!prefix || name.toLowerCase().startsWith(prefix)),
+                (!prefix || name.toLowerCase().startsWith(prefix)) &&
+                this.isNameAddressable(offset, name),
         );
 
         const baseItems = createReferenceCompletionItems(

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -528,12 +528,7 @@ export function getCompletionItems(
         const descendantNames =
             isDirectRef && takesIndex && !completionContext.hasIndex
                 ? new Set<string>()
-                : new Set(
-                      resolved.visibleDescendantNames ??
-                          this.sourceObj.getUniqueDescendantNamesForNode(
-                              resolvedNode,
-                          ),
-                  );
+                : new Set(resolved.visibleDescendantNames ?? []);
 
         // When the user has provided an index on a takesIndex composite
         // (e.g. $rep[1].), the referent is a replacement child — not the

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -375,7 +375,11 @@ export function getCompletionItems(
             .getAddressableNamesAtOffset(offset)
             .filter((parts) => parts.length === 1)
             .map((parts) => parts[0]);
-        const filteredNames = [...new Set(addressableNames)].filter((name) =>
+        const uniqueNames = [...new Set(addressableNames)];
+        const visibleNames = uniqueNames.filter((name) =>
+            this.isNameAddressable(offset, name),
+        );
+        const filteredNames = visibleNames.filter((name) =>
             prefix ? name.toLowerCase().startsWith(prefix) : true,
         );
 
@@ -410,7 +414,8 @@ export function getCompletionItems(
         }
 
         const descendantNames = new Set(
-            this.sourceObj.getUniqueDescendantNamesForNode(resolvedNode),
+            resolved.visibleDescendantNames ??
+                this.sourceObj.getUniqueDescendantNamesForNode(resolvedNode),
         );
 
         const componentType = this.normalizeElementName(resolvedNode.name);

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -272,7 +272,9 @@ function toRefSegmentInsertText(label: string) {
  * - For `takesIndex` composites with a bracket index: descendants are shown
  *   (replacement child names), properties are hidden (unknown type).
  * - For regular elements: both descendants and properties are shown.
- * - For invalid access (element doesn't take index but has one): both are empty.
+ *
+ * Note: Invalid access (non-takesIndex element with an index) is handled upstream
+ * in the resolver and returns null node before reaching this function.
  */
 function determineVisibleNames(
     takesIndex: boolean,
@@ -333,8 +335,12 @@ function createPropertyCompletionItems(
  *
  * This function analyzes the cursor context to determine what type of completions
  * are appropriate and returns a combination of:
- * - Ref-name completions after `$` in text content or attribute values
- * - Ref-member completions after `.` on a resolved ref chain
+ * - Ref-name completions after `$` in text content or attribute values, including
+ *   `$name[]` snippet completions for takesIndex elements
+ * - Ref-member completions after `.` on a resolved ref chain, filtered by addressability
+ *   and visibility rules (ChildrenInvisibleToTheirGrandparents, sugar hiding, etc.)
+ * - Additional injected ref names (e.g., repeat valueName/indexName) from
+ *   rustResolverAdapter.getDerivedRepeatNames()
  * - Schema-based element completions (allowed elements based on parent/context)
  * - Snippet completions (templates associated with allowed elements)
  * - Attribute name completions (when inside an opening tag)
@@ -342,8 +348,9 @@ function createPropertyCompletionItems(
  * - Closing tag completions (when appropriate)
  *
  * The completion behavior varies depending on the cursor position context:
- * - Body or attribute-value ref context after `$` or `.`: in-scope ref names,
- *   descendant names, and schema properties on resolved referents
+ * - Body or attribute-value ref context after `$` or `.`: in-scope ref names filtered
+ *   through isNameAddressable(), descendant names from visibleDescendantNames,
+ *   and schema properties on resolved referents
  * - Root level after `<`: top-level elements and their snippets
  * - Inside element body after `<`: allowed children and their snippets
  * - While typing element name (`openTagName`): filtered schema elements and snippets
@@ -356,6 +363,7 @@ function createPropertyCompletionItems(
  * insertion column.
  *
  * @param offset - Either a numeric offset into the source string, or a RowCol position
+ * @param cachedContext - Optional pre-computed CompletionContext to avoid redundant parsing
  * @returns Array of LSP CompletionItem objects suitable for the current context
  */
 export function getCompletionItems(

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -11,6 +11,8 @@ import { AutoCompleter } from "../index";
 // Keep these aligned with parser grammar in `packages/parser/src/macros/macros.peggy`:
 // - SimpleIdent = [a-zA-Z_][a-zA-Z0-9_]*
 const SIMPLE_IDENTIFIER_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
+// Cache by DAST root identity. AutoCompleter.setSource() replaces the root,
+// so stale maps naturally disappear with GC.
 const NAME_TO_ELEMENT_TYPE_MAP_CACHE = new WeakMap<
     DastRoot | DastElement,
     Map<string, string>
@@ -462,11 +464,10 @@ export function getCompletionItems(
         const uniqueNames = [
             ...new Set([...addressableNames, ...additionalNames]),
         ];
-        const visibleNames = uniqueNames.filter((name) =>
-            this.isNameAddressable(offset, name),
-        );
-        const filteredNames = visibleNames.filter((name) =>
-            prefix ? name.toLowerCase().startsWith(prefix) : true,
+        const filteredNames = uniqueNames.filter(
+            (name) =>
+                this.isNameAddressable(offset, name) &&
+                (!prefix || name.toLowerCase().startsWith(prefix)),
         );
 
         const baseItems = createReferenceCompletionItems(

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -1,7 +1,6 @@
 import { DoenetSourceObject, RowCol } from "../../doenet-source-object";
 import type { CompletionItem, Range } from "vscode-languageserver/browser";
 import { CompletionItemKind } from "vscode-languageserver/browser";
-import type { DastElement, DastRoot } from "@doenet/parser";
 import type {
     CompletionSnippetCompletionItemData,
     CompletionSnippetCursor,
@@ -11,12 +10,6 @@ import { AutoCompleter } from "../index";
 // Keep these aligned with parser grammar in `packages/parser/src/macros/macros.peggy`:
 // - SimpleIdent = [a-zA-Z_][a-zA-Z0-9_]*
 const SIMPLE_IDENTIFIER_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
-// Cache by DAST root identity. AutoCompleter.setSource() replaces the root,
-// so stale maps naturally disappear with GC.
-const NAME_TO_ELEMENT_TYPE_MAP_CACHE = new WeakMap<
-    DastRoot | DastElement,
-    Map<string, string>
->();
 
 /**
  * Create an LSP Range from source offset positions.
@@ -270,47 +263,6 @@ function toRefSegmentInsertText(label: string) {
 }
 
 /**
- * Walk the DAST and build a map from user-assigned `name` attribute values
- * to the element's tag name (component type).  Used to look up whether
- * a named element has `takesIndex`.
- */
-function buildNameToElementTypeMap(
-    root: DastRoot | DastElement,
-): Map<string, string> {
-    const cachedMap = NAME_TO_ELEMENT_TYPE_MAP_CACHE.get(root);
-    if (cachedMap) {
-        return cachedMap;
-    }
-
-    const map = new Map<string, string>();
-    function walk(node: DastRoot | DastElement) {
-        if (node.type === "element") {
-            const nameAttr = node.attributes?.name;
-            if (nameAttr) {
-                const nameVal =
-                    nameAttr.children.length === 1 &&
-                    nameAttr.children[0].type === "text"
-                        ? nameAttr.children[0].value
-                        : undefined;
-                if (nameVal) {
-                    map.set(nameVal, node.name);
-                }
-            }
-        }
-        if ("children" in node) {
-            for (const child of node.children) {
-                if (child.type === "element") {
-                    walk(child);
-                }
-            }
-        }
-    }
-    walk(root);
-    NAME_TO_ELEMENT_TYPE_MAP_CACHE.set(root, map);
-    return map;
-}
-
-/**
  * Determine which descendant and property names should be visible for a resolved
  * element, respecting takesIndex and per-segment index semantics.
  *
@@ -482,18 +434,15 @@ export function getCompletionItems(
         // For names that refer to takesIndex elements (repeat, select, …),
         // offer an additional "$name[]" snippet with cursor between the
         // brackets so the user can type the index directly.
-        const nameToElementType = buildNameToElementTypeMap(
-            this.sourceObj.dast,
-        );
         const replaceRange = createTextEditRange(
             this.sourceObj,
             completionContext.replaceFromOffset,
             offset,
         );
         for (const name of filteredNames) {
-            const elementType = nameToElementType.get(name);
-            if (!elementType) continue;
-            const normalized = this.normalizeElementName(elementType);
+            const referent = this.sourceObj.getReferentAtOffset(offset, name);
+            if (!referent) continue;
+            const normalized = this.normalizeElementName(referent.name);
             const schema = this.schemaElementsByName[normalized];
             if (!schema?.takesIndex) continue;
             const insertText = isParenthesizedContext

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -1,4 +1,5 @@
 import { DoenetSourceObject, RowCol } from "../../doenet-source-object";
+import type { CompletionContext } from "./get-completion-context";
 import type { CompletionItem, Range } from "vscode-languageserver/browser";
 import { CompletionItemKind } from "vscode-languageserver/browser";
 import type {
@@ -358,6 +359,7 @@ function createPropertyCompletionItems(
 export function getCompletionItems(
     this: AutoCompleter,
     offset: number | RowCol,
+    cachedContext?: CompletionContext,
 ): CompletionItem[] {
     if (typeof offset !== "number") {
         offset = this.sourceObj.rowColToOffset(offset);
@@ -382,7 +384,8 @@ export function getCompletionItems(
     const element = containingElement.node;
     let cursorPosition = containingElement.cursorPosition;
 
-    const completionContext = this.getCompletionContext(offset);
+    const completionContext =
+        cachedContext ?? this.getCompletionContext(offset);
     const allowRefCompletion =
         cursorPosition === "body" ||
         cursorPosition === "attributeValue" ||

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -270,7 +270,7 @@ export class RustResolverAdapter {
         this._sourceRevision += 1;
         this._visibleDescendantNamesCache.clear();
         if (!this._core) {
-            this._enabled = false;
+            this._disableAdapterState();
             return;
         }
         // The Rust core panics on empty source (index-out-of-bounds on a
@@ -278,14 +278,14 @@ export class RustResolverAdapter {
         // no elements (e.g. source is just "a" — only text nodes, zero
         // elements).  Skip the sync in both cases.
         if (!this._sourceObj.source.trim()) {
-            this._enabled = false;
+            this._disableAdapterState();
             return;
         }
         const hasElements = this._sourceObj.dast.children.some(
             (c) => c.type === "element",
         );
         if (!hasElements) {
-            this._enabled = false;
+            this._disableAdapterState();
             return;
         }
         try {
@@ -297,7 +297,7 @@ export class RustResolverAdapter {
             this._enabled = true;
         } catch (e) {
             console.warn("RustResolverAdapter: failed to sync source:", e);
-            this._enabled = false;
+            this._disableAdapterState();
         }
     }
 
@@ -309,6 +309,12 @@ export class RustResolverAdapter {
     _setCachedVisibleDescendantNames(resolvedIdx: number, names: string[]) {
         const key = `${this._sourceRevision}:${resolvedIdx}`;
         this._visibleDescendantNamesCache.set(key, names);
+    }
+
+    _disableAdapterState() {
+        this._enabled = false;
+        this._rustIndexToDastElement.clear();
+        this._dastElementToRustIndex.clear();
     }
 
     /**
@@ -440,6 +446,7 @@ export class RustResolverAdapter {
                 return {
                     node: null,
                     unresolvedPathParts,
+                    visibleDescendantNames: [],
                 };
             }
 
@@ -478,6 +485,7 @@ export class RustResolverAdapter {
                             node: null,
                             unresolvedPathParts:
                                 lookupParts.slice(pathPartIndex),
+                            visibleDescendantNames: [],
                         };
                     }
                     // Inverse: a non-takesIndex segment must not have an
@@ -492,6 +500,7 @@ export class RustResolverAdapter {
                             node: null,
                             unresolvedPathParts:
                                 lookupParts.slice(pathPartIndex),
+                            visibleDescendantNames: [],
                         };
                     }
                 }
@@ -525,6 +534,7 @@ export class RustResolverAdapter {
                 return {
                     node: null,
                     unresolvedPathParts: [],
+                    visibleDescendantNames: [],
                 };
             }
 

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -1,6 +1,7 @@
 import type { DastElement, DastNodes } from "@doenet/parser";
 import type { DoenetSourceObject } from "../doenet-source-object";
 import type {
+    RefMemberContainerResolution,
     ResolveRefMemberContainer,
     ResolveRefMemberContainerArgs,
 } from "./index";
@@ -180,9 +181,9 @@ export interface RustResolverAdapterOptions {
  * with the AutoCompleter's pluggable resolver seam.
  *
  * When constructed without a `core`, the adapter is disabled and its resolver
- * returns `null`, allowing the JS fallback to handle resolution. When a core
- * is supplied, source is synced to the Rust side, position-based index mappings
- * are built, and the resolver calls resolve_path() for each completion request.
+ * returns `null`. When a core is supplied, source is synced to the Rust side,
+ * position-based index mappings are built, and the resolver calls
+ * resolve_path() for each completion request.
  */
 export class RustResolverAdapter {
     private core: RustResolverCore | null = null;
@@ -282,6 +283,22 @@ export class RustResolverAdapter {
             this.rustIndexToDastElement.set(id, dastElm);
             this.dastElementToRustIndex.set(dastElm, id);
         }
+    }
+
+    /**
+     * Resolve a ref-member container for AutoCompleter member completion.
+     */
+    resolveRefMemberContainerAtOffset(
+        offset: number,
+        pathParts: string[],
+        hasIndex?: boolean,
+    ): RefMemberContainerResolution | null {
+        return this.createResolver()({
+            offset,
+            pathParts,
+            nodeIndex: this.sourceObj.getNodeIndexAtOffset(offset),
+            hasIndex,
+        });
     }
 
     /**
@@ -470,7 +487,7 @@ export class RustResolverAdapter {
      * This respects `ChildrenInvisibleToTheirGrandparents` etc.
      */
     isNameAddressableFromOffset(offset: number, name: string): boolean {
-        if (!this.enabled || !this.core) return true; // fallback: allow
+        if (!this.enabled || !this.core) return false;
 
         // Synthetic names from repeat valueName/indexName are always
         // addressable from inside the repeat — they bypass resolve_path.
@@ -512,7 +529,7 @@ export class RustResolverAdapter {
             resolveFromIndex = this.getRootOriginIndex();
         }
 
-        if (resolveFromIndex == null) return true;
+        if (resolveFromIndex == null) return false;
 
         try {
             const resolution = this.core.resolve_path(

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -396,6 +396,30 @@ export class RustResolverAdapter {
                 };
             }
 
+            // If any intermediate segment resolves through a takesIndex
+            // component without an index (e.g. $rep.myMath.), block member
+            // completions for that path. Indexed traversal must use
+            // $rep[n].member.
+            if (!hasIndex && resolution.nodesInResolvedPath.length > 1) {
+                const intermediatePathNodeIndices =
+                    resolution.nodesInResolvedPath.slice(0, -1);
+                const blockedPathPartIndex =
+                    intermediatePathNodeIndices.findIndex((nodeIdx) => {
+                        const pathNode =
+                            this._rustIndexToDastElement.get(nodeIdx);
+                        return !!(
+                            pathNode && this.componentTakesIndex(pathNode.name)
+                        );
+                    });
+                if (blockedPathPartIndex >= 0) {
+                    return {
+                        node: null,
+                        unresolvedPathParts:
+                            lookupParts.slice(blockedPathPartIndex),
+                    };
+                }
+            }
+
             // When the resolved element takes an index, descendants
             // are only accessible via $name[n].member — suppress them
             // unless the user has already provided a bracket index.

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -428,6 +428,20 @@ export class RustResolverAdapter {
                                 lookupParts.slice(pathPartIndex),
                         };
                     }
+                    // Inverse: a non-takesIndex segment must not have an
+                    // index. If it does the path is invalid — false positives
+                    // are worse than false negatives.
+                    if (
+                        pathNode &&
+                        !this._componentTakesIndex(pathNode.name) &&
+                        segmentHasIndex
+                    ) {
+                        return {
+                            node: null,
+                            unresolvedPathParts:
+                                lookupParts.slice(pathPartIndex),
+                        };
+                    }
                 }
             }
 
@@ -446,6 +460,19 @@ export class RustResolverAdapter {
                     node: resolvedNode,
                     unresolvedPathParts: [],
                     visibleDescendantNames: [],
+                };
+            }
+
+            // Inverse: a non-takesIndex resolved element must not have an
+            // index in its path segment — false positives are worse than
+            // false negatives.
+            if (
+                !this._componentTakesIndex(resolvedNode.name) &&
+                resolvedPartHasIndex
+            ) {
+                return {
+                    node: null,
+                    unresolvedPathParts: [],
                 };
             }
 

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -187,64 +187,64 @@ export interface RustResolverAdapterOptions {
  * resolve_path() for each completion request.
  */
 export class RustResolverAdapter {
-    private core: RustResolverCore | null = null;
-    private sourceObj: DoenetSourceObject;
-    private enabled = false;
-    private takesIndexComponentTypes: ReadonlySet<string> | null = null;
+    _core: RustResolverCore | null = null;
+    _sourceObj: DoenetSourceObject;
+    _enabled = false;
+    _takesIndexComponentTypes: ReadonlySet<string> | null = null;
 
     /** Rust flat index → JS DAST element (matched by source position). */
-    private rustIndexToDastElement: Map<number, DastElement> = new Map();
+    _rustIndexToDastElement: Map<number, DastElement> = new Map();
     /** JS DAST element → Rust flat index. */
-    private dastElementToRustIndex: Map<DastElement, number> = new Map();
+    _dastElementToRustIndex: Map<DastElement, number> = new Map();
 
     constructor(
         sourceObj: DoenetSourceObject,
         options?: RustResolverAdapterOptions,
     ) {
-        this.sourceObj = sourceObj;
-        this.takesIndexComponentTypes =
+        this._sourceObj = sourceObj;
+        this._takesIndexComponentTypes =
             options?.takesIndexComponentTypes ?? null;
         if (options?.core) {
-            this.core = options.core;
+            this._core = options.core;
             this.syncSource();
         }
     }
 
     private componentTakesIndex(componentType: string): boolean {
-        return this.takesIndexComponentTypes?.has(componentType) ?? false;
+        return this._takesIndexComponentTypes?.has(componentType) ?? false;
     }
 
     /**
      * Sync the DAST/source to the Rust core and rebuild index mappings.
      */
     private syncSource(): void {
-        if (!this.core) {
-            this.enabled = false;
+        if (!this._core) {
+            this._enabled = false;
             return;
         }
         // The Rust core panics on empty source (index-out-of-bounds on a
         // zero-length collection).  It also panics when the DAST contains
         // no elements (e.g. source is just "a" — only text nodes, zero
         // elements).  Skip the sync in both cases.
-        if (!this.sourceObj.source.trim()) {
-            this.enabled = false;
+        if (!this._sourceObj.source.trim()) {
+            this._enabled = false;
             return;
         }
-        const hasElements = this.sourceObj.dast.children.some(
+        const hasElements = this._sourceObj.dast.children.some(
             (c) => c.type === "element",
         );
         if (!hasElements) {
-            this.enabled = false;
+            this._enabled = false;
             return;
         }
         try {
-            this.core.set_source(this.sourceObj.dast, this.sourceObj.source);
-            const flatDast = this.core.return_dast();
+            this._core.set_source(this._sourceObj.dast, this._sourceObj.source);
+            const flatDast = this._core.return_dast();
             this.buildMappings(flatDast);
-            this.enabled = true;
+            this._enabled = true;
         } catch (e) {
             console.warn("RustResolverAdapter: failed to sync source:", e);
-            this.enabled = false;
+            this._enabled = false;
         }
     }
 
@@ -258,8 +258,8 @@ export class RustResolverAdapter {
             position?: { start: { offset?: number } };
         }>;
     }): void {
-        this.rustIndexToDastElement.clear();
-        this.dastElementToRustIndex.clear();
+        this._rustIndexToDastElement.clear();
+        this._dastElementToRustIndex.clear();
 
         // Collect JS DAST elements keyed by start offset.
         const dastByStartOffset = new Map<number, DastElement>();
@@ -274,7 +274,7 @@ export class RustResolverAdapter {
                 }
             }
         };
-        for (const child of this.sourceObj.dast.children) {
+        for (const child of this._sourceObj.dast.children) {
             collectElements(child as DastNodes);
         }
 
@@ -286,8 +286,8 @@ export class RustResolverAdapter {
             if (id == null) continue;
             const dastElm = dastByStartOffset.get(startOffset);
             if (!dastElm) continue;
-            this.rustIndexToDastElement.set(id, dastElm);
-            this.dastElementToRustIndex.set(dastElm, id);
+            this._rustIndexToDastElement.set(id, dastElm);
+            this._dastElementToRustIndex.set(dastElm, id);
         }
     }
 
@@ -302,7 +302,7 @@ export class RustResolverAdapter {
         return this.createResolver()({
             offset,
             pathParts,
-            nodeIndex: this.sourceObj.getNodeIndexAtOffset(offset),
+            nodeIndex: this._sourceObj.getNodeIndexAtOffset(offset),
             hasIndex,
         });
     }
@@ -313,7 +313,7 @@ export class RustResolverAdapter {
      */
     createResolver(): ResolveRefMemberContainer {
         return (args: ResolveRefMemberContainerArgs) => {
-            if (!this.enabled || !this.core) return null;
+            if (!this._enabled || !this._core) return null;
 
             const { offset, pathParts, hasIndex } = args;
             if (pathParts.length === 0) return null;
@@ -335,13 +335,13 @@ export class RustResolverAdapter {
             );
 
             try {
-                const resolution = this.core.resolve_path(
+                const resolution = this._core.resolve_path(
                     { path: flatPath },
                     originIndex,
                     false,
                 );
 
-                const resolvedNode = this.rustIndexToDastElement.get(
+                const resolvedNode = this._rustIndexToDastElement.get(
                     resolution.nodeIdx,
                 );
                 if (!resolvedNode) return null;
@@ -400,12 +400,12 @@ export class RustResolverAdapter {
                 // respects ChildrenInvisibleToTheirGrandparents etc.).
                 const resolvedIdx = resolution.nodeIdx;
                 const allNames =
-                    this.sourceObj.getUniqueDescendantNamesForNode(
+                    this._sourceObj.getUniqueDescendantNamesForNode(
                         resolvedNode,
                     );
                 const visibleDescendantNames = allNames.filter((name) => {
                     try {
-                        const probe = this.core!.resolve_path(
+                        const probe = this._core!.resolve_path(
                             {
                                 path: [
                                     {
@@ -451,9 +451,9 @@ export class RustResolverAdapter {
      * back to a mapped top-level element when the cursor is at root level.
      */
     private getOriginIndex(offset: number): number | null {
-        const containingElement = this.sourceObj.elementAtOffset(offset);
+        const containingElement = this._sourceObj.elementAtOffset(offset);
         if (containingElement) {
-            const idx = this.dastElementToRustIndex.get(containingElement);
+            const idx = this._dastElementToRustIndex.get(containingElement);
             if (idx != null) return idx;
         }
         return this.getRootOriginIndex();
@@ -466,9 +466,9 @@ export class RustResolverAdapter {
      */
     private getRootOriginIndex(): number | null {
         const topLevelIndices: number[] = [];
-        for (const child of this.sourceObj.dast.children) {
+        for (const child of this._sourceObj.dast.children) {
             if (child.type !== "element") continue;
-            const idx = this.dastElementToRustIndex.get(child);
+            const idx = this._dastElementToRustIndex.get(child);
             if (idx != null) {
                 topLevelIndices.push(idx);
             }
@@ -477,7 +477,7 @@ export class RustResolverAdapter {
             return Math.min(...topLevelIndices);
         }
 
-        const mappedIndices = [...this.rustIndexToDastElement.keys()];
+        const mappedIndices = [...this._rustIndexToDastElement.keys()];
         if (mappedIndices.length > 0) {
             return Math.min(...mappedIndices);
         }
@@ -490,7 +490,7 @@ export class RustResolverAdapter {
      * This respects `ChildrenInvisibleToTheirGrandparents` etc.
      */
     isNameAddressableFromOffset(offset: number, name: string): boolean {
-        if (!this.enabled || !this.core) return false;
+        if (!this._enabled || !this._core) return false;
 
         // Derived repeat names from valueName/indexName are always
         // addressable from inside the repeat and bypass resolve_path.
@@ -503,14 +503,14 @@ export class RustResolverAdapter {
         // upward, so to correctly probe the containing element's scope we
         // must resolve from one of its existing children rather than the
         // container itself.
-        const containingElement = this.sourceObj.elementAtOffset(offset);
+        const containingElement = this._sourceObj.elementAtOffset(offset);
         let resolveFromIndex: number | null = null;
 
         if (containingElement) {
             // Find the first child element that has a Rust index.
             for (const child of containingElement.children) {
                 if (child.type === "element") {
-                    const ci = this.dastElementToRustIndex.get(child);
+                    const ci = this._dastElementToRustIndex.get(child);
                     if (ci != null) {
                         resolveFromIndex = ci;
                         break;
@@ -522,7 +522,7 @@ export class RustResolverAdapter {
             // the parent-scope walk is still correct.
             if (resolveFromIndex == null) {
                 resolveFromIndex =
-                    this.dastElementToRustIndex.get(containingElement) ?? null;
+                    this._dastElementToRustIndex.get(containingElement) ?? null;
             }
         } else {
             // Root level — use the first top-level element (a child of the
@@ -535,7 +535,7 @@ export class RustResolverAdapter {
         if (resolveFromIndex == null) return false;
 
         try {
-            const resolution = this.core.resolve_path(
+            const resolution = this._core.resolve_path(
                 {
                     path: [
                         {
@@ -578,11 +578,11 @@ export class RustResolverAdapter {
      * The same pattern applies to `<select>` / `<option>` via `selectSugar`.
      */
     private isHiddenBySugar(rustIdx: number, cursorOffset: number): boolean {
-        const resolvedElement = this.rustIndexToDastElement.get(rustIdx);
+        const resolvedElement = this._rustIndexToDastElement.get(rustIdx);
         if (!resolvedElement) return false;
 
         let current: DastElement | DastNodes = resolvedElement;
-        let parent = this.sourceObj.getParent(current);
+        let parent = this._sourceObj.getParent(current);
 
         while (parent && parent.type !== "root") {
             if (
@@ -604,7 +604,7 @@ export class RustResolverAdapter {
                     // non-wrapper children that sugar will wrap, or deeper
                     // descendants already behind a wrapper barrier) is hidden.
                     const resolvedParent =
-                        this.sourceObj.getParent(resolvedElement);
+                        this._sourceObj.getParent(resolvedElement);
                     if (
                         resolvedParent &&
                         resolvedParent.type === "element" &&
@@ -619,13 +619,13 @@ export class RustResolverAdapter {
                 }
             }
             current = parent;
-            parent = this.sourceObj.getParent(parent);
+            parent = this._sourceObj.getParent(parent);
         }
         return false;
     }
 
     isEnabled(): boolean {
-        return this.enabled;
+        return this._enabled;
     }
 
     /**
@@ -637,10 +637,10 @@ export class RustResolverAdapter {
     getDerivedRepeatNames(offset: number): string[] {
         const names: string[] = [];
         let current: DastElement | undefined =
-            this.sourceObj.elementAtOffset(offset) ?? undefined;
+            this._sourceObj.elementAtOffset(offset) ?? undefined;
         while (current) {
             names.push(...getDerivedRepeatNamesFromElement(current));
-            const p = this.sourceObj.getParent(current);
+            const p = this._sourceObj.getParent(current);
             current =
                 p && p.type === "element" ? (p as DastElement) : undefined;
         }
@@ -651,7 +651,7 @@ export class RustResolverAdapter {
      * Update source and rebuild mappings. Call when the document changes.
      */
     updateSource(sourceObj: DoenetSourceObject): void {
-        this.sourceObj = sourceObj;
+        this._sourceObj = sourceObj;
         this.syncSource();
     }
 }

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -290,6 +290,8 @@ export class RustResolverAdapter {
         }
         try {
             this._core.set_source(this._sourceObj.dast, this._sourceObj.source);
+            // Set empty flags object for path-resolution-only use case.
+            this._core.set_flags("{}");
             const flatDast = this._core.return_dast();
             this._buildMappings(flatDast);
             this._enabled = true;
@@ -444,7 +446,8 @@ export class RustResolverAdapter {
             // If any intermediate segment resolves through a takesIndex
             // component without an index (e.g. $rep.myMath.), block member
             // completions for that path. Indexed traversal must use
-            // $rep[n].member.
+            // $rep[n].member.  Separately validate that non-takesIndex segments
+            // do not have indices (false positives worse than false negatives).
             if (resolution.nodesInResolvedPath.length > 1) {
                 // Rust includes the origin in nodesInResolvedPath, but when
                 // the origin is also the first resolved segment it may not be
@@ -455,6 +458,7 @@ export class RustResolverAdapter {
                     resolution.nodesInResolvedPath.slice(-lookupParts.length);
                 const intermediatePathNodeIndices =
                     alignedPathNodeIndices.slice(0, -1);
+                // Check each intermediate segment for proper index usage
                 for (
                     let pathPartIndex = 0;
                     pathPartIndex < intermediatePathNodeIndices.length;
@@ -667,8 +671,9 @@ export class RustResolverAdapter {
 
     /**
      * Pick a deterministic mapped index for root-level resolution.
-     * Prefer top-level elements from the parsed DAST root; fall back to any
-     * mapped element if top-level mappings are unavailable.
+     * Prefer top-level elements from the parsed DAST root (using the smallest
+     * Rust ID for determinism); fall back to any mapped element if top-level
+     * mappings are unavailable.
      */
     _getRootOriginIndex(): number | null {
         const topLevelIndices: number[] = [];
@@ -680,6 +685,7 @@ export class RustResolverAdapter {
             }
         }
         if (topLevelIndices.length > 0) {
+            // Use smallest index for deterministic root-level resolution
             return Math.min(...topLevelIndices);
         }
 

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -91,9 +91,17 @@ export class RustResolverAdapter {
             return;
         }
         // The Rust core panics on empty source (index-out-of-bounds on a
-        // zero-length collection).  Skip the sync — there is nothing to
-        // resolve when the document is empty.
+        // zero-length collection).  It also panics when the DAST contains
+        // no elements (e.g. source is just "a" — only text nodes, zero
+        // elements).  Skip the sync in both cases.
         if (!this.sourceObj.source.trim()) {
+            this.enabled = false;
+            return;
+        }
+        const hasElements = this.sourceObj.dast.children.some(
+            (c) => c.type === "element",
+        );
+        if (!hasElements) {
             this.enabled = false;
             return;
         }
@@ -142,10 +150,12 @@ export class RustResolverAdapter {
         for (const flatElm of flatDast.elements) {
             const startOffset = flatElm.position?.start?.offset;
             if (startOffset == null) continue;
+            const id = flatElm.data?.id;
+            if (id == null) continue;
             const dastElm = dastByStartOffset.get(startOffset);
             if (!dastElm) continue;
-            this.rustIndexToDastElement.set(flatElm.data.id, dastElm);
-            this.dastElementToRustIndex.set(dastElm, flatElm.data.id);
+            this.rustIndexToDastElement.set(id, dastElm);
+            this.dastElementToRustIndex.set(dastElm, id);
         }
     }
 

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -204,6 +204,8 @@ export class RustResolverAdapter {
     readonly _rustIndexToDastElement: Map<number, DastElement> = new Map();
     /** JS DAST element → Rust flat index. */
     readonly _dastElementToRustIndex: Map<DastElement, number> = new Map();
+    _sourceRevision = 0;
+    readonly _visibleDescendantNamesCache: Map<string, string[]> = new Map();
 
     constructor(
         sourceObj: DoenetSourceObject,
@@ -226,6 +228,8 @@ export class RustResolverAdapter {
      * Sync the DAST/source to the Rust core and rebuild index mappings.
      */
     private syncSource(): void {
+        this._sourceRevision += 1;
+        this._visibleDescendantNamesCache.clear();
         if (!this._core) {
             this._enabled = false;
             return;
@@ -254,6 +258,19 @@ export class RustResolverAdapter {
             console.warn("RustResolverAdapter: failed to sync source:", e);
             this._enabled = false;
         }
+    }
+
+    private getCachedVisibleDescendantNames(resolvedIdx: number) {
+        const key = `${this._sourceRevision}:${resolvedIdx}`;
+        return this._visibleDescendantNamesCache.get(key);
+    }
+
+    private setCachedVisibleDescendantNames(
+        resolvedIdx: number,
+        names: string[],
+    ) {
+        const key = `${this._sourceRevision}:${resolvedIdx}`;
+        this._visibleDescendantNamesCache.set(key, names);
     }
 
     /**
@@ -415,37 +432,47 @@ export class RustResolverAdapter {
             // from the resolved node using the Rust name_map (which
             // respects ChildrenInvisibleToTheirGrandparents etc.).
             const resolvedIdx = resolution.nodeIdx;
-            const allNames =
-                this._sourceObj.getUniqueDescendantNamesForNode(resolvedNode);
-            const visibleDescendantNames = allNames.filter((name) => {
-                try {
-                    const probe = this._core!.resolve_path(
-                        {
-                            path: [
-                                {
-                                    type: "flatPathPart" as const,
-                                    name,
-                                    index: [],
-                                },
-                            ],
-                        },
-                        resolvedIdx,
-                        true,
+            let visibleDescendantNames =
+                this.getCachedVisibleDescendantNames(resolvedIdx);
+            if (!visibleDescendantNames) {
+                const allNames =
+                    this._sourceObj.getUniqueDescendantNamesForNode(
+                        resolvedNode,
                     );
-                    // A fully-resolved path (no unresolved parts whose
-                    // first segment equals the original name) means the
-                    // name matched a visible descendant.
-                    if (
-                        probe.unresolvedPath &&
-                        probe.unresolvedPath.length > 0
-                    ) {
+                visibleDescendantNames = allNames.filter((name) => {
+                    try {
+                        const probe = this._core!.resolve_path(
+                            {
+                                path: [
+                                    {
+                                        type: "flatPathPart" as const,
+                                        name,
+                                        index: [],
+                                    },
+                                ],
+                            },
+                            resolvedIdx,
+                            true,
+                        );
+                        // A fully-resolved path (no unresolved parts whose
+                        // first segment equals the original name) means the
+                        // name matched a visible descendant.
+                        if (
+                            probe.unresolvedPath &&
+                            probe.unresolvedPath.length > 0
+                        ) {
+                            return false;
+                        }
+                        return true;
+                    } catch {
                         return false;
                     }
-                    return true;
-                } catch {
-                    return false;
-                }
-            });
+                });
+                this.setCachedVisibleDescendantNames(
+                    resolvedIdx,
+                    visibleDescendantNames,
+                );
+            }
 
             return {
                 node: resolvedNode,

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -84,7 +84,7 @@ function collectNamesFromCompositeChildren(
 
     for (const child of composite.children) {
         if (child.type !== "element") continue;
-        if (COMPOSITE_WRAPPER_NAMES.has(child.name.toLowerCase())) continue;
+        if (COMPOSITE_WRAPPER_NAMES.has(child.name)) continue;
 
         const nameAttr = child.attributes?.name;
         const nameVal =
@@ -104,7 +104,7 @@ function collectNamesFromCompositeChildren(
     for (const child of composite.children) {
         if (child.type !== "element") continue;
 
-        if (COMPOSITE_WRAPPER_NAMES.has(child.name.toLowerCase())) {
+        if (COMPOSITE_WRAPPER_NAMES.has(child.name)) {
             // Walk inside the wrapper transparently
             addUniqueNamesFromDescendants(
                 collectAllNamedDescendants(child),
@@ -139,8 +139,7 @@ function collectNamesFromCompositeChildren(
  * repeat or repeatForSequence element. Returns an empty array for other elements.
  */
 function getDerivedRepeatNamesFromElement(el: DastElement): string[] {
-    const elementName = el.name.toLowerCase();
-    if (elementName !== "repeat" && elementName !== "repeatforsequence") {
+    if (el.name !== "repeat" && el.name !== "repeatForSequence") {
         return [];
     }
     const names: string[] = [];
@@ -252,11 +251,7 @@ export class RustResolverAdapter {
     ) {
         this._sourceObj = sourceObj;
         this._takesIndexComponentTypes = options?.takesIndexComponentTypes
-            ? new Set(
-                  [...options.takesIndexComponentTypes].map((name) =>
-                      name.toLowerCase(),
-                  ),
-              )
+            ? new Set(options.takesIndexComponentTypes)
             : null;
         if (options?.core) {
             this._core = options.core;
@@ -265,10 +260,7 @@ export class RustResolverAdapter {
     }
 
     _componentTakesIndex(componentType: string): boolean {
-        return (
-            this._takesIndexComponentTypes?.has(componentType.toLowerCase()) ??
-            false
-        );
+        return this._takesIndexComponentTypes?.has(componentType) ?? false;
     }
 
     /**
@@ -537,7 +529,7 @@ export class RustResolverAdapter {
             // visible descendants by walking through wrapper children
             // (case/else/option) transparently.
             if (
-                resolvedNode.name.toLowerCase() === "conditionalcontent" ||
+                resolvedNode.name === "conditionalContent" ||
                 (resolvedPartHasIndex &&
                     this._componentTakesIndex(resolvedNode.name))
             ) {
@@ -812,8 +804,8 @@ export class RustResolverAdapter {
         while (parent && parent.type !== "root") {
             if (
                 parent.type === "element" &&
-                (parent.name.toLowerCase() === "conditionalcontent" ||
-                    parent.name.toLowerCase() === "select")
+                (parent.name === "conditionalContent" ||
+                    parent.name === "select")
             ) {
                 const start = parent.position?.start?.offset;
                 const end = parent.position?.end?.offset;
@@ -835,9 +827,7 @@ export class RustResolverAdapter {
                             resolvedParent &&
                             resolvedParent.type === "element" &&
                             resolvedParent === parent &&
-                            COMPOSITE_WRAPPER_NAMES.has(
-                                resolvedElement.name.toLowerCase(),
-                            )
+                            COMPOSITE_WRAPPER_NAMES.has(resolvedElement.name)
                         )
                     ) {
                         return true;

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -84,7 +84,7 @@ function collectNamesFromCompositeChildren(
 
     for (const child of composite.children) {
         if (child.type !== "element") continue;
-        if (COMPOSITE_WRAPPER_NAMES.has(child.name)) continue;
+        if (COMPOSITE_WRAPPER_NAMES.has(child.name.toLowerCase())) continue;
 
         const nameAttr = child.attributes?.name;
         const nameVal =
@@ -104,7 +104,7 @@ function collectNamesFromCompositeChildren(
     for (const child of composite.children) {
         if (child.type !== "element") continue;
 
-        if (COMPOSITE_WRAPPER_NAMES.has(child.name)) {
+        if (COMPOSITE_WRAPPER_NAMES.has(child.name.toLowerCase())) {
             // Walk inside the wrapper transparently
             addUniqueNamesFromDescendants(
                 collectAllNamedDescendants(child),
@@ -139,7 +139,10 @@ function collectNamesFromCompositeChildren(
  * repeat or repeatForSequence element. Returns an empty array for other elements.
  */
 function getDerivedRepeatNamesFromElement(el: DastElement): string[] {
-    if (el.name !== "repeat" && el.name !== "repeatForSequence") return [];
+    const elementName = el.name.toLowerCase();
+    if (elementName !== "repeat" && elementName !== "repeatforsequence") {
+        return [];
+    }
     const names: string[] = [];
     for (const attrName of ["valueName", "indexName"]) {
         const attr = el.attributes[attrName];
@@ -235,8 +238,13 @@ export class RustResolverAdapter {
         options?: RustResolverAdapterOptions,
     ) {
         this._sourceObj = sourceObj;
-        this._takesIndexComponentTypes =
-            options?.takesIndexComponentTypes ?? null;
+        this._takesIndexComponentTypes = options?.takesIndexComponentTypes
+            ? new Set(
+                  [...options.takesIndexComponentTypes].map((name) =>
+                      name.toLowerCase(),
+                  ),
+              )
+            : null;
         if (options?.core) {
             this._core = options.core;
             this._syncSource();
@@ -244,7 +252,10 @@ export class RustResolverAdapter {
     }
 
     _componentTakesIndex(componentType: string): boolean {
-        return this._takesIndexComponentTypes?.has(componentType) ?? false;
+        return (
+            this._takesIndexComponentTypes?.has(componentType.toLowerCase()) ??
+            false
+        );
     }
 
     /**
@@ -504,7 +515,7 @@ export class RustResolverAdapter {
             // visible descendants by walking through wrapper children
             // (case/else/option) transparently.
             if (
-                resolvedNode.name === "conditionalContent" ||
+                resolvedNode.name.toLowerCase() === "conditionalcontent" ||
                 (resolvedPartHasIndex &&
                     this._componentTakesIndex(resolvedNode.name))
             ) {
@@ -721,8 +732,8 @@ export class RustResolverAdapter {
         while (parent && parent.type !== "root") {
             if (
                 parent.type === "element" &&
-                (parent.name === "conditionalContent" ||
-                    parent.name === "select")
+                (parent.name.toLowerCase() === "conditionalcontent" ||
+                    parent.name.toLowerCase() === "select")
             ) {
                 const start = parent.position?.start?.offset;
                 const end = parent.position?.end?.offset;
@@ -744,7 +755,9 @@ export class RustResolverAdapter {
                             resolvedParent &&
                             resolvedParent.type === "element" &&
                             resolvedParent === parent &&
-                            COMPOSITE_WRAPPER_NAMES.has(resolvedElement.name)
+                            COMPOSITE_WRAPPER_NAMES.has(
+                                resolvedElement.name.toLowerCase(),
+                            )
                         )
                     ) {
                         return true;

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -293,6 +293,14 @@ export class RustResolverAdapter {
 
     /**
      * Resolve a ref-member container for AutoCompleter member completion.
+     *
+     * @param offset — The character offset in the source for scope resolution.
+     * @param pathParts — The path segments (e.g. ["rep", "myMath", ""] for `$rep.myMath.`).
+     * @param hasIndex — When true, indicates a bracket index was present in the path
+     *                     (e.g. `$sel[1].`), enabling descendant access for takesIndex
+     *                     elements. If false or undefined, takesIndex elements hide their
+     *                     descendants unless accessed via index notation.
+     * @returns The resolved node and visible descendant names, or null if resolution fails.
      */
     resolveRefMemberContainerAtOffset(
         offset: number,

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -216,18 +216,18 @@ export class RustResolverAdapter {
             options?.takesIndexComponentTypes ?? null;
         if (options?.core) {
             this._core = options.core;
-            this.syncSource();
+            this._syncSource();
         }
     }
 
-    private componentTakesIndex(componentType: string): boolean {
+    _componentTakesIndex(componentType: string): boolean {
         return this._takesIndexComponentTypes?.has(componentType) ?? false;
     }
 
     /**
      * Sync the DAST/source to the Rust core and rebuild index mappings.
      */
-    private syncSource(): void {
+    _syncSource(): void {
         this._sourceRevision += 1;
         this._visibleDescendantNamesCache.clear();
         if (!this._core) {
@@ -252,7 +252,7 @@ export class RustResolverAdapter {
         try {
             this._core.set_source(this._sourceObj.dast, this._sourceObj.source);
             const flatDast = this._core.return_dast();
-            this.buildMappings(flatDast);
+            this._buildMappings(flatDast);
             this._enabled = true;
         } catch (e) {
             console.warn("RustResolverAdapter: failed to sync source:", e);
@@ -260,15 +260,12 @@ export class RustResolverAdapter {
         }
     }
 
-    private getCachedVisibleDescendantNames(resolvedIdx: number) {
+    _getCachedVisibleDescendantNames(resolvedIdx: number) {
         const key = `${this._sourceRevision}:${resolvedIdx}`;
         return this._visibleDescendantNamesCache.get(key);
     }
 
-    private setCachedVisibleDescendantNames(
-        resolvedIdx: number,
-        names: string[],
-    ) {
+    _setCachedVisibleDescendantNames(resolvedIdx: number, names: string[]) {
         const key = `${this._sourceRevision}:${resolvedIdx}`;
         this._visibleDescendantNamesCache.set(key, names);
     }
@@ -277,7 +274,7 @@ export class RustResolverAdapter {
      * Build bidirectional mappings between Rust flat indices and JS DAST
      * elements by matching on source position (start offset).
      */
-    private buildMappings(flatDast: {
+    _buildMappings(flatDast: {
         elements: Array<{
             data: { id: number };
             position?: { start: { offset?: number } };
@@ -321,22 +318,19 @@ export class RustResolverAdapter {
      *
      * @param offset — The character offset in the source for scope resolution.
      * @param pathParts — The path segments (e.g. ["rep", "myMath", ""] for `$rep.myMath.`).
-     * @param hasIndex — When true, indicates a bracket index was present in the path
-     *                     (e.g. `$sel[1].`), enabling descendant access for takesIndex
-     *                     elements. If false or undefined, takesIndex elements hide their
-     *                     descendants unless accessed via index notation.
+     * @param pathPartHasIndex — Per-path-part index flags aligned with `pathParts`.
      * @returns The resolved node and visible descendant names, or null if resolution fails.
      */
     resolveRefMemberContainerAtOffset(
         offset: number,
         pathParts: string[],
-        hasIndex?: boolean,
+        pathPartHasIndex?: boolean[],
     ): RefMemberContainerResolution | null {
         return this._resolveRefMemberContainer({
             offset,
             pathParts,
+            pathPartHasIndex,
             nodeIndex: this._sourceObj.getNodeIndexAtOffset(offset),
-            hasIndex,
         });
     }
 
@@ -354,7 +348,7 @@ export class RustResolverAdapter {
     ): RefMemberContainerResolution | null {
         if (!this._enabled || !this._core) return null;
 
-        const { offset, pathParts, hasIndex } = args;
+        const { offset, pathParts, pathPartHasIndex } = args;
         if (pathParts.length === 0) return null;
 
         // Resolve up to but not including the last part (being edited).
@@ -362,8 +356,11 @@ export class RustResolverAdapter {
         if (lookupParts.length === 0) return null;
 
         // Determine origin: the Rust index of the enclosing element.
-        const originIndex = this.getOriginIndex(offset);
+        const originIndex = this._getOriginIndex(offset);
         if (originIndex == null) return null;
+
+        const effectivePathPartHasIndex =
+            pathPartHasIndex ?? lookupParts.map(() => false);
 
         const flatPath: FlatPathPartForResolver[] = lookupParts.map((name) => ({
             type: "flatPathPart" as const,
@@ -400,30 +397,44 @@ export class RustResolverAdapter {
             // component without an index (e.g. $rep.myMath.), block member
             // completions for that path. Indexed traversal must use
             // $rep[n].member.
-            if (!hasIndex && resolution.nodesInResolvedPath.length > 1) {
+            if (resolution.nodesInResolvedPath.length > 1) {
                 const intermediatePathNodeIndices =
                     resolution.nodesInResolvedPath.slice(0, -1);
-                const blockedPathPartIndex =
-                    intermediatePathNodeIndices.findIndex((nodeIdx) => {
-                        const pathNode =
-                            this._rustIndexToDastElement.get(nodeIdx);
-                        return !!(
-                            pathNode && this.componentTakesIndex(pathNode.name)
-                        );
-                    });
-                if (blockedPathPartIndex >= 0) {
-                    return {
-                        node: null,
-                        unresolvedPathParts:
-                            lookupParts.slice(blockedPathPartIndex),
-                    };
+                for (
+                    let pathPartIndex = 0;
+                    pathPartIndex < intermediatePathNodeIndices.length;
+                    pathPartIndex++
+                ) {
+                    const pathNode = this._rustIndexToDastElement.get(
+                        intermediatePathNodeIndices[pathPartIndex],
+                    );
+                    const segmentHasIndex =
+                        effectivePathPartHasIndex[pathPartIndex] ?? false;
+                    if (
+                        pathNode &&
+                        this._componentTakesIndex(pathNode.name) &&
+                        !segmentHasIndex
+                    ) {
+                        return {
+                            node: null,
+                            unresolvedPathParts:
+                                lookupParts.slice(pathPartIndex),
+                        };
+                    }
                 }
             }
+
+            const resolvedPathPartIndex = lookupParts.length - 1;
+            const resolvedPartHasIndex =
+                effectivePathPartHasIndex[resolvedPathPartIndex] ?? false;
 
             // When the resolved element takes an index, descendants
             // are only accessible via $name[n].member — suppress them
             // unless the user has already provided a bracket index.
-            if (this.componentTakesIndex(resolvedNode.name) && !hasIndex) {
+            if (
+                this._componentTakesIndex(resolvedNode.name) &&
+                !resolvedPartHasIndex
+            ) {
                 return {
                     node: resolvedNode,
                     unresolvedPathParts: [],
@@ -437,7 +448,8 @@ export class RustResolverAdapter {
             // (case/else/option) transparently.
             if (
                 resolvedNode.name === "conditionalContent" ||
-                (hasIndex && this.componentTakesIndex(resolvedNode.name))
+                (resolvedPartHasIndex &&
+                    this._componentTakesIndex(resolvedNode.name))
             ) {
                 const names = collectNamesFromCompositeChildren(resolvedNode);
                 // For repeat/repeatForSequence, also expose
@@ -457,7 +469,7 @@ export class RustResolverAdapter {
             // respects ChildrenInvisibleToTheirGrandparents etc.).
             const resolvedIdx = resolution.nodeIdx;
             let visibleDescendantNames =
-                this.getCachedVisibleDescendantNames(resolvedIdx);
+                this._getCachedVisibleDescendantNames(resolvedIdx);
             if (!visibleDescendantNames) {
                 const allNames =
                     this._sourceObj.getUniqueDescendantNamesForNode(
@@ -492,7 +504,7 @@ export class RustResolverAdapter {
                         return false;
                     }
                 });
-                this.setCachedVisibleDescendantNames(
+                this._setCachedVisibleDescendantNames(
                     resolvedIdx,
                     visibleDescendantNames,
                 );
@@ -514,13 +526,13 @@ export class RustResolverAdapter {
      * Uses the nearest enclosing element of the given offset, falling
      * back to a mapped top-level element when the cursor is at root level.
      */
-    private getOriginIndex(offset: number): number | null {
+    _getOriginIndex(offset: number): number | null {
         const containingElement = this._sourceObj.elementAtOffset(offset);
         if (containingElement) {
             const idx = this._dastElementToRustIndex.get(containingElement);
             if (idx != null) return idx;
         }
-        return this.getRootOriginIndex();
+        return this._getRootOriginIndex();
     }
 
     /**
@@ -528,7 +540,7 @@ export class RustResolverAdapter {
      * Prefer top-level elements from the parsed DAST root; fall back to any
      * mapped element if top-level mappings are unavailable.
      */
-    private getRootOriginIndex(): number | null {
+    _getRootOriginIndex(): number | null {
         const topLevelIndices: number[] = [];
         for (const child of this._sourceObj.dast.children) {
             if (child.type !== "element") continue;
@@ -595,7 +607,7 @@ export class RustResolverAdapter {
             // document root).  resolve_path from it with skip_parent_search=
             // false searches root scope, which is what a reference at root
             // level would see.
-            resolveFromIndex = this.getRootOriginIndex();
+            resolveFromIndex = this._getRootOriginIndex();
         }
 
         if (resolveFromIndex == null) return false;
@@ -620,7 +632,7 @@ export class RustResolverAdapter {
             // conditionalContent and select children are direct children,
             // but at runtime sugar wraps them in <case>/<option>, making
             // deeper descendants invisible from outside the composite.
-            if (this.isHiddenBySugar(resolution.nodeIdx, offset)) {
+            if (this._isHiddenBySugar(resolution.nodeIdx, offset)) {
                 return false;
             }
 
@@ -643,7 +655,7 @@ export class RustResolverAdapter {
      *
      * The same pattern applies to `<select>` / `<option>` via `selectSugar`.
      */
-    private isHiddenBySugar(rustIdx: number, cursorOffset: number): boolean {
+    _isHiddenBySugar(rustIdx: number, cursorOffset: number): boolean {
         const resolvedElement = this._rustIndexToDastElement.get(rustIdx);
         if (!resolvedElement) return false;
 
@@ -715,6 +727,6 @@ export class RustResolverAdapter {
      */
     updateSource(sourceObj: DoenetSourceObject): void {
         this._sourceObj = sourceObj;
-        this.syncSource();
+        this._syncSource();
     }
 }

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -398,8 +398,15 @@ export class RustResolverAdapter {
             // completions for that path. Indexed traversal must use
             // $rep[n].member.
             if (resolution.nodesInResolvedPath.length > 1) {
+                // Rust includes the origin in nodesInResolvedPath, but when
+                // the origin is also the first resolved segment it may not be
+                // duplicated. Align to lookupParts by taking the trailing
+                // nodes that correspond to the resolved path segments, then
+                // exclude the final resolved node to inspect only intermediates.
+                const alignedPathNodeIndices =
+                    resolution.nodesInResolvedPath.slice(-lookupParts.length);
                 const intermediatePathNodeIndices =
-                    resolution.nodesInResolvedPath.slice(0, -1);
+                    alignedPathNodeIndices.slice(0, -1);
                 for (
                     let pathPartIndex = 0;
                     pathPartIndex < intermediatePathNodeIndices.length;

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -73,12 +73,33 @@ function addUniqueNamesFromDescendants(
  * — but another wrapper where it is unique still contributes it.
  *
  * Direct children of the composite that are NOT wrapper elements are also
- * walked (sugared cc without explicit case/else).
+ * walked (sugared cc without explicit case/else). Their own names are
+ * included only when unique across direct sibling children.
  */
 function collectNamesFromCompositeChildren(
     composite: DastElement,
 ): Set<string> {
     const result = new Set<string>();
+    const directChildNameCounts = new Map<string, number>();
+
+    for (const child of composite.children) {
+        if (child.type !== "element") continue;
+        if (COMPOSITE_WRAPPER_NAMES.has(child.name)) continue;
+
+        const nameAttr = child.attributes?.name;
+        const nameVal =
+            nameAttr &&
+            nameAttr.children?.length === 1 &&
+            nameAttr.children[0].type === "text"
+                ? nameAttr.children[0].value
+                : undefined;
+        if (nameVal) {
+            directChildNameCounts.set(
+                nameVal,
+                (directChildNameCounts.get(nameVal) ?? 0) + 1,
+            );
+        }
+    }
 
     for (const child of composite.children) {
         if (child.type !== "element") continue;
@@ -90,16 +111,18 @@ function collectNamesFromCompositeChildren(
                 result,
             );
         } else {
-            // Direct child of composite (not a wrapper) — collect its names
-            // plus the child itself if named.
+            // Direct child of composite (not a wrapper): include its own name
+            // only when unique among direct siblings, and always collect
+            // unique descendant names from within the child subtree.
             const nameAttr = child.attributes?.name;
-            if (nameAttr) {
-                const nameVal =
-                    nameAttr.children?.length === 1 &&
-                    nameAttr.children[0].type === "text"
-                        ? nameAttr.children[0].value
-                        : undefined;
-                if (nameVal) result.add(nameVal);
+            const nameVal =
+                nameAttr &&
+                nameAttr.children?.length === 1 &&
+                nameAttr.children[0].type === "text"
+                    ? nameAttr.children[0].value
+                    : undefined;
+            if (nameVal && directChildNameCounts.get(nameVal) === 1) {
+                result.add(nameVal);
             }
             addUniqueNamesFromDescendants(
                 collectAllNamedDescendants(child),

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -157,6 +157,19 @@ function getDerivedRepeatNamesFromElement(el: DastElement): string[] {
     return names;
 }
 
+/** Return the literal `name` attribute value for an element, if present. */
+function getElementNameAttributeValue(el: DastElement): string | null {
+    const nameAttr = el.attributes?.name;
+    if (
+        nameAttr &&
+        nameAttr.children?.length === 1 &&
+        nameAttr.children[0].type === "text"
+    ) {
+        return nameAttr.children[0].value;
+    }
+    return null;
+}
+
 /**
  * Minimal interface matching the subset of PublicDoenetMLCore methods needed
  * for path resolution. Consumers provide an initialized WASM-backed instance;
@@ -382,7 +395,16 @@ export class RustResolverAdapter {
     ): RefMemberContainerResolution | null {
         if (!this._enabled || !this._core) return null;
 
-        const { offset, pathParts, pathPartHasIndex } = args;
+        const {
+            offset,
+            pathParts: rawPathParts,
+            pathPartHasIndex: rawPathPartHasIndex,
+        } = args;
+        const { pathParts, pathPartHasIndex } = this._normalizePathParts(
+            offset,
+            rawPathParts,
+            rawPathPartHasIndex,
+        );
         if (pathParts.length === 0) return null;
 
         // Resolve up to but not including the last part (being edited).
@@ -567,6 +589,15 @@ export class RustResolverAdapter {
                         ) {
                             return false;
                         }
+                        const probeElement = this._rustIndexToDastElement.get(
+                            probe.nodeIdx,
+                        );
+                        const probeName = probeElement
+                            ? getElementNameAttributeValue(probeElement)
+                            : null;
+                        if (probeName !== name) {
+                            return false;
+                        }
                         return true;
                     } catch {
                         return false;
@@ -601,6 +632,45 @@ export class RustResolverAdapter {
             if (idx != null) return idx;
         }
         return this._getRootOriginIndex();
+    }
+
+    /**
+     * Normalize parsed ref path metadata before resolver lookup.
+     *
+     * Some parser/fallback paths can drop the final empty segment when the
+     * cursor is immediately after a trailing dot (e.g. `$a.b.|` represented as
+     * `pathParts = ["a", "b"]` instead of `["a", "b", ""]`). For member
+     * completion, that final empty segment is semantically important because
+     * resolution should treat `b` as the container being completed, not as the
+     * currently edited token to skip.
+     *
+     * When the source confirms a trailing dot and the empty segment is missing,
+     * append it and keep `pathPartHasIndex` aligned by appending `false`.
+     */
+    _normalizePathParts(
+        offset: number,
+        pathParts: string[],
+        pathPartHasIndex?: boolean[],
+    ): { pathParts: string[]; pathPartHasIndex?: boolean[] } {
+        if (pathParts.length === 0) {
+            return { pathParts, pathPartHasIndex };
+        }
+
+        const charBeforeCursor =
+            offset > 0 ? this._sourceObj.source.charAt(offset - 1) : "";
+        const endsWithTypedMemberDot = charBeforeCursor === ".";
+        const alreadyHasTrailingEmpty = pathParts[pathParts.length - 1] === "";
+
+        if (!endsWithTypedMemberDot || alreadyHasTrailingEmpty) {
+            return { pathParts, pathPartHasIndex };
+        }
+
+        return {
+            pathParts: [...pathParts, ""],
+            pathPartHasIndex: pathPartHasIndex
+                ? [...pathPartHasIndex, false]
+                : pathPartHasIndex,
+        };
     }
 
     /**
@@ -694,6 +764,16 @@ export class RustResolverAdapter {
                 resolveFromIndex,
                 false,
             );
+
+            const resolvedElement = this._rustIndexToDastElement.get(
+                resolution.nodeIdx,
+            );
+            const resolvedName = resolvedElement
+                ? getElementNameAttributeValue(resolvedElement)
+                : null;
+            if (resolvedName !== name) {
+                return false;
+            }
 
             // Post-filter: check whether the resolved element is hidden
             // by sugar at runtime.  In raw DAST (no sugar),

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -21,7 +21,7 @@ function collectAllNamedDescendants(
     root: DastElement,
 ): Array<{ name: string; element: DastElement }> {
     const result: Array<{ name: string; element: DastElement }> = [];
-    const walk = (node: DastNodes) => {
+    function walk(node: DastNodes) {
         if (node.type === "element") {
             const nameAttr = node.attributes?.name;
             if (nameAttr) {
@@ -39,7 +39,7 @@ function collectAllNamedDescendants(
                 walk(child as DastNodes);
             }
         }
-    };
+    }
     for (const child of root.children) {
         walk(child as DastNodes);
     }
@@ -104,10 +104,10 @@ function collectNamesFromCompositeChildren(
 }
 
 /**
- * Extract `valueName`/`indexName` attribute values from a repeat or
- * repeatForSequence element.  Returns an empty array for other elements.
+ * Extract derived repeat names from `valueName`/`indexName` attributes on a
+ * repeat or repeatForSequence element. Returns an empty array for other elements.
  */
-function getSyntheticNamesFromElement(el: DastElement): string[] {
+function getDerivedRepeatNamesFromElement(el: DastElement): string[] {
     if (el.name !== "repeat" && el.name !== "repeatForSequence") return [];
     const names: string[] = [];
     for (const attrName of ["valueName", "indexName"]) {
@@ -169,11 +169,12 @@ export interface RustResolverAdapterOptions {
     /** An initialized PublicDoenetMLCore (or compatible) instance. */
     core?: RustResolverCore;
     /**
-     * Optional callback to check whether a component type takes an index.
-     * When provided, the resolver suppresses descendant names for elements
-     * whose type returns `true`, forcing member access through `$name[n].`.
+     * Optional set of component types that take an index. When provided, the
+     * resolver suppresses descendant names for those elements unless the user
+     * has already provided a bracket index, forcing member access through
+     * `$name[n].`.
      */
-    takesIndex?: (componentType: string) => boolean;
+    takesIndexComponentTypes?: ReadonlySet<string>;
 }
 
 /**
@@ -189,7 +190,7 @@ export class RustResolverAdapter {
     private core: RustResolverCore | null = null;
     private sourceObj: DoenetSourceObject;
     private enabled = false;
-    private takesIndexFn: ((componentType: string) => boolean) | null = null;
+    private takesIndexComponentTypes: ReadonlySet<string> | null = null;
 
     /** Rust flat index → JS DAST element (matched by source position). */
     private rustIndexToDastElement: Map<number, DastElement> = new Map();
@@ -201,11 +202,16 @@ export class RustResolverAdapter {
         options?: RustResolverAdapterOptions,
     ) {
         this.sourceObj = sourceObj;
-        this.takesIndexFn = options?.takesIndex ?? null;
+        this.takesIndexComponentTypes =
+            options?.takesIndexComponentTypes ?? null;
         if (options?.core) {
             this.core = options.core;
             this.syncSource();
         }
+    }
+
+    private componentTakesIndex(componentType: string): boolean {
+        return this.takesIndexComponentTypes?.has(componentType) ?? false;
     }
 
     /**
@@ -356,11 +362,7 @@ export class RustResolverAdapter {
                 // When the resolved element takes an index, descendants
                 // are only accessible via $name[n].member — suppress them
                 // unless the user has already provided a bracket index.
-                if (
-                    this.takesIndexFn &&
-                    this.takesIndexFn(resolvedNode.name) &&
-                    !hasIndex
-                ) {
+                if (this.componentTakesIndex(resolvedNode.name) && !hasIndex) {
                     return {
                         node: resolvedNode,
                         unresolvedPathParts: [],
@@ -374,21 +376,22 @@ export class RustResolverAdapter {
                 // (case/else/option) transparently.
                 if (
                     resolvedNode.name === "conditionalContent" ||
-                    (hasIndex &&
-                        this.takesIndexFn &&
-                        this.takesIndexFn(resolvedNode.name))
+                    (hasIndex && this.componentTakesIndex(resolvedNode.name))
                 ) {
                     const names =
                         collectNamesFromCompositeChildren(resolvedNode);
                     // For repeat/repeatForSequence, also expose
                     // valueName/indexName as member completions when
                     // accessed with an index (e.g. $rep[1].v).
-                    const syntheticNames =
-                        getSyntheticNamesFromElement(resolvedNode);
+                    const derivedRepeatNames =
+                        getDerivedRepeatNamesFromElement(resolvedNode);
                     return {
                         node: resolvedNode,
                         unresolvedPathParts: [],
-                        visibleDescendantNames: [...names, ...syntheticNames],
+                        visibleDescendantNames: [
+                            ...names,
+                            ...derivedRepeatNames,
+                        ],
                     };
                 }
 
@@ -489,10 +492,10 @@ export class RustResolverAdapter {
     isNameAddressableFromOffset(offset: number, name: string): boolean {
         if (!this.enabled || !this.core) return false;
 
-        // Synthetic names from repeat valueName/indexName are always
-        // addressable from inside the repeat — they bypass resolve_path.
-        const syntheticNames = this.getRepeatSyntheticNames(offset);
-        if (syntheticNames.includes(name)) return true;
+        // Derived repeat names from valueName/indexName are always
+        // addressable from inside the repeat and bypass resolve_path.
+        const derivedRepeatNames = this.getDerivedRepeatNames(offset);
+        if (derivedRepeatNames.includes(name)) return true;
 
         // A $name reference typed at `offset` will become a child of the
         // element whose body contains the cursor.  resolve_path with
@@ -626,17 +629,17 @@ export class RustResolverAdapter {
     }
 
     /**
-     * Return synthetic names from `valueName`/`indexName` attributes of
-     * enclosing `<repeat>` elements at the given offset.  These names
-     * don't exist in the raw DAST but are created by repeat sugar at
-     * runtime, so they must be injected into the completion pipeline.
+     * Return derived repeat names from `valueName`/`indexName` attributes of
+     * enclosing `<repeat>` elements at the given offset. These names don't
+     * exist in the raw DAST but are introduced by repeat sugar at runtime, so
+     * they must be injected into the completion pipeline.
      */
-    getRepeatSyntheticNames(offset: number): string[] {
+    getDerivedRepeatNames(offset: number): string[] {
         const names: string[] = [];
         let current: DastElement | undefined =
             this.sourceObj.elementAtOffset(offset) ?? undefined;
         while (current) {
-            names.push(...getSyntheticNamesFromElement(current));
+            names.push(...getDerivedRepeatNamesFromElement(current));
             const p = this.sourceObj.getParent(current);
             current =
                 p && p.type === "element" ? (p as DastElement) : undefined;

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -13,6 +13,12 @@ import type {
 export interface RustResolverCore {
     set_source(dast: unknown, source: string): void;
     /**
+     * Set runtime flags (as a JSON string). Must be called at least once
+     * before `return_dast()`.  An empty object `"{}"` is sufficient for
+     * pure path-resolution use-cases.
+     */
+    set_flags(flags: string): void;
+    /**
      * Triggers Rust core initialization and returns the flat DAST.
      * The adapter uses the returned elements to build position-based index mappings.
      */
@@ -81,6 +87,13 @@ export class RustResolverAdapter {
      */
     private syncSource(): void {
         if (!this.core) {
+            this.enabled = false;
+            return;
+        }
+        // The Rust core panics on empty source (index-out-of-bounds on a
+        // zero-length collection).  Skip the sync — there is nothing to
+        // resolve when the document is empty.
+        if (!this.sourceObj.source.trim()) {
             this.enabled = false;
             return;
         }
@@ -179,9 +192,52 @@ export class RustResolverAdapter {
                     resolution.unresolvedPath ?? []
                 ).map((p) => p.name);
 
+                if (unresolvedPathParts.length > 0) {
+                    return { node: null, unresolvedPathParts };
+                }
+
+                // Determine which descendant names are actually visible
+                // from the resolved node using the Rust name_map (which
+                // respects ChildrenInvisibleToTheirGrandparents etc.).
+                const resolvedIdx = resolution.nodeIdx;
+                const allNames =
+                    this.sourceObj.getUniqueDescendantNamesForNode(
+                        resolvedNode,
+                    );
+                const visibleDescendantNames = allNames.filter((name) => {
+                    try {
+                        const probe = this.core!.resolve_path(
+                            {
+                                path: [
+                                    {
+                                        type: "flatPathPart" as const,
+                                        name,
+                                        index: [],
+                                    },
+                                ],
+                            },
+                            resolvedIdx,
+                            true,
+                        );
+                        // A fully-resolved path (no unresolved parts whose
+                        // first segment equals the original name) means the
+                        // name matched a visible descendant.
+                        if (
+                            probe.unresolvedPath &&
+                            probe.unresolvedPath.length > 0
+                        ) {
+                            return false;
+                        }
+                        return true;
+                    } catch {
+                        return false;
+                    }
+                });
+
                 return {
-                    node: unresolvedPathParts.length > 0 ? null : resolvedNode,
-                    unresolvedPathParts,
+                    node: resolvedNode,
+                    unresolvedPathParts: [],
+                    visibleDescendantNames,
                 };
             } catch {
                 // Resolution error (NoReferent, NonUniqueReferent, etc.)
@@ -193,7 +249,7 @@ export class RustResolverAdapter {
     /**
      * Get the Rust flat index to use as the origin for resolve_path.
      * Uses the nearest enclosing element of the given offset, falling
-     * back to 0 when the cursor is at root level.
+     * back to a mapped top-level element when the cursor is at root level.
      */
     private getOriginIndex(offset: number): number | null {
         const containingElement = this.sourceObj.elementAtOffset(offset);
@@ -201,11 +257,97 @@ export class RustResolverAdapter {
             const idx = this.dastElementToRustIndex.get(containingElement);
             if (idx != null) return idx;
         }
-        // Root level — use first element if available.
-        if (this.rustIndexToDastElement.size > 0) {
-            return 0;
+        return this.getRootOriginIndex();
+    }
+
+    /**
+     * Pick a deterministic mapped index for root-level resolution.
+     * Prefer top-level elements from the parsed DAST root; fall back to any
+     * mapped element if top-level mappings are unavailable.
+     */
+    private getRootOriginIndex(): number | null {
+        const topLevelIndices: number[] = [];
+        for (const child of this.sourceObj.dast.children) {
+            if (child.type !== "element") continue;
+            const idx = this.dastElementToRustIndex.get(child);
+            if (idx != null) {
+                topLevelIndices.push(idx);
+            }
+        }
+        if (topLevelIndices.length > 0) {
+            return Math.min(...topLevelIndices);
+        }
+
+        const mappedIndices = [...this.rustIndexToDastElement.keys()];
+        if (mappedIndices.length > 0) {
+            return Math.min(...mappedIndices);
         }
         return null;
+    }
+
+    /**
+     * Test whether `name` can be resolved from the cursor position at
+     * `offset` using the Rust resolver (with full parent search).
+     * This respects `ChildrenInvisibleToTheirGrandparents` etc.
+     */
+    isNameAddressableFromOffset(offset: number, name: string): boolean {
+        if (!this.enabled || !this.core) return true; // fallback: allow
+
+        // A $name reference typed at `offset` will become a child of the
+        // element whose body contains the cursor.  resolve_path with
+        // skip_parent_search=false searches from the origin's PARENT scope
+        // upward, so to correctly probe the containing element's scope we
+        // must resolve from one of its existing children rather than the
+        // container itself.
+        const containingElement = this.sourceObj.elementAtOffset(offset);
+        let resolveFromIndex: number | null = null;
+
+        if (containingElement) {
+            // Find the first child element that has a Rust index.
+            for (const child of containingElement.children) {
+                if (child.type === "element") {
+                    const ci = this.dastElementToRustIndex.get(child);
+                    if (ci != null) {
+                        resolveFromIndex = ci;
+                        break;
+                    }
+                }
+            }
+            // If the container has no mapped child elements, fall back to the
+            // container itself.  There are no named children to be hidden, so
+            // the parent-scope walk is still correct.
+            if (resolveFromIndex == null) {
+                resolveFromIndex =
+                    this.dastElementToRustIndex.get(containingElement) ?? null;
+            }
+        } else {
+            // Root level — use the first top-level element (a child of the
+            // document root).  resolve_path from it with skip_parent_search=
+            // false searches root scope, which is what a reference at root
+            // level would see.
+            resolveFromIndex = this.getRootOriginIndex();
+        }
+
+        if (resolveFromIndex == null) return true;
+
+        try {
+            this.core.resolve_path(
+                {
+                    path: [
+                        {
+                            type: "flatPathPart" as const,
+                            name,
+                            index: [],
+                        },
+                    ],
+                },
+                resolveFromIndex,
+                false,
+            );
+            return true;
+        } catch {
+            return false;
+        }
     }
 
     isEnabled(): boolean {

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -6,6 +6,123 @@ import type {
 } from "./index";
 
 /**
+ * Wrapper elements whose children should be treated as direct children of
+ * the composite for autocomplete purposes.  At runtime, sugar inserts these
+ * wrappers and then strips them during replacement expansion.
+ */
+const COMPOSITE_WRAPPER_NAMES = new Set(["case", "else", "option"]);
+
+/**
+ * Walk all descendants of `root`, returning an array of `{ name, element }`
+ * for every element with a `name` attribute.
+ */
+function collectAllNamedDescendants(
+    root: DastElement,
+): Array<{ name: string; element: DastElement }> {
+    const result: Array<{ name: string; element: DastElement }> = [];
+    const walk = (node: DastNodes) => {
+        if (node.type === "element") {
+            const nameAttr = node.attributes?.name;
+            if (nameAttr) {
+                // name attribute value is stored in children[0].value
+                const nameVal =
+                    nameAttr.children?.length === 1 &&
+                    nameAttr.children[0].type === "text"
+                        ? nameAttr.children[0].value
+                        : undefined;
+                if (nameVal) {
+                    result.push({ name: nameVal, element: node });
+                }
+            }
+            for (const child of node.children) {
+                walk(child as DastNodes);
+            }
+        }
+    };
+    for (const child of root.children) {
+        walk(child as DastNodes);
+    }
+    return result;
+}
+
+/**
+ * Collect descendant names from a composite element (conditionalContent or
+ * select) by walking through wrapper children (case/else/option)
+ * transparently.
+ *
+ * A name is included if **at least one** wrapper child has it as a unique
+ * descendant.  If a name appears multiple times within a single wrapper
+ * (ambiguous within that wrapper), that wrapper does not contribute the name
+ * — but another wrapper where it is unique still contributes it.
+ *
+ * Direct children of the composite that are NOT wrapper elements are also
+ * walked (sugared cc without explicit case/else).
+ */
+function collectNamesFromCompositeChildren(
+    composite: DastElement,
+): Set<string> {
+    const result = new Set<string>();
+
+    for (const child of composite.children) {
+        if (child.type !== "element") continue;
+
+        if (COMPOSITE_WRAPPER_NAMES.has(child.name)) {
+            // Walk inside the wrapper transparently
+            const descendants = collectAllNamedDescendants(child);
+            const counts = new Map<string, number>();
+            for (const { name } of descendants) {
+                counts.set(name, (counts.get(name) ?? 0) + 1);
+            }
+            for (const [name, count] of counts) {
+                if (count === 1) result.add(name);
+            }
+        } else {
+            // Direct child of composite (not a wrapper) — collect its names
+            // plus the child itself if named.
+            const nameAttr = child.attributes?.name;
+            if (nameAttr) {
+                const nameVal =
+                    nameAttr.children?.length === 1 &&
+                    nameAttr.children[0].type === "text"
+                        ? nameAttr.children[0].value
+                        : undefined;
+                if (nameVal) result.add(nameVal);
+            }
+            const descendants = collectAllNamedDescendants(child);
+            const counts = new Map<string, number>();
+            for (const { name } of descendants) {
+                counts.set(name, (counts.get(name) ?? 0) + 1);
+            }
+            for (const [name, count] of counts) {
+                if (count === 1) result.add(name);
+            }
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Extract `valueName`/`indexName` attribute values from a repeat or
+ * repeatForSequence element.  Returns an empty array for other elements.
+ */
+function getSyntheticNamesFromElement(el: DastElement): string[] {
+    if (el.name !== "repeat" && el.name !== "repeatForSequence") return [];
+    const names: string[] = [];
+    for (const attrName of ["valueName", "indexName"]) {
+        const attr = el.attributes[attrName];
+        if (
+            attr &&
+            attr.children.length === 1 &&
+            attr.children[0].type === "text"
+        ) {
+            names.push(attr.children[0].value);
+        }
+    }
+    return names;
+}
+
+/**
  * Minimal interface matching the subset of PublicDoenetMLCore methods needed
  * for path resolution. Consumers provide an initialized WASM-backed instance;
  * lsp-tools does not depend on the WASM package directly.
@@ -50,6 +167,12 @@ interface FlatPathPartForResolver {
 export interface RustResolverAdapterOptions {
     /** An initialized PublicDoenetMLCore (or compatible) instance. */
     core?: RustResolverCore;
+    /**
+     * Optional callback to check whether a component type takes an index.
+     * When provided, the resolver suppresses descendant names for elements
+     * whose type returns `true`, forcing member access through `$name[n].`.
+     */
+    takesIndex?: (componentType: string) => boolean;
 }
 
 /**
@@ -65,6 +188,7 @@ export class RustResolverAdapter {
     private core: RustResolverCore | null = null;
     private sourceObj: DoenetSourceObject;
     private enabled = false;
+    private takesIndexFn: ((componentType: string) => boolean) | null = null;
 
     /** Rust flat index → JS DAST element (matched by source position). */
     private rustIndexToDastElement: Map<number, DastElement> = new Map();
@@ -76,6 +200,7 @@ export class RustResolverAdapter {
         options?: RustResolverAdapterOptions,
     ) {
         this.sourceObj = sourceObj;
+        this.takesIndexFn = options?.takesIndex ?? null;
         if (options?.core) {
             this.core = options.core;
             this.syncSource();
@@ -167,7 +292,7 @@ export class RustResolverAdapter {
         return (args: ResolveRefMemberContainerArgs) => {
             if (!this.enabled || !this.core) return null;
 
-            const { offset, pathParts } = args;
+            const { offset, pathParts, hasIndex } = args;
             if (pathParts.length === 0) return null;
 
             // Resolve up to but not including the last part (being edited).
@@ -202,8 +327,52 @@ export class RustResolverAdapter {
                     resolution.unresolvedPath ?? []
                 ).map((p) => p.name);
 
+                // When there are unresolved parts, the path is invalid —
+                // return null so the caller offers no completions.
                 if (unresolvedPathParts.length > 0) {
-                    return { node: null, unresolvedPathParts };
+                    return {
+                        node: null,
+                        unresolvedPathParts,
+                    };
+                }
+
+                // When the resolved element takes an index, descendants
+                // are only accessible via $name[n].member — suppress them
+                // unless the user has already provided a bracket index.
+                if (
+                    this.takesIndexFn &&
+                    this.takesIndexFn(resolvedNode.name) &&
+                    !hasIndex
+                ) {
+                    return {
+                        node: resolvedNode,
+                        unresolvedPathParts: [],
+                        visibleDescendantNames: [],
+                    };
+                }
+
+                // For composites (conditionalContent, and any
+                // takesIndex composite with an index present), compute
+                // visible descendants by walking through wrapper children
+                // (case/else/option) transparently.
+                if (
+                    resolvedNode.name === "conditionalContent" ||
+                    (hasIndex &&
+                        this.takesIndexFn &&
+                        this.takesIndexFn(resolvedNode.name))
+                ) {
+                    const names =
+                        collectNamesFromCompositeChildren(resolvedNode);
+                    // For repeat/repeatForSequence, also expose
+                    // valueName/indexName as member completions when
+                    // accessed with an index (e.g. $rep[1].v).
+                    const syntheticNames =
+                        getSyntheticNamesFromElement(resolvedNode);
+                    return {
+                        node: resolvedNode,
+                        unresolvedPathParts: [],
+                        visibleDescendantNames: [...names, ...syntheticNames],
+                    };
                 }
 
                 // Determine which descendant names are actually visible
@@ -303,6 +472,11 @@ export class RustResolverAdapter {
     isNameAddressableFromOffset(offset: number, name: string): boolean {
         if (!this.enabled || !this.core) return true; // fallback: allow
 
+        // Synthetic names from repeat valueName/indexName are always
+        // addressable from inside the repeat — they bypass resolve_path.
+        const syntheticNames = this.getRepeatSyntheticNames(offset);
+        if (syntheticNames.includes(name)) return true;
+
         // A $name reference typed at `offset` will become a child of the
         // element whose body contains the cursor.  resolve_path with
         // skip_parent_search=false searches from the origin's PARENT scope
@@ -341,7 +515,7 @@ export class RustResolverAdapter {
         if (resolveFromIndex == null) return true;
 
         try {
-            this.core.resolve_path(
+            const resolution = this.core.resolve_path(
                 {
                     path: [
                         {
@@ -354,14 +528,103 @@ export class RustResolverAdapter {
                 resolveFromIndex,
                 false,
             );
+
+            // Post-filter: check whether the resolved element is hidden
+            // by sugar at runtime.  In raw DAST (no sugar),
+            // conditionalContent and select children are direct children,
+            // but at runtime sugar wraps them in <case>/<option>, making
+            // deeper descendants invisible from outside the composite.
+            if (this.isHiddenBySugar(resolution.nodeIdx, offset)) {
+                return false;
+            }
+
             return true;
         } catch {
             return false;
         }
     }
 
+    /**
+     * Check whether a resolved node at `rustIdx` would be hidden by
+     * `conditionalContent` / `select` sugar when the cursor is at `offset`.
+     *
+     * In raw DAST, children of `<conditionalContent>` that are NOT wrapped
+     * in explicit `<case>`/`<else>` are direct children.  At runtime,
+     * `conditionalContentSugar` wraps them in `<case><group>…</group></case>`,
+     * and `<case>` is in `CHILDREN_INVISIBLE_TO_THEIR_GRANDPARENTS`, so those
+     * children become invisible from outside.  Explicit `<case name="…">`
+     * children remain accessible because they ARE direct children of cc.
+     *
+     * The same pattern applies to `<select>` / `<option>` via `selectSugar`.
+     */
+    private isHiddenBySugar(rustIdx: number, cursorOffset: number): boolean {
+        const resolvedElement = this.rustIndexToDastElement.get(rustIdx);
+        if (!resolvedElement) return false;
+
+        let current: DastElement | DastNodes = resolvedElement;
+        let parent = this.sourceObj.getParent(current);
+
+        while (parent && parent.type !== "root") {
+            if (
+                parent.type === "element" &&
+                (parent.name === "conditionalContent" ||
+                    parent.name === "select")
+            ) {
+                const start = parent.position?.start?.offset;
+                const end = parent.position?.end?.offset;
+                // Cursor is outside this composite element
+                if (
+                    start != null &&
+                    end != null &&
+                    (cursorOffset < start || cursorOffset >= end)
+                ) {
+                    // Only direct children that are wrapper elements
+                    // (case/else/option) remain visible from outside — these
+                    // are NOT re-wrapped by sugar.  Everything else (direct
+                    // non-wrapper children that sugar will wrap, or deeper
+                    // descendants already behind a wrapper barrier) is hidden.
+                    const resolvedParent =
+                        this.sourceObj.getParent(resolvedElement);
+                    if (
+                        resolvedParent &&
+                        resolvedParent.type === "element" &&
+                        resolvedParent === parent &&
+                        COMPOSITE_WRAPPER_NAMES.has(resolvedElement.name)
+                    ) {
+                        // resolvedElement is a direct case/else/option child
+                        // of cc/select — not hidden by sugar.
+                    } else {
+                        return true;
+                    }
+                }
+            }
+            current = parent;
+            parent = this.sourceObj.getParent(parent);
+        }
+        return false;
+    }
+
     isEnabled(): boolean {
         return this.enabled;
+    }
+
+    /**
+     * Return synthetic names from `valueName`/`indexName` attributes of
+     * enclosing `<repeat>` elements at the given offset.  These names
+     * don't exist in the raw DAST but are created by repeat sugar at
+     * runtime, so they must be injected into the completion pipeline.
+     */
+    getRepeatSyntheticNames(offset: number): string[] {
+        const names: string[] = [];
+        let current: DastElement | undefined =
+            this.sourceObj.elementAtOffset(offset) ?? undefined;
+        while (current) {
+            names.push(...getSyntheticNamesFromElement(current));
+            const p = this.sourceObj.getParent(current);
+            current =
+                p && p.type === "element" ? (p as DastElement) : undefined;
+        }
+        return names;
     }
 
     /**

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -195,15 +195,15 @@ export interface RustResolverAdapterOptions {
  * resolve_path() for each completion request.
  */
 export class RustResolverAdapter {
-    _core: RustResolverCore | null = null;
+    readonly _core: RustResolverCore | null = null;
     _sourceObj: DoenetSourceObject;
     _enabled = false;
-    _takesIndexComponentTypes: ReadonlySet<string> | null = null;
+    readonly _takesIndexComponentTypes: ReadonlySet<string> | null = null;
 
     /** Rust flat index → JS DAST element (matched by source position). */
-    _rustIndexToDastElement: Map<number, DastElement> = new Map();
+    readonly _rustIndexToDastElement: Map<number, DastElement> = new Map();
     /** JS DAST element → Rust flat index. */
-    _dastElementToRustIndex: Map<DastElement, number> = new Map();
+    readonly _dastElementToRustIndex: Map<DastElement, number> = new Map();
 
     constructor(
         sourceObj: DoenetSourceObject,

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -47,6 +47,22 @@ function collectAllNamedDescendants(
 }
 
 /**
+ * Add only names that appear exactly once in the given descendant list.
+ */
+function addUniqueNamesFromDescendants(
+    descendants: Array<{ name: string; element: DastElement }>,
+    result: Set<string>,
+): void {
+    const counts = new Map<string, number>();
+    for (const { name } of descendants) {
+        counts.set(name, (counts.get(name) ?? 0) + 1);
+    }
+    for (const [name, count] of counts) {
+        if (count === 1) result.add(name);
+    }
+}
+
+/**
  * Collect descendant names from a composite element (conditionalContent or
  * select) by walking through wrapper children (case/else/option)
  * transparently.
@@ -69,14 +85,10 @@ function collectNamesFromCompositeChildren(
 
         if (COMPOSITE_WRAPPER_NAMES.has(child.name)) {
             // Walk inside the wrapper transparently
-            const descendants = collectAllNamedDescendants(child);
-            const counts = new Map<string, number>();
-            for (const { name } of descendants) {
-                counts.set(name, (counts.get(name) ?? 0) + 1);
-            }
-            for (const [name, count] of counts) {
-                if (count === 1) result.add(name);
-            }
+            addUniqueNamesFromDescendants(
+                collectAllNamedDescendants(child),
+                result,
+            );
         } else {
             // Direct child of composite (not a wrapper) — collect its names
             // plus the child itself if named.
@@ -89,14 +101,10 @@ function collectNamesFromCompositeChildren(
                         : undefined;
                 if (nameVal) result.add(nameVal);
             }
-            const descendants = collectAllNamedDescendants(child);
-            const counts = new Map<string, number>();
-            for (const { name } of descendants) {
-                counts.set(name, (counts.get(name) ?? 0) + 1);
-            }
-            for (const [name, count] of counts) {
-                if (count === 1) result.add(name);
-            }
+            addUniqueNamesFromDescendants(
+                collectAllNamedDescendants(child),
+                result,
+            );
         }
     }
 
@@ -307,7 +315,7 @@ export class RustResolverAdapter {
         pathParts: string[],
         hasIndex?: boolean,
     ): RefMemberContainerResolution | null {
-        return this.createResolver()({
+        return this._resolveRefMemberContainer({
             offset,
             pathParts,
             nodeIndex: this._sourceObj.getNodeIndexAtOffset(offset),
@@ -316,141 +324,138 @@ export class RustResolverAdapter {
     }
 
     /**
-     * Create a resolver callback suitable for AutoCompleter's
-     * `resolveRefMemberContainerAtOffset` option.
+     * Create a resolver callback suitable for external callers that need
+     * `ResolveRefMemberContainer` shape.
      */
     createResolver(): ResolveRefMemberContainer {
-        return (args: ResolveRefMemberContainerArgs) => {
-            if (!this._enabled || !this._core) return null;
+        return (args: ResolveRefMemberContainerArgs) =>
+            this._resolveRefMemberContainer(args);
+    }
 
-            const { offset, pathParts, hasIndex } = args;
-            if (pathParts.length === 0) return null;
+    _resolveRefMemberContainer(
+        args: ResolveRefMemberContainerArgs,
+    ): RefMemberContainerResolution | null {
+        if (!this._enabled || !this._core) return null;
 
-            // Resolve up to but not including the last part (being edited).
-            const lookupParts = pathParts.slice(0, -1);
-            if (lookupParts.length === 0) return null;
+        const { offset, pathParts, hasIndex } = args;
+        if (pathParts.length === 0) return null;
 
-            // Determine origin: the Rust index of the enclosing element.
-            const originIndex = this.getOriginIndex(offset);
-            if (originIndex == null) return null;
+        // Resolve up to but not including the last part (being edited).
+        const lookupParts = pathParts.slice(0, -1);
+        if (lookupParts.length === 0) return null;
 
-            const flatPath: FlatPathPartForResolver[] = lookupParts.map(
-                (name) => ({
-                    type: "flatPathPart" as const,
-                    name,
-                    index: [],
-                }),
+        // Determine origin: the Rust index of the enclosing element.
+        const originIndex = this.getOriginIndex(offset);
+        if (originIndex == null) return null;
+
+        const flatPath: FlatPathPartForResolver[] = lookupParts.map((name) => ({
+            type: "flatPathPart" as const,
+            name,
+            index: [],
+        }));
+
+        try {
+            const resolution = this._core.resolve_path(
+                { path: flatPath },
+                originIndex,
+                false,
             );
 
-            try {
-                const resolution = this._core.resolve_path(
-                    { path: flatPath },
-                    originIndex,
-                    false,
-                );
+            const resolvedNode = this._rustIndexToDastElement.get(
+                resolution.nodeIdx,
+            );
+            if (!resolvedNode) return null;
 
-                const resolvedNode = this._rustIndexToDastElement.get(
-                    resolution.nodeIdx,
-                );
-                if (!resolvedNode) return null;
+            const unresolvedPathParts = (resolution.unresolvedPath ?? []).map(
+                (p) => p.name,
+            );
 
-                const unresolvedPathParts = (
-                    resolution.unresolvedPath ?? []
-                ).map((p) => p.name);
+            // When there are unresolved parts, the path is invalid —
+            // return null so the caller offers no completions.
+            if (unresolvedPathParts.length > 0) {
+                return {
+                    node: null,
+                    unresolvedPathParts,
+                };
+            }
 
-                // When there are unresolved parts, the path is invalid —
-                // return null so the caller offers no completions.
-                if (unresolvedPathParts.length > 0) {
-                    return {
-                        node: null,
-                        unresolvedPathParts,
-                    };
-                }
-
-                // When the resolved element takes an index, descendants
-                // are only accessible via $name[n].member — suppress them
-                // unless the user has already provided a bracket index.
-                if (this.componentTakesIndex(resolvedNode.name) && !hasIndex) {
-                    return {
-                        node: resolvedNode,
-                        unresolvedPathParts: [],
-                        visibleDescendantNames: [],
-                    };
-                }
-
-                // For composites (conditionalContent, and any
-                // takesIndex composite with an index present), compute
-                // visible descendants by walking through wrapper children
-                // (case/else/option) transparently.
-                if (
-                    resolvedNode.name === "conditionalContent" ||
-                    (hasIndex && this.componentTakesIndex(resolvedNode.name))
-                ) {
-                    const names =
-                        collectNamesFromCompositeChildren(resolvedNode);
-                    // For repeat/repeatForSequence, also expose
-                    // valueName/indexName as member completions when
-                    // accessed with an index (e.g. $rep[1].v).
-                    const derivedRepeatNames =
-                        getDerivedRepeatNamesFromElement(resolvedNode);
-                    return {
-                        node: resolvedNode,
-                        unresolvedPathParts: [],
-                        visibleDescendantNames: [
-                            ...names,
-                            ...derivedRepeatNames,
-                        ],
-                    };
-                }
-
-                // Determine which descendant names are actually visible
-                // from the resolved node using the Rust name_map (which
-                // respects ChildrenInvisibleToTheirGrandparents etc.).
-                const resolvedIdx = resolution.nodeIdx;
-                const allNames =
-                    this._sourceObj.getUniqueDescendantNamesForNode(
-                        resolvedNode,
-                    );
-                const visibleDescendantNames = allNames.filter((name) => {
-                    try {
-                        const probe = this._core!.resolve_path(
-                            {
-                                path: [
-                                    {
-                                        type: "flatPathPart" as const,
-                                        name,
-                                        index: [],
-                                    },
-                                ],
-                            },
-                            resolvedIdx,
-                            true,
-                        );
-                        // A fully-resolved path (no unresolved parts whose
-                        // first segment equals the original name) means the
-                        // name matched a visible descendant.
-                        if (
-                            probe.unresolvedPath &&
-                            probe.unresolvedPath.length > 0
-                        ) {
-                            return false;
-                        }
-                        return true;
-                    } catch {
-                        return false;
-                    }
-                });
-
+            // When the resolved element takes an index, descendants
+            // are only accessible via $name[n].member — suppress them
+            // unless the user has already provided a bracket index.
+            if (this.componentTakesIndex(resolvedNode.name) && !hasIndex) {
                 return {
                     node: resolvedNode,
                     unresolvedPathParts: [],
-                    visibleDescendantNames,
+                    visibleDescendantNames: [],
                 };
-            } catch {
-                // Resolution error (NoReferent, NonUniqueReferent, etc.)
-                return null;
             }
-        };
+
+            // For composites (conditionalContent, and any
+            // takesIndex composite with an index present), compute
+            // visible descendants by walking through wrapper children
+            // (case/else/option) transparently.
+            if (
+                resolvedNode.name === "conditionalContent" ||
+                (hasIndex && this.componentTakesIndex(resolvedNode.name))
+            ) {
+                const names = collectNamesFromCompositeChildren(resolvedNode);
+                // For repeat/repeatForSequence, also expose
+                // valueName/indexName as member completions when
+                // accessed with an index (e.g. $rep[1].v).
+                const derivedRepeatNames =
+                    getDerivedRepeatNamesFromElement(resolvedNode);
+                return {
+                    node: resolvedNode,
+                    unresolvedPathParts: [],
+                    visibleDescendantNames: [...names, ...derivedRepeatNames],
+                };
+            }
+
+            // Determine which descendant names are actually visible
+            // from the resolved node using the Rust name_map (which
+            // respects ChildrenInvisibleToTheirGrandparents etc.).
+            const resolvedIdx = resolution.nodeIdx;
+            const allNames =
+                this._sourceObj.getUniqueDescendantNamesForNode(resolvedNode);
+            const visibleDescendantNames = allNames.filter((name) => {
+                try {
+                    const probe = this._core!.resolve_path(
+                        {
+                            path: [
+                                {
+                                    type: "flatPathPart" as const,
+                                    name,
+                                    index: [],
+                                },
+                            ],
+                        },
+                        resolvedIdx,
+                        true,
+                    );
+                    // A fully-resolved path (no unresolved parts whose
+                    // first segment equals the original name) means the
+                    // name matched a visible descendant.
+                    if (
+                        probe.unresolvedPath &&
+                        probe.unresolvedPath.length > 0
+                    ) {
+                        return false;
+                    }
+                    return true;
+                } catch {
+                    return false;
+                }
+            });
+
+            return {
+                node: resolvedNode,
+                unresolvedPathParts: [],
+                visibleDescendantNames,
+            };
+        } catch {
+            // Resolution error (NoReferent, NonUniqueReferent, etc.)
+            return null;
+        }
     }
 
     /**
@@ -500,8 +505,10 @@ export class RustResolverAdapter {
     isNameAddressableFromOffset(offset: number, name: string): boolean {
         if (!this._enabled || !this._core) return false;
 
-        // Derived repeat names from valueName/indexName are always
-        // addressable from inside the repeat and bypass resolve_path.
+        // Derived repeat names from valueName/indexName are introduced by
+        // repeat runtime behavior and are always addressable from within the
+        // repeat body. They are not affected by conditional/select sugar,
+        // so this intentionally bypasses isHiddenBySugar().
         const derivedRepeatNames = this.getDerivedRepeatNames(offset);
         if (derivedRepeatNames.includes(name)) return true;
 
@@ -589,8 +596,7 @@ export class RustResolverAdapter {
         const resolvedElement = this._rustIndexToDastElement.get(rustIdx);
         if (!resolvedElement) return false;
 
-        let current: DastElement | DastNodes = resolvedElement;
-        let parent = this._sourceObj.getParent(current);
+        let parent = this._sourceObj.getParent(resolvedElement);
 
         while (parent && parent.type !== "root") {
             if (
@@ -614,19 +620,17 @@ export class RustResolverAdapter {
                     const resolvedParent =
                         this._sourceObj.getParent(resolvedElement);
                     if (
-                        resolvedParent &&
-                        resolvedParent.type === "element" &&
-                        resolvedParent === parent &&
-                        COMPOSITE_WRAPPER_NAMES.has(resolvedElement.name)
+                        !(
+                            resolvedParent &&
+                            resolvedParent.type === "element" &&
+                            resolvedParent === parent &&
+                            COMPOSITE_WRAPPER_NAMES.has(resolvedElement.name)
+                        )
                     ) {
-                        // resolvedElement is a direct case/else/option child
-                        // of cc/select — not hidden by sugar.
-                    } else {
                         return true;
                     }
                 }
             }
-            current = parent;
             parent = this._sourceObj.getParent(parent);
         }
         return false;

--- a/packages/lsp-tools/src/dev-site.tsx
+++ b/packages/lsp-tools/src/dev-site.tsx
@@ -54,8 +54,9 @@ const simpleSchema = {
 };
 
 const sourceObj = new DoenetSourceObject(INITIAL_DOENET_SOURCE);
-const completionObj = new AutoCompleter("", simpleSchema.elements);
-completionObj.setDoenetSourceObject(sourceObj);
+const completionObj = new AutoCompleter(undefined, simpleSchema.elements, {
+    sourceObj,
+});
 console.log(sourceObj, completionObj);
 (window as any).sourceObj = sourceObj;
 (window as any).completionObj = completionObj;

--- a/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
+++ b/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
@@ -184,10 +184,21 @@ export function elementAtOffsetWithContext(
     // If `node.name === ""`, then there is some error. The user has probably typed `<` and nothing else.
     // In this case, pretend we are the node before the cursor.
     if (node && node.name === "") {
-        if (offset > 0) {
+        if (cursorPosition === "body") {
+            // We already know we're in the body (e.g. from a StartCloseTag boundary).
+            // Don't recurse — just use the parent element instead of the empty-named node.
+            const parent = this.getParent(node);
+            if (parent?.type === "element") {
+                node = parent as DastElement;
+            } else {
+                node = null;
+                cursorPosition = "unknown";
+            }
+        } else if (offset > 0) {
             return this.elementAtOffsetWithContext(offset - 1);
+        } else {
+            return { node: null, cursorPosition: "unknown" };
         }
-        return { node: null, cursorPosition: "unknown" };
     }
 
     return { node, cursorPosition };

--- a/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
+++ b/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
@@ -38,6 +38,17 @@ export function elementAtOffsetWithContext(
         cursorPosition = "body";
     }
 
+    if (
+        node?.type === "element" &&
+        node.position?.start?.offset === offset &&
+        parent?.type === "element" &&
+        prevChar &&
+        !prevChar.match(/(\s|\n|<)/)
+    ) {
+        cursorPosition = "body";
+        node = parent as DastElement;
+    }
+
     if (!node) {
         cursorPosition = "unknown";
     }

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -263,6 +263,16 @@ describe("AutoCompleter", () => {
             `);
         }
     });
+
+    it("Matches open-tag component completions case-insensitively and keeps canonical label case", () => {
+        const source = `<MATHIN`;
+        const autoCompleter = new AutoCompleter(source, doenetSchema.elements);
+        const items = autoCompleter.getCompletionItems(source.length);
+        const labels = items.map((item) => String(item.label));
+
+        expect(labels).toContain("mathInput");
+    });
+
     it("Suggests child elements (not attributes) when < is typed inside a closed element", () => {
         // Regression: typing `<` inside `<aa>...</aa>` used to return
         // aa's attributes instead of its allowed child elements.
@@ -524,6 +534,39 @@ describe("AutoCompleter", () => {
             ).toBe(true);
         });
 
+        it("Matches $ref prefix case-insensitively but keeps inserted canonical case", () => {
+            const source = `<math name="myMath" />\n$MYM`;
+            const autoCompleter = createRefAutoCompleter(source);
+
+            const offset = source.length;
+            const items = autoCompleter.getCompletionItems(offset);
+            const match = items.find((item) => item.label === "myMath");
+
+            expect(match).toBeDefined();
+            expect(match?.textEdit).toBeDefined();
+            const textEdit = match?.textEdit;
+            if (textEdit && "newText" in textEdit) {
+                expect(textEdit.newText).toBe("myMath");
+            }
+        });
+
+        it("Keeps names that differ only by case as separate $ref completion options", () => {
+            const source = `<math name="myMath" /><math name="MyMath" />\n$myma`;
+            const autoCompleter = createRefAutoCompleter(source);
+
+            const items = autoCompleter.getCompletionItems(source.length);
+            const labels = items.map((item) => String(item.label));
+
+            expect(labels).toContain("myMath");
+            expect(labels).toContain("MyMath");
+            expect(labels.filter((label) => label === "myMath")).toHaveLength(
+                1,
+            );
+            expect(labels.filter((label) => label === "MyMath")).toHaveLength(
+                1,
+            );
+        });
+
         it("Inserts parenthesized macro text for hyphenated names after $", () => {
             const source = `<math name="foo-bar" />\n$f`;
             const autoCompleter = createRefAutoCompleter(source);
@@ -592,6 +635,17 @@ describe("AutoCompleter", () => {
             const myPItems = items.filter((item) => item.label === "myP");
             expect(myPItems).toHaveLength(1);
             expect(myPItems[0].kind).toBe(CompletionItemKind.Reference);
+        });
+
+        it("Matches member prefix case-insensitively and preserves distinct-case labels", () => {
+            const source = `<section name="mySection"><p name="myMath" /><p name="MyMath" /></section>\n$mySection.myma`;
+            const autoCompleter = createRefAutoCompleter(source);
+
+            const items = autoCompleter.getCompletionItems(source.length);
+            const labels = items.map((item) => String(item.label));
+
+            expect(labels).toContain("myMath");
+            expect(labels).toContain("MyMath");
         });
 
         it("Only suggests uniquely addressable descendant names after dot", () => {

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -374,9 +374,8 @@ describe("AutoCompleter", () => {
         {
             const offset = source.indexOf(".") + 1;
             const elm = autoCompleter.getCompletionContext(offset);
-            expect(elm).toMatchObject({
-                cursorPos: "refMember",
-                typedPrefix: "",
+            expect(elm).toEqual({
+                cursorPos: "body",
             });
         }
 
@@ -635,6 +634,20 @@ describe("AutoCompleter", () => {
             const myPItems = items.filter((item) => item.label === "myP");
             expect(myPItems).toHaveLength(1);
             expect(myPItems[0].kind).toBe(CompletionItemKind.Reference);
+        });
+
+        it("Does not suggest ref-member completions when there is whitespace before dot", () => {
+            // `$mySection .` is not a valid reference path; do not offer
+            // descendant/property member completions.
+            const source = `<section name="mySection"><p name="myP" /></section>\n$mySection .`;
+            const autoCompleter = createRefAutoCompleter(source);
+
+            const offset = source.length;
+            const items = autoCompleter.getCompletionItems(offset);
+            const labels = items.map((item) => item.label);
+
+            expect(labels).not.toContain("myP");
+            expect(labels).not.toContain("sectionProp");
         });
 
         it("Matches member prefix case-insensitively and preserves distinct-case labels", () => {

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -752,6 +752,7 @@ describe("AutoCompleter", () => {
                 offset: source.length,
                 pathParts: ["missing", ""],
                 nodeIndex: expect.any(Number), // Index may vary based on structure
+                hasIndex: false,
             });
             expect(items.some((item) => item.label === "myP")).toBe(true);
             expect(items.some((item) => item.label === "sectionProp")).toBe(
@@ -778,7 +779,7 @@ describe("AutoCompleter", () => {
             expect(items.some((item) => item.label === "myP")).toBe(true);
         });
 
-        it("Reports unresolved path segments from default member resolution", () => {
+        it("Reports unresolved path segments from default member resolution with null node", () => {
             const source = `<section name="mySection"><p name="myP" /></section>\n$mySection.missing.`;
             const autoCompleter = new AutoCompleter(source, refSchema.elements);
 
@@ -787,6 +788,7 @@ describe("AutoCompleter", () => {
                 ["mySection", "missing", ""],
             );
 
+            // Invalid path — node is null so no completions are offered.
             expect(resolution.node).toBeNull();
             expect(resolution.unresolvedPathParts).toEqual(["missing"]);
         });
@@ -1415,7 +1417,7 @@ describe("AutoCompleter", () => {
                 pathParts: ["s1", "p1", "x"],
             });
 
-            // Unresolved path means node is null (can't complete from an unresolved member)
+            // Invalid path — node is null so no completions are offered.
             expect(result).not.toBeNull();
             expect(result!.node).toBeNull();
             expect(result!.unresolvedPathParts).toEqual(["remaining"]);

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -1256,6 +1256,9 @@ describe("AutoCompleter", () => {
                 unresolvedPath: Array<{ name: string }> | null;
                 originalPath: Array<{ name: string }>;
             },
+            options?: {
+                startId?: number;
+            },
         ): {
             core: RustResolverCore;
             calls: { path: unknown; origin: number; skip: boolean }[];
@@ -1269,7 +1272,7 @@ describe("AutoCompleter", () => {
                 data: { id: number };
                 position?: { start: { offset?: number } };
             }> = [];
-            let nextId = 0;
+            let nextId = options?.startId ?? 0;
             const collectElements = (node: any) => {
                 if (node.type === "element") {
                     elements.push({
@@ -1287,6 +1290,7 @@ describe("AutoCompleter", () => {
 
             const core: RustResolverCore = {
                 set_source: () => {},
+                set_flags: () => {},
                 return_dast: () => ({ elements }),
                 resolve_path: (path, origin, skip) => {
                     calls.push({ path, origin, skip });
@@ -1332,7 +1336,9 @@ describe("AutoCompleter", () => {
                 pathParts: ["s1", ""],
             });
 
-            expect(calls.length).toBe(1);
+            // First call resolves the container ("s1"), subsequent calls
+            // probe descendant visibility (one per unique descendant name).
+            expect(calls.length).toBeGreaterThanOrEqual(1);
             expect(calls[0].path).toEqual({
                 path: [{ type: "flatPathPart", name: "s1", index: [] }],
             });
@@ -1343,6 +1349,8 @@ describe("AutoCompleter", () => {
                 (result!.node as any)?.attributes?.name?.children?.[0]?.value,
             ).toBe("s1");
             expect(result!.unresolvedPathParts).toEqual([]);
+            // Visibility probing returns names the mock considers resolvable
+            expect(result!.visibleDescendantNames).toBeDefined();
         });
 
         it("Returns null when resolve_path throws", () => {
@@ -1351,6 +1359,7 @@ describe("AutoCompleter", () => {
 
             const core: RustResolverCore = {
                 set_source: () => {},
+                set_flags: () => {},
                 return_dast: () => {
                     const elements: Array<{
                         data: { id: number };
@@ -1459,6 +1468,34 @@ describe("AutoCompleter", () => {
             expect(adapter.isEnabled()).toBe(true);
         });
 
+        it("Uses mapped root origin index when Rust ids are non-zero", () => {
+            const source = `<section name="s1"><p name="p1" /></section>\n$s1.`;
+            const sourceObj = new DoenetSourceObject(source + " ");
+            const { core, calls } = createMockCore(
+                source,
+                sourceObj,
+                {
+                    nodeIdx: 10,
+                    nodesInResolvedPath: [10],
+                    unresolvedPath: null,
+                    originalPath: [{ name: "s1" }],
+                },
+                { startId: 10 },
+            );
+
+            const adapter = new RustResolverAdapter(sourceObj, { core });
+            const resolver = adapter.createResolver();
+
+            const result = resolver({
+                offset: source.indexOf("$s1.") + 4,
+                pathParts: ["s1", ""],
+            });
+
+            expect(result).not.toBeNull();
+            expect(calls.length).toBeGreaterThan(0);
+            expect(calls[0].origin).toBe(10);
+        });
+
         it("Disables adapter when set_source throws", () => {
             const source = `<section name="s1"></section>`;
             const sourceObj = new DoenetSourceObject(source);
@@ -1467,6 +1504,7 @@ describe("AutoCompleter", () => {
                 set_source: () => {
                     throw new Error("WASM error");
                 },
+                set_flags: () => {},
                 return_dast: () => ({ elements: [] }),
                 resolve_path: () => ({
                     nodeIdx: 0,

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -1531,6 +1531,102 @@ describe("AutoCompleter", () => {
             expect(result!.unresolvedPathParts).toEqual(["remaining"]);
         });
 
+        it("Blocks unindexed traversal from the first takesIndex segment, not the following segment", () => {
+            const source = `<section name="sec"><repeatForSequence name="rep"><math name="myMath">x</math></repeatForSequence>\n$rep.myMath.</section>`;
+            const sourceObj = new DoenetSourceObject(source + " ");
+            const { core } = createMockCore(source, sourceObj, {
+                nodeIdx: 2, // myMath
+                nodesInResolvedPath: [0, 1, 2],
+                unresolvedPath: null,
+                originalPath: [{ name: "rep" }, { name: "myMath" }],
+            });
+
+            const adapter = new RustResolverAdapter(sourceObj, {
+                core,
+                takesIndexComponentTypes: new Set(["repeatForSequence"]),
+            });
+            const resolver = adapter.createResolver();
+
+            const result = resolver({
+                offset: source.indexOf("$rep.myMath.") + "$rep.myMath.".length,
+                pathParts: ["rep", "myMath", ""],
+                pathPartHasIndex: [false, false, false],
+            });
+
+            expect(result).not.toBeNull();
+            expect(result!.node).toBeNull();
+            expect(result!.unresolvedPathParts).toEqual(["rep", "myMath"]);
+        });
+
+        it("Allows indexed traversal when the indexed segment is after the origin entry", () => {
+            const source = `<section name="sec"><repeatForSequence name="rep"><math name="myMath">x</math></repeatForSequence>\n$rep[1].myMath.</section>`;
+            const sourceObj = new DoenetSourceObject(source + " ");
+            const { core } = createMockCore(source, sourceObj, {
+                nodeIdx: 2, // myMath
+                nodesInResolvedPath: [0, 1, 2],
+                unresolvedPath: null,
+                originalPath: [{ name: "rep" }, { name: "myMath" }],
+            });
+
+            const adapter = new RustResolverAdapter(sourceObj, {
+                core,
+                takesIndexComponentTypes: new Set(["repeatForSequence"]),
+            });
+            const resolver = adapter.createResolver();
+
+            const result = resolver({
+                offset:
+                    source.indexOf("$rep[1].myMath.") +
+                    "$rep[1].myMath.".length,
+                pathParts: ["rep", "myMath", ""],
+                pathPartHasIndex: [true, false, false],
+            });
+
+            expect(result).not.toBeNull();
+            expect(result!.node).not.toBeNull();
+            expect((result!.node as DastElement).name).toBe("math");
+            expect(result!.unresolvedPathParts).toEqual([]);
+        });
+
+        it("Aligns to the trailing path nodes when nodesInResolvedPath has extra leading entries", () => {
+            const source = `<section name="sec"><repeat name="outer"><repeatForSequence name="inner"><math name="myMath">x</math></repeatForSequence></repeat>\n$outer[1].inner[1].myMath.</section>`;
+            const sourceObj = new DoenetSourceObject(source + " ");
+            const { core } = createMockCore(source, sourceObj, {
+                nodeIdx: 3, // myMath
+                // Simulate a resolver shape with an extra leading bookkeeping node
+                // before the actual path-aligned tail [1, 2, 3].
+                nodesInResolvedPath: [0, 0, 1, 2, 3],
+                unresolvedPath: null,
+                originalPath: [
+                    { name: "outer" },
+                    { name: "inner" },
+                    { name: "myMath" },
+                ],
+            });
+
+            const adapter = new RustResolverAdapter(sourceObj, {
+                core,
+                takesIndexComponentTypes: new Set([
+                    "repeat",
+                    "repeatForSequence",
+                ]),
+            });
+            const resolver = adapter.createResolver();
+
+            const result = resolver({
+                offset:
+                    source.indexOf("$outer[1].inner[1].myMath.") +
+                    "$outer[1].inner[1].myMath.".length,
+                pathParts: ["outer", "inner", "myMath", ""],
+                pathPartHasIndex: [true, true, false, false],
+            });
+
+            expect(result).not.toBeNull();
+            expect(result!.node).not.toBeNull();
+            expect((result!.node as DastElement).name).toBe("math");
+            expect(result!.unresolvedPathParts).toEqual([]);
+        });
+
         it("Handles updateSource to re-sync with core", () => {
             const source1 = `<section name="s1"><p name="p1" /></section>`;
             const sourceObj1 = new DoenetSourceObject(source1);

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -1331,10 +1331,17 @@ describe("AutoCompleter", () => {
             },
         ): {
             core: RustResolverCore;
-            calls: { path: unknown; origin: number; skip: boolean }[];
+            calls: {
+                path: unknown;
+                origin: number;
+                skip_parent_search: boolean;
+            }[];
         } {
-            const calls: { path: unknown; origin: number; skip: boolean }[] =
-                [];
+            const calls: {
+                path: unknown;
+                origin: number;
+                skip_parent_search: boolean;
+            }[] = [];
 
             // Build a minimal flat DAST from the JS DAST by assigning sequential
             // ids to elements in depth-first order (matching Rust's pre-order).
@@ -1362,8 +1369,8 @@ describe("AutoCompleter", () => {
                 set_source: () => {},
                 set_flags: () => {},
                 return_dast: () => ({ elements }),
-                resolve_path: (path, origin, skip) => {
-                    calls.push({ path, origin, skip });
+                resolve_path: (path, origin, skip_parent_search) => {
+                    calls.push({ path, origin, skip_parent_search });
                     if (resolveResult) return resolveResult;
                     // Default: resolve to first element, no unresolved path
                     return {
@@ -1558,6 +1565,66 @@ describe("AutoCompleter", () => {
 
             const resolver = adapter.createResolver();
             expect(resolver({ offset: 0, pathParts: ["s1", ""] })).toBeNull();
+        });
+
+        it("Caches visibility probes for repeated member resolutions", () => {
+            const source = `<section name="s1"><p name="p1" /></section>\n$s1.`;
+            const sourceObj = new DoenetSourceObject(source + " ");
+            const { core, calls } = createMockCore(source, sourceObj, {
+                nodeIdx: 0,
+                nodesInResolvedPath: [0],
+                unresolvedPath: null,
+                originalPath: [{ name: "s1" }],
+            });
+
+            const adapter = new RustResolverAdapter(sourceObj, { core });
+            const resolver = adapter.createResolver();
+            const offset = source.indexOf("$s1.") + 4;
+
+            resolver({ offset, pathParts: ["s1", ""] });
+            resolver({ offset, pathParts: ["s1", ""] });
+
+            // The container resolution runs each time
+            // (skip_parent_search=false), but the descendant visibility probe
+            // path (skip_parent_search=true) should be cached after the first
+            // call for this source revision and resolved node.
+            const probeCalls = calls.filter((c) => c.skip_parent_search);
+            expect(probeCalls.length).toBe(1);
+        });
+
+        it("Invalidates visibility-probe cache when source changes", () => {
+            const source1 = `<section name="s1"><p name="p1" /></section>\n$s1.`;
+            const sourceObj1 = new DoenetSourceObject(source1 + " ");
+            const { core, calls } = createMockCore(source1, sourceObj1, {
+                nodeIdx: 0,
+                nodesInResolvedPath: [0],
+                unresolvedPath: null,
+                originalPath: [{ name: "s1" }],
+            });
+
+            const adapter = new RustResolverAdapter(sourceObj1, { core });
+            const resolver = adapter.createResolver();
+            const offset1 = source1.indexOf("$s1.") + 4;
+
+            resolver({ offset: offset1, pathParts: ["s1", ""] });
+            resolver({ offset: offset1, pathParts: ["s1", ""] });
+
+            const firstProbeCount = calls.filter(
+                (c) => c.skip_parent_search,
+            ).length;
+            expect(firstProbeCount).toBe(1);
+
+            const source2 = `<section name="s2"><p name="p2" /></section>\n$s2.`;
+            const sourceObj2 = new DoenetSourceObject(source2 + " ");
+            adapter.updateSource(sourceObj2);
+
+            const offset2 = source2.indexOf("$s2.") + 4;
+            resolver({ offset: offset2, pathParts: ["s2", ""] });
+
+            const secondProbeCount = calls.filter(
+                (c) => c.skip_parent_search,
+            ).length;
+            expect(secondProbeCount).toBe(2);
         });
     });
 });

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -382,9 +382,83 @@ describe("AutoCompleter", () => {
             ],
         };
 
+        function createRefAutoCompleter(source: string) {
+            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+            autoCompleter.setRustResolverAdapter({
+                isNameAddressableFromOffset: () => true,
+                resolveRefMemberContainerAtOffset: (
+                    offset: number,
+                    pathParts: string[],
+                ) => {
+                    if (pathParts.length === 0) {
+                        return {
+                            node: null,
+                            unresolvedPathParts: [],
+                        };
+                    }
+
+                    const lookupPathParts = pathParts.slice(0, -1);
+                    if (lookupPathParts.length === 0) {
+                        return {
+                            node: null,
+                            unresolvedPathParts: [],
+                        };
+                    }
+
+                    let referent = autoCompleter.sourceObj.getReferentAtOffset(
+                        offset,
+                        lookupPathParts[0],
+                    );
+                    if (!referent) {
+                        return {
+                            node: null,
+                            unresolvedPathParts: lookupPathParts,
+                        };
+                    }
+
+                    let firstUnresolvedPartIndex = -1;
+                    for (let i = 1; i < lookupPathParts.length; i++) {
+                        const part = lookupPathParts[i];
+                        const child =
+                            autoCompleter.sourceObj.getNamedDescendant(
+                                referent,
+                                part,
+                            );
+                        if (!child) {
+                            firstUnresolvedPartIndex = i;
+                            break;
+                        }
+                        referent = child;
+                    }
+
+                    const unresolvedPathParts =
+                        firstUnresolvedPartIndex === -1
+                            ? []
+                            : lookupPathParts.slice(firstUnresolvedPartIndex);
+
+                    if (unresolvedPathParts.length > 0) {
+                        return {
+                            node: null,
+                            unresolvedPathParts,
+                        };
+                    }
+
+                    return {
+                        node: referent,
+                        unresolvedPathParts: [],
+                        visibleDescendantNames:
+                            autoCompleter.sourceObj.getUniqueDescendantNamesForNode(
+                                referent,
+                            ),
+                    };
+                },
+            } as unknown as RustResolverAdapter);
+            return autoCompleter;
+        }
+
         it("Suggests reference names after $ with prefix filtering", () => {
             const source = `<section name="mySection"><p name="myP" /></section><p name="other" />\n$myS`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+            const autoCompleter = createRefAutoCompleter(source);
 
             const offset = source.length;
             const items = autoCompleter.getCompletionItems(offset);
@@ -408,7 +482,7 @@ describe("AutoCompleter", () => {
 
         it("Inserts parenthesized macro text for hyphenated names after $", () => {
             const source = `<math name="foo-bar" />\n$f`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+            const autoCompleter = createRefAutoCompleter(source);
 
             const items = autoCompleter.getCompletionItems(source.length);
             const fooBarItem = items.find((item) => item.label === "foo-bar");
@@ -423,7 +497,7 @@ describe("AutoCompleter", () => {
 
         it("Keeps plain macro text for simple names after $", () => {
             const source = `<math name="foo_bar" />\n$f`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+            const autoCompleter = createRefAutoCompleter(source);
 
             const items = autoCompleter.getCompletionItems(source.length);
             const fooBarItem = items.find((item) => item.label === "foo_bar");
@@ -438,7 +512,7 @@ describe("AutoCompleter", () => {
 
         it("Suggests descendant names and properties after dot, with descendants winning collisions", () => {
             const source = `<section name="mySection"><p name="myP" /></section>\n$mySection.`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+            const autoCompleter = createRefAutoCompleter(source);
 
             const offset = source.length;
             const items = autoCompleter.getCompletionItems(offset);
@@ -455,7 +529,7 @@ describe("AutoCompleter", () => {
 
         it("Only suggests uniquely addressable descendant names after dot", () => {
             const source = `<section name="mySection"><p name="dup" /><p name="dup" /><p name="unique" /></section>\n$mySection.`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+            const autoCompleter = createRefAutoCompleter(source);
 
             const offset = source.length;
             const items = autoCompleter.getCompletionItems(offset);
@@ -468,7 +542,7 @@ describe("AutoCompleter", () => {
 
         it("Only suggests member names that resolve uniquely from the same context", () => {
             const source = `<section name="mySection"><p name="dup" /><p name="dup" /><p name="unique" /></section>\n$mySection.`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+            const autoCompleter = createRefAutoCompleter(source);
 
             const offset = source.length;
             const section = autoCompleter.sourceObj.getReferentAtOffset(
@@ -492,7 +566,7 @@ describe("AutoCompleter", () => {
 
         it("Excludes ambiguous names in top-level completions after $", () => {
             const source = `<section><p name="dup" /><p name="dup" /><p name="unique" /></section>\n$`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+            const autoCompleter = createRefAutoCompleter(source);
 
             const items = autoCompleter
                 .getCompletionItems(source.length)
@@ -505,7 +579,7 @@ describe("AutoCompleter", () => {
 
         it("Suggests descendant names and properties after dot at the start of the file", () => {
             const source = `$mySection.\n<section name="mySection"><p name="myP" /></section>`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+            const autoCompleter = createRefAutoCompleter(source);
 
             const offset = source.indexOf("\n");
             const items = autoCompleter.getCompletionItems(offset);
@@ -518,7 +592,7 @@ describe("AutoCompleter", () => {
 
         it("Suggests members after chained descendant access", () => {
             const source = `<section name="mySection"><p name="myP" /></section>\n$mySection.myP.`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+            const autoCompleter = createRefAutoCompleter(source);
 
             const offset = source.length;
             const items = autoCompleter.getCompletionItems(offset);
@@ -531,7 +605,7 @@ describe("AutoCompleter", () => {
 
         it("Suggests reference names inside attribute values after $", () => {
             const source = `<section name="mySection" /><line through="$myS" />`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+            const autoCompleter = createRefAutoCompleter(source);
 
             const offset = source.indexOf("$myS") + "$myS".length;
             const items = autoCompleter.getCompletionItems(offset);
@@ -547,7 +621,7 @@ describe("AutoCompleter", () => {
 
         it("Suggests descendant members inside attribute values after dot with member prefix", () => {
             const source = `<section name="mySection"><p name="myP" /></section><line through="$mySection.my" />`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+            const autoCompleter = createRefAutoCompleter(source);
 
             const offset =
                 source.indexOf("$mySection.my") + "$mySection.my".length;
@@ -564,7 +638,7 @@ describe("AutoCompleter", () => {
 
         it("Suggests reference names in parenthesized macros with hyphenated prefixes", () => {
             const source = `<math name="foo-bar" /><math name="foo-baz" />\n$(foo-ba`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+            const autoCompleter = createRefAutoCompleter(source);
 
             const offset = source.length;
             const completionContext =
@@ -582,7 +656,7 @@ describe("AutoCompleter", () => {
 
         it("Suggests member completions in parenthesized macros with hyphenated names", () => {
             const source = `<section name="foo-bar"><p name="myP" /></section>\n$(foo-bar.my`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+            const autoCompleter = createRefAutoCompleter(source);
 
             const offset = source.length;
             const completionContext =
@@ -599,7 +673,7 @@ describe("AutoCompleter", () => {
 
         it("Suggests member completions after dot on completed parenthesized macros", () => {
             const source = `<section name="foo-bar"><p name="myP" /></section>\n$(foo-bar).`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+            const autoCompleter = createRefAutoCompleter(source);
 
             const offset = source.length;
             const completionContext =
@@ -620,7 +694,7 @@ describe("AutoCompleter", () => {
 
         it("Inserts parenthesized member text for hyphenated names after dot", () => {
             const source = `<section name="base"><p name="my-p" /><p name="my_p" /></section>\n$base.my`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+            const autoCompleter = createRefAutoCompleter(source);
 
             const items = autoCompleter.getCompletionItems(source.length);
             const hyphenItem = items.find((item) => item.label === "my-p");
@@ -642,7 +716,7 @@ describe("AutoCompleter", () => {
 
         it("Applies same member insertion policy after dot in parenthesized refs", () => {
             const source = `<section name="base"><p name="my-p" /><p name="my_p" /></section>\n$(base).my`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+            const autoCompleter = createRefAutoCompleter(source);
 
             const items = autoCompleter.getCompletionItems(source.length);
             const hyphenItem = items.find((item) => item.label === "my-p");
@@ -664,7 +738,7 @@ describe("AutoCompleter", () => {
 
         it("Classifies parenthesized member-segment syntax after dot as refMember", () => {
             const source = `<section name="base"><p name="my-p" /></section>\n$(base).(my`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+            const autoCompleter = createRefAutoCompleter(source);
 
             const completionContext = autoCompleter.getCompletionContext(
                 source.length,
@@ -677,7 +751,7 @@ describe("AutoCompleter", () => {
 
         it("Does not double-parenthesize insertion in .(member) contexts", () => {
             const source = `<section name="base"><p name="my-p" /></section>\n$(base).(my`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+            const autoCompleter = createRefAutoCompleter(source);
 
             const items = autoCompleter.getCompletionItems(source.length);
             const hyphenItem = items.find((item) => item.label === "my-p");
@@ -689,7 +763,7 @@ describe("AutoCompleter", () => {
             }
         });
 
-        it("Keeps completion visible when a descendant member is fully typed", () => {
+        it("Returns no ref-member completion when no resolver is configured", () => {
             const pointSchema = {
                 elements: [
                     {
@@ -717,11 +791,7 @@ describe("AutoCompleter", () => {
 
             const offset = source.length;
             const items = autoCompleter.getCompletionItems(offset);
-            const coordsItems = items.filter((item) => item.label === "coords");
-
-            expect(coordsItems).toHaveLength(1);
-            expect(coordsItems[0].kind).toBe(CompletionItemKind.Reference);
-            expect(coordsItems[0].detail).toBe("Descendant reference name");
+            expect(items).toEqual([]);
         });
 
         it("Returns no ref completions in invalid or unresolved contexts", () => {
@@ -750,45 +820,52 @@ describe("AutoCompleter", () => {
             }
         });
 
-        it("Uses injected resolver hook for member completion", () => {
+        it("Uses adapter-provided member resolution for completions", () => {
             const source = `<section name="mySection"><p name="myP" /></section>\n$missing.`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
-            const resolver = vi.fn(({ offset }: { offset: number }) => ({
+            const autoCompleter = createRefAutoCompleter(source);
+            const resolver = vi.fn((offset: number) => ({
                 node: autoCompleter.sourceObj.getReferentAtOffset(
                     offset,
                     "mySection",
                 ),
                 unresolvedPathParts: [],
+                visibleDescendantNames: ["myP"],
             }));
-            autoCompleter.setResolveRefMemberContainerAtOffset(resolver);
+            autoCompleter.setRustResolverAdapter({
+                isNameAddressableFromOffset: () => true,
+                resolveRefMemberContainerAtOffset: resolver,
+            } as unknown as RustResolverAdapter);
 
             const items = autoCompleter.getCompletionItems(source.length);
 
             expect(resolver).toHaveBeenCalledOnce();
-            expect(resolver).toHaveBeenCalledWith({
-                offset: source.length,
-                pathParts: ["missing", ""],
-                nodeIndex: expect.any(Number), // Index may vary based on structure
-                hasIndex: false,
-            });
+            expect(resolver).toHaveBeenCalledWith(
+                source.length,
+                ["missing", ""],
+                false,
+            );
             expect(items.some((item) => item.label === "myP")).toBe(true);
             expect(items.some((item) => item.label === "sectionProp")).toBe(
                 true,
             );
         });
 
-        it("Allows setting resolver hook after construction", () => {
+        it("Allows attaching a Rust resolver adapter after construction", () => {
             const source = `<section name="mySection"><p name="myP" /></section>\n$missing.`;
             const autoCompleter = new AutoCompleter(source, refSchema.elements);
-            const resolver = vi.fn(({ offset }: { offset: number }) => ({
+            const resolver = vi.fn((offset: number) => ({
                 node: autoCompleter.sourceObj.getReferentAtOffset(
                     offset,
                     "mySection",
                 ),
                 unresolvedPathParts: [],
+                visibleDescendantNames: ["myP"],
             }));
 
-            autoCompleter.setResolveRefMemberContainerAtOffset(resolver);
+            autoCompleter.setRustResolverAdapter({
+                isNameAddressableFromOffset: () => true,
+                resolveRefMemberContainerAtOffset: resolver,
+            } as unknown as RustResolverAdapter);
 
             const items = autoCompleter.getCompletionItems(source.length);
 
@@ -798,7 +875,7 @@ describe("AutoCompleter", () => {
 
         it("Reports unresolved path segments from default member resolution with null node", () => {
             const source = `<section name="mySection"><p name="myP" /></section>\n$mySection.missing.`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+            const autoCompleter = createRefAutoCompleter(source);
 
             const resolution = autoCompleter.resolveRefMemberContainerAtOffset(
                 source.length,
@@ -812,28 +889,22 @@ describe("AutoCompleter", () => {
 
         it("Passes node index to resolver for index-based resolution", () => {
             const source = `<section name="mySection"><p name="myP" /></section>\n$missing.`;
+            const autoCompleter = new AutoCompleter(source, refSchema.elements);
 
             // Mock resolver that captures the nodeIndex parameter
             const indexCapture: (number | null)[] = [];
             const resolver = vi.fn(
-                ({
-                    nodeIndex,
-                }: {
-                    offset: number;
-                    pathParts: string[];
-                    nodeIndex?: number | null;
-                }) => {
-                    indexCapture.push(nodeIndex ?? null);
-                    // Return no resolution (mock behavior)
+                (offset: number, _pathParts: string[], _hasIndex?: boolean) => {
+                    indexCapture.push(
+                        autoCompleter.sourceObj.getNodeIndexAtOffset(offset),
+                    );
                     return null;
                 },
             );
-
-            const autoCompleter = new AutoCompleter(
-                source,
-                refSchema.elements,
-                { resolveRefMemberContainerAtOffset: resolver },
-            );
+            autoCompleter.setRustResolverAdapter({
+                isNameAddressableFromOffset: () => true,
+                resolveRefMemberContainerAtOffset: resolver,
+            } as unknown as RustResolverAdapter);
 
             autoCompleter.getCompletionItems(source.length);
 
@@ -846,21 +917,21 @@ describe("AutoCompleter", () => {
         it("Allows Rust-backed resolver to use node index directly", () => {
             const source = `<section name="mySection"><p name="myP" /></section>\n$missing.`;
 
-            // Simulate Rust resolver: receives offset and index, performs resolution
+            const autoCompleter = new AutoCompleter(source, refSchema.elements);
+
+            // Simulate Rust resolver: receives offset/path, then derives node index.
             const rustSimulator = vi.fn(
-                ({
-                    offset,
-                    nodeIndex,
-                    pathParts,
-                }: {
-                    offset: number;
-                    nodeIndex?: number | null;
-                    pathParts: string[];
-                }) => {
-                    // In real Rust implementation, would call:
-                    // resolve_path(origin_index, path_parts) -> {node_index, unresolved_path}
+                (offset: number, pathParts: string[]) => {
+                    const nodeIndex =
+                        autoCompleter.sourceObj.getNodeIndexAtOffset(offset);
+                    // In real Rust implementation, adapter would call
+                    // resolve_path(origin_index, path_parts).
                     // For this test, simulate successful resolution to the root element
-                    if (nodeIndex !== null && nodeIndex !== undefined) {
+                    if (
+                        nodeIndex !== null &&
+                        nodeIndex !== undefined &&
+                        pathParts.length > 0
+                    ) {
                         return {
                             node: {
                                 name: "section",
@@ -874,23 +945,19 @@ describe("AutoCompleter", () => {
                     return null;
                 },
             );
-
-            const autoCompleter = new AutoCompleter(
-                source,
-                refSchema.elements,
-                { resolveRefMemberContainerAtOffset: rustSimulator },
-            );
+            autoCompleter.setRustResolverAdapter({
+                isNameAddressableFromOffset: () => true,
+                resolveRefMemberContainerAtOffset: rustSimulator,
+            } as unknown as RustResolverAdapter);
 
             const items = autoCompleter.getCompletionItems(source.length);
 
-            // Verify the Rust-backed resolver was called with the node index
+            // Verify the Rust-backed resolver was called with the source context.
             expect(rustSimulator).toHaveBeenCalledOnce();
             expect(rustSimulator).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    offset: source.length,
-                    nodeIndex: expect.any(Number),
-                    pathParts: expect.any(Array),
-                }),
+                source.length,
+                expect.any(Array),
+                false,
             );
             // Since resolver provided a section node with properties, should have completion items
             expect(items.length).toBeGreaterThan(0);
@@ -1131,62 +1198,36 @@ describe("AutoCompleter", () => {
         });
     });
 
-    describe("RustResolverAdapter architecture", () => {
-        it("Creates a resolver callback compatible with AutoCompleter", () => {
+    describe("RustResolverAdapter contract", () => {
+        it("Creates a disabled resolver callback when no core is attached", () => {
             const source = `<section name="mySection"><p name="myP" /></section>`;
             const sourceObj = new DoenetSourceObject(source);
 
             const adapter = new RustResolverAdapter(sourceObj);
-            const resolver = adapter.createResolver();
+            expect(adapter.isEnabled()).toBe(false);
 
-            // Verify resolver is a function
+            const resolver = adapter.createResolver();
             expect(typeof resolver).toBe("function");
 
-            // Verify it accepts resolver args and returns RefMemberContainerResolution
             const result = resolver({
                 offset: 10,
                 pathParts: ["foo", "bar"],
                 nodeIndex: 2,
             });
 
-            // When Rust backend is not initialized, resolver returns null (fallback)
+            // Without a core, the adapter exposes a disabled resolver.
             expect(result).toBeNull();
         });
 
-        it("Provides disabled resolver when WASM not initialized", () => {
-            const source = `<aa><b></b></aa>`;
-            const sourceObj = new DoenetSourceObject(source);
-
-            const adapter = new RustResolverAdapter(sourceObj);
-
-            // Resolver should be disabled by default if WASM not available
-            expect(adapter.isEnabled()).toBe(false);
-
-            const resolver = adapter.createResolver();
-            const result = resolver({
-                offset: 5,
-                pathParts: ["x", "y"],
-                nodeIndex: 3,
-            });
-
-            // Disabled resolver returns null, allowing JS fallback
-            expect(result).toBeNull();
-        });
-
-        it("Demonstrates node index flow to resolver", () => {
+        it("Passes node index through resolver args", () => {
             const source = `<section name="root"><p name="child" /></section>\n$root.`;
             const sourceObj = new DoenetSourceObject(source);
 
-            // Get node index at offset
             const offset = source.length - 1; // At the dot
             const nodeIndex = sourceObj.getNodeIndexAtOffset(offset);
 
             expect(typeof nodeIndex).toBe("number");
 
-            // Create adapter and resolver
-            const adapter = new RustResolverAdapter(sourceObj);
-
-            // Resolver receives the node index - demonstrate flow
             const testResolver = (args: any) => {
                 expect(args.nodeIndex).toBe(nodeIndex);
                 return null;
@@ -1199,7 +1240,7 @@ describe("AutoCompleter", () => {
             });
         });
 
-        it("Integrates with AutoCompleter via dependency injection", () => {
+        it("Returns no ref completions when the adapter is disabled", () => {
             const source = `<section name="s1"><p name="p1" /></section>\n$s1.`;
             const sourceObj = new DoenetSourceObject(source);
 
@@ -1224,40 +1265,13 @@ describe("AutoCompleter", () => {
             ];
 
             const adapter = new RustResolverAdapter(sourceObj);
-            const resolver = adapter.createResolver();
-
-            // Pass resolver to AutoCompleter
             const autoCompleter = new AutoCompleter(source, testSchema, {
-                resolveRefMemberContainerAtOffset: resolver,
+                rustResolverAdapter: adapter,
             });
 
-            // Resolver will be called during completion lookup
-            // When WASM not initialized, falls back to JS resolver
             const items = autoCompleter.getCompletionItems(source.length);
 
-            // Should have completion items (from JS fallback)
-            expect(items.length).toBeGreaterThan(0);
-        });
-
-        it("Documents architecture for Rust resolver integration", () => {
-            // This test documents the integration point for Rust resolver
-            // When PublicDoenetMLCore.resolve_path() is called, interface will be:
-            //
-            // Current incomplete adapter returns null -> JS fallback
-            // Future: Load WASM, call resolve_path(), map results back to DAST
-            //
-            // Architecture pattern:
-            // 1. Offset -> getNodeIndexAtOffset() -> node index
-            // 2. Node index + pathParts -> resolver callback
-            // 3. Resolver calls resolve_path(origin_index) with Rust PathToCheck format
-            // 4. Maps result.node_idx back to DAST for completions
-
-            const sourceObj = new DoenetSourceObject("<aa></aa>");
-            const adapter = new RustResolverAdapter(sourceObj);
-
-            // Without a core, adapter is disabled
-            expect(adapter.isEnabled()).toBe(false);
-            expect(typeof adapter.createResolver).toBe("function");
+            expect(items).toEqual([]);
         });
     });
 
@@ -1438,39 +1452,6 @@ describe("AutoCompleter", () => {
             expect(result).not.toBeNull();
             expect(result!.node).toBeNull();
             expect(result!.unresolvedPathParts).toEqual(["remaining"]);
-        });
-
-        it("Falls back to JS resolver when adapter disabled", () => {
-            const source = `<section name="s1"><p name="p1" /></section>\n$s1.`;
-            const sourceObj = new DoenetSourceObject(source + " ");
-            const testSchema = [
-                {
-                    name: "section",
-                    children: ["p"],
-                    attributes: [],
-                    properties: [{ name: "p1" }],
-                    top: true,
-                    acceptsStringChildren: true,
-                },
-                {
-                    name: "p",
-                    children: [],
-                    attributes: [],
-                    properties: [],
-                    top: false,
-                    acceptsStringChildren: true,
-                },
-            ];
-
-            // No core → disabled adapter → falls back to JS
-            const adapter = new RustResolverAdapter(sourceObj);
-            const resolver = adapter.createResolver();
-
-            const autoCompleter = new AutoCompleter(source, testSchema, {
-                resolveRefMemberContainerAtOffset: resolver,
-            });
-            const items = autoCompleter.getCompletionItems(source.length);
-            expect(items.length).toBeGreaterThan(0);
         });
 
         it("Handles updateSource to re-sync with core", () => {

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -263,6 +263,23 @@ describe("AutoCompleter", () => {
             `);
         }
     });
+    it("Suggests child elements (not attributes) when < is typed inside a closed element", () => {
+        // Regression: typing `<` inside `<aa>...</aa>` used to return
+        // aa's attributes instead of its allowed child elements.
+        const source = `<aa><</aa>`;
+        const autoCompleter = new AutoCompleter(source, schema.elements);
+        const offset = source.indexOf("><") + 2;
+        const items = autoCompleter.getCompletionItems(offset);
+        const labels = items.map((i) => i.label);
+        // Should contain child elements, not attribute names
+        expect(labels).toContain("b");
+        expect(labels).toContain("c");
+        expect(labels).toContain("d");
+        expect(labels).not.toContain("x");
+        expect(labels).not.toContain("y");
+        expect(labels).not.toContain("xyx");
+    });
+
     it("Can suggest completions for closing tags at the end of the string", () => {
         let source: string;
         let autoCompleter: AutoCompleter;

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -382,78 +382,88 @@ describe("AutoCompleter", () => {
             ],
         };
 
-        function createRefAutoCompleter(source: string) {
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
-            autoCompleter.setRustResolverAdapter({
-                isNameAddressableFromOffset: () => true,
-                resolveRefMemberContainerAtOffset: (
-                    offset: number,
-                    pathParts: string[],
-                ) => {
-                    if (pathParts.length === 0) {
-                        return {
-                            node: null,
-                            unresolvedPathParts: [],
-                        };
-                    }
+        function createRefAutoCompleter(
+            source: string,
+            createAdapter: (
+                sourceObj: DoenetSourceObject,
+            ) => RustResolverAdapter = (sourceObj) =>
+                ({
+                    isNameAddressableFromOffset: () => true,
+                    resolveRefMemberContainerAtOffset: (
+                        offset: number,
+                        pathParts: string[],
+                    ) => {
+                        if (pathParts.length === 0) {
+                            return {
+                                node: null,
+                                unresolvedPathParts: [],
+                            };
+                        }
 
-                    const lookupPathParts = pathParts.slice(0, -1);
-                    if (lookupPathParts.length === 0) {
-                        return {
-                            node: null,
-                            unresolvedPathParts: [],
-                        };
-                    }
+                        const lookupPathParts = pathParts.slice(0, -1);
+                        if (lookupPathParts.length === 0) {
+                            return {
+                                node: null,
+                                unresolvedPathParts: [],
+                            };
+                        }
 
-                    let referent = autoCompleter.sourceObj.getReferentAtOffset(
-                        offset,
-                        lookupPathParts[0],
-                    );
-                    if (!referent) {
-                        return {
-                            node: null,
-                            unresolvedPathParts: lookupPathParts,
-                        };
-                    }
+                        let referent = sourceObj.getReferentAtOffset(
+                            offset,
+                            lookupPathParts[0],
+                        );
+                        if (!referent) {
+                            return {
+                                node: null,
+                                unresolvedPathParts: lookupPathParts,
+                            };
+                        }
 
-                    let firstUnresolvedPartIndex = -1;
-                    for (let i = 1; i < lookupPathParts.length; i++) {
-                        const part = lookupPathParts[i];
-                        const child =
-                            autoCompleter.sourceObj.getNamedDescendant(
+                        let firstUnresolvedPartIndex = -1;
+                        for (let i = 1; i < lookupPathParts.length; i++) {
+                            const part = lookupPathParts[i];
+                            const child = sourceObj.getNamedDescendant(
                                 referent,
                                 part,
                             );
-                        if (!child) {
-                            firstUnresolvedPartIndex = i;
-                            break;
+                            if (!child) {
+                                firstUnresolvedPartIndex = i;
+                                break;
+                            }
+                            referent = child;
                         }
-                        referent = child;
-                    }
 
-                    const unresolvedPathParts =
-                        firstUnresolvedPartIndex === -1
-                            ? []
-                            : lookupPathParts.slice(firstUnresolvedPartIndex);
+                        const unresolvedPathParts =
+                            firstUnresolvedPartIndex === -1
+                                ? []
+                                : lookupPathParts.slice(
+                                      firstUnresolvedPartIndex,
+                                  );
 
-                    if (unresolvedPathParts.length > 0) {
+                        if (unresolvedPathParts.length > 0) {
+                            return {
+                                node: null,
+                                unresolvedPathParts,
+                            };
+                        }
+
                         return {
-                            node: null,
-                            unresolvedPathParts,
+                            node: referent,
+                            unresolvedPathParts: [],
+                            visibleDescendantNames:
+                                sourceObj.getUniqueDescendantNamesForNode(
+                                    referent,
+                                ),
                         };
-                    }
-
-                    return {
-                        node: referent,
-                        unresolvedPathParts: [],
-                        visibleDescendantNames:
-                            autoCompleter.sourceObj.getUniqueDescendantNamesForNode(
-                                referent,
-                            ),
-                    };
-                },
-            } as unknown as RustResolverAdapter);
-            return autoCompleter;
+                    },
+                }) as unknown as RustResolverAdapter,
+        ) {
+            const sourceObj = new DoenetSourceObject();
+            sourceObj.setSource(source + " ");
+            return new AutoCompleter(undefined, refSchema.elements, {
+                sourceObj,
+                rustResolverAdapter: createAdapter(sourceObj),
+            });
         }
 
         it("Suggests reference names after $ with prefix filtering", () => {
@@ -822,24 +832,29 @@ describe("AutoCompleter", () => {
 
         it("Uses adapter-provided member resolution for completions", () => {
             const source = `<section name="mySection"><p name="myP" /></section>\n$missing.`;
-            const autoCompleter = createRefAutoCompleter(source);
-            const resolver = vi.fn((offset: number) => ({
-                node: autoCompleter.sourceObj.getReferentAtOffset(
-                    offset,
-                    "mySection",
-                ),
-                unresolvedPathParts: [],
-                visibleDescendantNames: ["myP"],
-            }));
-            autoCompleter.setRustResolverAdapter({
-                isNameAddressableFromOffset: () => true,
-                resolveRefMemberContainerAtOffset: resolver,
-            } as unknown as RustResolverAdapter);
+            let resolver: ReturnType<typeof vi.fn>;
+            const autoCompleter = createRefAutoCompleter(
+                source,
+                (sourceObj) => {
+                    resolver = vi.fn((offset: number) => ({
+                        node: sourceObj.getReferentAtOffset(
+                            offset,
+                            "mySection",
+                        ),
+                        unresolvedPathParts: [],
+                        visibleDescendantNames: ["myP"],
+                    }));
+                    return {
+                        isNameAddressableFromOffset: () => true,
+                        resolveRefMemberContainerAtOffset: resolver,
+                    } as unknown as RustResolverAdapter;
+                },
+            );
 
             const items = autoCompleter.getCompletionItems(source.length);
 
-            expect(resolver).toHaveBeenCalledOnce();
-            expect(resolver).toHaveBeenCalledWith(
+            expect(resolver!).toHaveBeenCalledOnce();
+            expect(resolver!).toHaveBeenCalledWith(
                 source.length,
                 ["missing", ""],
                 false,
@@ -850,26 +865,30 @@ describe("AutoCompleter", () => {
             );
         });
 
-        it("Allows attaching a Rust resolver adapter after construction", () => {
+        it("Allows providing a Rust resolver adapter during construction", () => {
             const source = `<section name="mySection"><p name="myP" /></section>\n$missing.`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
-            const resolver = vi.fn((offset: number) => ({
-                node: autoCompleter.sourceObj.getReferentAtOffset(
-                    offset,
-                    "mySection",
-                ),
-                unresolvedPathParts: [],
-                visibleDescendantNames: ["myP"],
-            }));
-
-            autoCompleter.setRustResolverAdapter({
-                isNameAddressableFromOffset: () => true,
-                resolveRefMemberContainerAtOffset: resolver,
-            } as unknown as RustResolverAdapter);
+            let resolver: ReturnType<typeof vi.fn>;
+            const autoCompleter = createRefAutoCompleter(
+                source,
+                (sourceObj) => {
+                    resolver = vi.fn((offset: number) => ({
+                        node: sourceObj.getReferentAtOffset(
+                            offset,
+                            "mySection",
+                        ),
+                        unresolvedPathParts: [],
+                        visibleDescendantNames: ["myP"],
+                    }));
+                    return {
+                        isNameAddressableFromOffset: () => true,
+                        resolveRefMemberContainerAtOffset: resolver,
+                    } as unknown as RustResolverAdapter;
+                },
+            );
 
             const items = autoCompleter.getCompletionItems(source.length);
 
-            expect(resolver).toHaveBeenCalledOnce();
+            expect(resolver!).toHaveBeenCalledOnce();
             expect(items.some((item) => item.label === "myP")).toBe(true);
         });
 
@@ -889,22 +908,27 @@ describe("AutoCompleter", () => {
 
         it("Passes node index to resolver for index-based resolution", () => {
             const source = `<section name="mySection"><p name="myP" /></section>\n$missing.`;
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
-
-            // Mock resolver that captures the nodeIndex parameter
             const indexCapture: (number | null)[] = [];
-            const resolver = vi.fn(
-                (offset: number, _pathParts: string[], _hasIndex?: boolean) => {
-                    indexCapture.push(
-                        autoCompleter.sourceObj.getNodeIndexAtOffset(offset),
-                    );
-                    return null;
-                },
+            let resolver!: ReturnType<typeof vi.fn>;
+            const autoCompleter = createRefAutoCompleter(
+                source,
+                (sourceObj) =>
+                    ({
+                        isNameAddressableFromOffset: () => true,
+                        resolveRefMemberContainerAtOffset: (resolver = vi.fn(
+                            (
+                                offset: number,
+                                _pathParts: string[],
+                                _hasIndex?: boolean,
+                            ) => {
+                                indexCapture.push(
+                                    sourceObj.getNodeIndexAtOffset(offset),
+                                );
+                                return null;
+                            },
+                        )),
+                    }) as unknown as RustResolverAdapter,
             );
-            autoCompleter.setRustResolverAdapter({
-                isNameAddressableFromOffset: () => true,
-                resolveRefMemberContainerAtOffset: resolver,
-            } as unknown as RustResolverAdapter);
 
             autoCompleter.getCompletionItems(source.length);
 
@@ -916,45 +940,47 @@ describe("AutoCompleter", () => {
 
         it("Allows Rust-backed resolver to use node index directly", () => {
             const source = `<section name="mySection"><p name="myP" /></section>\n$missing.`;
-
-            const autoCompleter = new AutoCompleter(source, refSchema.elements);
-
-            // Simulate Rust resolver: receives offset/path, then derives node index.
-            const rustSimulator = vi.fn(
-                (offset: number, pathParts: string[]) => {
-                    const nodeIndex =
-                        autoCompleter.sourceObj.getNodeIndexAtOffset(offset);
-                    // In real Rust implementation, adapter would call
-                    // resolve_path(origin_index, path_parts).
-                    // For this test, simulate successful resolution to the root element
-                    if (
-                        nodeIndex !== null &&
-                        nodeIndex !== undefined &&
-                        pathParts.length > 0
-                    ) {
-                        return {
-                            node: {
-                                name: "section",
-                                attributes: {},
-                                children: [],
-                                type: "element",
-                            } as DastElement,
-                            unresolvedPathParts: [],
-                        };
-                    }
-                    return null;
+            let rustSimulator: ReturnType<typeof vi.fn>;
+            const autoCompleter = createRefAutoCompleter(
+                source,
+                (sourceObj) => {
+                    rustSimulator = vi.fn(
+                        (offset: number, pathParts: string[]) => {
+                            const nodeIndex =
+                                sourceObj.getNodeIndexAtOffset(offset);
+                            // In real Rust implementation, adapter would call
+                            // resolve_path(origin_index, path_parts).
+                            // For this test, simulate successful resolution to the root element
+                            if (
+                                nodeIndex !== null &&
+                                nodeIndex !== undefined &&
+                                pathParts.length > 0
+                            ) {
+                                return {
+                                    node: {
+                                        name: "section",
+                                        attributes: {},
+                                        children: [],
+                                        type: "element",
+                                    } as DastElement,
+                                    unresolvedPathParts: [],
+                                };
+                            }
+                            return null;
+                        },
+                    );
+                    return {
+                        isNameAddressableFromOffset: () => true,
+                        resolveRefMemberContainerAtOffset: rustSimulator,
+                    } as unknown as RustResolverAdapter;
                 },
             );
-            autoCompleter.setRustResolverAdapter({
-                isNameAddressableFromOffset: () => true,
-                resolveRefMemberContainerAtOffset: rustSimulator,
-            } as unknown as RustResolverAdapter);
 
             const items = autoCompleter.getCompletionItems(source.length);
 
             // Verify the Rust-backed resolver was called with the source context.
-            expect(rustSimulator).toHaveBeenCalledOnce();
-            expect(rustSimulator).toHaveBeenCalledWith(
+            expect(rustSimulator!).toHaveBeenCalledOnce();
+            expect(rustSimulator!).toHaveBeenCalledWith(
                 source.length,
                 expect.any(Array),
                 false,

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -868,7 +868,7 @@ describe("AutoCompleter", () => {
             expect(resolver!).toHaveBeenCalledWith(
                 source.length,
                 ["missing", ""],
-                false,
+                [false, false],
             );
             expect(items.some((item) => item.label === "myP")).toBe(true);
             expect(items.some((item) => item.label === "sectionProp")).toBe(
@@ -930,6 +930,7 @@ describe("AutoCompleter", () => {
                             (
                                 offset: number,
                                 _pathParts: string[],
+                                _pathPartHasIndex?: boolean[],
                                 _hasIndex?: boolean,
                             ) => {
                                 indexCapture.push(
@@ -994,7 +995,7 @@ describe("AutoCompleter", () => {
             expect(rustSimulator!).toHaveBeenCalledWith(
                 source.length,
                 expect.any(Array),
-                false,
+                expect.any(Array),
             );
             // Since resolver provided a section node with properties, should have completion items
             expect(items.length).toBeGreaterThan(0);

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -358,6 +358,17 @@ describe("AutoCompleter", () => {
                 typedPrefix: "",
             });
         }
+
+        source = ` $foo . `;
+        autoCompleter = new AutoCompleter(source, schema.elements);
+        {
+            const offset = source.indexOf(".") + 1;
+            const elm = autoCompleter.getCompletionContext(offset);
+            expect(elm).toMatchObject({
+                cursorPos: "refMember",
+                typedPrefix: "",
+            });
+        }
     });
 
     describe("Reference completions", () => {

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -390,6 +390,15 @@ describe("AutoCompleter", () => {
                     top: true,
                     acceptsStringChildren: true,
                 },
+                {
+                    name: "select",
+                    children: [],
+                    attributes: [],
+                    properties: [],
+                    top: true,
+                    acceptsStringChildren: true,
+                    takesIndex: true,
+                },
             ],
         };
 
@@ -514,6 +523,29 @@ describe("AutoCompleter", () => {
             if (textEdit && "newText" in textEdit) {
                 expect(textEdit.newText).toBe("(foo-bar)");
             }
+        });
+
+        it("does not offer $name[] when local referent is non-takesIndex but a later duplicate name is takesIndex", () => {
+            const source = `<section name="A"><math>$dup</math><p name="dup">a</p></section><section name="B"><select name="dup"><option><math name="m">1</math></option></select></section>`;
+            const autoCompleter = createRefAutoCompleter(source);
+
+            const offset = source.indexOf("$dup") + "$dup".length;
+            const items = autoCompleter.getCompletionItems(offset);
+            const labels = items.map((i) => i.label);
+
+            expect(labels).toContain("dup");
+            expect(labels).not.toContain("dup[]");
+        });
+
+        it("offers ref completions immediately before a following tag without requiring a space", () => {
+            const source = `<section name="A">$dup<p name="dup">a</p></section><section name="B"><select name="dup"><option><math name="m">1</math></option></select></section>`;
+            const autoCompleter = createRefAutoCompleter(source);
+
+            const offset = source.indexOf("$dup") + "$dup".length;
+            const items = autoCompleter.getCompletionItems(offset);
+            const labels = items.map((i) => i.label);
+
+            expect(labels).toContain("dup");
         });
 
         it("Keeps plain macro text for simple names after $", () => {

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -1627,6 +1627,70 @@ describe("AutoCompleter", () => {
             expect(result!.unresolvedPathParts).toEqual([]);
         });
 
+        it("Blocks traversal when an intermediate non-takesIndex segment has an index", () => {
+            // $sec[1].myP. — section does not takesIndex, so the [1] is spurious
+            // and should produce no completions (false positive is worse than false negative).
+            const source = `<section name="sec"><p name="myP">text</p></section>\n$sec[1].myP.`;
+            const sourceObj = new DoenetSourceObject(source + " ");
+            const { core } = createMockCore(source, sourceObj, {
+                nodeIdx: 1, // p
+                nodesInResolvedPath: [0, 1], // section then p
+                unresolvedPath: null,
+                originalPath: [{ name: "sec" }, { name: "myP" }],
+            });
+
+            const adapter = new RustResolverAdapter(sourceObj, {
+                core,
+                takesIndexComponentTypes: new Set([
+                    "repeat",
+                    "repeatForSequence",
+                ]),
+            });
+            const resolver = adapter.createResolver();
+
+            const result = resolver({
+                offset: source.indexOf("$sec[1].myP.") + "$sec[1].myP.".length,
+                pathParts: ["sec", "myP", ""],
+                pathPartHasIndex: [true, false, false],
+            });
+
+            expect(result).not.toBeNull();
+            expect(result!.node).toBeNull();
+            expect(result!.unresolvedPathParts).toEqual(["sec", "myP"]);
+        });
+
+        it("Blocks completions when the resolved non-takesIndex element has an index", () => {
+            // $myMath[1]. — math does not takesIndex, so the [1] is spurious
+            // and should produce no completions.
+            const source = `<math name="myMath">x</math>\n$myMath[1].`;
+            const sourceObj = new DoenetSourceObject(source + " ");
+            const { core } = createMockCore(source, sourceObj, {
+                nodeIdx: 0, // myMath
+                nodesInResolvedPath: [0],
+                unresolvedPath: null,
+                originalPath: [{ name: "myMath" }],
+            });
+
+            const adapter = new RustResolverAdapter(sourceObj, {
+                core,
+                takesIndexComponentTypes: new Set([
+                    "repeat",
+                    "repeatForSequence",
+                ]),
+            });
+            const resolver = adapter.createResolver();
+
+            const result = resolver({
+                offset: source.indexOf("$myMath[1].") + "$myMath[1].".length,
+                pathParts: ["myMath", ""],
+                pathPartHasIndex: [true, false],
+            });
+
+            expect(result).not.toBeNull();
+            expect(result!.node).toBeNull();
+            expect(result!.unresolvedPathParts).toEqual([]);
+        });
+
         it("Handles updateSource to re-sync with core", () => {
             const source1 = `<section name="s1"><p name="p1" /></section>`;
             const sourceObj1 = new DoenetSourceObject(source1);

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -369,6 +369,20 @@ describe("AutoCompleter", () => {
                 typedPrefix: "",
             });
         }
+
+        source = ` $foo[1]. `;
+        autoCompleter = new AutoCompleter(source, schema.elements);
+        {
+            const offset = source.indexOf(".") + 1;
+            const elm = autoCompleter.getCompletionContext(offset);
+            expect(elm).toEqual({
+                cursorPos: "refMember",
+                typedPrefix: "",
+                replaceFromOffset: source.indexOf(".") + 1,
+                pathParts: ["foo", ""],
+                pathPartHasIndex: [true, false],
+            });
+        }
     });
 
     describe("Reference completions", () => {
@@ -1529,6 +1543,119 @@ describe("AutoCompleter", () => {
             expect(result).not.toBeNull();
             expect(result!.node).toBeNull();
             expect(result!.unresolvedPathParts).toEqual(["remaining"]);
+        });
+
+        it("Treats missing trailing member segment as an implicit empty segment", () => {
+            const source = `<section name="s"><p name="p1" /></section>\n$s.p1.`;
+            const sourceObj = new DoenetSourceObject(source + " ");
+            const { core, calls } = createMockCore(source, sourceObj, {
+                nodeIdx: 1,
+                nodesInResolvedPath: [0, 1],
+                unresolvedPath: null,
+                originalPath: [{ name: "s" }, { name: "p1" }],
+            });
+
+            const adapter = new RustResolverAdapter(sourceObj, { core });
+            const resolver = adapter.createResolver();
+
+            const result = resolver({
+                offset: source.indexOf("$s.p1.") + "$s.p1.".length,
+                // Simulates a parser/context path that dropped the final empty segment.
+                pathParts: ["s", "p1"],
+            });
+
+            expect(result).not.toBeNull();
+            expect(calls[0].path).toEqual({
+                path: [
+                    { type: "flatPathPart", name: "s", index: [] },
+                    { type: "flatPathPart", name: "p1", index: [] },
+                ],
+            });
+        });
+
+        it("isNameAddressableFromOffset enforces exact case for resolved referent names", () => {
+            const source = `<section name="sec"><math name="Inside">x</math>$in</section>`;
+            const sourceObj = new DoenetSourceObject(source + " ");
+            const { core } = createMockCore(source, sourceObj, {
+                nodeIdx: 1,
+                nodesInResolvedPath: [1],
+                unresolvedPath: null,
+                originalPath: [{ name: "Inside" }],
+            });
+
+            const adapter = new RustResolverAdapter(sourceObj, { core });
+
+            const offset = source.indexOf("$in") + 1;
+            expect(adapter.isNameAddressableFromOffset(offset, "inside")).toBe(
+                false,
+            );
+            expect(adapter.isNameAddressableFromOffset(offset, "Inside")).toBe(
+                true,
+            );
+        });
+
+        it("Filters visibleDescendantNames by exact-case referent match", () => {
+            const source = `<section name="sec"><math name="inside">x</math></section><math name="Inside">y</math>\n$sec.`;
+            const sourceObj = new DoenetSourceObject(source + " ");
+
+            const elements: Array<{
+                data: { id: number };
+                position?: { start: { offset?: number } };
+            }> = [];
+            let nextId = 0;
+            const collectElements = (node: any) => {
+                if (node.type === "element") {
+                    elements.push({
+                        data: { id: nextId++ },
+                        position: node.position,
+                    });
+                    for (const child of node.children || []) {
+                        collectElements(child);
+                    }
+                }
+            };
+            for (const child of sourceObj.dast.children) {
+                collectElements(child);
+            }
+
+            const core: RustResolverCore = {
+                set_source: () => {},
+                set_flags: () => {},
+                return_dast: () => ({ elements }),
+                resolve_path: (path) => {
+                    const first = (path.path[0] as { name: string }).name;
+                    // Resolve $sec. to section (id 0), but resolve probe "inside"
+                    // to differently cased "Inside" outside the section (id 2).
+                    if (first === "sec") {
+                        return {
+                            nodeIdx: 0,
+                            nodesInResolvedPath: [0],
+                            unresolvedPath: null,
+                            originalPath: [{ name: "sec" }],
+                        };
+                    }
+                    if (first === "inside") {
+                        return {
+                            nodeIdx: 2,
+                            nodesInResolvedPath: [2],
+                            unresolvedPath: null,
+                            originalPath: [{ name: "inside" }],
+                        };
+                    }
+                    throw new Error("NoReferent");
+                },
+            };
+
+            const adapter = new RustResolverAdapter(sourceObj, { core });
+            const resolver = adapter.createResolver();
+
+            const result = resolver({
+                offset: source.indexOf("$sec.") + "$sec.".length,
+                pathParts: ["sec", ""],
+            });
+
+            expect(result).not.toBeNull();
+            expect(result!.visibleDescendantNames).not.toContain("inside");
         });
 
         it("Blocks unindexed traversal from the first takesIndex segment, not the following segment", () => {

--- a/packages/lsp-tools/test/doenet-source-object.test.ts
+++ b/packages/lsp-tools/test/doenet-source-object.test.ts
@@ -215,6 +215,19 @@ describe("DoenetSourceObject", () => {
         }
     });
 
+    it("Returns body (not openTag) when < is typed inside an element", () => {
+        // When a user types `<` inside an element, the completion should
+        // recognize the cursor is in the body (to suggest child elements),
+        // not in the parent's open tag (which would suggest attributes).
+        const source = `<booleanInput name="bi"><</booleanInput>`;
+        const sourceObj = new DoenetSourceObject(source);
+        const offset = source.indexOf("><") + 2; // right after the typed `<`
+        const { cursorPosition, node } =
+            sourceObj.elementAtOffsetWithContext(offset);
+        expect(cursorPosition).toEqual("body");
+        expect(node).toMatchObject({ type: "element", name: "booleanInput" });
+    });
+
     it("Can get cursor position when element contains macro", () => {
         let source: string;
         let sourceObj: DoenetSourceObject;

--- a/packages/lsp-tools/test/resolver-parity.test.ts
+++ b/packages/lsp-tools/test/resolver-parity.test.ts
@@ -108,7 +108,6 @@ describe("Resolver Parity - Member Completion Resolution", () => {
 
         it("Stops resolution at unresolved path segment", () => {
             const source = `<section name="s" />\n$s.nonexistent.`;
-            const sourceObj = new DoenetSourceObject(source);
             const completer = new AutoCompleter(source, testSchema);
 
             const items = completer.getCompletionItems(source.length);

--- a/packages/lsp-tools/test/resolver-parity.test.ts
+++ b/packages/lsp-tools/test/resolver-parity.test.ts
@@ -9,9 +9,6 @@ import { DastElement } from "@doenet/parser";
  *
  * These tests focus on resolver parity for common member-chain paths,
  * including hyphenated non-first path segments.
- *
- * When Rust resolver is integrated via RustResolverAdapter, these tests
- * should pass for both TypeScript and Rust resolution backends.
  */
 describe("Resolver Parity - Member Completion Resolution", () => {
     const testSchema = [
@@ -41,11 +38,65 @@ describe("Resolver Parity - Member Completion Resolution", () => {
         },
     ];
 
+    function createCompleter(source: string) {
+        const completer = new AutoCompleter(source, testSchema);
+        completer.setRustResolverAdapter({
+            isNameAddressableFromOffset: () => true,
+            resolveRefMemberContainerAtOffset: (
+                offset: number,
+                pathParts: string[],
+            ) => {
+                if (pathParts.length === 0) {
+                    return { node: null, unresolvedPathParts: [] };
+                }
+                const lookupPathParts = pathParts.slice(0, -1);
+                if (lookupPathParts.length === 0) {
+                    return { node: null, unresolvedPathParts: [] };
+                }
+
+                let referent = completer.sourceObj.getReferentAtOffset(
+                    offset,
+                    lookupPathParts[0],
+                );
+                if (!referent) {
+                    return {
+                        node: null,
+                        unresolvedPathParts: lookupPathParts,
+                    };
+                }
+
+                for (let i = 1; i < lookupPathParts.length; i++) {
+                    const next = completer.sourceObj.getNamedDescendant(
+                        referent,
+                        lookupPathParts[i],
+                    );
+                    if (!next) {
+                        return {
+                            node: null,
+                            unresolvedPathParts: lookupPathParts.slice(i),
+                        };
+                    }
+                    referent = next;
+                }
+
+                return {
+                    node: referent,
+                    unresolvedPathParts: [],
+                    visibleDescendantNames:
+                        completer.sourceObj.getUniqueDescendantNamesForNode(
+                            referent,
+                        ),
+                };
+            },
+        } as any);
+        return completer;
+    }
+
     describe("Single-level member access", () => {
         it("Resolves direct child reference by name", () => {
             const source = `<section name="s"><p name="p1" /></section>\n$s.`;
             const sourceObj = new DoenetSourceObject(source);
-            const completer = new AutoCompleter(source, testSchema);
+            const completer = createCompleter(source);
 
             // At the dot, should suggest properties and children
             const items = completer.getCompletionItems(source.length);
@@ -57,7 +108,7 @@ describe("Resolver Parity - Member Completion Resolution", () => {
         it("Resolves section properties when section reference is used", () => {
             const source = `<section name="mySection" />\n$mySection.`;
             const sourceObj = new DoenetSourceObject(source);
-            const completer = new AutoCompleter(source, testSchema);
+            const completer = createCompleter(source);
 
             const items = completer.getCompletionItems(source.length);
 
@@ -71,7 +122,7 @@ describe("Resolver Parity - Member Completion Resolution", () => {
         it("Returns empty completions for unresolvable reference", () => {
             const source = `<section name="s" />\n$unknown.`;
             const sourceObj = new DoenetSourceObject(source);
-            const completer = new AutoCompleter(source, testSchema);
+            const completer = createCompleter(source);
 
             const items = completer.getCompletionItems(source.length);
 
@@ -84,7 +135,7 @@ describe("Resolver Parity - Member Completion Resolution", () => {
         it("Resolves nested property access through chain", () => {
             const source = `<section name="s"><subsection name="sub"><p name="p1" /></subsection></section>\n$s.sub.`;
             const sourceObj = new DoenetSourceObject(source);
-            const completer = new AutoCompleter(source, testSchema);
+            const completer = createCompleter(source);
 
             const items = completer.getCompletionItems(source.length);
 
@@ -98,7 +149,7 @@ describe("Resolver Parity - Member Completion Resolution", () => {
         it("Resolves nested member access when a non-first segment has a hyphen", () => {
             const source = `<section name="s"><subsection name="sub-sec"><p name="p1" /></subsection></section>\n$s.sub-sec.`;
             const sourceObj = new DoenetSourceObject(source);
-            const completer = new AutoCompleter(source, testSchema);
+            const completer = createCompleter(source);
 
             const items = completer.getCompletionItems(source.length);
 
@@ -108,7 +159,7 @@ describe("Resolver Parity - Member Completion Resolution", () => {
 
         it("Stops resolution at unresolved path segment", () => {
             const source = `<section name="s" />\n$s.nonexistent.`;
-            const completer = new AutoCompleter(source, testSchema);
+            const completer = createCompleter(source);
 
             const items = completer.getCompletionItems(source.length);
 
@@ -119,7 +170,7 @@ describe("Resolver Parity - Member Completion Resolution", () => {
         it("Reports unresolved path for partial resolution", () => {
             const source = `<section name="s"><p name="p1" /></section>\n$s.p1.textProp`;
             const sourceObj = new DoenetSourceObject(source);
-            const completer = new AutoCompleter(source, testSchema);
+            const completer = createCompleter(source);
 
             // Request at 'textProp' position
             const offset = source.lastIndexOf("textProp") + "textProp".length;
@@ -131,56 +182,22 @@ describe("Resolver Parity - Member Completion Resolution", () => {
         });
     });
 
-    describe("Node index tracking", () => {
-        it("Provides node index for resolver at each offset", () => {
-            const source = `<section name="s"><p name="p1" /></section>\n$s.`;
-            const sourceObj = new DoenetSourceObject(source);
-
-            // Get node index at the dot
-            const dotOffset = source.length - 1;
-            const nodeIndex = sourceObj.getNodeIndexAtOffset(dotOffset);
-
-            // Should have a valid node index
-            expect(typeof nodeIndex).toBe("number");
-            expect(nodeIndex).toBeGreaterThanOrEqual(0);
-        });
-
-        it("Maintains consistent node indices across multiple calls", () => {
-            const source = `<section name="s"><p name="p1" /></section>`;
-            const sourceObj = new DoenetSourceObject(source);
-
-            // Offsets in different elements
-            const sectionStart = 1; // Inside <section>
-            const pStart = 19; // Inside <p>
-
-            const sectionIdx1 = sourceObj.getNodeIndexAtOffset(sectionStart);
-            const sectionIdx2 = sourceObj.getNodeIndexAtOffset(sectionStart);
-            const pIdx1 = sourceObj.getNodeIndexAtOffset(pStart);
-            const pIdx2 = sourceObj.getNodeIndexAtOffset(pStart);
-
-            // Same offset should always give same index
-            expect(sectionIdx1).toBe(sectionIdx2);
-            expect(pIdx1).toBe(pIdx2);
-
-            // Different elements should have different indices (in depth-first order)
-            expect(sectionIdx1).not.toBe(pIdx1);
-        });
-    });
-
     describe("Resolver interface contract", () => {
-        it("Resolver callback receives all required arguments including nodeIndex", () => {
+        it("Resolver callback receives offset/path/hasIndex", () => {
             const source = `<section name="s"><p name="p1" /></section>\n$s.`;
-            const sourceObj = new DoenetSourceObject(source);
-
             const capturedArgs: any[] = [];
-            const testResolver = (args: any) => {
-                capturedArgs.push(args);
-                return null; // Fall back to JS resolver
-            };
-
-            const completer = new AutoCompleter(source, testSchema, {
-                resolveRefMemberContainerAtOffset: testResolver,
-            });
+            const completer = new AutoCompleter(source, testSchema);
+            completer.setRustResolverAdapter({
+                isNameAddressableFromOffset: () => true,
+                resolveRefMemberContainerAtOffset: (
+                    offset: number,
+                    pathParts: string[],
+                    hasIndex?: boolean,
+                ) => {
+                    capturedArgs.push({ offset, pathParts, hasIndex });
+                    return null;
+                },
+            } as any);
 
             completer.getCompletionItems(source.length);
 
@@ -191,31 +208,14 @@ describe("Resolver Parity - Member Completion Resolution", () => {
             const lastCall = capturedArgs[capturedArgs.length - 1];
             expect(lastCall).toHaveProperty("offset");
             expect(lastCall).toHaveProperty("pathParts");
-            expect(lastCall).toHaveProperty("nodeIndex");
-
-            // nodeIndex should be a number
-            expect(typeof lastCall.nodeIndex).toBe("number");
+            expect(lastCall).toHaveProperty("hasIndex");
         });
 
-        it("Resolver can return null to trigger JS resolver fallback", () => {
-            const source = `<section name="s"><p name="p1" /></section>\n$s.`;
-            const sourceObj = new DoenetSourceObject(source);
-
-            const completer = new AutoCompleter(source, testSchema, {
-                resolveRefMemberContainerAtOffset: () => null, // Always return null
-            });
-
-            // Should still get completions from JS resolver
-            const items = completer.getCompletionItems(source.length);
-            expect(items.length).toBeGreaterThan(0);
-        });
-
-        it("Resolver can provide resolution to override JS behavior", () => {
+        it("Resolver can provide resolution for member completions", () => {
             const source = `<section name="s"><p name="p1" /></section>\n$custom.`;
-            const sourceObj = new DoenetSourceObject(source);
-
-            // Provide custom resolution for non-existent reference
-            const completer = new AutoCompleter(source, testSchema, {
+            const completer = new AutoCompleter(source, testSchema);
+            completer.setRustResolverAdapter({
+                isNameAddressableFromOffset: () => true,
                 resolveRefMemberContainerAtOffset: () => ({
                     node: {
                         name: "section",
@@ -224,8 +224,9 @@ describe("Resolver Parity - Member Completion Resolution", () => {
                         children: [],
                     } as DastElement,
                     unresolvedPathParts: [],
+                    visibleDescendantNames: ["p1"],
                 }),
-            });
+            } as any);
 
             const items = completer.getCompletionItems(source.length);
 
@@ -236,33 +237,25 @@ describe("Resolver Parity - Member Completion Resolution", () => {
         });
     });
 
-    describe("Resolver fallback behavior", () => {
-        it("JS resolver provides completions when custom resolver returns null", () => {
+    describe("Resolver disabled behavior", () => {
+        it("No member completions when resolver returns null", () => {
             const source = `<section name="s"><p name="p1" /></section>\n$s.`;
-            const sourceObj = new DoenetSourceObject(source);
-
-            const completer = new AutoCompleter(source, testSchema, {
+            const completer = new AutoCompleter(source, testSchema);
+            completer.setRustResolverAdapter({
+                isNameAddressableFromOffset: () => true,
                 resolveRefMemberContainerAtOffset: () => null,
-            });
+            } as any);
 
             const items = completer.getCompletionItems(source.length);
-
-            // JS fallback should suggest children
-            expect(items.some((item) => item.label === "p1")).toBe(true);
+            expect(items).toEqual([]);
         });
 
-        it("JS resolver is called when no custom resolver is provided", () => {
+        it("No member completions when no resolver is provided", () => {
             const source = `<section name="s"><p name="p1" /></section>\n$s.`;
-            const sourceObj = new DoenetSourceObject(source);
-
-            // No custom resolver provided
             const completer = new AutoCompleter(source, testSchema);
 
             const items = completer.getCompletionItems(source.length);
-
-            // JS resolver should provide completions
-            expect(items.length).toBeGreaterThan(0);
-            expect(items.some((item) => item.label === "p1")).toBe(true);
+            expect(items).toEqual([]);
         });
     });
 
@@ -272,14 +265,16 @@ describe("Resolver Parity - Member Completion Resolution", () => {
             const sourceObj = new DoenetSourceObject(source);
 
             const capturedPaths: string[][] = [];
-            const testResolver = (args: any) => {
-                capturedPaths.push(args.pathParts);
+            const testResolver = (_offset: number, pathParts: string[]) => {
+                capturedPaths.push(pathParts);
                 return null;
             };
 
-            const completer = new AutoCompleter(source, testSchema, {
+            const completer = new AutoCompleter(source, testSchema);
+            completer.setRustResolverAdapter({
+                isNameAddressableFromOffset: () => true,
                 resolveRefMemberContainerAtOffset: testResolver,
-            });
+            } as any);
 
             completer.getCompletionItems(source.length);
 

--- a/packages/lsp-tools/test/resolver-parity.test.ts
+++ b/packages/lsp-tools/test/resolver-parity.test.ts
@@ -184,7 +184,7 @@ describe("Resolver Parity - Member Completion Resolution", () => {
     });
 
     describe("Resolver interface contract", () => {
-        it("Resolver callback receives offset/path/hasIndex", () => {
+        it("Resolver callback receives offset/path/pathPartHasIndex", () => {
             const source = `<section name="s"><p name="p1" /></section>\n$s.`;
             const capturedArgs: any[] = [];
             const completer = new AutoCompleter(source, testSchema, {
@@ -193,9 +193,13 @@ describe("Resolver Parity - Member Completion Resolution", () => {
                     resolveRefMemberContainerAtOffset: (
                         offset: number,
                         pathParts: string[],
-                        hasIndex?: boolean,
+                        pathPartHasIndex?: boolean[],
                     ) => {
-                        capturedArgs.push({ offset, pathParts, hasIndex });
+                        capturedArgs.push({
+                            offset,
+                            pathParts,
+                            pathPartHasIndex,
+                        });
                         return null;
                     },
                 } as any,
@@ -210,7 +214,7 @@ describe("Resolver Parity - Member Completion Resolution", () => {
             const lastCall = capturedArgs[capturedArgs.length - 1];
             expect(lastCall).toHaveProperty("offset");
             expect(lastCall).toHaveProperty("pathParts");
-            expect(lastCall).toHaveProperty("hasIndex");
+            expect(lastCall).toHaveProperty("pathPartHasIndex");
         });
 
         it("Resolver can provide resolution for member completions", () => {

--- a/packages/lsp-tools/test/resolver-parity.test.ts
+++ b/packages/lsp-tools/test/resolver-parity.test.ts
@@ -39,57 +39,58 @@ describe("Resolver Parity - Member Completion Resolution", () => {
     ];
 
     function createCompleter(source: string) {
-        const completer = new AutoCompleter(source, testSchema);
-        completer.setRustResolverAdapter({
-            isNameAddressableFromOffset: () => true,
-            resolveRefMemberContainerAtOffset: (
-                offset: number,
-                pathParts: string[],
-            ) => {
-                if (pathParts.length === 0) {
-                    return { node: null, unresolvedPathParts: [] };
-                }
-                const lookupPathParts = pathParts.slice(0, -1);
-                if (lookupPathParts.length === 0) {
-                    return { node: null, unresolvedPathParts: [] };
-                }
+        const sourceObj = new DoenetSourceObject();
+        sourceObj.setSource(source + " ");
+        return new AutoCompleter(undefined, testSchema, {
+            sourceObj,
+            rustResolverAdapter: {
+                isNameAddressableFromOffset: () => true,
+                resolveRefMemberContainerAtOffset: (
+                    offset: number,
+                    pathParts: string[],
+                ) => {
+                    if (pathParts.length === 0) {
+                        return { node: null, unresolvedPathParts: [] };
+                    }
+                    const lookupPathParts = pathParts.slice(0, -1);
+                    if (lookupPathParts.length === 0) {
+                        return { node: null, unresolvedPathParts: [] };
+                    }
 
-                let referent = completer.sourceObj.getReferentAtOffset(
-                    offset,
-                    lookupPathParts[0],
-                );
-                if (!referent) {
-                    return {
-                        node: null,
-                        unresolvedPathParts: lookupPathParts,
-                    };
-                }
-
-                for (let i = 1; i < lookupPathParts.length; i++) {
-                    const next = completer.sourceObj.getNamedDescendant(
-                        referent,
-                        lookupPathParts[i],
+                    let referent = sourceObj.getReferentAtOffset(
+                        offset,
+                        lookupPathParts[0],
                     );
-                    if (!next) {
+                    if (!referent) {
                         return {
                             node: null,
-                            unresolvedPathParts: lookupPathParts.slice(i),
+                            unresolvedPathParts: lookupPathParts,
                         };
                     }
-                    referent = next;
-                }
 
-                return {
-                    node: referent,
-                    unresolvedPathParts: [],
-                    visibleDescendantNames:
-                        completer.sourceObj.getUniqueDescendantNamesForNode(
+                    for (let i = 1; i < lookupPathParts.length; i++) {
+                        const next = sourceObj.getNamedDescendant(
                             referent,
-                        ),
-                };
-            },
-        } as any);
-        return completer;
+                            lookupPathParts[i],
+                        );
+                        if (!next) {
+                            return {
+                                node: null,
+                                unresolvedPathParts: lookupPathParts.slice(i),
+                            };
+                        }
+                        referent = next;
+                    }
+
+                    return {
+                        node: referent,
+                        unresolvedPathParts: [],
+                        visibleDescendantNames:
+                            sourceObj.getUniqueDescendantNamesForNode(referent),
+                    };
+                },
+            } as any,
+        });
     }
 
     describe("Single-level member access", () => {
@@ -186,18 +187,19 @@ describe("Resolver Parity - Member Completion Resolution", () => {
         it("Resolver callback receives offset/path/hasIndex", () => {
             const source = `<section name="s"><p name="p1" /></section>\n$s.`;
             const capturedArgs: any[] = [];
-            const completer = new AutoCompleter(source, testSchema);
-            completer.setRustResolverAdapter({
-                isNameAddressableFromOffset: () => true,
-                resolveRefMemberContainerAtOffset: (
-                    offset: number,
-                    pathParts: string[],
-                    hasIndex?: boolean,
-                ) => {
-                    capturedArgs.push({ offset, pathParts, hasIndex });
-                    return null;
-                },
-            } as any);
+            const completer = new AutoCompleter(source, testSchema, {
+                rustResolverAdapter: {
+                    isNameAddressableFromOffset: () => true,
+                    resolveRefMemberContainerAtOffset: (
+                        offset: number,
+                        pathParts: string[],
+                        hasIndex?: boolean,
+                    ) => {
+                        capturedArgs.push({ offset, pathParts, hasIndex });
+                        return null;
+                    },
+                } as any,
+            });
 
             completer.getCompletionItems(source.length);
 
@@ -213,20 +215,21 @@ describe("Resolver Parity - Member Completion Resolution", () => {
 
         it("Resolver can provide resolution for member completions", () => {
             const source = `<section name="s"><p name="p1" /></section>\n$custom.`;
-            const completer = new AutoCompleter(source, testSchema);
-            completer.setRustResolverAdapter({
-                isNameAddressableFromOffset: () => true,
-                resolveRefMemberContainerAtOffset: () => ({
-                    node: {
-                        name: "section",
-                        type: "element",
-                        attributes: {},
-                        children: [],
-                    } as DastElement,
-                    unresolvedPathParts: [],
-                    visibleDescendantNames: ["p1"],
-                }),
-            } as any);
+            const completer = new AutoCompleter(source, testSchema, {
+                rustResolverAdapter: {
+                    isNameAddressableFromOffset: () => true,
+                    resolveRefMemberContainerAtOffset: () => ({
+                        node: {
+                            name: "section",
+                            type: "element",
+                            attributes: {},
+                            children: [],
+                        } as DastElement,
+                        unresolvedPathParts: [],
+                        visibleDescendantNames: ["p1"],
+                    }),
+                } as any,
+            });
 
             const items = completer.getCompletionItems(source.length);
 
@@ -240,11 +243,12 @@ describe("Resolver Parity - Member Completion Resolution", () => {
     describe("Resolver disabled behavior", () => {
         it("No member completions when resolver returns null", () => {
             const source = `<section name="s"><p name="p1" /></section>\n$s.`;
-            const completer = new AutoCompleter(source, testSchema);
-            completer.setRustResolverAdapter({
-                isNameAddressableFromOffset: () => true,
-                resolveRefMemberContainerAtOffset: () => null,
-            } as any);
+            const completer = new AutoCompleter(source, testSchema, {
+                rustResolverAdapter: {
+                    isNameAddressableFromOffset: () => true,
+                    resolveRefMemberContainerAtOffset: () => null,
+                } as any,
+            });
 
             const items = completer.getCompletionItems(source.length);
             expect(items).toEqual([]);
@@ -265,16 +269,17 @@ describe("Resolver Parity - Member Completion Resolution", () => {
             const sourceObj = new DoenetSourceObject(source);
 
             const capturedPaths: string[][] = [];
-            const testResolver = (_offset: number, pathParts: string[]) => {
+            function testResolver(_offset: number, pathParts: string[]) {
                 capturedPaths.push(pathParts);
                 return null;
-            };
+            }
 
-            const completer = new AutoCompleter(source, testSchema);
-            completer.setRustResolverAdapter({
-                isNameAddressableFromOffset: () => true,
-                resolveRefMemberContainerAtOffset: testResolver,
-            } as any);
+            const completer = new AutoCompleter(source, testSchema, {
+                rustResolverAdapter: {
+                    isNameAddressableFromOffset: () => true,
+                    resolveRefMemberContainerAtOffset: testResolver,
+                } as any,
+            });
 
             completer.getCompletionItems(source.length);
 

--- a/packages/lsp-tools/test/rust-resolver-integration.test.ts
+++ b/packages/lsp-tools/test/rust-resolver-integration.test.ts
@@ -594,6 +594,23 @@ describe.skipIf(!wasmAvailable)(
             expect(result!.visibleDescendantNames).toContain("m2");
         });
 
+        it("visibleDescendantNames for sugared cc excludes ambiguous direct child names", () => {
+            // Sugared form: duplicate direct child names are ambiguous and
+            // should not be offered as visible descendants.
+            const source = `<conditionalContent name="cc" condition="true"><math name="dup">1</math><math name="dup">2</math><math name="unique">3</math></conditionalContent>\n$cc.`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            const resolver = adapter.createResolver();
+            const result = resolver({
+                offset: source.indexOf("$cc.") + "$cc.".length,
+                pathParts: ["cc", ""],
+            });
+
+            expect(result).not.toBeNull();
+            expect(result!.visibleDescendantNames).toContain("unique");
+            expect(result!.visibleDescendantNames).not.toContain("dup");
+        });
+
         // ---- Index bracket parsing & pathPartHasIndex wiring ----
 
         it("$sel[1]. with pathPartHasIndex shows descendants inside select options", () => {

--- a/packages/lsp-tools/test/rust-resolver-integration.test.ts
+++ b/packages/lsp-tools/test/rust-resolver-integration.test.ts
@@ -705,6 +705,18 @@ describe.skipIf(!wasmAvailable)(
                 expect(propertyItems.length).toBeGreaterThan(0);
             }
 
+            // $rep.myMath. — unindexed traversal through takesIndex composite
+            // should be blocked.
+            {
+                const source = `<repeatForSequence name="rep"><math name="myMath">x<math name="dec">y</math></math></repeatForSequence>\n$rep.myMath.`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const offset = source.length;
+                const items = completer.getCompletionItems(offset);
+                expect(items).toHaveLength(0);
+            }
+
             // $rep[1]. should include valueName/indexName as completions
             {
                 const source = `<repeat name="rep" valueName="v" indexName="i"><math name="m">x</math></repeat>\n$rep[1].`;

--- a/packages/lsp-tools/test/rust-resolver-integration.test.ts
+++ b/packages/lsp-tools/test/rust-resolver-integration.test.ts
@@ -798,6 +798,44 @@ describe.skipIf(!wasmAvailable)(
             }
         });
 
+        it("Blocks completions when a non-takesIndex segment has a spurious index", () => {
+            // $sec[1].myP. — section is not takesIndex, so the [1] is invalid.
+            // Prefer false negative over false positive.
+            {
+                const source = `<section name="sec"><p name="myP">hello</p></section>\n$sec[1].myP.`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const offset = source.length;
+                const items = completer.getCompletionItems(offset);
+                expect(items).toHaveLength(0);
+            }
+
+            // $myMath[1]. — math is not takesIndex, so the [1] is invalid.
+            {
+                const source = `<math name="myMath">x</math>\n$myMath[1].`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const offset = source.length;
+                const items = completer.getCompletionItems(offset);
+                expect(items).toHaveLength(0);
+            }
+
+            // $rep[1].myMath[1]. — rep (repeat) is takesIndex so $rep[1] is
+            // valid. But myMath (math) is not takesIndex, so myMath[1] is
+            // invalid and completions should be suppressed.
+            {
+                const source = `<repeat name="rep"><math name="myMath">x</math></repeat>\n$rep[1].myMath[1].`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const offset = source.length;
+                const items = completer.getCompletionItems(offset);
+                expect(items).toHaveLength(0);
+            }
+        });
+
         it("select without index suppresses descendant-name completions", () => {
             // For direct member access ($sel.), select is takesIndex so
             // descendant names should be suppressed.

--- a/packages/lsp-tools/test/rust-resolver-integration.test.ts
+++ b/packages/lsp-tools/test/rust-resolver-integration.test.ts
@@ -353,24 +353,23 @@ describe.skipIf(!wasmAvailable)(
             }
         });
 
-        it("mixed-case Repeat still enforces takesIndex and injects derived names", () => {
-            // With mixed-case element names from source, behavior should still
-            // match canonical lower-case component handling.
+        it("mixed-case component types are treated case-sensitively by resolver semantics", () => {
+            // Completion matching can be case-insensitive, but semantic behavior
+            // of parsed component types must remain case-sensitive.
 
-            // Indexed member access should expose descendants and repeat names.
+            // `<Repeat>` should not inherit canonical `repeat` takesIndex behavior,
+            // so indexed member access should be invalid.
             {
                 const source = `<Repeat name="rep" valueName="v" indexName="i"><Math name="m">x</Math></Repeat>\n$rep[1].`;
                 const { completer } = createCompleterWithAdapter(source, {
                     includeAdditionalRefNames: true,
                 });
                 const items = completer.getCompletionItems(source.length);
-                const labels = items.map((i) => i.label);
-                expect(labels).toContain("m");
-                expect(labels).toContain("v");
-                expect(labels).toContain("i");
+                expect(items).toEqual([]);
             }
 
-            // Unindexed member access should be blocked for takesIndex elements.
+            // Unindexed access should not inject repeat-derived names because
+            // `<Repeat>` is not the canonical `repeat` component type.
             {
                 const source = `<Repeat name="rep" valueName="v" indexName="i"><Math name="m">x</Math></Repeat>\n$rep.`;
                 const { completer } = createCompleterWithAdapter(source, {

--- a/packages/lsp-tools/test/rust-resolver-integration.test.ts
+++ b/packages/lsp-tools/test/rust-resolver-integration.test.ts
@@ -39,19 +39,21 @@ try {
 
 // --------------- helpers ---------------
 
-/** Build a takesIndex lookup from the real DoenetML schema. */
+/** Build a static takesIndex lookup from the real DoenetML schema. */
 const takesIndexSet = new Set(
     doenetSchema.elements
         .filter((el: any) => el.takesIndex)
         .map((el: any) => el.name as string),
 );
-const takesIndex = (name: string) => takesIndexSet.has(name);
 
 function createCoreAndAdapter(source: string) {
     const core = PublicDoenetMLCore.new() as RustResolverCore;
     core.set_flags("{}");
     const sourceObj = new DoenetSourceObject(source);
-    const adapter = new RustResolverAdapter(sourceObj, { core, takesIndex });
+    const adapter = new RustResolverAdapter(sourceObj, {
+        core,
+        takesIndexComponentTypes: takesIndexSet,
+    });
     return { core, sourceObj, adapter };
 }
 
@@ -59,19 +61,21 @@ function createCompleterWithAdapter(
     source: string,
     options?: { includeAdditionalRefNames?: boolean },
 ) {
-    const completer = new AutoCompleter(source);
+    const sourceObj = new DoenetSourceObject();
+    sourceObj.setSource(source + " ");
     const core = PublicDoenetMLCore.new() as RustResolverCore;
     core.set_flags("{}");
-    const adapter = new RustResolverAdapter(completer.sourceObj, {
+    const adapter = new RustResolverAdapter(sourceObj, {
         core,
-        takesIndex: (name: string) => takesIndexSet.has(name),
+        takesIndexComponentTypes: takesIndexSet,
     });
-    completer.setRustResolverAdapter(adapter);
-    if (options?.includeAdditionalRefNames) {
-        completer.setGetAdditionalRefNames((offset) =>
-            adapter.getRepeatSyntheticNames(offset),
-        );
-    }
+    const completer = new AutoCompleter(undefined, undefined, {
+        sourceObj,
+        rustResolverAdapter: adapter,
+        getAdditionalRefNames: options?.includeAdditionalRefNames
+            ? (offset) => adapter.getDerivedRepeatNames(offset)
+            : undefined,
+    });
     return { completer, adapter };
 }
 

--- a/packages/lsp-tools/test/rust-resolver-integration.test.ts
+++ b/packages/lsp-tools/test/rust-resolver-integration.test.ts
@@ -805,5 +805,59 @@ describe.skipIf(!wasmAvailable)(
             // Unresolved parts reported
             expect(result!.unresolvedPathParts.length).toBeGreaterThan(0);
         });
+
+        // ---- repeatForSequence / else visibility ----
+
+        it("isNameAddressableFromOffset returns false for names inside repeatForSequence from outside", () => {
+            const source = `<repeatForSequence name="rep"><math name="myMath">x</math></repeatForSequence>\n$my`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            const outsideOffset = source.lastIndexOf("$my") + 1;
+            expect(
+                adapter.isNameAddressableFromOffset(outsideOffset, "myMath"),
+            ).toBe(false);
+            expect(
+                adapter.isNameAddressableFromOffset(outsideOffset, "rep"),
+            ).toBe(true);
+        });
+
+        it("names inside repeatForSequence are accessible from INSIDE", () => {
+            const source = `<repeatForSequence name="rep"><math name="myMath">x</math>$my</repeatForSequence>`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            const insideOffset = source.indexOf("$my") + 1;
+            expect(
+                adapter.isNameAddressableFromOffset(insideOffset, "myMath"),
+            ).toBe(true);
+        });
+
+        it("end-to-end: getCompletionItems omits names inside repeatForSequence from outside", () => {
+            const source = `<repeatForSequence name="rep"><math name="myMath">x</math></repeatForSequence>\n$`;
+            const { completer } = createCompleterWithAdapter(source);
+            const items = completer.getCompletionItems(source.length);
+            const labels = items.map((i) => i.label);
+            expect(labels).toContain("rep");
+            expect(labels).toContain("rep[]");
+            expect(labels).not.toContain("myMath");
+        });
+
+        it("isNameAddressableFromOffset returns false for names inside else from outside", () => {
+            // Raw DAST keeps <else> as-is (sugar is not applied in the LSP).
+            // Adding "else" to CHILDREN_INVISIBLE means its children are
+            // hidden from grandparent scopes in the resolver.
+            const source = `<conditionalContent name="cc"><case condition="true"><text name="caseChild">a</text></case><else><text name="elseChild">b</text></else></conditionalContent>\n$`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            const outsideOffset = source.lastIndexOf("$") + 1;
+            expect(
+                adapter.isNameAddressableFromOffset(outsideOffset, "caseChild"),
+            ).toBe(false);
+            expect(
+                adapter.isNameAddressableFromOffset(outsideOffset, "elseChild"),
+            ).toBe(false);
+            expect(
+                adapter.isNameAddressableFromOffset(outsideOffset, "cc"),
+            ).toBe(true);
+        });
     },
 );

--- a/packages/lsp-tools/test/rust-resolver-integration.test.ts
+++ b/packages/lsp-tools/test/rust-resolver-integration.test.ts
@@ -66,10 +66,7 @@ function createCompleterWithAdapter(
         core,
         takesIndex: (name: string) => takesIndexSet.has(name),
     });
-    completer.setResolveRefMemberContainerAtOffset(adapter.createResolver());
-    completer.setIsNameAddressable((offset, name) =>
-        adapter.isNameAddressableFromOffset(offset, name),
-    );
+    completer.setRustResolverAdapter(adapter);
     if (options?.includeAdditionalRefNames) {
         completer.setGetAdditionalRefNames((offset) =>
             adapter.getRepeatSyntheticNames(offset),
@@ -163,16 +160,9 @@ describe.skipIf(!wasmAvailable)(
             ).toBe("s2");
         });
 
-        it("Rust resolver produces same result as JS fallback for basic refs", () => {
+        it("Rust resolver resolves basic refs", () => {
             const source = `<section name="sec"><p name="para">stuff</p></section>\n$sec.`;
             const sourceObj = new DoenetSourceObject(source);
-
-            const acJS = new AutoCompleter();
-            acJS.setSource(source);
-            const jsResult = acJS.resolveRefMemberContainerAtOffset(
-                source.indexOf("$sec.") + 5,
-                ["sec", ""],
-            );
 
             const core = PublicDoenetMLCore.new() as RustResolverCore;
             core.set_flags("{}");
@@ -184,18 +174,12 @@ describe.skipIf(!wasmAvailable)(
             });
 
             expect(rustResult).not.toBeNull();
-            expect(jsResult.node?.type).toBe("element");
             expect(rustResult!.node?.type).toBe("element");
-            expect(
-                (jsResult.node as any)?.attributes?.name?.children?.[0]?.value,
-            ).toBe("sec");
             expect(
                 (rustResult!.node as any)?.attributes?.name?.children?.[0]
                     ?.value,
             ).toBe("sec");
-            expect(rustResult!.unresolvedPathParts).toEqual(
-                jsResult.unresolvedPathParts,
-            );
+            expect(rustResult!.unresolvedPathParts).toEqual([]);
         });
 
         it("visibleDescendantNames respects ChildrenInvisibleToTheirGrandparents for <repeat>", () => {

--- a/packages/lsp-tools/test/rust-resolver-integration.test.ts
+++ b/packages/lsp-tools/test/rust-resolver-integration.test.ts
@@ -594,14 +594,14 @@ describe.skipIf(!wasmAvailable)(
             expect(result!.visibleDescendantNames).toContain("m2");
         });
 
-        // ---- Index bracket parsing & hasIndex wiring ----
+        // ---- Index bracket parsing & pathPartHasIndex wiring ----
 
-        it("$sel[1]. with hasIndex shows descendants inside select options", () => {
+        it("$sel[1]. with pathPartHasIndex shows descendants inside select options", () => {
             const source = `<select name="sel"><option><math name="a">1</math></option><option><math name="b">2</math></option></select>\n$sel[1].`;
             const { adapter } = createCoreAndAdapter(source);
 
             const resolver = adapter.createResolver();
-            // Without hasIndex (bare $sel.) — descendants suppressed
+            // Without per-part index info (bare $sel.) — descendants suppressed
             const noIndex = resolver({
                 offset: source.indexOf("$sel[1].") + "$sel[1].".length,
                 pathParts: ["sel", ""],
@@ -609,23 +609,23 @@ describe.skipIf(!wasmAvailable)(
             expect(noIndex).not.toBeNull();
             expect(noIndex!.visibleDescendantNames).toEqual([]);
 
-            // With hasIndex — descendants should be visible
+            // With per-part index info — descendants should be visible
             const withIndex = resolver({
                 offset: source.indexOf("$sel[1].") + "$sel[1].".length,
                 pathParts: ["sel", ""],
-                hasIndex: true,
+                pathPartHasIndex: [true, false],
             });
             expect(withIndex).not.toBeNull();
             expect(withIndex!.visibleDescendantNames).toContain("a");
             expect(withIndex!.visibleDescendantNames).toContain("b");
         });
 
-        it("$rep[2]. with hasIndex shows descendants inside repeat", () => {
+        it("$rep[2]. with pathPartHasIndex shows descendants inside repeat", () => {
             const source = `<repeat name="rep" numRepetitions="3"><math name="inner">x</math></repeat>\n$rep[2].`;
             const { adapter } = createCoreAndAdapter(source);
 
             const resolver = adapter.createResolver();
-            // Without hasIndex — descendants suppressed
+            // Without per-part index info — descendants suppressed
             const noIndex = resolver({
                 offset: source.indexOf("$rep[2].") + "$rep[2].".length,
                 pathParts: ["rep", ""],
@@ -633,17 +633,17 @@ describe.skipIf(!wasmAvailable)(
             expect(noIndex).not.toBeNull();
             expect(noIndex!.visibleDescendantNames).toEqual([]);
 
-            // With hasIndex — descendants visible
+            // With per-part index info — descendants visible
             const withIndex = resolver({
                 offset: source.indexOf("$rep[2].") + "$rep[2].".length,
                 pathParts: ["rep", ""],
-                hasIndex: true,
+                pathPartHasIndex: [true, false],
             });
             expect(withIndex).not.toBeNull();
             expect(withIndex!.visibleDescendantNames).toContain("inner");
         });
 
-        it("context parser strips bracket indices and sets hasIndex", () => {
+        it("context parser strips bracket indices and sets pathPartHasIndex", () => {
             // $sel[1]. should show descendants of select option children
             // but NOT properties of select (the referent is a child, not the select)
             {
@@ -687,7 +687,7 @@ describe.skipIf(!wasmAvailable)(
 
             // $rep[1].myMath. — deeper path through indexed composite
             // The resolved node is myMath (a math), so we should see its
-            // descendants (dec) AND math properties, NOT blocked by hasIndex.
+            // descendants (dec) AND math properties, NOT blocked by pathPartHasIndex.
             {
                 const source = `<repeatForSequence name="rep"><math name="myMath">x<math name="dec">y</math></math></repeatForSequence>\n$rep[1].myMath.`;
                 const { completer } = createCompleterWithAdapter(source, {
@@ -759,7 +759,7 @@ describe.skipIf(!wasmAvailable)(
                 pathParts: ["sel", ""],
             });
             expect(result).not.toBeNull();
-            // select takesIndex, so without hasIndex, descendants suppressed
+            // select takesIndex, so without per-part index info, descendants suppressed
             expect(result!.visibleDescendantNames).toEqual([]);
         });
 

--- a/packages/lsp-tools/test/rust-resolver-integration.test.ts
+++ b/packages/lsp-tools/test/rust-resolver-integration.test.ts
@@ -353,6 +353,37 @@ describe.skipIf(!wasmAvailable)(
             }
         });
 
+        it("mixed-case Repeat still enforces takesIndex and injects derived names", () => {
+            // With mixed-case element names from source, behavior should still
+            // match canonical lower-case component handling.
+
+            // Indexed member access should expose descendants and repeat names.
+            {
+                const source = `<Repeat name="rep" valueName="v" indexName="i"><Math name="m">x</Math></Repeat>\n$rep[1].`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const items = completer.getCompletionItems(source.length);
+                const labels = items.map((i) => i.label);
+                expect(labels).toContain("m");
+                expect(labels).toContain("v");
+                expect(labels).toContain("i");
+            }
+
+            // Unindexed member access should be blocked for takesIndex elements.
+            {
+                const source = `<Repeat name="rep" valueName="v" indexName="i"><Math name="m">x</Math></Repeat>\n$rep.`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const items = completer.getCompletionItems(source.length);
+                const labels = items.map((i) => i.label);
+                expect(labels).not.toContain("m");
+                expect(labels).not.toContain("v");
+                expect(labels).not.toContain("i");
+            }
+        });
+
         it("repeatForSequence valueName/indexName appear in completions", () => {
             // repeatForSequence with valueName/indexName
             {

--- a/packages/lsp-tools/test/rust-resolver-integration.test.ts
+++ b/packages/lsp-tools/test/rust-resolver-integration.test.ts
@@ -764,6 +764,33 @@ describe.skipIf(!wasmAvailable)(
                 expect(items).toHaveLength(0);
             }
 
+            // $sec.rep[1]. — the resolved terminal segment ("rep") is a
+            // takesIndex composite AND carries an index.  This is an indirect
+            // path (three segments: sec / rep[1] / <empty>), so rep is not
+            // the root of the ref.  The behaviour should be the same as the
+            // direct case $rep[1].: the index means the cursor is after a
+            // replacement child of unknown type, so descendant names should
+            // be offered but schema properties of repeatForSequence should
+            // NOT (they describe the composite, not its unknown replacement).
+            {
+                const source = `<section name="sec"><repeatForSequence name="rep"><math name="myMath">x</math></repeatForSequence></section>\n$sec.rep[1].`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const offset = source.length;
+                const items = completer.getCompletionItems(offset);
+                const labels = items.map((i) => i.label);
+                // Descendant names of the replacement are visible.
+                expect(labels).toContain("myMath");
+                // Schema properties of repeatForSequence must NOT appear —
+                // the indexed form dereferences a replacement child of
+                // unknown component type.
+                const propertyItems = items.filter(
+                    (i) => i.kind === CompletionItemKind.Property,
+                );
+                expect(propertyItems).toHaveLength(0);
+            }
+
             // The same indexed traversal should also work when the ref is
             // resolved from inside an enclosing element whose node becomes the
             // origin in the Rust resolver output.

--- a/packages/lsp-tools/test/rust-resolver-integration.test.ts
+++ b/packages/lsp-tools/test/rust-resolver-integration.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Integration tests that exercise `RustResolverAdapter` with a **real**
+ * `PublicDoenetMLCore` WASM instance.
+ *
+ * These tests are skipped when the WASM module cannot be loaded (e.g. when
+ * the worker-rust package has not been built).
+ */
+import { describe, expect, it } from "vitest";
+import { DoenetSourceObject } from "../src/doenet-source-object";
+import { AutoCompleter, RustResolverAdapter } from "../src";
+import type { RustResolverCore } from "../src";
+
+// --------------- WASM bootstrap (skips if unavailable) ---------------
+
+let PublicDoenetMLCore: any;
+let wasmAvailable = false;
+
+try {
+    // Synchronous import check — vitest evaluates this at module load time.
+    const mod = await import("@doenet/doenetml-worker-rust");
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const wasmPath = path.resolve(
+        import.meta.dirname,
+        "../../doenetml-worker-rust/dist/lib_doenetml_worker_bg.wasm",
+    );
+    const wasmBytes = fs.readFileSync(wasmPath);
+    mod.initSync(wasmBytes);
+    PublicDoenetMLCore = mod.PublicDoenetMLCore;
+    wasmAvailable = true;
+} catch (e) {
+    console.warn(
+        "Skipping WASM integration tests — could not load WASM:",
+        (e as Error).message,
+    );
+}
+
+// --------------- helpers ---------------
+
+function createCoreAndAdapter(source: string) {
+    const core = PublicDoenetMLCore.new() as RustResolverCore;
+    core.set_flags("{}");
+    const sourceObj = new DoenetSourceObject(source);
+    const adapter = new RustResolverAdapter(sourceObj, { core });
+    return { core, sourceObj, adapter };
+}
+
+// --------------- tests ---------------
+
+describe.skipIf(!wasmAvailable)(
+    "RustResolverAdapter integration (real WASM)",
+    () => {
+        it("simple $name. resolution returns the named element", () => {
+            const source = `<section name="s1"><p name="p1">hello</p></section>\n$s1.`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            expect(adapter.isEnabled()).toBe(true);
+
+            const resolver = adapter.createResolver();
+            const result = resolver({
+                offset: source.indexOf("$s1.") + 4,
+                pathParts: ["s1", ""],
+            });
+
+            expect(result).not.toBeNull();
+            expect(result!.node?.type).toBe("element");
+            expect(
+                (result!.node as any)?.attributes?.name?.children?.[0]?.value,
+            ).toBe("s1");
+            expect(result!.unresolvedPathParts).toEqual([]);
+        });
+
+        it("multi-level $a.b. resolves through nested names", () => {
+            const source = `<section name="outer"><section name="inner"><p name="target">text</p></section></section>\n$outer.inner.`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            const resolver = adapter.createResolver();
+            const result = resolver({
+                offset:
+                    source.indexOf("$outer.inner.") + "$outer.inner.".length,
+                pathParts: ["outer", "inner", ""],
+            });
+
+            expect(result).not.toBeNull();
+            expect(result!.node?.type).toBe("element");
+            expect(
+                (result!.node as any)?.attributes?.name?.children?.[0]?.value,
+            ).toBe("inner");
+            expect(result!.unresolvedPathParts).toEqual([]);
+        });
+
+        it("non-existent ref returns null", () => {
+            const source = `<section name="s1"><p name="p1" /></section>\n$noexist.`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            const resolver = adapter.createResolver();
+            const result = resolver({
+                offset: source.indexOf("$noexist.") + "$noexist.".length,
+                pathParts: ["noexist", ""],
+            });
+
+            expect(result).toBeNull();
+        });
+
+        it("updateSource re-syncs and resolves correctly", () => {
+            const source1 = `<section name="s1"><p name="p1" /></section>\n$s1.`;
+            const { adapter } = createCoreAndAdapter(source1);
+
+            const source2 = `<section name="s2"><p name="p1" /></section>\n$s2.`;
+            const sourceObj2 = new DoenetSourceObject(source2);
+            adapter.updateSource(sourceObj2);
+
+            const resolver = adapter.createResolver();
+
+            const oldResult = resolver({
+                offset: source2.indexOf("$s2.") + 4,
+                pathParts: ["s1", ""],
+            });
+            expect(oldResult).toBeNull();
+
+            const newResult = resolver({
+                offset: source2.indexOf("$s2.") + 4,
+                pathParts: ["s2", ""],
+            });
+            expect(newResult).not.toBeNull();
+            expect(newResult!.node?.type).toBe("element");
+            expect(
+                (newResult!.node as any)?.attributes?.name?.children?.[0]
+                    ?.value,
+            ).toBe("s2");
+        });
+
+        it("Rust resolver produces same result as JS fallback for basic refs", () => {
+            const source = `<section name="sec"><p name="para">stuff</p></section>\n$sec.`;
+            const sourceObj = new DoenetSourceObject(source);
+
+            const acJS = new AutoCompleter();
+            acJS.setSource(source);
+            const jsResult = acJS.resolveRefMemberContainerAtOffset(
+                source.indexOf("$sec.") + 5,
+                ["sec", ""],
+            );
+
+            const core = PublicDoenetMLCore.new() as RustResolverCore;
+            core.set_flags("{}");
+            const adapter = new RustResolverAdapter(sourceObj, { core });
+            const resolver = adapter.createResolver();
+            const rustResult = resolver({
+                offset: source.indexOf("$sec.") + 5,
+                pathParts: ["sec", ""],
+            });
+
+            expect(rustResult).not.toBeNull();
+            expect(jsResult.node?.type).toBe("element");
+            expect(rustResult!.node?.type).toBe("element");
+            expect(
+                (jsResult.node as any)?.attributes?.name?.children?.[0]?.value,
+            ).toBe("sec");
+            expect(
+                (rustResult!.node as any)?.attributes?.name?.children?.[0]
+                    ?.value,
+            ).toBe("sec");
+            expect(rustResult!.unresolvedPathParts).toEqual(
+                jsResult.unresolvedPathParts,
+            );
+        });
+
+        it("visibleDescendantNames respects ChildrenInvisibleToTheirGrandparents for <repeat>", () => {
+            // "inside" is a child of <repeat>, which is
+            // ChildrenInvisibleToTheirGrandparents.  From the section's
+            // perspective, "inside" is NOT directly visible — it must be
+            // reached via $sec.rep.inside, not $sec.inside.
+            const source = `<section name="sec"><repeat name="rep"><math name="inside">x</math></repeat></section>\n$sec.`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            const resolver = adapter.createResolver();
+            const result = resolver({
+                offset: source.indexOf("$sec.") + 5,
+                pathParts: ["sec", ""],
+            });
+
+            expect(result).not.toBeNull();
+            expect(result!.visibleDescendantNames).toBeDefined();
+            // "rep" should be visible (it is a direct child of section)
+            expect(result!.visibleDescendantNames).toContain("rep");
+            // "inside" should NOT be visible from section (hidden behind repeat)
+            expect(result!.visibleDescendantNames).not.toContain("inside");
+        });
+
+        it("visibleDescendantNames includes hidden names when resolved via the repeat itself", () => {
+            // When resolving $sec.rep., the <repeat> is the container,
+            // and "inside" IS visible from it.
+            const source = `<section name="sec"><repeat name="rep"><math name="inside">x</math></repeat></section>\n$sec.rep.`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            const resolver = adapter.createResolver();
+            const result = resolver({
+                offset: source.indexOf("$sec.rep.") + "$sec.rep.".length,
+                pathParts: ["sec", "rep", ""],
+            });
+
+            expect(result).not.toBeNull();
+            expect(result!.visibleDescendantNames).toBeDefined();
+            // "inside" IS visible when accessed through the repeat
+            expect(result!.visibleDescendantNames).toContain("inside");
+        });
+
+        it("isNameAddressableFromOffset filters $name completions by visibility", () => {
+            // "inside" is a child of <repeat>, which has
+            // ChildrenInvisibleToTheirGrandparents.  From OUTSIDE the repeat,
+            // $inside should NOT be addressable.  From INSIDE, it should.
+            const source = `<section name="sec"><repeat name="rep"><math name="inside">x</math>$ins</repeat></section>\n$ins`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            // Cursor at the trailing "$ins" (outside repeat) — "inside" is NOT addressable
+            const outsideOffset = source.lastIndexOf("$ins") + 1;
+            expect(
+                adapter.isNameAddressableFromOffset(outsideOffset, "inside"),
+            ).toBe(false);
+            // "sec" and "rep" should still be addressable from outside
+            expect(
+                adapter.isNameAddressableFromOffset(outsideOffset, "sec"),
+            ).toBe(true);
+            expect(
+                adapter.isNameAddressableFromOffset(outsideOffset, "rep"),
+            ).toBe(true);
+
+            // Cursor at the first "$ins" (inside repeat) — "inside" IS addressable
+            const insideOffset = source.indexOf("$ins") + 1;
+            expect(
+                adapter.isNameAddressableFromOffset(insideOffset, "inside"),
+            ).toBe(true);
+        });
+
+        it("getCompletionItems excludes $inside outside repeat but includes it inside repeat", () => {
+            // End-to-end test: wire isNameAddressable into an AutoCompleter
+            // and verify the actual completion list.
+
+            function makeCompleterWithAdapter(source: string) {
+                const completer = new AutoCompleter(source);
+                const core = PublicDoenetMLCore.new() as RustResolverCore;
+                core.set_flags("{}");
+                const adapter = new RustResolverAdapter(completer.sourceObj, {
+                    core,
+                });
+                completer.setResolveRefMemberContainerAtOffset(
+                    adapter.createResolver(),
+                );
+                completer.setIsNameAddressable((offset, name) =>
+                    adapter.isNameAddressableFromOffset(offset, name),
+                );
+                return { completer, adapter };
+            }
+
+            // --- Outside the repeat: bare `$` lists all names ---
+            {
+                // Use bare `$` so prefix is empty and all names are returned.
+                const source = `<section name="sec"><repeat name="rep"><math name="inside">x</math></repeat></section>\n$`;
+                const { completer } = makeCompleterWithAdapter(source);
+
+                const items = completer.getCompletionItems(source.length);
+                const labels = items.map((i) => i.label);
+                // "sec" and "rep" are visible at root
+                expect(labels).toContain("sec");
+                expect(labels).toContain("rep");
+                // "inside" is hidden behind repeat
+                expect(labels).not.toContain("inside");
+            }
+
+            // --- Outside the repeat: `$ins` prefix matches only "inside" ---
+            {
+                const source = `<section name="sec"><repeat name="rep"><math name="inside">x</math></repeat></section>\n$ins`;
+                const { completer } = makeCompleterWithAdapter(source);
+
+                const items = completer.getCompletionItems(source.length);
+                const labels = items.map((i) => i.label);
+                // "inside" is the only name matching prefix "ins", but it's
+                // invisible from outside the repeat → no completions.
+                expect(labels).not.toContain("inside");
+                expect(labels).toHaveLength(0);
+            }
+
+            // --- Inside the repeat: `$ins` matches "inside" ---
+            {
+                const source = `<section name="sec"><repeat name="rep"><math name="inside">x</math>$ins</repeat></section>`;
+                const { completer } = makeCompleterWithAdapter(source);
+
+                const offset = source.indexOf("$ins") + "$ins".length;
+                const items = completer.getCompletionItems(offset);
+                const labels = items.map((i) => i.label);
+                expect(labels).toContain("inside");
+            }
+        });
+    },
+);

--- a/packages/lsp-tools/test/rust-resolver-integration.test.ts
+++ b/packages/lsp-tools/test/rust-resolver-integration.test.ts
@@ -291,5 +291,36 @@ describe.skipIf(!wasmAvailable)(
                 expect(labels).toContain("inside");
             }
         });
+
+        it("does not crash on empty source", () => {
+            const { adapter } = createCoreAndAdapter("");
+            expect(adapter.isEnabled()).toBe(false);
+        });
+
+        it("does not crash on source with no elements (text only)", () => {
+            const { adapter } = createCoreAndAdapter("a");
+            expect(adapter.isEnabled()).toBe(false);
+        });
+
+        it("does not crash on incomplete element markup", () => {
+            const { adapter } = createCoreAndAdapter("<a");
+            // May or may not be enabled depending on how the Rust core
+            // handles the incomplete element, but must not throw.
+            expect(typeof adapter.isEnabled()).toBe("boolean");
+        });
+
+        it("recovers after blank document receives first element", () => {
+            // Simulates: blank document → user types "<p>"
+            const core = PublicDoenetMLCore.new() as RustResolverCore;
+            core.set_flags("{}");
+            const sourceObj = new DoenetSourceObject("");
+            const adapter = new RustResolverAdapter(sourceObj, { core });
+            expect(adapter.isEnabled()).toBe(false);
+
+            // User types "<p name='x'>hi</p>"
+            sourceObj.setSource('<p name="x">hi</p>');
+            adapter.updateSource(sourceObj);
+            expect(adapter.isEnabled()).toBe(true);
+        });
     },
 );

--- a/packages/lsp-tools/test/rust-resolver-integration.test.ts
+++ b/packages/lsp-tools/test/rust-resolver-integration.test.ts
@@ -717,6 +717,57 @@ describe.skipIf(!wasmAvailable)(
                 expect(items).toHaveLength(0);
             }
 
+            // The same indexed traversal should also work when the ref is
+            // resolved from inside an enclosing element whose node becomes the
+            // origin in the Rust resolver output.
+            {
+                const source = `<section name="sec"><repeatForSequence name="rep"><math name="myMath">x<math name="dec">y</math></math></repeatForSequence>\n$rep[1].myMath.</section>`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const offset =
+                    source.indexOf("$rep[1].myMath.") +
+                    "$rep[1].myMath.".length;
+                const items = completer.getCompletionItems(offset);
+                const labels = items.map((i) => i.label);
+                expect(labels).toContain("dec");
+                const propertyItems = items.filter(
+                    (i) => i.kind === CompletionItemKind.Property,
+                );
+                expect(propertyItems.length).toBeGreaterThan(0);
+            }
+
+            // Two nested takesIndex composites should both require indices,
+            // and the doubly-indexed path should still resolve through to the
+            // concrete math target and its descendants.
+            {
+                const source = `<repeat name="outer" numRepetitions="2"><repeatForSequence name="inner"><math name="myMath">x<math name="dec">y</math></math></repeatForSequence></repeat>\n$outer[1].inner[1].myMath.`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const offset = source.length;
+                const items = completer.getCompletionItems(offset);
+                const labels = items.map((i) => i.label);
+                expect(labels).toContain("dec");
+                const propertyItems = items.filter(
+                    (i) => i.kind === CompletionItemKind.Property,
+                );
+                expect(propertyItems.length).toBeGreaterThan(0);
+            }
+
+            // If the first takesIndex segment is indexed but a later
+            // takesIndex segment is not, traversal should still be blocked at
+            // the unindexed segment.
+            {
+                const source = `<repeat name="outer" numRepetitions="2"><repeatForSequence name="inner"><math name="myMath">x<math name="dec">y</math></math></repeatForSequence></repeat>\n$outer[1].inner.myMath.`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const offset = source.length;
+                const items = completer.getCompletionItems(offset);
+                expect(items).toHaveLength(0);
+            }
+
             // $rep[1]. should include valueName/indexName as completions
             {
                 const source = `<repeat name="rep" valueName="v" indexName="i"><math name="m">x</math></repeat>\n$rep[1].`;

--- a/packages/lsp-tools/test/rust-resolver-integration.test.ts
+++ b/packages/lsp-tools/test/rust-resolver-integration.test.ts
@@ -9,6 +9,8 @@ import { describe, expect, it } from "vitest";
 import { DoenetSourceObject } from "../src/doenet-source-object";
 import { AutoCompleter, RustResolverAdapter } from "../src";
 import type { RustResolverCore } from "../src";
+import { doenetSchema } from "@doenet/static-assets/schema";
+import { CompletionItemKind } from "vscode-languageserver/browser";
 
 // --------------- WASM bootstrap (skips if unavailable) ---------------
 
@@ -37,12 +39,43 @@ try {
 
 // --------------- helpers ---------------
 
+/** Build a takesIndex lookup from the real DoenetML schema. */
+const takesIndexSet = new Set(
+    doenetSchema.elements
+        .filter((el: any) => el.takesIndex)
+        .map((el: any) => el.name as string),
+);
+const takesIndex = (name: string) => takesIndexSet.has(name);
+
 function createCoreAndAdapter(source: string) {
     const core = PublicDoenetMLCore.new() as RustResolverCore;
     core.set_flags("{}");
     const sourceObj = new DoenetSourceObject(source);
-    const adapter = new RustResolverAdapter(sourceObj, { core });
+    const adapter = new RustResolverAdapter(sourceObj, { core, takesIndex });
     return { core, sourceObj, adapter };
+}
+
+function createCompleterWithAdapter(
+    source: string,
+    options?: { includeAdditionalRefNames?: boolean },
+) {
+    const completer = new AutoCompleter(source);
+    const core = PublicDoenetMLCore.new() as RustResolverCore;
+    core.set_flags("{}");
+    const adapter = new RustResolverAdapter(completer.sourceObj, {
+        core,
+        takesIndex: (name: string) => takesIndexSet.has(name),
+    });
+    completer.setResolveRefMemberContainerAtOffset(adapter.createResolver());
+    completer.setIsNameAddressable((offset, name) =>
+        adapter.isNameAddressableFromOffset(offset, name),
+    );
+    if (options?.includeAdditionalRefNames) {
+        completer.setGetAdditionalRefNames((offset) =>
+            adapter.getRepeatSyntheticNames(offset),
+        );
+    }
+    return { completer, adapter };
 }
 
 // --------------- tests ---------------
@@ -187,9 +220,10 @@ describe.skipIf(!wasmAvailable)(
             expect(result!.visibleDescendantNames).not.toContain("inside");
         });
 
-        it("visibleDescendantNames includes hidden names when resolved via the repeat itself", () => {
+        it("visibleDescendantNames is empty for takesIndex element (repeat)", () => {
             // When resolving $sec.rep., the <repeat> is the container,
-            // and "inside" IS visible from it.
+            // but repeat has takesIndex so descendants should NOT be
+            // offered as dot-completions (use $rep[1].inside instead).
             const source = `<section name="sec"><repeat name="rep"><math name="inside">x</math></repeat></section>\n$sec.rep.`;
             const { adapter } = createCoreAndAdapter(source);
 
@@ -201,8 +235,8 @@ describe.skipIf(!wasmAvailable)(
 
             expect(result).not.toBeNull();
             expect(result!.visibleDescendantNames).toBeDefined();
-            // "inside" IS visible when accessed through the repeat
-            expect(result!.visibleDescendantNames).toContain("inside");
+            // takesIndex means no dot-access descendants
+            expect(result!.visibleDescendantNames).toEqual([]);
         });
 
         it("isNameAddressableFromOffset filters $name completions by visibility", () => {
@@ -236,27 +270,11 @@ describe.skipIf(!wasmAvailable)(
             // End-to-end test: wire isNameAddressable into an AutoCompleter
             // and verify the actual completion list.
 
-            function makeCompleterWithAdapter(source: string) {
-                const completer = new AutoCompleter(source);
-                const core = PublicDoenetMLCore.new() as RustResolverCore;
-                core.set_flags("{}");
-                const adapter = new RustResolverAdapter(completer.sourceObj, {
-                    core,
-                });
-                completer.setResolveRefMemberContainerAtOffset(
-                    adapter.createResolver(),
-                );
-                completer.setIsNameAddressable((offset, name) =>
-                    adapter.isNameAddressableFromOffset(offset, name),
-                );
-                return { completer, adapter };
-            }
-
             // --- Outside the repeat: bare `$` lists all names ---
             {
                 // Use bare `$` so prefix is empty and all names are returned.
                 const source = `<section name="sec"><repeat name="rep"><math name="inside">x</math></repeat></section>\n$`;
-                const { completer } = makeCompleterWithAdapter(source);
+                const { completer } = createCompleterWithAdapter(source);
 
                 const items = completer.getCompletionItems(source.length);
                 const labels = items.map((i) => i.label);
@@ -270,7 +288,7 @@ describe.skipIf(!wasmAvailable)(
             // --- Outside the repeat: `$ins` prefix matches only "inside" ---
             {
                 const source = `<section name="sec"><repeat name="rep"><math name="inside">x</math></repeat></section>\n$ins`;
-                const { completer } = makeCompleterWithAdapter(source);
+                const { completer } = createCompleterWithAdapter(source);
 
                 const items = completer.getCompletionItems(source.length);
                 const labels = items.map((i) => i.label);
@@ -283,12 +301,122 @@ describe.skipIf(!wasmAvailable)(
             // --- Inside the repeat: `$ins` matches "inside" ---
             {
                 const source = `<section name="sec"><repeat name="rep"><math name="inside">x</math>$ins</repeat></section>`;
-                const { completer } = makeCompleterWithAdapter(source);
+                const { completer } = createCompleterWithAdapter(source);
 
                 const offset = source.indexOf("$ins") + "$ins".length;
                 const items = completer.getCompletionItems(offset);
                 const labels = items.map((i) => i.label);
                 expect(labels).toContain("inside");
+            }
+        });
+
+        it("$name[] snippet offered for takesIndex elements (repeat, select)", () => {
+            // "rep" is a repeat (takesIndex) — should offer "rep[]" snippet
+            {
+                const source = `<section name="sec"><repeat name="rep"><math name="inside">x</math></repeat></section>\n$rep`;
+                const { completer } = createCompleterWithAdapter(source);
+                const items = completer.getCompletionItems(source.length);
+                const labels = items.map((i) => i.label);
+                expect(labels).toContain("rep");
+                expect(labels).toContain("rep[]");
+                // The rep[] item should use snippet cursor protocol
+                const snippetItem = items.find((i) => i.label === "rep[]");
+                expect(snippetItem).toBeDefined();
+                expect(snippetItem!.data).toEqual({
+                    snippetCursor: { caretOffset: 4 }, // cursor between [ and ]
+                });
+            }
+
+            // "sec" is a section (NOT takesIndex) — should NOT offer "sec[]"
+            {
+                const source = `<section name="sec"><repeat name="rep"><math name="inside">x</math></repeat></section>\n$sec`;
+                const { completer } = createCompleterWithAdapter(source);
+                const items = completer.getCompletionItems(source.length);
+                const labels = items.map((i) => i.label);
+                expect(labels).toContain("sec");
+                expect(labels).not.toContain("sec[]");
+            }
+        });
+
+        it("repeat valueName/indexName appear in completions inside repeat", () => {
+            // Inside repeat with valueName="v" indexName="i": $v and $i should appear
+            {
+                const source = `<repeat valueName="v" indexName="i"><math>$</math></repeat>`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const offset = source.indexOf("$") + 1;
+                const items = completer.getCompletionItems(offset);
+                const labels = items.map((i) => i.label);
+                expect(labels).toContain("v");
+                expect(labels).toContain("i");
+            }
+
+            // Outside repeat: $v should NOT appear
+            {
+                const source = `<repeat valueName="v" indexName="i"><math>x</math></repeat>\n$`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const items = completer.getCompletionItems(source.length);
+                const labels = items.map((i) => i.label);
+                expect(labels).not.toContain("v");
+                expect(labels).not.toContain("i");
+            }
+        });
+
+        it("repeatForSequence valueName/indexName appear in completions", () => {
+            // repeatForSequence with valueName/indexName
+            {
+                const source = `<repeatForSequence valueName="val" indexName="idx"><math>$</math></repeatForSequence>`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const offset = source.indexOf("$") + 1;
+                const items = completer.getCompletionItems(offset);
+                const labels = items.map((i) => i.label);
+                expect(labels).toContain("val");
+                expect(labels).toContain("idx");
+            }
+
+            // Only valueName specified
+            {
+                const source = `<repeat valueName="v"><math>$</math></repeat>`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const offset = source.indexOf("$") + 1;
+                const items = completer.getCompletionItems(offset);
+                const labels = items.map((i) => i.label);
+                expect(labels).toContain("v");
+                // Default indexName is not injected
+                expect(labels).not.toContain("i");
+            }
+
+            // Nested repeats: inner names visible inside, outer names also visible
+            {
+                const source = `<repeat valueName="outer"><repeat valueName="inner"><math>$</math></repeat></repeat>`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const offset = source.indexOf("$") + 1;
+                const items = completer.getCompletionItems(offset);
+                const labels = items.map((i) => i.label);
+                expect(labels).toContain("inner");
+                expect(labels).toContain("outer");
+            }
+
+            // Between nested repeats: inner name NOT visible, outer IS
+            {
+                const source = `<repeat valueName="outer"><repeat valueName="inner"><math>x</math></repeat>$</repeat>`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const offset = source.indexOf("$") + 1;
+                const items = completer.getCompletionItems(offset);
+                const labels = items.map((i) => i.label);
+                expect(labels).toContain("outer");
+                expect(labels).not.toContain("inner");
             }
         });
 
@@ -321,6 +449,361 @@ describe.skipIf(!wasmAvailable)(
             sourceObj.setSource('<p name="x">hi</p>');
             adapter.updateSource(sourceObj);
             expect(adapter.isEnabled()).toBe(true);
+        });
+
+        // ---- conditionalContent / select sugar visibility ----
+
+        it("isNameAddressableFromOffset returns false for names inside sugared conditionalContent from outside", () => {
+            // In raw DAST, <math name="inside"> is a direct child of <conditionalContent>.
+            // At runtime, sugar wraps it in <case><group>…</group></case>, hiding it.
+            const source = `<conditionalContent name="cc" condition="$x"><math name="inside">x</math></conditionalContent>\n$ins`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            const outsideOffset = source.lastIndexOf("$ins") + 1;
+            // "inside" should NOT be addressable from outside cc
+            expect(
+                adapter.isNameAddressableFromOffset(outsideOffset, "inside"),
+            ).toBe(false);
+            // "cc" SHOULD be addressable from outside
+            expect(
+                adapter.isNameAddressableFromOffset(outsideOffset, "cc"),
+            ).toBe(true);
+        });
+
+        it("isNameAddressableFromOffset returns false for names inside sugared select from outside", () => {
+            const source = `<select name="sel"><math name="x">1</math><math name="y">2</math></select>\n$x`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            const outsideOffset = source.lastIndexOf("$x") + 1;
+            // "x" and "y" should NOT be addressable from outside select
+            expect(
+                adapter.isNameAddressableFromOffset(outsideOffset, "x"),
+            ).toBe(false);
+            expect(
+                adapter.isNameAddressableFromOffset(outsideOffset, "y"),
+            ).toBe(false);
+            // "sel" SHOULD be addressable
+            expect(
+                adapter.isNameAddressableFromOffset(outsideOffset, "sel"),
+            ).toBe(true);
+        });
+
+        it("names inside conditionalContent are accessible from INSIDE the cc", () => {
+            const source = `<conditionalContent name="cc" condition="$x"><math name="inside">x</math>$ins</conditionalContent>`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            const insideOffset = source.indexOf("$ins") + 1;
+            expect(
+                adapter.isNameAddressableFromOffset(insideOffset, "inside"),
+            ).toBe(true);
+        });
+
+        it("explicit case name is still addressable from outside conditionalContent", () => {
+            const source = `<conditionalContent name="cc"><case name="positiveCase" condition="true"><text>hello</text></case></conditionalContent>\n$pos`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            const outsideOffset = source.lastIndexOf("$pos") + 1;
+            // "positiveCase" is a direct child of cc — should be addressable
+            expect(
+                adapter.isNameAddressableFromOffset(
+                    outsideOffset,
+                    "positiveCase",
+                ),
+            ).toBe(true);
+            // "cc" also addressable
+            expect(
+                adapter.isNameAddressableFromOffset(outsideOffset, "cc"),
+            ).toBe(true);
+        });
+
+        it("end-to-end: getCompletionItems omits names inside sugared cc from outside", () => {
+            // Outside cc: "inside" should not be offered
+            {
+                const source = `<conditionalContent name="cc" condition="$x"><math name="inside">x</math></conditionalContent>\n$`;
+                const { completer } = createCompleterWithAdapter(source);
+                const items = completer.getCompletionItems(source.length);
+                const labels = items.map((i) => i.label);
+                expect(labels).toContain("cc");
+                expect(labels).not.toContain("inside");
+            }
+
+            // Outside select: "x" should not be offered
+            {
+                const source = `<select name="sel"><math name="x">1</math></select>\n$`;
+                const { completer } = createCompleterWithAdapter(source);
+                const items = completer.getCompletionItems(source.length);
+                const labels = items.map((i) => i.label);
+                expect(labels).toContain("sel");
+                expect(labels).not.toContain("x");
+            }
+        });
+
+        it("visibleDescendantNames for $cc. includes names from explicit case children", () => {
+            // <text name="animal"> is inside <case>, which normally blocks
+            // visibility in the Rust resolver.  But for cc member access,
+            // we walk through case/else transparently.
+            const source = `<conditionalContent name="cc"><case condition="true"><text name="animal">dog</text></case><else><text name="animal">cat</text></else></conditionalContent>\n$cc.`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            const resolver = adapter.createResolver();
+            const result = resolver({
+                offset: source.indexOf("$cc.") + "$cc.".length,
+                pathParts: ["cc", ""],
+            });
+
+            expect(result).not.toBeNull();
+            expect(result!.visibleDescendantNames).toBeDefined();
+            expect(result!.visibleDescendantNames).toContain("animal");
+        });
+
+        it("visibleDescendantNames for $cc. includes names from mixed case children", () => {
+            // Two cases with different unique names + one shared name
+            const source = `<conditionalContent name="cc"><case condition="true"><text name="a">1</text><text name="shared">s</text></case><case condition="false"><text name="b">2</text><text name="shared">s</text></case></conditionalContent>\n$cc.`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            const resolver = adapter.createResolver();
+            const result = resolver({
+                offset: source.indexOf("$cc.") + "$cc.".length,
+                pathParts: ["cc", ""],
+            });
+
+            expect(result).not.toBeNull();
+            expect(result!.visibleDescendantNames).toContain("a");
+            expect(result!.visibleDescendantNames).toContain("b");
+            expect(result!.visibleDescendantNames).toContain("shared");
+        });
+
+        it("visibleDescendantNames for $cc. excludes ambiguous names within a single case", () => {
+            // "dup" appears twice in the SAME case → not contributed by that case
+            // It appears once in the other case → still contributed
+            const source = `<conditionalContent name="cc"><case condition="true"><text name="dup">1</text><text name="dup">2</text></case><case condition="false"><text name="dup">3</text></case></conditionalContent>\n$cc.`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            const resolver = adapter.createResolver();
+            const result = resolver({
+                offset: source.indexOf("$cc.") + "$cc.".length,
+                pathParts: ["cc", ""],
+            });
+
+            expect(result).not.toBeNull();
+            // "dup" is unique in the second case, so it should be included
+            expect(result!.visibleDescendantNames).toContain("dup");
+        });
+
+        it("visibleDescendantNames for sugared cc (no explicit case) includes children", () => {
+            // Sugared form: children are direct, not wrapped in case/else
+            const source = `<conditionalContent name="cc" condition="true"><math name="m1">1</math><math name="m2">2</math></conditionalContent>\n$cc.`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            const resolver = adapter.createResolver();
+            const result = resolver({
+                offset: source.indexOf("$cc.") + "$cc.".length,
+                pathParts: ["cc", ""],
+            });
+
+            expect(result).not.toBeNull();
+            expect(result!.visibleDescendantNames).toContain("m1");
+            expect(result!.visibleDescendantNames).toContain("m2");
+        });
+
+        // ---- Index bracket parsing & hasIndex wiring ----
+
+        it("$sel[1]. with hasIndex shows descendants inside select options", () => {
+            const source = `<select name="sel"><option><math name="a">1</math></option><option><math name="b">2</math></option></select>\n$sel[1].`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            const resolver = adapter.createResolver();
+            // Without hasIndex (bare $sel.) — descendants suppressed
+            const noIndex = resolver({
+                offset: source.indexOf("$sel[1].") + "$sel[1].".length,
+                pathParts: ["sel", ""],
+            });
+            expect(noIndex).not.toBeNull();
+            expect(noIndex!.visibleDescendantNames).toEqual([]);
+
+            // With hasIndex — descendants should be visible
+            const withIndex = resolver({
+                offset: source.indexOf("$sel[1].") + "$sel[1].".length,
+                pathParts: ["sel", ""],
+                hasIndex: true,
+            });
+            expect(withIndex).not.toBeNull();
+            expect(withIndex!.visibleDescendantNames).toContain("a");
+            expect(withIndex!.visibleDescendantNames).toContain("b");
+        });
+
+        it("$rep[2]. with hasIndex shows descendants inside repeat", () => {
+            const source = `<repeat name="rep" numRepetitions="3"><math name="inner">x</math></repeat>\n$rep[2].`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            const resolver = adapter.createResolver();
+            // Without hasIndex — descendants suppressed
+            const noIndex = resolver({
+                offset: source.indexOf("$rep[2].") + "$rep[2].".length,
+                pathParts: ["rep", ""],
+            });
+            expect(noIndex).not.toBeNull();
+            expect(noIndex!.visibleDescendantNames).toEqual([]);
+
+            // With hasIndex — descendants visible
+            const withIndex = resolver({
+                offset: source.indexOf("$rep[2].") + "$rep[2].".length,
+                pathParts: ["rep", ""],
+                hasIndex: true,
+            });
+            expect(withIndex).not.toBeNull();
+            expect(withIndex!.visibleDescendantNames).toContain("inner");
+        });
+
+        it("context parser strips bracket indices and sets hasIndex", () => {
+            // $sel[1]. should show descendants of select option children
+            // but NOT properties of select (the referent is a child, not the select)
+            {
+                const source = `<select name="sel"><option><math name="a">1</math></option><option><math name="b">2</math></option></select>\n$sel[1].`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const offset = source.length;
+                const items = completer.getCompletionItems(offset);
+                const labels = items.map((i) => i.label);
+                // Should include descendant names from inside options
+                expect(labels).toContain("a");
+                expect(labels).toContain("b");
+                // Should NOT include properties of the select element itself
+                const kinds = items.map((i) => i.kind);
+                expect(kinds).not.toContain(CompletionItemKind.Property);
+            }
+
+            // $sel. (no index) should NOT show descendants, only properties
+            {
+                const source = `<select name="sel"><option><math name="a">1</math></option></select>\n$sel.`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const offset = source.length;
+                const items = completer.getCompletionItems(offset);
+                const labels = items.map((i) => i.label);
+                expect(labels).not.toContain("a");
+            }
+
+            // $sec[1]. where sec is a section (NOT takesIndex) — should return nothing
+            {
+                const source = `<section name="sec"><math name="m">x</math></section>\n$sec[1].`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const offset = source.length;
+                const items = completer.getCompletionItems(offset);
+                expect(items).toHaveLength(0);
+            }
+
+            // $rep[1].myMath. — deeper path through indexed composite
+            // The resolved node is myMath (a math), so we should see its
+            // descendants (dec) AND math properties, NOT blocked by hasIndex.
+            {
+                const source = `<repeatForSequence name="rep"><math name="myMath">x<math name="dec">y</math></math></repeatForSequence>\n$rep[1].myMath.`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const offset = source.length;
+                const items = completer.getCompletionItems(offset);
+                const labels = items.map((i) => i.label);
+                // Descendant of myMath
+                expect(labels).toContain("dec");
+                // Properties of math should also appear
+                const propertyItems = items.filter(
+                    (i) => i.kind === CompletionItemKind.Property,
+                );
+                expect(propertyItems.length).toBeGreaterThan(0);
+            }
+
+            // $rep[1]. should include valueName/indexName as completions
+            {
+                const source = `<repeat name="rep" valueName="v" indexName="i"><math name="m">x</math></repeat>\n$rep[1].`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const offset = source.length;
+                const items = completer.getCompletionItems(offset);
+                const labels = items.map((i) => i.label);
+                expect(labels).toContain("v");
+                expect(labels).toContain("i");
+                expect(labels).toContain("m");
+            }
+
+            // $rep. (no index) should NOT include valueName/indexName
+            {
+                const source = `<repeat name="rep" valueName="v" indexName="i"><math name="m">x</math></repeat>\n$rep.`;
+                const { completer } = createCompleterWithAdapter(source, {
+                    includeAdditionalRefNames: true,
+                });
+                const offset = source.length;
+                const items = completer.getCompletionItems(offset);
+                const labels = items.map((i) => i.label);
+                expect(labels).not.toContain("v");
+                expect(labels).not.toContain("i");
+                // descendants also suppressed without index
+                expect(labels).not.toContain("m");
+            }
+        });
+
+        it("select without index suppresses descendant-name completions", () => {
+            // For direct member access ($sel.), select is takesIndex so
+            // descendant names should be suppressed.
+            const source = `<select name="sel"><option><math name="m">1</math></option></select>\n$sel.`;
+            const { adapter } = createCoreAndAdapter(source);
+
+            const resolver = adapter.createResolver();
+            const result = resolver({
+                offset: source.indexOf("$sel.") + "$sel.".length,
+                pathParts: ["sel", ""],
+            });
+            expect(result).not.toBeNull();
+            // select takesIndex, so without hasIndex, descendants suppressed
+            expect(result!.visibleDescendantNames).toEqual([]);
+        });
+
+        // ---- $$ function refs and partial resolution ----
+
+        it("$$ triggers refName completions just like $", () => {
+            // $$f should show named elements
+            {
+                const source = `<function name="f">x^2</function>\n$$f`;
+                const { completer } = createCompleterWithAdapter(source);
+                const items = completer.getCompletionItems(source.length);
+                const labels = items.map((i) => i.label);
+                expect(labels).toContain("f");
+            }
+
+            // $$ alone should trigger completions
+            {
+                const source = `<function name="f">x^2</function>\n$$`;
+                const { completer } = createCompleterWithAdapter(source);
+                const items = completer.getCompletionItems(source.length);
+                const labels = items.map((i) => i.label);
+                expect(labels).toContain("f");
+            }
+        });
+
+        it("partial resolution returns null node when path is invalid", () => {
+            // $s.nonexistent. — "s" resolves to section, "nonexistent" fails.
+            // The path is invalid so no completions should be offered.
+            const source = `<section name="s"><p name="p1" /></section>\n$s.nonexistent.`;
+            const { adapter } = createCoreAndAdapter(source);
+            const resolver = adapter.createResolver();
+
+            const result = resolver({
+                offset:
+                    source.indexOf("$s.nonexistent.") +
+                    "$s.nonexistent.".length,
+                pathParts: ["s", "nonexistent", ""],
+            });
+
+            expect(result).not.toBeNull();
+            // Node is null — invalid path
+            expect(result!.node).toBeNull();
+            // Unresolved parts reported
+            expect(result!.unresolvedPathParts.length).toBeGreaterThan(0);
         });
     },
 );

--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -39,7 +39,8 @@
             ],
             "dependencies": [
                 "../lsp-tools:build",
-                "../parser:build"
+                "../parser:build",
+                "../doenetml-worker-rust:build"
             ]
         }
     }

--- a/packages/lsp/src/features/completions.ts
+++ b/packages/lsp/src/features/completions.ts
@@ -11,6 +11,9 @@ export function addDocumentCompletionSupport(
         if (!info) {
             return [];
         }
+        if (info.rustState !== "ready" || !info.rustAdapter) {
+            return [];
+        }
         const completions = info.autoCompleter.getCompletionItems(
             params.position,
         );

--- a/packages/lsp/src/features/completions.ts
+++ b/packages/lsp/src/features/completions.ts
@@ -11,9 +11,20 @@ export function addDocumentCompletionSupport(
         if (!info) {
             return [];
         }
-        if (info.rustState !== "ready" || !info.rustAdapter) {
+
+        const completionContext = info.autoCompleter.getCompletionContext(
+            params.position,
+        );
+        const isRustDependentRefContext =
+            completionContext.cursorPos === "refName" ||
+            completionContext.cursorPos === "refMember";
+        if (
+            isRustDependentRefContext &&
+            (info.rustState !== "ready" || !info.rustAdapter)
+        ) {
             return [];
         }
+
         const completions = info.autoCompleter.getCompletionItems(
             params.position,
         );

--- a/packages/lsp/src/features/completions.ts
+++ b/packages/lsp/src/features/completions.ts
@@ -27,6 +27,7 @@ export function addDocumentCompletionSupport(
 
         const completions = info.autoCompleter.getCompletionItems(
             params.position,
+            completionContext,
         );
         return completions;
     });

--- a/packages/lsp/src/features/validate.ts
+++ b/packages/lsp/src/features/validate.ts
@@ -78,7 +78,7 @@ export function addValidationSupport(
 
     // The content of a text document has changed. This event is emitted
     // when the text document first opened or when its content has changed.
-    documents.onDidChangeContent((change) => {
+    documents.onDidChangeContent(async (change) => {
         const uri = change.document.uri;
         let info = documentInfo.get(uri);
         if (!info) {
@@ -102,48 +102,47 @@ export function addValidationSupport(
             // until Rust is ready.
             info.rustState = "initializing";
             const capturedInfo = info;
-            getRustCore()
-                .then((core) => {
-                    const currentInfo = documentInfo.get(uri);
-                    if (!currentInfo || currentInfo !== capturedInfo) return;
-                    if (capturedInfo.rustAdapter) return;
-                    const sourceObj = capturedInfo.autoCompleter.sourceObj;
-                    // Intentionally create a dedicated core/adapter for this
-                    // document. This avoids cross-document source switching
-                    // complexity and keeps Rust state aligned with this
-                    // document's AutoCompleter mappings.
-                    const adapter = new RustResolverAdapter(sourceObj, {
-                        core: core as RustResolverCore,
-                        takesIndexComponentTypes: getTakesIndexComponentTypes(
-                            capturedInfo.autoCompleter,
-                        ),
-                    });
-                    capturedInfo.rustAdapter = adapter;
-                    capturedInfo.autoCompleter = new AutoCompleter(
-                        undefined,
-                        undefined,
-                        {
-                            sourceObj,
-                            rustResolverAdapter: adapter,
-                            getAdditionalRefNames: (offset: number) =>
-                                adapter.getDerivedRepeatNames(offset),
-                        },
-                    );
-                    capturedInfo.rustState = "ready";
-                })
-                .catch((error) => {
-                    console.warn(
-                        "Rust autocomplete unavailable; completions disabled for this document.",
-                        error,
-                    );
-                    const currentInfo = documentInfo.get(uri);
-                    if (currentInfo === capturedInfo) {
-                        capturedInfo.rustState = "unavailable";
-                    }
+            try {
+                const core = await getRustCore();
+                const currentInfo = documentInfo.get(uri);
+                if (!currentInfo || currentInfo !== capturedInfo) return;
+                if (capturedInfo.rustAdapter) return;
+                const sourceObj = capturedInfo.autoCompleter.sourceObj;
+                // Intentionally create a dedicated core/adapter for this
+                // document. This avoids cross-document source switching
+                // complexity and keeps Rust state aligned with this
+                // document's AutoCompleter mappings.
+                const adapter = new RustResolverAdapter(sourceObj, {
+                    core: core as RustResolverCore,
+                    takesIndexComponentTypes: getTakesIndexComponentTypes(
+                        capturedInfo.autoCompleter,
+                    ),
                 });
+                capturedInfo.rustAdapter = adapter;
+                capturedInfo.autoCompleter = new AutoCompleter(
+                    undefined,
+                    undefined,
+                    {
+                        sourceObj,
+                        rustResolverAdapter: adapter,
+                        getAdditionalRefNames: (offset: number) =>
+                            adapter.getDerivedRepeatNames(offset),
+                    },
+                );
+                capturedInfo.rustState = "ready";
+            } catch (error) {
+                console.warn(
+                    "Rust autocomplete unavailable; completions disabled for this document.",
+                    error,
+                );
+                const currentInfo = documentInfo.get(uri);
+                if (currentInfo === capturedInfo) {
+                    capturedInfo.rustState = "unavailable";
+                }
+            }
         }
 
-        validateTextDocument(change.document);
+        await validateTextDocument(change.document);
     });
 
     async function validateTextDocument(

--- a/packages/lsp/src/features/validate.ts
+++ b/packages/lsp/src/features/validate.ts
@@ -20,6 +20,21 @@ import {
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { getRustCore } from "../rust-core";
 
+let takesIndexComponentTypes: ReadonlySet<string> | null = null;
+
+function getTakesIndexComponentTypes(
+    autoCompleter: AutoCompleter,
+): ReadonlySet<string> {
+    if (!takesIndexComponentTypes) {
+        takesIndexComponentTypes = new Set(
+            Object.entries(autoCompleter.schemaElementsByName)
+                .filter(([, schemaElement]) => schemaElement?.takesIndex)
+                .map(([componentType]) => componentType),
+        );
+    }
+    return takesIndexComponentTypes;
+}
+
 export function addValidationSupport(
     connection: Connection,
     documentInfo: DocumentInfo,
@@ -99,13 +114,9 @@ export function addValidationSupport(
                     // document's AutoCompleter mappings.
                     const adapter = new RustResolverAdapter(sourceObj, {
                         core: core as RustResolverCore,
-                        takesIndex: (componentType: string) => {
-                            const s =
-                                capturedInfo.autoCompleter.schemaElementsByName[
-                                    componentType
-                                ];
-                            return s?.takesIndex ?? false;
-                        },
+                        takesIndexComponentTypes: getTakesIndexComponentTypes(
+                            capturedInfo.autoCompleter,
+                        ),
                     });
                     capturedInfo.rustAdapter = adapter;
                     capturedInfo.autoCompleter = new AutoCompleter(
@@ -115,7 +126,7 @@ export function addValidationSupport(
                             sourceObj,
                             rustResolverAdapter: adapter,
                             getAdditionalRefNames: (offset: number) =>
-                                adapter.getRepeatSyntheticNames(offset),
+                                adapter.getDerivedRepeatNames(offset),
                         },
                     );
                     capturedInfo.rustState = "ready";

--- a/packages/lsp/src/features/validate.ts
+++ b/packages/lsp/src/features/validate.ts
@@ -12,7 +12,11 @@ import {
     documentSettings,
     documents,
 } from "../globals";
-import { AutoCompleter, RustResolverAdapter } from "@doenet/lsp-tools";
+import {
+    AutoCompleter,
+    RustResolverAdapter,
+    type RustResolverCore,
+} from "@doenet/lsp-tools";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { getRustCore } from "../rust-core";
 
@@ -84,9 +88,21 @@ export function addValidationSupport(
                     const currentInfo = documentInfo.get(uri);
                     if (!currentInfo || currentInfo !== capturedInfo) return;
                     if (capturedInfo.rustAdapter) return;
+                    // Intentionally create a dedicated core/adapter for this
+                    // document. This avoids cross-document source switching
+                    // complexity and keeps Rust state aligned with this
+                    // document's AutoCompleter mappings.
                     const adapter = new RustResolverAdapter(
                         capturedInfo.autoCompleter.sourceObj,
-                        { core: core as any },
+                        {
+                            core: core as RustResolverCore,
+                            takesIndex: (componentType: string) => {
+                                const s =
+                                    capturedInfo.autoCompleter
+                                        .schemaElementsByName[componentType];
+                                return s?.takesIndex ?? false;
+                            },
+                        },
                     );
                     capturedInfo.rustAdapter = adapter;
                     capturedInfo.autoCompleter.setResolveRefMemberContainerAtOffset(
@@ -95,6 +111,9 @@ export function addValidationSupport(
                     capturedInfo.autoCompleter.setIsNameAddressable(
                         (offset, name) =>
                             adapter.isNameAddressableFromOffset(offset, name),
+                    );
+                    capturedInfo.autoCompleter.setGetAdditionalRefNames(
+                        (offset) => adapter.getRepeatSyntheticNames(offset),
                     );
                 })
                 .catch(() => {

--- a/packages/lsp/src/features/validate.ts
+++ b/packages/lsp/src/features/validate.ts
@@ -12,8 +12,9 @@ import {
     documentSettings,
     documents,
 } from "../globals";
-import { AutoCompleter } from "@doenet/lsp-tools";
+import { AutoCompleter, RustResolverAdapter } from "@doenet/lsp-tools";
 import { TextDocument } from "vscode-languageserver-textdocument";
+import { getRustCore } from "../rust-core";
 
 export function addValidationSupport(
     connection: Connection,
@@ -59,15 +60,48 @@ export function addValidationSupport(
     // The content of a text document has changed. This event is emitted
     // when the text document first opened or when its content has changed.
     documents.onDidChangeContent((change) => {
-        let info = documentInfo.get(change.document.uri);
+        const uri = change.document.uri;
+        let info = documentInfo.get(uri);
         if (!info) {
             const autoCompleter = new AutoCompleter();
             info = { autoCompleter, additionalDiagnostics: [] };
-            documentInfo.set(change.document.uri, info);
+            documentInfo.set(uri, info);
         }
         info.autoCompleter.setSource(change.document.getText());
         // Additional diagnostics may no longer be relevant after the contents of the file changes
         info.additionalDiagnostics.length = 0;
+
+        if (info.rustAdapter) {
+            // Adapter already wired — just resync source.
+            info.rustAdapter.updateSource(info.autoCompleter.sourceObj);
+        } else {
+            // Fire-and-forget: first completions use the JS fallback until
+            // the WASM module finishes loading, then the Rust resolver
+            // activates for subsequent requests.
+            const capturedInfo = info;
+            getRustCore()
+                .then((core) => {
+                    const currentInfo = documentInfo.get(uri);
+                    if (!currentInfo || currentInfo !== capturedInfo) return;
+                    if (capturedInfo.rustAdapter) return;
+                    const adapter = new RustResolverAdapter(
+                        capturedInfo.autoCompleter.sourceObj,
+                        { core: core as any },
+                    );
+                    capturedInfo.rustAdapter = adapter;
+                    capturedInfo.autoCompleter.setResolveRefMemberContainerAtOffset(
+                        adapter.createResolver(),
+                    );
+                    capturedInfo.autoCompleter.setIsNameAddressable(
+                        (offset, name) =>
+                            adapter.isNameAddressableFromOffset(offset, name),
+                    );
+                })
+                .catch(() => {
+                    // WASM unavailable — JS fallback is fine.
+                });
+        }
+
         validateTextDocument(change.document);
     });
 

--- a/packages/lsp/src/features/validate.ts
+++ b/packages/lsp/src/features/validate.ts
@@ -68,20 +68,24 @@ export function addValidationSupport(
         let info = documentInfo.get(uri);
         if (!info) {
             const autoCompleter = new AutoCompleter();
-            info = { autoCompleter, additionalDiagnostics: [] };
+            info = {
+                autoCompleter,
+                additionalDiagnostics: [],
+                rustState: "uninitialized",
+            };
             documentInfo.set(uri, info);
         }
         info.autoCompleter.setSource(change.document.getText());
         // Additional diagnostics may no longer be relevant after the contents of the file changes
         info.additionalDiagnostics.length = 0;
 
-        if (info.rustAdapter) {
+        if (info.rustState === "ready" && info.rustAdapter) {
             // Adapter already wired — just resync source.
             info.rustAdapter.updateSource(info.autoCompleter.sourceObj);
-        } else {
-            // Fire-and-forget: first completions use the JS fallback until
-            // the WASM module finishes loading, then the Rust resolver
-            // activates for subsequent requests.
+        } else if (info.rustState === "uninitialized") {
+            // Fire-and-forget initialization. Completions remain disabled
+            // until Rust is ready.
+            info.rustState = "initializing";
             const capturedInfo = info;
             getRustCore()
                 .then((core) => {
@@ -105,19 +109,21 @@ export function addValidationSupport(
                         },
                     );
                     capturedInfo.rustAdapter = adapter;
-                    capturedInfo.autoCompleter.setResolveRefMemberContainerAtOffset(
-                        adapter.createResolver(),
-                    );
-                    capturedInfo.autoCompleter.setIsNameAddressable(
-                        (offset, name) =>
-                            adapter.isNameAddressableFromOffset(offset, name),
-                    );
+                    capturedInfo.autoCompleter.setRustResolverAdapter(adapter);
                     capturedInfo.autoCompleter.setGetAdditionalRefNames(
                         (offset) => adapter.getRepeatSyntheticNames(offset),
                     );
+                    capturedInfo.rustState = "ready";
                 })
-                .catch(() => {
-                    // WASM unavailable — JS fallback is fine.
+                .catch((error) => {
+                    console.warn(
+                        "Rust autocomplete unavailable; completions disabled for this document.",
+                        error,
+                    );
+                    const currentInfo = documentInfo.get(uri);
+                    if (currentInfo === capturedInfo) {
+                        capturedInfo.rustState = "unavailable";
+                    }
                 });
         }
 

--- a/packages/lsp/src/features/validate.ts
+++ b/packages/lsp/src/features/validate.ts
@@ -17,23 +17,15 @@ import {
     RustResolverAdapter,
     type RustResolverCore,
 } from "@doenet/lsp-tools";
+import { doenetSchema } from "@doenet/static-assets/schema";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { getRustCore } from "../rust-core";
 
-let takesIndexComponentTypes: ReadonlySet<string> | null = null;
-
-function getTakesIndexComponentTypes(
-    autoCompleter: AutoCompleter,
-): ReadonlySet<string> {
-    if (!takesIndexComponentTypes) {
-        takesIndexComponentTypes = new Set(
-            Object.entries(autoCompleter.schemaElementsByName)
-                .filter(([, schemaElement]) => schemaElement?.takesIndex)
-                .map(([componentType]) => componentType),
-        );
-    }
-    return takesIndexComponentTypes;
-}
+const TAKES_INDEX_COMPONENT_TYPES: ReadonlySet<string> = new Set(
+    doenetSchema.elements
+        .filter((schemaElement) => schemaElement?.takesIndex)
+        .map((schemaElement) => schemaElement.name),
+);
 
 export function addValidationSupport(
     connection: Connection,
@@ -106,7 +98,6 @@ export function addValidationSupport(
                 const core = await getRustCore();
                 const currentInfo = documentInfo.get(uri);
                 if (!currentInfo || currentInfo !== capturedInfo) return;
-                if (capturedInfo.rustAdapter) return;
                 const sourceObj = capturedInfo.autoCompleter.sourceObj;
                 // Intentionally create a dedicated core/adapter for this
                 // document. This avoids cross-document source switching
@@ -114,9 +105,7 @@ export function addValidationSupport(
                 // document's AutoCompleter mappings.
                 const adapter = new RustResolverAdapter(sourceObj, {
                     core: core as RustResolverCore,
-                    takesIndexComponentTypes: getTakesIndexComponentTypes(
-                        capturedInfo.autoCompleter,
-                    ),
+                    takesIndexComponentTypes: TAKES_INDEX_COMPONENT_TYPES,
                 });
                 capturedInfo.rustAdapter = adapter;
                 capturedInfo.autoCompleter = new AutoCompleter(

--- a/packages/lsp/src/features/validate.ts
+++ b/packages/lsp/src/features/validate.ts
@@ -64,13 +64,13 @@ export function addValidationSupport(
                 return;
             }
 
-            void validateTextDocument(textDocument);
+            validateTextDocument(textDocument).catch(() => undefined);
         },
     );
 
     // The content of a text document has changed. This event is emitted
     // when the text document first opened or when its content has changed.
-    documents.onDidChangeContent(async (change) => {
+    documents.onDidChangeContent((change) => {
         const uri = change.document.uri;
         let info = documentInfo.get(uri);
         if (!info) {
@@ -90,48 +90,56 @@ export function addValidationSupport(
             // Adapter already wired — just resync source.
             info.rustAdapter.updateSource(info.autoCompleter.sourceObj);
         } else if (info.rustState === "uninitialized") {
-            // Fire-and-forget initialization. Completions remain disabled
-            // until Rust is ready.
+            // Fire-and-forget initialization. Diagnostics should not wait
+            // for Rust to load.
             info.rustState = "initializing";
             const capturedInfo = info;
-            try {
-                const core = await getRustCore();
-                const currentInfo = documentInfo.get(uri);
-                if (!currentInfo || currentInfo !== capturedInfo) return;
-                const sourceObj = capturedInfo.autoCompleter.sourceObj;
-                // Intentionally create a dedicated core/adapter for this
-                // document. This avoids cross-document source switching
-                // complexity and keeps Rust state aligned with this
-                // document's AutoCompleter mappings.
-                const adapter = new RustResolverAdapter(sourceObj, {
-                    core: core as RustResolverCore,
-                    takesIndexComponentTypes: TAKES_INDEX_COMPONENT_TYPES,
-                });
-                capturedInfo.rustAdapter = adapter;
-                capturedInfo.autoCompleter = new AutoCompleter(
-                    undefined,
-                    undefined,
-                    {
-                        sourceObj,
-                        rustResolverAdapter: adapter,
-                        getAdditionalRefNames: (offset: number) =>
-                            adapter.getDerivedRepeatNames(offset),
-                    },
-                );
-                capturedInfo.rustState = "ready";
-            } catch (error) {
-                console.warn(
-                    "Rust autocomplete unavailable; completions disabled for this document.",
-                    error,
-                );
-                const currentInfo = documentInfo.get(uri);
-                if (currentInfo === capturedInfo) {
-                    capturedInfo.rustState = "unavailable";
+            (async () => {
+                try {
+                    const core = await getRustCore();
+                    const currentInfo = documentInfo.get(uri);
+                    if (!currentInfo || currentInfo !== capturedInfo) return;
+                    const sourceObj = capturedInfo.autoCompleter.sourceObj;
+                    // Intentionally create a dedicated core/adapter for this
+                    // document. This avoids cross-document source switching
+                    // complexity and keeps Rust state aligned with this
+                    // document's AutoCompleter mappings.
+                    const adapter = new RustResolverAdapter(sourceObj, {
+                        core: core as RustResolverCore,
+                        takesIndexComponentTypes: TAKES_INDEX_COMPONENT_TYPES,
+                    });
+                    capturedInfo.rustAdapter = adapter;
+                    capturedInfo.autoCompleter = new AutoCompleter(
+                        undefined,
+                        undefined,
+                        {
+                            sourceObj,
+                            rustResolverAdapter: adapter,
+                            getAdditionalRefNames: (offset: number) =>
+                                adapter.getDerivedRepeatNames(offset),
+                        },
+                    );
+                    capturedInfo.rustState = "ready";
+                    const latestDocument = documents.get(uri);
+                    if (latestDocument) {
+                        validateTextDocument(latestDocument).catch(
+                            () => undefined,
+                        );
+                    }
+                } catch (error) {
+                    console.warn(
+                        "Rust autocomplete unavailable; completions disabled for this document.",
+                        error,
+                    );
+                    const currentInfo = documentInfo.get(uri);
+                    if (currentInfo === capturedInfo) {
+                        capturedInfo.rustState = "unavailable";
+                    }
                 }
-            }
+            })().catch(() => undefined);
         }
 
-        await validateTextDocument(change.document);
+        validateTextDocument(change.document).catch(() => undefined);
     });
 
     async function validateTextDocument(

--- a/packages/lsp/src/features/validate.ts
+++ b/packages/lsp/src/features/validate.ts
@@ -142,6 +142,11 @@ export function addValidationSupport(
         validateTextDocument(change.document).catch(() => undefined);
     });
 
+    // Release per-document validation/autocomplete state when a document closes.
+    documents.onDidClose((event) => {
+        documentInfo.delete(event.document.uri);
+    });
+
     async function validateTextDocument(
         textDocument: TextDocument,
     ): Promise<void> {

--- a/packages/lsp/src/features/validate.ts
+++ b/packages/lsp/src/features/validate.ts
@@ -92,26 +92,31 @@ export function addValidationSupport(
                     const currentInfo = documentInfo.get(uri);
                     if (!currentInfo || currentInfo !== capturedInfo) return;
                     if (capturedInfo.rustAdapter) return;
+                    const sourceObj = capturedInfo.autoCompleter.sourceObj;
                     // Intentionally create a dedicated core/adapter for this
                     // document. This avoids cross-document source switching
                     // complexity and keeps Rust state aligned with this
                     // document's AutoCompleter mappings.
-                    const adapter = new RustResolverAdapter(
-                        capturedInfo.autoCompleter.sourceObj,
-                        {
-                            core: core as RustResolverCore,
-                            takesIndex: (componentType: string) => {
-                                const s =
-                                    capturedInfo.autoCompleter
-                                        .schemaElementsByName[componentType];
-                                return s?.takesIndex ?? false;
-                            },
+                    const adapter = new RustResolverAdapter(sourceObj, {
+                        core: core as RustResolverCore,
+                        takesIndex: (componentType: string) => {
+                            const s =
+                                capturedInfo.autoCompleter.schemaElementsByName[
+                                    componentType
+                                ];
+                            return s?.takesIndex ?? false;
                         },
-                    );
+                    });
                     capturedInfo.rustAdapter = adapter;
-                    capturedInfo.autoCompleter.setRustResolverAdapter(adapter);
-                    capturedInfo.autoCompleter.setGetAdditionalRefNames(
-                        (offset) => adapter.getRepeatSyntheticNames(offset),
+                    capturedInfo.autoCompleter = new AutoCompleter(
+                        undefined,
+                        undefined,
+                        {
+                            sourceObj,
+                            rustResolverAdapter: adapter,
+                            getAdditionalRefNames: (offset: number) =>
+                                adapter.getRepeatSyntheticNames(offset),
+                        },
                     );
                     capturedInfo.rustState = "ready";
                 })

--- a/packages/lsp/src/globals.ts
+++ b/packages/lsp/src/globals.ts
@@ -4,7 +4,7 @@ import {
     TextDocuments,
 } from "vscode-languageserver/browser";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { AutoCompleter } from "@doenet/lsp-tools";
+import { AutoCompleter, RustResolverAdapter } from "@doenet/lsp-tools";
 
 export interface DoenetDocumentSettings {
     formatMode: "doenet" | "xml";
@@ -46,6 +46,10 @@ export const documentInfo: Map<
          * like an externally-running version of Core.
          */
         additionalDiagnostics: Diagnostic[];
+        /**
+         * Rust WASM resolver adapter, created lazily once the WASM module loads.
+         */
+        rustAdapter?: RustResolverAdapter;
     }
 > = new Map();
 export type DocumentInfo = typeof documentInfo;

--- a/packages/lsp/src/globals.ts
+++ b/packages/lsp/src/globals.ts
@@ -50,6 +50,10 @@ export const documentInfo: Map<
          * Rust WASM resolver adapter, created lazily once the WASM module loads.
          */
         rustAdapter?: RustResolverAdapter;
+        /**
+         * Rust resolver lifecycle state for this document.
+         */
+        rustState: "uninitialized" | "initializing" | "ready" | "unavailable";
     }
 > = new Map();
 export type DocumentInfo = typeof documentInfo;

--- a/packages/lsp/src/rust-core.ts
+++ b/packages/lsp/src/rust-core.ts
@@ -23,12 +23,49 @@ try {
 
 let wasmInitPromise: Promise<unknown> | null = null;
 
+type NodeProcessLike = {
+    cwd(): string;
+    versions?: {
+        node?: unknown;
+    };
+};
+
+function getNodeProcess(): NodeProcessLike | undefined {
+    return (globalThis as typeof globalThis & { process?: NodeProcessLike })
+        .process;
+}
+
+async function initWasmWithNodePathWorkaround(): Promise<void> {
+    try {
+        await init(wasmBlobUrl);
+        return;
+    } catch (error) {
+        const nodeProcess = getNodeProcess();
+        const runningInNode = !!nodeProcess?.versions?.node;
+        const canTryFsPath = runningInNode && wasmBlobUrl.startsWith("/");
+        if (!canTryFsPath) {
+            throw error;
+        }
+
+        // In Node-based test runners, Vite may resolve `?url` as a
+        // workspace-root-relative path (e.g. `/packages/...wasm`) rather
+        // than a fetchable URL. Load bytes from disk in that case.
+        // @ts-expect-error Node-only import in a browser-targeted package.
+        const fs = await import("node:fs/promises");
+        // @ts-expect-error Node-only import in a browser-targeted package.
+        const path = await import("node:path");
+        const wasmPath = path.resolve(nodeProcess.cwd(), `.${wasmBlobUrl}`);
+        const wasmBytes = await fs.readFile(wasmPath);
+        await init(wasmBytes);
+    }
+}
+
 /**
  * Lazily initialize the WASM module once per worker runtime.
  */
 function ensureRustWasmInitialized(): Promise<void> {
     if (!wasmInitPromise) {
-        wasmInitPromise = init(wasmBlobUrl);
+        wasmInitPromise = initWasmWithNodePathWorkaround();
     }
     return wasmInitPromise.then(() => {});
 }

--- a/packages/lsp/src/rust-core.ts
+++ b/packages/lsp/src/rust-core.ts
@@ -97,11 +97,11 @@ async function initWasmWithNodePathWorkaround(): Promise<void> {
 /**
  * Lazily initialize the WASM module once per worker runtime.
  */
-function ensureRustWasmInitialized(): Promise<void> {
+async function ensureRustWasmInitialized(): Promise<void> {
     if (!wasmInitPromise) {
         wasmInitPromise = initWasmWithNodePathWorkaround();
     }
-    return wasmInitPromise.then(() => {});
+    await wasmInitPromise;
 }
 
 /**
@@ -112,13 +112,11 @@ function ensureRustWasmInitialized(): Promise<void> {
  * The LSP keeps one adapter/core per open document so Rust-side source state
  * and JS-side index mappings stay aligned in multi-document sessions.
  */
-export function getRustCore(): Promise<PublicDoenetMLCore> {
-    return (async () => {
-        await ensureRustWasmInitialized();
-        const core = PublicDoenetMLCore.new();
-        // Flags must be set before the core can process source.
-        // An empty flags object is sufficient for path resolution.
-        core.set_flags("{}");
-        return core;
-    })();
+export async function getRustCore(): Promise<PublicDoenetMLCore> {
+    await ensureRustWasmInitialized();
+    const core = PublicDoenetMLCore.new();
+    // Flags must be set before the core can process source.
+    // An empty flags object is sufficient for path resolution.
+    core.set_flags("{}");
+    return core;
 }

--- a/packages/lsp/src/rust-core.ts
+++ b/packages/lsp/src/rust-core.ts
@@ -48,15 +48,48 @@ async function initWasmWithNodePathWorkaround(): Promise<void> {
         }
 
         // In Node-based test runners, Vite may resolve `?url` as a
-        // workspace-root-relative path (e.g. `/packages/...wasm`) rather
-        // than a fetchable URL. Load bytes from disk in that case.
+        // non-fetchable path-like string (e.g. `/packages/...wasm` or
+        // `/@fs/<absolute-path>`). Load bytes from disk in that case.
         // @ts-expect-error Node-only import in a browser-targeted package.
         const fs = await import("node:fs/promises");
         // @ts-expect-error Node-only import in a browser-targeted package.
         const path = await import("node:path");
-        const wasmPath = path.resolve(nodeProcess.cwd(), `.${wasmBlobUrl}`);
-        const wasmBytes = await fs.readFile(wasmPath);
-        await init(wasmBytes);
+
+        const stripQueryAndHash = (value: string) =>
+            value.replace(/[?#].*$/, "");
+
+        const normalized = stripQueryAndHash(wasmBlobUrl);
+        const candidatePaths: string[] = [];
+
+        if (normalized.startsWith("file://")) {
+            const fromFileUrl = decodeURIComponent(
+                new URL(normalized).pathname,
+            );
+            if (fromFileUrl) {
+                candidatePaths.push(fromFileUrl);
+            }
+        } else if (normalized.startsWith("/@fs/")) {
+            candidatePaths.push(normalized.replace(/^\/@fs\//, "/"));
+        } else if (path.isAbsolute(normalized)) {
+            // Some runners surface workspace-root-relative paths like
+            // `/packages/...` rather than absolute filesystem paths.
+            candidatePaths.push(normalized);
+            candidatePaths.push(
+                path.resolve(nodeProcess.cwd(), `.${normalized}`),
+            );
+        }
+
+        for (const wasmPath of candidatePaths) {
+            try {
+                const wasmBytes = await fs.readFile(wasmPath);
+                await init(wasmBytes);
+                return;
+            } catch {
+                // Try the next candidate path.
+            }
+        }
+
+        throw error;
     }
 }
 

--- a/packages/lsp/src/rust-core.ts
+++ b/packages/lsp/src/rust-core.ts
@@ -1,0 +1,49 @@
+import init, { PublicDoenetMLCore } from "@doenet/doenetml-worker-rust";
+// @ts-ignore — Vite ?url resolves to a data-URL string at build time
+import WASM_BYTES_DATA_URL from "@doenet/doenetml-worker-rust/lib_doenetml_worker_bg.wasm?url";
+
+// Convert data-URL to a blob URL so fetch() works regardless of the
+// Worker's origin (data: URLs lack a usable base for relative fetches).
+let wasmBlobUrl: string = WASM_BYTES_DATA_URL;
+try {
+    if (wasmBlobUrl.match(/^data:.*;base64,/)) {
+        const base64 = wasmBlobUrl.split(",")[1];
+        const byteCharacters = atob(base64);
+        const byteNumbers = new Uint8Array(byteCharacters.length);
+        for (let i = 0; i < byteCharacters.length; i++) {
+            byteNumbers[i] = byteCharacters.charCodeAt(i);
+        }
+        wasmBlobUrl = URL.createObjectURL(
+            new Blob([byteNumbers], { type: "application/wasm" }),
+        );
+    }
+} catch (e) {
+    console.warn("Error while creating blob URL for wasm bundle", e);
+}
+
+let wasmInitPromise: Promise<unknown> | null = null;
+
+/**
+ * Lazily initialize the WASM module once per worker runtime.
+ */
+function ensureRustWasmInitialized(): Promise<void> {
+    if (!wasmInitPromise) {
+        wasmInitPromise = init(wasmBlobUrl);
+    }
+    return wasmInitPromise.then(() => {});
+}
+
+/**
+ * Lazily initialize the WASM module and return a fresh
+ * `PublicDoenetMLCore` instance for each caller.
+ */
+export function getRustCore(): Promise<PublicDoenetMLCore> {
+    return (async () => {
+        await ensureRustWasmInitialized();
+        const core = PublicDoenetMLCore.new();
+        // Flags must be set before the core can process source.
+        // An empty flags object is sufficient for path resolution.
+        core.set_flags("{}");
+        return core;
+    })();
+}

--- a/packages/lsp/src/rust-core.ts
+++ b/packages/lsp/src/rust-core.ts
@@ -78,14 +78,17 @@ async function initWasmWithNodePathWorkaround(): Promise<void> {
         const fs = await import("node:fs/promises");
         // @ts-expect-error Node-only import in a browser-targeted package.
         const path = await import("node:path");
+        // @ts-expect-error Node-only import in a browser-targeted package.
+        const { fileURLToPath } = await import("node:url");
 
         const normalized = stripQueryAndHash(wasmBlobUrl);
         const candidatePaths: string[] = [];
 
         if (normalized.startsWith("file://")) {
-            const fromFileUrl = decodeURIComponent(
-                new URL(normalized).pathname,
-            );
+            // Use fileURLToPath so that Windows file:///C:/... URLs are
+            // converted to C:\... rather than /C:/... (which fs.readFile
+            // cannot open on Windows).
+            const fromFileUrl = fileURLToPath(normalized);
             if (fromFileUrl) {
                 candidatePaths.push(fromFileUrl);
             }

--- a/packages/lsp/src/rust-core.ts
+++ b/packages/lsp/src/rust-core.ts
@@ -40,9 +40,21 @@ async function initWasmWithNodePathWorkaround(): Promise<void> {
         await init(wasmBlobUrl);
         return;
     } catch (error) {
+        function stripQueryAndHash(value: string) {
+            return value.replace(/[?#].*$/, "");
+        }
+
         const nodeProcess = getNodeProcess();
         const runningInNode = !!nodeProcess?.versions?.node;
-        const canTryFsPath = runningInNode && wasmBlobUrl.startsWith("/");
+        const normalizedForGate = stripQueryAndHash(wasmBlobUrl);
+        const looksLikeWindowsAbsPath = /^[A-Za-z]:[\\/]/.test(
+            normalizedForGate,
+        );
+        const canTryFsPath =
+            runningInNode &&
+            (normalizedForGate.startsWith("/") ||
+                normalizedForGate.startsWith("file://") ||
+                looksLikeWindowsAbsPath);
         if (!canTryFsPath) {
             throw error;
         }
@@ -54,10 +66,6 @@ async function initWasmWithNodePathWorkaround(): Promise<void> {
         const fs = await import("node:fs/promises");
         // @ts-expect-error Node-only import in a browser-targeted package.
         const path = await import("node:path");
-
-        function stripQueryAndHash(value: string) {
-            return value.replace(/[?#].*$/, "");
-        }
 
         const normalized = stripQueryAndHash(wasmBlobUrl);
         const candidatePaths: string[] = [];

--- a/packages/lsp/src/rust-core.ts
+++ b/packages/lsp/src/rust-core.ts
@@ -1,5 +1,5 @@
 import init, { PublicDoenetMLCore } from "@doenet/doenetml-worker-rust";
-// @ts-ignore — Vite ?url resolves to a data-URL string at build time
+// @ts-expect-error — Vite ?url resolves to a data-URL string at build time
 import WASM_BYTES_DATA_URL from "@doenet/doenetml-worker-rust/lib_doenetml_worker_bg.wasm?url";
 
 // Convert data-URL to a blob URL so fetch() works regardless of the
@@ -36,6 +36,10 @@ function ensureRustWasmInitialized(): Promise<void> {
 /**
  * Lazily initialize the WASM module and return a fresh
  * `PublicDoenetMLCore` instance for each caller.
+ *
+ * Important: this intentionally does NOT return a global core singleton.
+ * The LSP keeps one adapter/core per open document so Rust-side source state
+ * and JS-side index mappings stay aligned in multi-document sessions.
  */
 export function getRustCore(): Promise<PublicDoenetMLCore> {
     return (async () => {

--- a/packages/lsp/src/rust-core.ts
+++ b/packages/lsp/src/rust-core.ts
@@ -55,8 +55,9 @@ async function initWasmWithNodePathWorkaround(): Promise<void> {
         // @ts-expect-error Node-only import in a browser-targeted package.
         const path = await import("node:path");
 
-        const stripQueryAndHash = (value: string) =>
-            value.replace(/[?#].*$/, "");
+        function stripQueryAndHash(value: string) {
+            return value.replace(/[?#].*$/, "");
+        }
 
         const normalized = stripQueryAndHash(wasmBlobUrl);
         const candidatePaths: string[] = [];

--- a/packages/lsp/src/rust-core.ts
+++ b/packages/lsp/src/rust-core.ts
@@ -90,7 +90,10 @@ async function initWasmWithNodePathWorkaround(): Promise<void> {
                 candidatePaths.push(fromFileUrl);
             }
         } else if (normalized.startsWith("/@fs/")) {
-            candidatePaths.push(normalized.replace(/^\/@fs\//, "/"));
+            const fspath = normalized.slice("/@fs".length);
+            candidatePaths.push(
+                /^\/[A-Za-z]:/.test(fspath) ? fspath.slice(1) : fspath,
+            );
         } else if (path.isAbsolute(normalized)) {
             // Some runners surface workspace-root-relative paths like
             // `/packages/...` rather than absolute filesystem paths.

--- a/packages/lsp/src/rust-core.ts
+++ b/packages/lsp/src/rust-core.ts
@@ -5,6 +5,7 @@ import WASM_BYTES_DATA_URL from "@doenet/doenetml-worker-rust/lib_doenetml_worke
 // Convert data-URL to a blob URL so fetch() works regardless of the
 // Worker's origin (data: URLs lack a usable base for relative fetches).
 let wasmBlobUrl: string = WASM_BYTES_DATA_URL;
+let createdWasmBlobUrl = false;
 try {
     if (wasmBlobUrl.match(/^data:.*;base64,/)) {
         const base64 = wasmBlobUrl.split(",")[1];
@@ -16,9 +17,20 @@ try {
         wasmBlobUrl = URL.createObjectURL(
             new Blob([byteNumbers], { type: "application/wasm" }),
         );
+        createdWasmBlobUrl = true;
     }
 } catch (e) {
     console.warn("Error while creating blob URL for wasm bundle", e);
+}
+
+let wasmBlobUrlRevoked = false;
+
+function revokeWasmBlobUrlIfNeeded() {
+    if (!createdWasmBlobUrl || wasmBlobUrlRevoked) {
+        return;
+    }
+    URL.revokeObjectURL(wasmBlobUrl);
+    wasmBlobUrlRevoked = true;
 }
 
 let wasmInitPromise: Promise<unknown> | null = null;
@@ -99,6 +111,10 @@ async function initWasmWithNodePathWorkaround(): Promise<void> {
         }
 
         throw error;
+    } finally {
+        // The module is initialized once per worker runtime, so this blob URL
+        // is no longer needed after the first init attempt completes.
+        revokeWasmBlobUrlIfNeeded();
     }
 }
 

--- a/packages/lsp/test/completions-feature.test.ts
+++ b/packages/lsp/test/completions-feature.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Focused unit tests for `features/completions.ts` gating behavior.
+ *
+ * These tests verify the policy split between:
+ * - non-ref completion contexts (which should remain available when Rust is unavailable), and
+ * - Rust-dependent `$ref` contexts (which should be gated until Rust is ready).
+ *
+ * This file intentionally mocks the connection and document info map so
+ * regressions in completion gating are caught without needing full worker
+ * integration.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { addDocumentCompletionSupport } from "../src/features/completions";
+
+describe("addDocumentCompletionSupport", () => {
+    it("allows non-ref completions when Rust is unavailable", () => {
+        const uri = "file:///test.doenet";
+        const getCompletionItems = vi.fn(() => [{ label: "graph", kind: 10 }]);
+
+        const documentInfo = new Map([
+            [
+                uri,
+                {
+                    autoCompleter: {
+                        getCompletionContext: () => ({ cursorPos: "body" }),
+                        getCompletionItems,
+                    },
+                    additionalDiagnostics: [],
+                    rustState: "unavailable",
+                    rustAdapter: undefined,
+                },
+            ],
+        ]);
+
+        let completionHandler:
+            | ((params: any) => Array<{ label: string; kind: number }>)
+            | undefined;
+        const connection = {
+            onCompletion: (handler: any) => {
+                completionHandler = handler;
+            },
+            onCompletionResolve: () => {},
+        };
+
+        addDocumentCompletionSupport(connection as any, documentInfo as any);
+
+        const items = completionHandler!({
+            textDocument: { uri },
+            position: { line: 0, character: 1 },
+        });
+
+        expect(items).toEqual([{ label: "graph", kind: 10 }]);
+        expect(getCompletionItems).toHaveBeenCalledOnce();
+    });
+
+    it("gates ref completions when Rust is unavailable", () => {
+        const uri = "file:///test.doenet";
+        const getCompletionItems = vi.fn(() => [{ label: "x", kind: 18 }]);
+
+        const documentInfo = new Map([
+            [
+                uri,
+                {
+                    autoCompleter: {
+                        getCompletionContext: () => ({
+                            cursorPos: "refMember",
+                        }),
+                        getCompletionItems,
+                    },
+                    additionalDiagnostics: [],
+                    rustState: "unavailable",
+                    rustAdapter: undefined,
+                },
+            ],
+        ]);
+
+        let completionHandler:
+            | ((params: any) => Array<{ label: string; kind: number }>)
+            | undefined;
+        const connection = {
+            onCompletion: (handler: any) => {
+                completionHandler = handler;
+            },
+            onCompletionResolve: () => {},
+        };
+
+        addDocumentCompletionSupport(connection as any, documentInfo as any);
+
+        const items = completionHandler!({
+            textDocument: { uri },
+            position: { line: 0, character: 8 },
+        });
+
+        expect(items).toEqual([]);
+        expect(getCompletionItems).not.toHaveBeenCalled();
+    });
+});

--- a/packages/lsp/test/language-server.test.ts
+++ b/packages/lsp/test/language-server.test.ts
@@ -124,6 +124,65 @@ describe("Doenet Language Server", async () => {
           ]
         `);
     });
+
+    it("keeps ref-member completions isolated across documents", async () => {
+        const worker: Worker = new LSPWorker();
+        const lspConn = (await initWorker(worker)).lspConn;
+
+        const uriA = "file:///doc-a.doenet";
+        const uriB = "file:///doc-b.doenet";
+        const textA = `<section name="secA"><p name="fromA">A</p></section>\n$secA.`;
+        const textB = `<section name="secB"><p name="fromB">B</p></section>\n$secB.`;
+
+        await lspConn.textDocumentOpened({
+            textDocument: {
+                uri: uriA,
+                languageId: "doenet",
+                version: 1,
+                text: textA,
+            },
+        });
+        await lspConn.textDocumentOpened({
+            textDocument: {
+                uri: uriB,
+                languageId: "doenet",
+                version: 1,
+                text: textB,
+            },
+        });
+
+        const completionA1 = (await lspConn.getCompletion({
+            textDocument: { uri: uriA },
+            position: { line: 1, character: 6 },
+        })) as CompletionItem[];
+
+        expect(completionA1.some((item) => item.label === "fromA")).toBe(true);
+        expect(completionA1.some((item) => item.label === "fromB")).toBe(false);
+
+        await lspConn.textDocumentChanged({
+            textDocument: { uri: uriB, version: 2 },
+            contentChanges: [
+                {
+                    text: `<section name="secB"><p name="fromB2">B</p></section>\n$secB.`,
+                    range: {
+                        start: { character: 0, line: 0 },
+                        end: { line: Number.MAX_SAFE_INTEGER, character: 0 },
+                    },
+                },
+            ],
+        });
+
+        const completionA2 = (await lspConn.getCompletion({
+            textDocument: { uri: uriA },
+            position: { line: 1, character: 6 },
+        })) as CompletionItem[];
+
+        expect(completionA2.some((item) => item.label === "fromA")).toBe(true);
+        expect(completionA2.some((item) => item.label === "fromB2")).toBe(
+            false,
+        );
+    });
+
     it("can supply external diagnostics", async () => {
         const worker: Worker = new LSPWorker();
         const { lspConn, workerConn } = await initWorker(worker);

--- a/packages/lsp/test/language-server.test.ts
+++ b/packages/lsp/test/language-server.test.ts
@@ -22,10 +22,13 @@ async function waitForCompletions(
 ): Promise<CompletionItem[]> {
     const maxAttempts = 40;
     for (let i = 0; i < maxAttempts; i++) {
-        const completions = (await lspConn.getCompletion({
+        const completionResult = await lspConn.getCompletion({
             textDocument,
             position,
-        })) as CompletionItem[];
+        });
+        const completions = Array.isArray(completionResult)
+            ? completionResult
+            : (completionResult?.items ?? []);
         if (completions.length > 0) {
             return completions;
         }

--- a/packages/lsp/test/language-server.test.ts
+++ b/packages/lsp/test/language-server.test.ts
@@ -15,6 +15,25 @@ console.log = (...args) => {
     origLog(...args.map((x) => util.inspect(x, false, 10, true)));
 };
 
+async function waitForCompletions(
+    lspConn: Awaited<ReturnType<typeof initWorker>>["lspConn"],
+    textDocument: { uri: string },
+    position: { line: number; character: number },
+): Promise<CompletionItem[]> {
+    const maxAttempts = 40;
+    for (let i = 0; i < maxAttempts; i++) {
+        const completions = (await lspConn.getCompletion({
+            textDocument,
+            position,
+        })) as CompletionItem[];
+        if (completions.length > 0) {
+            return completions;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    return [];
+}
+
 describe("Doenet Language Server", async () => {
     it("can initialize language server as a webworker", async () => {
         const worker: Worker = new LSPWorker();
@@ -65,15 +84,16 @@ describe("Doenet Language Server", async () => {
                 text: "<gra  ",
             },
         });
-        const diags = await lspConn.getCompletion({
-            textDocument: {
+        const diags = await waitForCompletions(
+            lspConn,
+            {
                 uri: "file:///test.doenet",
             },
-            position: {
+            {
                 line: 0,
                 character: 3,
             },
-        });
+        );
         expect(diags).toMatchInlineSnapshot(`
           [
             {
@@ -106,15 +126,16 @@ describe("Doenet Language Server", async () => {
                 },
             ],
         });
-        const diags = await lspConn.getCompletion({
-            textDocument: {
+        const diags = await waitForCompletions(
+            lspConn,
+            {
                 uri: "file:///test.doenet",
             },
-            position: {
+            {
                 line: 0,
                 character: 3,
             },
-        });
+        );
         expect(diags).toMatchInlineSnapshot(`
           [
             {
@@ -151,10 +172,11 @@ describe("Doenet Language Server", async () => {
             },
         });
 
-        const completionA1 = (await lspConn.getCompletion({
-            textDocument: { uri: uriA },
-            position: { line: 1, character: 6 },
-        })) as CompletionItem[];
+        const completionA1 = await waitForCompletions(
+            lspConn,
+            { uri: uriA },
+            { line: 1, character: 6 },
+        );
 
         expect(completionA1.some((item) => item.label === "fromA")).toBe(true);
         expect(completionA1.some((item) => item.label === "fromB")).toBe(false);
@@ -172,10 +194,11 @@ describe("Doenet Language Server", async () => {
             ],
         });
 
-        const completionA2 = (await lspConn.getCompletion({
-            textDocument: { uri: uriA },
-            position: { line: 1, character: 6 },
-        })) as CompletionItem[];
+        const completionA2 = await waitForCompletions(
+            lspConn,
+            { uri: uriA },
+            { line: 1, character: 6 },
+        );
 
         expect(completionA2.some((item) => item.label === "fromA")).toBe(true);
         expect(completionA2.some((item) => item.label === "fromB2")).toBe(
@@ -352,15 +375,16 @@ describe("Doenet Language Server", async () => {
                 text: "<",
             },
         });
-        const completions = (await lspConn.getCompletion({
-            textDocument: {
+        const completions = await waitForCompletions(
+            lspConn,
+            {
                 uri: "file:///test-snippet.doenet",
             },
-            position: {
+            {
                 line: 0,
                 character: 1,
             },
-        })) as CompletionItem[];
+        );
 
         // The test schema should have some elements
         // Check that we get completion items back

--- a/packages/lsp/test/validate-feature.test.ts
+++ b/packages/lsp/test/validate-feature.test.ts
@@ -12,13 +12,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TextDocument } from "vscode-languageserver-textdocument";
 
 type ChangeHandler = (change: { document: TextDocument }) => void;
+type CloseHandler = (event: { document: TextDocument }) => void;
 
 let onDidChangeContentHandler: ChangeHandler | undefined;
+let onDidCloseHandler: CloseHandler | undefined;
 let activeDocument: TextDocument | undefined;
 
 const documentsMock = {
     onDidChangeContent: vi.fn((handler: ChangeHandler) => {
         onDidChangeContentHandler = handler;
+    }),
+    onDidClose: vi.fn((handler: CloseHandler) => {
+        onDidCloseHandler = handler;
     }),
     all: vi.fn(() => []),
     get: vi.fn((uri: string) =>
@@ -114,8 +119,10 @@ async function flushMicrotasks() {
 describe("addValidationSupport", () => {
     beforeEach(() => {
         onDidChangeContentHandler = undefined;
+        onDidCloseHandler = undefined;
         activeDocument = undefined;
         documentsMock.onDidChangeContent.mockClear();
+        documentsMock.onDidClose.mockClear();
         documentsMock.all.mockClear();
         documentsMock.get.mockClear();
         getRustCoreMock.mockClear();

--- a/packages/lsp/test/validate-feature.test.ts
+++ b/packages/lsp/test/validate-feature.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Focused unit tests for `features/validate.ts` async timing behavior.
+ *
+ * The primary goal is to guarantee that diagnostics are emitted immediately on
+ * document change and are not blocked by Rust core initialization. Once Rust
+ * becomes ready, validation should run again with updated state.
+ *
+ * This file uses lightweight mocks instead of full LSP worker integration so
+ * the event-ordering contract is explicit and stable.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TextDocument } from "vscode-languageserver-textdocument";
+
+type ChangeHandler = (change: { document: TextDocument }) => void;
+
+let onDidChangeContentHandler: ChangeHandler | undefined;
+let activeDocument: TextDocument | undefined;
+
+const documentsMock = {
+    onDidChangeContent: vi.fn((handler: ChangeHandler) => {
+        onDidChangeContentHandler = handler;
+    }),
+    all: vi.fn(() => []),
+    get: vi.fn((uri: string) =>
+        activeDocument?.uri === uri ? activeDocument : undefined,
+    ),
+};
+
+const configMock = {
+    hasConfigurationCapability: false,
+    hasWorkspaceFolderCapability: false,
+    hasDiagnosticRelatedInformationCapability: false,
+    globalSettings: { formatMode: "doenet" as const },
+};
+
+const documentSettingsMock = new Map();
+
+type Deferred<T> = {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+    reject: (error: unknown) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+    let resolve!: (value: T) => void;
+    let reject!: (error: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+let rustCoreDeferred = createDeferred<unknown>();
+const getRustCoreMock = vi.fn(() => rustCoreDeferred.promise);
+
+vi.mock("../src/globals", () => ({
+    config: configMock,
+    defaultSettings: { formatMode: "doenet" },
+    documentSettings: documentSettingsMock,
+    documents: documentsMock,
+}));
+
+vi.mock("../src/rust-core", () => ({
+    getRustCore: () => getRustCoreMock(),
+}));
+
+vi.mock("@doenet/parser", () => ({
+    extractDastErrors: () => [],
+}));
+
+vi.mock("@doenet/static-assets/schema", () => ({
+    doenetSchema: {
+        elements: [],
+    },
+}));
+
+vi.mock("@doenet/lsp-tools", () => {
+    class AutoCompleter {
+        sourceObj: any;
+
+        constructor(_source?: unknown, _schema?: unknown, options?: any) {
+            this.sourceObj = options?.sourceObj ?? { dast: {} };
+        }
+
+        setSource(_source: string) {}
+
+        getSchemaViolations() {
+            return [];
+        }
+    }
+
+    class RustResolverAdapter {
+        constructor(_sourceObj: unknown, _options?: unknown) {}
+
+        updateSource(_sourceObj: unknown) {}
+
+        getDerivedRepeatNames(_offset: number) {
+            return [];
+        }
+    }
+
+    return {
+        AutoCompleter,
+        RustResolverAdapter,
+    };
+});
+
+async function flushMicrotasks() {
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+describe("addValidationSupport", () => {
+    beforeEach(() => {
+        onDidChangeContentHandler = undefined;
+        activeDocument = undefined;
+        documentsMock.onDidChangeContent.mockClear();
+        documentsMock.all.mockClear();
+        documentsMock.get.mockClear();
+        getRustCoreMock.mockClear();
+        rustCoreDeferred = createDeferred<unknown>();
+        getRustCoreMock.mockImplementation(() => rustCoreDeferred.promise);
+    });
+
+    it("sends diagnostics immediately before Rust init resolves, then revalidates when ready", async () => {
+        const { addValidationSupport } =
+            await import("../src/features/validate");
+
+        const uri = "file:///diag-timing.doenet";
+        const autoCompleter = {
+            sourceObj: { dast: {} },
+            setSource: vi.fn(),
+            getSchemaViolations: vi.fn(() => []),
+        };
+        const documentInfo = new Map([
+            [
+                uri,
+                {
+                    autoCompleter,
+                    additionalDiagnostics: [],
+                    rustState: "uninitialized" as const,
+                    rustAdapter: undefined,
+                },
+            ],
+        ]);
+
+        const sendDiagnostics = vi.fn();
+        const connection = {
+            onDidChangeConfiguration: vi.fn(),
+            onRequest: vi.fn(),
+            sendDiagnostics,
+        };
+
+        addValidationSupport(connection as any, documentInfo as any);
+
+        activeDocument = TextDocument.create(
+            uri,
+            "doenet",
+            1,
+            "<graph></graph>",
+        );
+
+        onDidChangeContentHandler!({ document: activeDocument });
+
+        // Validation should run immediately, without waiting for Rust init.
+        expect(sendDiagnostics).toHaveBeenCalledTimes(1);
+        expect(getRustCoreMock).toHaveBeenCalledTimes(1);
+        expect(documentInfo.get(uri)?.rustState).toBe("initializing");
+
+        rustCoreDeferred.resolve({});
+        await flushMicrotasks();
+
+        // Once Rust is ready, validate is run again on the latest document.
+        expect(documentInfo.get(uri)?.rustState).toBe("ready");
+        expect(sendDiagnostics).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/lsp/vite.config.ts
+++ b/packages/lsp/vite.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
     build: {
         minify: true,
         sourcemap: true,
+        // Inline the WASM binary (≈4 MB) as a data URL so the IIFE bundle
+        // is fully self-contained.  The blob-URL conversion in rust-core.ts
+        // turns it back into a loadable WASM URL at runtime.
+        assetsInlineLimit: 10 * 1024 * 1024,
         lib: {
             entry: "./src/index.ts",
             name: "DoenetLanguageServer",

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -53,6 +53,11 @@ type ComponentClass = {
      * (It is assumed, but not checked, that the component actually does inherit from those types.)
      */
     inSchemaOnlyInheritAs?: string[];
+    /**
+     * If true, descendants are accessible only via index (e.g. $name[1].member).
+     * Autocomplete uses this to decide whether `$name.` offers descendant names.
+     */
+    takesIndex?: boolean;
     getAdapterComponentType: (...args: any[]) => string;
     numAdapters: number;
     /**
@@ -137,6 +142,8 @@ type SchemaElement = {
     top: boolean;
     /** Whether this component accepts string children */
     acceptsStringChildren: boolean;
+    /** Whether descendants are accessible only via index */
+    takesIndex: boolean;
 };
 
 /**
@@ -450,6 +457,7 @@ export function getSchema() {
                 cClass.componentType === "document" ||
                 documentChildrenSet.has(cClass.componentType),
             acceptsStringChildren,
+            takesIndex: cClass.takesIndex ?? false,
         });
     }
 

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -259,7 +259,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "rightHandSide",
@@ -826,7 +827,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "description",
@@ -1251,7 +1253,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "xLabel",
@@ -1590,7 +1593,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "yLabel",
@@ -1929,7 +1933,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "statement",
@@ -2354,7 +2359,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "introduction",
@@ -2779,7 +2785,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "conclusion",
@@ -3204,7 +3211,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "topic",
@@ -3554,7 +3562,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "br",
@@ -3661,7 +3670,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "hr",
@@ -3768,7 +3778,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "cascadeMessage",
@@ -4113,7 +4124,8 @@
                 }
             ],
             "top": false,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "else",
@@ -4463,7 +4475,8 @@
                 }
             ],
             "top": false,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "m",
@@ -4791,7 +4804,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "me",
@@ -5119,7 +5133,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "men",
@@ -5452,7 +5467,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "md",
@@ -5634,7 +5650,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "mdn",
@@ -5816,7 +5833,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "mrow",
@@ -6156,7 +6174,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "not",
@@ -6510,7 +6529,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "and",
@@ -6776,7 +6796,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "or",
@@ -7042,7 +7063,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "xor",
@@ -7308,7 +7330,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "isInteger",
@@ -7641,7 +7664,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "isNumber",
@@ -7974,7 +7998,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "isBetween",
@@ -8327,7 +8352,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "sum",
@@ -8918,7 +8944,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "product",
@@ -9509,7 +9536,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "clampNumber",
@@ -10092,7 +10120,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "wrapNumberPeriodic",
@@ -10675,7 +10704,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "round",
@@ -11258,7 +11288,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "setSmallToZero",
@@ -11833,7 +11864,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "convertSetToList",
@@ -12388,7 +12420,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "ceil",
@@ -12955,7 +12988,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "floor",
@@ -13522,7 +13556,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "abs",
@@ -14089,7 +14124,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "sign",
@@ -14656,7 +14692,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "mean",
@@ -15247,7 +15284,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "median",
@@ -15838,7 +15876,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "variance",
@@ -16441,7 +16480,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "standardDeviation",
@@ -17044,7 +17084,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "count",
@@ -17635,7 +17676,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "min",
@@ -18226,7 +18268,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "max",
@@ -18817,7 +18860,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "mod",
@@ -19408,7 +19452,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "gcd",
@@ -19999,7 +20044,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "lcm",
@@ -20590,7 +20636,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "extractMath",
@@ -21183,7 +21230,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "clampFunction",
@@ -21851,7 +21899,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "wrapFunctionPeriodic",
@@ -22519,7 +22568,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "derivative",
@@ -23195,7 +23245,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "extractMathOperator",
@@ -23531,7 +23582,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "em",
@@ -23787,7 +23839,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "alert",
@@ -24043,7 +24096,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "q",
@@ -24299,7 +24353,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "sq",
@@ -24555,7 +24610,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "term",
@@ -24811,7 +24867,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "c",
@@ -25067,7 +25124,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "tag",
@@ -25323,7 +25381,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "tage",
@@ -25579,7 +25638,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "tagc",
@@ -25835,7 +25895,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "attr",
@@ -26091,7 +26152,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "ndash",
@@ -26203,7 +26265,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "mdash",
@@ -26315,7 +26378,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "nbsp",
@@ -26427,7 +26491,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "ellipsis",
@@ -26539,7 +26604,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "lq",
@@ -26651,7 +26717,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "rq",
@@ -26763,7 +26830,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "lsq",
@@ -26875,7 +26943,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "rsq",
@@ -26987,7 +27056,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "section",
@@ -27538,7 +27608,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "subsection",
@@ -28089,7 +28160,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "subsubsection",
@@ -28640,7 +28712,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "paragraphs",
@@ -29191,7 +29264,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "aside",
@@ -29768,7 +29842,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "objectives",
@@ -30319,7 +30394,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "problem",
@@ -30877,7 +30953,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "exercise",
@@ -31435,7 +31512,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "question",
@@ -31993,7 +32071,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "activity",
@@ -32551,7 +32630,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "example",
@@ -33102,7 +33182,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "definition",
@@ -33653,7 +33734,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "note",
@@ -34204,7 +34286,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "theorem",
@@ -34755,7 +34838,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "part",
@@ -35306,7 +35390,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "task",
@@ -35857,7 +35942,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "proof",
@@ -36425,7 +36511,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "problems",
@@ -36967,7 +37054,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "exercises",
@@ -37509,7 +37597,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "ol",
@@ -37636,7 +37725,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "ul",
@@ -37763,7 +37853,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "li",
@@ -38193,7 +38284,8 @@
                 }
             ],
             "top": false,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "odeSystem",
@@ -38527,7 +38619,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "cobwebPolyline",
@@ -39001,7 +39094,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "equilibriumPoint",
@@ -39454,7 +39548,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "equilibriumLine",
@@ -39896,7 +39991,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "equilibriumCurve",
@@ -40528,7 +40624,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "atom",
@@ -40797,7 +40894,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "ion",
@@ -40986,7 +41084,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "ionicCompound",
@@ -41136,7 +41235,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "electronConfiguration",
@@ -41703,7 +41803,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "orbitalDiagram",
@@ -41900,7 +42001,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "orbitalDiagramInput",
@@ -42038,7 +42140,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "feedbackDefinition",
@@ -42151,7 +42254,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "styleDefinition",
@@ -42355,7 +42459,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "sideBySide",
@@ -42594,7 +42699,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "sbsGroup",
@@ -42768,7 +42874,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "stack",
@@ -43106,7 +43213,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "h",
@@ -43459,7 +43567,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "idx",
@@ -43623,7 +43732,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "div",
@@ -44048,7 +44158,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "span",
@@ -44473,7 +44584,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "pre",
@@ -44811,7 +44923,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "displayDoenetML",
@@ -45169,7 +45282,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "paginator",
@@ -45520,7 +45634,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "paginatorControls",
@@ -45659,7 +45774,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "matrixInput",
@@ -46031,7 +46147,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "solution",
@@ -46341,7 +46458,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "givenAnswer",
@@ -46651,7 +46769,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "document",
@@ -47023,7 +47142,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "text",
@@ -47373,7 +47493,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "textList",
@@ -47561,7 +47682,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": true
         },
         {
             "name": "p",
@@ -47906,7 +48028,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "boolean",
@@ -48255,7 +48378,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "booleanList",
@@ -48380,7 +48504,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": true
         },
         {
             "name": "math",
@@ -48947,7 +49072,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "mathList",
@@ -49198,7 +49324,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": true
         },
         {
             "name": "tupleList",
@@ -49449,7 +49576,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": true
         },
         {
             "name": "numberList",
@@ -49653,7 +49781,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": true
         },
         {
             "name": "collect",
@@ -49710,7 +49839,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": true
         },
         {
             "name": "ref",
@@ -50081,7 +50211,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "point",
@@ -50510,7 +50641,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "coords",
@@ -51070,7 +51202,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "line",
@@ -51488,7 +51621,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "lineSegment",
@@ -51773,7 +51907,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "ray",
@@ -52049,7 +52184,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "polyline",
@@ -52407,7 +52543,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "polygon",
@@ -52797,7 +52934,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "triangle",
@@ -53187,7 +53325,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "rectangle",
@@ -53608,7 +53747,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "regularPolygon",
@@ -54058,7 +54198,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "circle",
@@ -54559,7 +54700,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "parabola",
@@ -55023,7 +55165,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "curve",
@@ -55631,7 +55774,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "bezierControls",
@@ -55832,7 +55976,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "controlVectors",
@@ -56059,7 +56204,8 @@
                 }
             ],
             "top": false,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "vector",
@@ -56514,7 +56660,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "angle",
@@ -56855,7 +57002,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "answer",
@@ -57583,7 +57731,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "award",
@@ -58034,7 +58183,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "when",
@@ -58405,7 +58555,8 @@
                 }
             ],
             "top": false,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "mathInput",
@@ -58934,7 +59085,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "textInput",
@@ -59324,7 +59476,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "booleanInput",
@@ -59661,7 +59814,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "choiceInput",
@@ -60003,7 +60157,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "choice",
@@ -60402,7 +60557,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "number",
@@ -60745,7 +60901,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "integer",
@@ -61093,7 +61250,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "graph",
@@ -61710,7 +61868,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "annotations",
@@ -61820,7 +61979,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "annotation",
@@ -61973,7 +62133,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "function",
@@ -62625,7 +62786,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "piecewiseFunction",
@@ -63172,7 +63334,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "interval",
@@ -63732,7 +63895,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "option",
@@ -64086,7 +64250,8 @@
                 }
             ],
             "top": false,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "sequence",
@@ -64211,7 +64376,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": true
         },
         {
             "name": "slider",
@@ -64563,7 +64729,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "spreadsheet",
@@ -64925,7 +65092,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "cell",
@@ -65339,7 +65507,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "row",
@@ -65521,7 +65690,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "column",
@@ -65659,7 +65829,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "cellBlock",
@@ -65788,7 +65959,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "tabular",
@@ -65997,7 +66169,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "table",
@@ -66331,7 +66504,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "figure",
@@ -66665,7 +66839,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "markers",
@@ -66865,7 +67040,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "repeat",
@@ -67193,7 +67369,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": true
         },
         {
             "name": "repeatForSequence",
@@ -67538,7 +67715,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": true
         },
         {
             "name": "pegboard",
@@ -67719,7 +67897,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "constrainToGrid",
@@ -67874,7 +68053,8 @@
                 }
             ],
             "top": false,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "constrainToGraph",
@@ -67989,7 +68169,8 @@
                 }
             ],
             "top": false,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "attractToGrid",
@@ -68180,7 +68361,8 @@
                 }
             ],
             "top": false,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "constrainTo",
@@ -68382,7 +68564,8 @@
                 }
             ],
             "top": false,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "attractTo",
@@ -68592,7 +68775,8 @@
                 }
             ],
             "top": false,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "constraintUnion",
@@ -68709,7 +68893,8 @@
                 }
             ],
             "top": false,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "attractToConstraint",
@@ -68834,7 +69019,8 @@
                 }
             ],
             "top": false,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "constrainToInterior",
@@ -69036,7 +69222,8 @@
                 }
             ],
             "top": false,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "intersection",
@@ -69138,7 +69325,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "conditionalContent",
@@ -69465,7 +69653,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "asList",
@@ -69726,7 +69915,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "variantControl",
@@ -69855,7 +70045,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "selectFromSequence",
@@ -70027,7 +70218,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": true
         },
         {
             "name": "select",
@@ -70147,7 +70339,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": true
         },
         {
             "name": "group",
@@ -70481,7 +70674,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "animateFromSequence",
@@ -70675,7 +70869,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "evaluate",
@@ -71196,7 +71391,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "selectRandomNumbers",
@@ -71374,7 +71570,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": true
         },
         {
             "name": "sampleRandomNumbers",
@@ -71564,7 +71761,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": true
         },
         {
             "name": "selectPrimeNumbers",
@@ -71717,7 +71915,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": true
         },
         {
             "name": "samplePrimeNumbers",
@@ -71855,7 +72054,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": true
         },
         {
             "name": "substitute",
@@ -72278,7 +72478,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": true
         },
         {
             "name": "periodicSet",
@@ -72822,7 +73023,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "image",
@@ -73085,7 +73287,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "video",
@@ -73298,7 +73501,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "hint",
@@ -73646,7 +73850,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "intComma",
@@ -74001,7 +74206,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "pluralize",
@@ -74372,7 +74578,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "feedback",
@@ -74708,7 +74915,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "considerAsResponses",
@@ -75046,7 +75254,8 @@
                 }
             ],
             "top": false,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "case",
@@ -75396,7 +75605,8 @@
                 }
             ],
             "top": false,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "lorem",
@@ -75524,7 +75734,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "updateValue",
@@ -75738,7 +75949,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "callAction",
@@ -75939,7 +76151,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "triggerSet",
@@ -76125,7 +76338,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "functionIterates",
@@ -76339,7 +76553,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "module",
@@ -76665,7 +76880,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "moduleAttributes",
@@ -76983,7 +77199,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "setup",
@@ -77303,7 +77520,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "footnote",
@@ -77564,7 +77782,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "caption",
@@ -77874,7 +78093,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "endpoint",
@@ -78327,7 +78547,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "sort",
@@ -78678,7 +78899,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": true
         },
         {
             "name": "shuffle",
@@ -79006,7 +79228,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": true
         },
         {
             "name": "solveEquations",
@@ -79247,7 +79470,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "subsetOfRealsInput",
@@ -79490,7 +79714,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "subsetOfReals",
@@ -80124,7 +80349,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "split",
@@ -80463,7 +80689,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "bestFitLine",
@@ -80806,7 +81033,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "regionBetweenCurveXAxis",
@@ -80976,7 +81204,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "regionBetweenCurves",
@@ -81160,7 +81389,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "regionHalfPlane",
@@ -81341,7 +81571,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "codeEditor",
@@ -81789,7 +82020,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "hasSameFactoring",
@@ -82146,7 +82378,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "dataFrame",
@@ -82309,7 +82542,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "summaryStatistics",
@@ -82539,7 +82773,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "legend",
@@ -82714,7 +82949,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "label",
@@ -83053,7 +83289,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "matchesPattern",
@@ -83475,7 +83712,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "matrix",
@@ -83974,7 +84212,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "eigenDecomposition",
@@ -84233,7 +84472,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "latex",
@@ -84608,7 +84848,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "blockQuote",
@@ -84946,7 +85187,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "stickyGroup",
@@ -85209,7 +85451,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "pretzel",
@@ -85507,7 +85750,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": false
+            "acceptsStringChildren": false,
+            "takesIndex": false
         },
         {
             "name": "cascade",
@@ -86080,7 +86324,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "shortDescription",
@@ -86435,7 +86680,8 @@
                 }
             ],
             "top": false,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "pointList",
@@ -86639,7 +86885,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "intervalList",
@@ -86843,7 +87090,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         },
         {
             "name": "vectorList",
@@ -87047,7 +87295,8 @@
                 }
             ],
             "top": true,
-            "acceptsStringChildren": true
+            "acceptsStringChildren": true,
+            "takesIndex": false
         }
     ]
 }

--- a/packages/test-cypress/cypress/e2e/EditorViewer/autocompletion.cy.js
+++ b/packages/test-cypress/cypress/e2e/EditorViewer/autocompletion.cy.js
@@ -25,15 +25,14 @@ describe("Autocompletion via $ref.member", { tags: ["@group5"] }, function () {
             "hello",
         );
 
-        // Wait for the LSP worker to initialize and process the document
-        cy.wait(2000);
+        // Avoid fixed LSP startup sleeps; completion assertions below are retryable.
 
         // Move cursor to end and type a ref with a dot
         cy.get(".cm-content").click();
         cy.get(".cm-activeLine").type("{ctrl+end}$s1.");
+        cy.get(".cm-activeLine").should("contain.text", "$s1.");
 
         // Explicitly trigger autocompletion with Ctrl+Space
-        cy.wait(500);
         cy.get(".cm-activeLine").type("{ctrl} ");
 
         // The autocomplete tooltip should appear with member completions
@@ -71,17 +70,16 @@ describe(
                 win.postMessage({ doenetML }, "*");
             });
 
-            // Wait for the viewer to render and LSP to boot
+            // Wait for the viewer to render; avoid fixed LSP startup sleeps.
             cy.get(".doenet-viewer", { timeout: 10000 }).should("exist");
-            cy.wait(3000);
 
             // ------ Inside the repeat: $ins should offer "inside" ------
             // Place cursor at the blank line inside the repeat (line 2)
             cy.get(".cm-content").click();
             // Go to line 2 (the newline inside <repeat>, before </repeat>)
             cy.get(".cm-activeLine").type("{ctrl+home}{downArrow}{end}$ins");
+            cy.get(".cm-activeLine").should("contain.text", "$ins");
 
-            cy.wait(500);
             cy.get(".cm-activeLine").type("{ctrl} ");
 
             cy.get(".cm-tooltip-autocomplete", { timeout: 10000 }).should(
@@ -99,8 +97,8 @@ describe(
             // ------ Outside the repeat: $ins should NOT offer "inside" ------
             // Move to the very end (root level, after </section>)
             cy.get(".cm-activeLine").type("{ctrl+end}$ins");
+            cy.get(".cm-activeLine").should("contain.text", "$ins");
 
-            cy.wait(500);
             cy.get(".cm-activeLine").type("{ctrl} ");
 
             // Either no autocomplete tooltip at all, or it exists but

--- a/packages/test-cypress/cypress/e2e/EditorViewer/autocompletion.cy.js
+++ b/packages/test-cypress/cypress/e2e/EditorViewer/autocompletion.cy.js
@@ -1,0 +1,120 @@
+describe("Autocompletion via $ref.member", { tags: ["@group5"] }, function () {
+    beforeEach(() => {
+        cy.clearIndexedDB();
+        cy.visit("/");
+        // Show editor
+        cy.get("#testRunner_toggleControls").click();
+        cy.get("#testRunner_showEditor").click();
+        cy.wait(100);
+        cy.get("#testRunner_toggleControls").click();
+    });
+
+    it("shows member completions for $ref.", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `<section name="s1"><p name="innerP">hello</p></section>\n`,
+                },
+                "*",
+            );
+        });
+
+        // Wait for content to render in the viewer
+        cy.get(".doenet-viewer", { timeout: 10000 }).should(
+            "contain.text",
+            "hello",
+        );
+
+        // Wait for the LSP worker to initialize and process the document
+        cy.wait(2000);
+
+        // Move cursor to end and type a ref with a dot
+        cy.get(".cm-content").click();
+        cy.get(".cm-activeLine").type("{ctrl+end}$s1.");
+
+        // Explicitly trigger autocompletion with Ctrl+Space
+        cy.wait(500);
+        cy.get(".cm-activeLine").type("{ctrl} ");
+
+        // The autocomplete tooltip should appear with member completions
+        cy.get(".cm-tooltip-autocomplete", { timeout: 10000 }).should("exist");
+
+        // Should include the named child "innerP" as a completion
+        cy.get(".cm-tooltip-autocomplete").should("contain.text", "innerP");
+    });
+});
+
+describe(
+    "$name visibility filtering with <repeat>",
+    { tags: ["@group5"] },
+    function () {
+        beforeEach(() => {
+            cy.clearIndexedDB();
+            cy.visit("/");
+            // Show editor
+            cy.get("#testRunner_toggleControls").click();
+            cy.get("#testRunner_showEditor").click();
+            cy.wait(100);
+            cy.get("#testRunner_toggleControls").click();
+        });
+
+        it("shows $inside inside repeat but not outside", () => {
+            // The document has a <repeat> containing a named <math>.
+            // "inside" should be completable from within the repeat but
+            // NOT from root level (ChildrenInvisibleToTheirGrandparents).
+            //
+            // We place the cursor at two locations and verify completions.
+
+            const doenetML = `<section name="sec"><repeat name="rep"><math name="inside">x</math>\n</repeat></section>\n`;
+
+            cy.window().then(async (win) => {
+                win.postMessage({ doenetML }, "*");
+            });
+
+            // Wait for the viewer to render and LSP to boot
+            cy.get(".doenet-viewer", { timeout: 10000 }).should("exist");
+            cy.wait(3000);
+
+            // ------ Inside the repeat: $ins should offer "inside" ------
+            // Place cursor at the blank line inside the repeat (line 2)
+            cy.get(".cm-content").click();
+            // Go to line 2 (the newline inside <repeat>, before </repeat>)
+            cy.get(".cm-activeLine").type("{ctrl+home}{downArrow}{end}$ins");
+
+            cy.wait(500);
+            cy.get(".cm-activeLine").type("{ctrl} ");
+
+            cy.get(".cm-tooltip-autocomplete", { timeout: 10000 }).should(
+                "exist",
+            );
+            cy.get(".cm-tooltip-autocomplete").should("contain.text", "inside");
+
+            // Accept/dismiss the autocomplete and clear what we typed
+            cy.get(".cm-activeLine").type("{esc}");
+            // Remove the "$ins" we just typed
+            cy.get(".cm-activeLine").type(
+                "{backspace}{backspace}{backspace}{backspace}",
+            );
+
+            // ------ Outside the repeat: $ins should NOT offer "inside" ------
+            // Move to the very end (root level, after </section>)
+            cy.get(".cm-activeLine").type("{ctrl+end}$ins");
+
+            cy.wait(500);
+            cy.get(".cm-activeLine").type("{ctrl} ");
+
+            // Either no autocomplete tooltip at all, or it exists but
+            // does NOT contain "inside".
+            cy.get("body").then(($body) => {
+                if ($body.find(".cm-tooltip-autocomplete").length > 0) {
+                    cy.get(".cm-tooltip-autocomplete").should(
+                        "not.contain.text",
+                        "inside",
+                    );
+                }
+                // If no tooltip appeared, that's also correct — nothing
+                // matched the prefix from outside the repeat.
+            });
+        });
+    },
+);


### PR DESCRIPTION
## Summary

Wire the Rust WASM resolver (`PublicDoenetMLCore.resolve_path`) into the LSP autocomplete pipeline, replacing the JS-only heuristic for `$name.member` resolution. Then fix a series of autocomplete bugs and add several new features on top of the resolver integration.

## Changes

### Rust resolver integration (commit 1)
- `RustResolverAdapter` bridges the `DoenetSourceObject` DAST with the Rust WASM core, maintaining synchronized index mappings
- Replaces the JS fallback for `resolveRefMemberContainerAtOffset` and adds `isNameAddressableFromOffset` for scope-aware `$name` filtering
- Lazy WASM initialization in the LSP server (`validate.ts` / `rust-core.ts`)

### Hardening (commit 2)
- Guard `syncSource()` and `buildMappings()` against empty, text-only, and incomplete DAST sources
- Regression tests for edge cases (empty doc, `<a`, text-only, recovery after blank)

### Autocomplete bug fixes and features (commit 3)

**Sugar visibility (Bugs A & B from audit)**
- `isHiddenBySugar()` post-filter: names inside sugared `conditionalContent`/`select` are hidden from outside their scope
- Transparent walking through `case`/`else`/`option` wrappers for `$cc.member` and `$sel.member` completions

**`takesIndex` support**
- Add `static takesIndex = true` to 17 composite component classes (Repeat, Select, Sequence, etc.)
- Wire `takesIndex` through schema generation → `doenet-schema.json` → adapter → completion items
- Suppress dot-access descendants for `takesIndex` composites unless bracket index is present (`$name[1].member`)

**`$name[]` snippet completions**
- Offer `$name[]` snippet items for `takesIndex` elements with cursor positioned between brackets using the CodeMirror `CompletionSnippetCursor` protocol

**Repeat `valueName`/`indexName` injection**
- `getRepeatSyntheticNames()` injects `valueName`/`indexName` as completions inside repeat bodies
- Also available as member completions via `$rep[1].valueName`

**Index bracket parsing**
- Context parser recognizes `$name[n]` syntax, strips indices from path parts, and threads `hasIndex` through the resolver and completion pipeline

**Partial resolution**
- Unresolved intermediate path segments (`$s.nonexistent.`) return `node: null` → no completions (previously leaked parent properties)

**Vite/Cypress fix**
- Custom `raw-lsp-bundle` plugin (base64 encoding) to handle `?raw` import of the ~7 MB LSP IIFE bundle with inlined WASM

## Tests
- **133 vitest** tests pass (31 new integration tests)
- **42 Cypress component** tests pass (1 new `$name[]` snippet cursor test)
- All files formatted with Prettier