### PR TITLE
Replace sortResults with sort attribute for selectFromSequence and selectPrimeNumbers

### DIFF
--- a/.changeset/sleepy-cats-belong.md
+++ b/.changeset/sleepy-cats-belong.md
@@ -1,0 +1,8 @@
+---
+"@doenet/doenetml": minor
+"@doenet/standalone": minor
+"@doenet/doenetml-iframe": minor
+"@doenet/v06-to-v07": minor
+---
+
+Replace `sortResults` boolean attribute with `sort` text attribute for `selectFromSequence` and `selectPrimeNumbers` components. The new `sort` attribute accepts three values: "unsorted", "increasing", and "decreasing". Backward compatibility is maintained through deprecation shims that automatically convert `sort="true"` to `sort="increasing"` and `sort="false"` to `sort="unsorted"`.

--- a/packages/docs-nextra/pages/reference/selectFromSequence.mdx
+++ b/packages/docs-nextra/pages/reference/selectFromSequence.mdx
@@ -117,13 +117,13 @@ editor to see different variants of the document.
 
 ---
 
-### Attribute Example: sortResults
+### Attribute Example: sort
 
 
 ```doenet-editor-horiz
 <selectFromSequence 
   name="s" 
-  sortResults 
+  sort="increasing" 
   from="0" 
   to="50" 
   numToSelect="5"
@@ -138,7 +138,12 @@ editor to see different variants of the document.
 
 
 
-The `sortResults` attribute sorts the selected results in increasing order.
+The `sort` attribute determines how selected results are sorted. It accepts three values:
+- `"unsorted"` (default) - results are in the order they were selected
+- `"increasing"` - results are sorted in increasing order
+- `"decreasing"` - results are sorted in decreasing order
+
+Alternatively, `sort` and `sort="true"` are equivalent to `sort="increasing"`, and `sort="false"` is equivalent to `sort="unsorted"`.
 
 Select a new page variant from the pulldown menu at the top of the 
 editor to see different variants of the document.

--- a/packages/docs-nextra/pages/reference/selectPrimeNumbers.mdx
+++ b/packages/docs-nextra/pages/reference/selectPrimeNumbers.mdx
@@ -91,13 +91,13 @@ editor to see different variants of the document.
 
 ---
 
-### Attribute Example: sortResults
+### Attribute Example: sort
 
 
 ```doenet-editor-horiz
 <selectPrimeNumbers 
   name="s" 
-  sortResults 
+  sort="increasing" 
   from="2" 
   to="50" 
   numToSelect="5"
@@ -112,7 +112,12 @@ editor to see different variants of the document.
 
 
 
-The `sortResults` attribute sorts the selected results in increasing order.
+The `sort` attribute determines how selected results are sorted. It accepts three values:
+- `"unsorted"` (default) - results are in the order they were selected
+- `"increasing"` - results are sorted in increasing order
+- `"decreasing"` - results are sorted in decreasing order
+
+Alternatively, `sort` and `sort="true"` are equivalent to `sort="increasing"`, and `sort="false"` is equivalent to `sort="unsorted"`.
 
 Select a new page variant from the pulldown menu at the top of the 
 editor to see different variants of the document.

--- a/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
@@ -38,11 +38,15 @@ export default class SelectFromSequence extends Sequence {
             defaultValue: false,
             public: true,
         };
-        attributes.sortResults = {
-            createComponentOfType: "boolean",
-            createStateVariable: "sortResults",
-            defaultValue: false,
+        attributes.sort = {
+            createComponentOfType: "text",
+            createStateVariable: "sort",
+            defaultValue: "unsorted",
             public: true,
+            toLowerCase: true,
+            valueForTrue: "increasing",
+            valueForNone: "unsorted",
+            validValues: ["unsorted", "increasing", "decreasing"],
         };
         attributes.excludeCombinations = {
             createComponentOfType: "_componentListOfListsWithSelectableType",
@@ -207,9 +211,9 @@ export default class SelectFromSequence extends Sequence {
                     dependencyType: "stateVariable",
                     variableName: "lowercase",
                 },
-                sortResults: {
+                sort: {
                     dependencyType: "stateVariable",
-                    variableName: "sortResults",
+                    variableName: "sort",
                 },
                 variants: {
                     dependencyType: "stateVariable",
@@ -672,36 +676,36 @@ export default class SelectFromSequence extends Sequence {
             }
         }
 
-        let sortResults;
+        let sort;
 
-        let sortResultsComponent =
-            serializedComponent.attributes.sortResults?.component;
-        if (sortResultsComponent) {
+        let sortComponent = serializedComponent.attributes.sort?.component;
+        if (sortComponent) {
             // only implemented if have a single string child
 
             if (
-                sortResultsComponent.children?.length === 1 &&
-                typeof sortResultsComponent.children[0] === "string"
+                sortComponent.children?.length === 1 &&
+                typeof sortComponent.children[0] === "string"
             ) {
-                sortResults =
-                    sortResultsComponent.children[0].toLowerCase() === "true";
+                sort = sortComponent.children[0].toLowerCase();
             } else if (
-                (!sortResultsComponent.children ||
-                    sortResultsComponent.children?.length === 0) &&
-                typeof sortResultsComponent.state?.value === "boolean"
+                (!sortComponent.children ||
+                    sortComponent.children?.length === 0) &&
+                typeof sortComponent.state?.value === "string"
             ) {
-                sortResults = sortResultsComponent.state.value;
+                sort = sortComponent.state.value;
             } else {
                 console.log(
-                    `cannot determine unique variants of selectFromSequence as sortResults isn't a constant.`,
+                    `cannot determine unique variants of selectFromSequence as sort isn't a constant.`,
                 );
                 return { success: false };
             }
+        } else {
+            sort = "unsorted";
         }
 
-        if (sortResults && numToSelect > 1) {
+        if (sort !== "unsorted" && numToSelect > 1) {
             console.log(
-                "have not implemented unique variants of a selectFromSequence with sortResults",
+                "have not implemented unique variants of a selectFromSequence with sort",
             );
             return { success: false };
         }
@@ -1262,7 +1266,7 @@ function makeSelection({ dependencyValues }) {
         }
     }
 
-    if (dependencyValues.sortResults) {
+    if (dependencyValues.sort !== "unsorted") {
         // combine selectedIndices and selectedValues to sort together
         let combinedList = [];
         for (let [ind, val] of selectedValues.entries()) {
@@ -1270,12 +1274,24 @@ function makeSelection({ dependencyValues }) {
         }
 
         if (dependencyValues.type === "number") {
-            combinedList.sort((a, b) => a.value - b.value);
+            if (dependencyValues.sort === "increasing") {
+                combinedList.sort((a, b) => a.value - b.value);
+            } else if (dependencyValues.sort === "decreasing") {
+                combinedList.sort((a, b) => b.value - a.value);
+            }
         } else if (dependencyValues.type === "letters") {
             // sort according to their numerical value, not as words
-            combinedList.sort(
-                (a, b) => lettersToNumber(a.value) - lettersToNumber(b.value),
-            );
+            if (dependencyValues.sort === "increasing") {
+                combinedList.sort(
+                    (a, b) =>
+                        lettersToNumber(a.value) - lettersToNumber(b.value),
+                );
+            } else if (dependencyValues.sort === "decreasing") {
+                combinedList.sort(
+                    (a, b) =>
+                        lettersToNumber(b.value) - lettersToNumber(a.value),
+                );
+            }
         }
 
         selectedValues = combinedList.map((x) => x.value);

--- a/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
@@ -685,7 +685,6 @@ export default class SelectFromSequence extends Sequence {
         if (!sortResult.success) {
             return { success: false };
         }
-        let sort = sortResult.sort;
 
         sequencePars = calculateSequenceParameters(sequencePars);
 

--- a/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
@@ -46,7 +46,7 @@ export default class SelectFromSequence extends Sequence {
             public: true,
             toLowerCase: true,
             valueForTrue: "increasing",
-            valueForNone: "unsorted",
+            valueForFalse: "unsorted",
             validValues: ["unsorted", "increasing", "decreasing"],
         };
         attributes.excludeCombinations = {

--- a/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
@@ -9,6 +9,7 @@ import { lettersToNumber, enumerateSelectionCombinations } from "@doenet/utils";
 import { convertUnresolvedAttributesForComponentType } from "../utils/dast/convertNormalizedDast";
 import { returnRoundingAttributes } from "../utils/rounding";
 import { textToMathFactory } from "../utils/math";
+import { extractConstantSortAttribute } from "../utils/variants";
 import {
     checkForExcludedCombination,
     estimateNumberOfDuplicateCombinations,
@@ -676,39 +677,15 @@ export default class SelectFromSequence extends Sequence {
             }
         }
 
-        let sort;
-
-        let sortComponent = serializedComponent.attributes.sort?.component;
-        if (sortComponent) {
-            // only implemented if have a single string child
-
-            if (
-                sortComponent.children?.length === 1 &&
-                typeof sortComponent.children[0] === "string"
-            ) {
-                sort = sortComponent.children[0].toLowerCase();
-            } else if (
-                (!sortComponent.children ||
-                    sortComponent.children?.length === 0) &&
-                typeof sortComponent.state?.value === "string"
-            ) {
-                sort = sortComponent.state.value;
-            } else {
-                console.log(
-                    `cannot determine unique variants of selectFromSequence as sort isn't a constant.`,
-                );
-                return { success: false };
-            }
-        } else {
-            sort = "unsorted";
-        }
-
-        if (sort !== "unsorted" && numToSelect > 1) {
-            console.log(
-                "have not implemented unique variants of a selectFromSequence with sort",
-            );
+        let sortResult = extractConstantSortAttribute(
+            serializedComponent,
+            "selectFromSequence",
+            numToSelect,
+        );
+        if (!sortResult.success) {
             return { success: false };
         }
+        let sort = sortResult.sort;
 
         sequencePars = calculateSequenceParameters(sequencePars);
 

--- a/packages/doenetml-worker-javascript/src/components/SelectPrimeNumbers.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectPrimeNumbers.js
@@ -61,7 +61,7 @@ export default class SelectPrimeNumbers extends CompositeComponent {
             public: true,
             toLowerCase: true,
             valueForTrue: "increasing",
-            valueForNone: "unsorted",
+            valueForFalse: "unsorted",
             validValues: ["unsorted", "increasing", "decreasing"],
         };
         attributes.excludeCombinations = {

--- a/packages/doenetml-worker-javascript/src/components/SelectPrimeNumbers.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectPrimeNumbers.js
@@ -53,11 +53,15 @@ export default class SelectPrimeNumbers extends CompositeComponent {
             defaultValue: false,
             public: true,
         };
-        attributes.sortResults = {
-            createComponentOfType: "boolean",
-            createStateVariable: "sortResults",
-            defaultValue: false,
+        attributes.sort = {
+            createComponentOfType: "text",
+            createStateVariable: "sort",
+            defaultValue: "unsorted",
             public: true,
+            toLowerCase: true,
+            valueForTrue: "increasing",
+            valueForNone: "unsorted",
+            validValues: ["unsorted", "increasing", "decreasing"],
         };
         attributes.excludeCombinations = {
             createComponentOfType: "_listOfNumberLists",
@@ -186,9 +190,9 @@ export default class SelectPrimeNumbers extends CompositeComponent {
                     dependencyType: "stateVariable",
                     variableName: "excludedCombinations",
                 },
-                sortResults: {
+                sort: {
                     dependencyType: "stateVariable",
-                    variableName: "sortResults",
+                    variableName: "sort",
                 },
                 variants: {
                     dependencyType: "stateVariable",
@@ -447,36 +451,36 @@ export default class SelectPrimeNumbers extends CompositeComponent {
             primePars.exclude = exclude;
         }
 
-        let sortResults;
+        let sort;
 
-        let sortResultsComponent =
-            serializedComponent.attributes.sortResults?.component;
-        if (sortResultsComponent) {
+        let sortComponent = serializedComponent.attributes.sort?.component;
+        if (sortComponent) {
             // only implemented if have a single string child
 
             if (
-                sortResultsComponent.children?.length === 1 &&
-                typeof sortResultsComponent.children[0] === "string"
+                sortComponent.children?.length === 1 &&
+                typeof sortComponent.children[0] === "string"
             ) {
-                sortResults =
-                    sortResultsComponent.children[0].toLowerCase() === "true";
+                sort = sortComponent.children[0].toLowerCase();
             } else if (
-                (!sortResultsComponent.children ||
-                    sortResultsComponent.children?.length === 0) &&
-                typeof sortResultsComponent.state?.value === "boolean"
+                (!sortComponent.children ||
+                    sortComponent.children?.length === 0) &&
+                typeof sortComponent.state?.value === "string"
             ) {
-                sortResults = sortResultsComponent.state.value;
+                sort = sortComponent.state.value;
             } else {
                 console.log(
-                    `cannot determine unique variants of selectPrimeNumbers as sortResults isn't a constant.`,
+                    `cannot determine unique variants of selectPrimeNumbers as sort isn't a constant.`,
                 );
                 return { success: false };
             }
+        } else {
+            sort = "unsorted";
         }
 
-        if (sortResults && numToSelect > 1) {
+        if (sort !== "unsorted" && numToSelect > 1) {
             console.log(
-                "have not implemented unique variants of a selectPrimeNumbers with sortResults",
+                "have not implemented unique variants of a selectPrimeNumbers with sort",
             );
             return { success: false };
         }
@@ -790,8 +794,10 @@ function makeSelection({ dependencyValues }) {
         }
     }
 
-    if (dependencyValues.sortResults) {
+    if (dependencyValues.sort === "increasing") {
         selectedValues.sort((a, b) => a - b);
+    } else if (dependencyValues.sort === "decreasing") {
+        selectedValues.sort((a, b) => b - a);
     }
 
     return {

--- a/packages/doenetml-worker-javascript/src/components/SelectPrimeNumbers.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectPrimeNumbers.js
@@ -460,7 +460,6 @@ export default class SelectPrimeNumbers extends CompositeComponent {
         if (!sortResult.success) {
             return { success: false };
         }
-        let sort = sortResult.sort;
 
         let primes = createPrimesList(primePars);
 

--- a/packages/doenetml-worker-javascript/src/components/SelectPrimeNumbers.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectPrimeNumbers.js
@@ -1,4 +1,5 @@
 import { enumerateSelectionCombinations } from "@doenet/utils";
+import { extractConstantSortAttribute } from "../utils/variants";
 import {
     checkForExcludedCombination,
     estimateNumberOfDuplicateCombinations,
@@ -451,39 +452,15 @@ export default class SelectPrimeNumbers extends CompositeComponent {
             primePars.exclude = exclude;
         }
 
-        let sort;
-
-        let sortComponent = serializedComponent.attributes.sort?.component;
-        if (sortComponent) {
-            // only implemented if have a single string child
-
-            if (
-                sortComponent.children?.length === 1 &&
-                typeof sortComponent.children[0] === "string"
-            ) {
-                sort = sortComponent.children[0].toLowerCase();
-            } else if (
-                (!sortComponent.children ||
-                    sortComponent.children?.length === 0) &&
-                typeof sortComponent.state?.value === "string"
-            ) {
-                sort = sortComponent.state.value;
-            } else {
-                console.log(
-                    `cannot determine unique variants of selectPrimeNumbers as sort isn't a constant.`,
-                );
-                return { success: false };
-            }
-        } else {
-            sort = "unsorted";
-        }
-
-        if (sort !== "unsorted" && numToSelect > 1) {
-            console.log(
-                "have not implemented unique variants of a selectPrimeNumbers with sort",
-            );
+        let sortResult = extractConstantSortAttribute(
+            serializedComponent,
+            "selectPrimeNumbers",
+            numToSelect,
+        );
+        if (!sortResult.success) {
             return { success: false };
         }
+        let sort = sortResult.sort;
 
         let primes = createPrimesList(primePars);
 

--- a/packages/doenetml-worker-javascript/src/test/diagnostics/warningsInfos.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/diagnostics/warningsInfos.test.ts
@@ -124,14 +124,14 @@ describe("Warning Tests @group4", async () => {
     it("Deprecated selectPrimeNumbers attributes", async () => {
         const { core } = await createTestCore({
             doenetML: `
-<selectPrimeNumbers minValue="10" maxValue="50" />
+<selectPrimeNumbers minValue="10" maxValue="50" sortResults="true" />
             `,
         });
 
         const diagnosticsByType = getDiagnosticsByType(core);
 
         expect(diagnosticsByType.errors.length).eq(0);
-        expect(diagnosticsByType.warnings.length).eq(2);
+        expect(diagnosticsByType.warnings.length).eq(3);
 
         expect(
             diagnosticsByType.warnings.some((warning) =>
@@ -145,6 +145,35 @@ describe("Warning Tests @group4", async () => {
             diagnosticsByType.warnings.some((warning) =>
                 warning.message.includes(
                     "Attribute `maxValue` on `<selectPrimeNumbers>` is deprecated; use `to` instead.",
+                ),
+            ),
+        ).eq(true);
+
+        expect(
+            diagnosticsByType.warnings.some((warning) =>
+                warning.message.includes(
+                    "Attribute `sortResults` on `<selectPrimeNumbers>` is deprecated; use `sort` instead.",
+                ),
+            ),
+        ).eq(true);
+    });
+
+    it("Deprecated selectFromSequence sortResults attribute", async () => {
+        const { core } = await createTestCore({
+            doenetML: `
+<selectFromSequence from="1" to="10" sortResults="true" />
+            `,
+        });
+
+        const diagnosticsByType = getDiagnosticsByType(core);
+
+        expect(diagnosticsByType.errors.length).eq(0);
+        expect(diagnosticsByType.warnings.length).eq(1);
+
+        expect(
+            diagnosticsByType.warnings.some((warning) =>
+                warning.message.includes(
+                    "Attribute `sortResults` on `<selectFromSequence>` is deprecated; use `sort` instead.",
                 ),
             ),
         ).eq(true);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/selectfromsequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/selectfromsequence.test.ts
@@ -2200,6 +2200,34 @@ describe("SelectFromSequence tag tests @group4", async () => {
         expect(secondNumbers).eqls(originalNumbers);
     });
 
+    it("sort with whitespace and uppercase false value", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p name="p1"><selectFromSequence name="s" numToSelect="10" sort="  FALSE  " from="1" to="10" /></p>
+    <p extend="$p1" name="p2" />
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("s")].stateValues.sort,
+        ).eq("unsorted");
+
+        let originalNumbers = stateVariables[
+            await resolvePathToNodeIdx("p1")
+        ].activeChildren.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+        let secondNumbers = stateVariables[
+            await resolvePathToNodeIdx("p2")
+        ].activeChildren.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+
+        expect(secondNumbers).eqls(originalNumbers);
+    });
+
     it("sort with no value should be sorted increasing", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/selectfromsequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/selectfromsequence.test.ts
@@ -1131,7 +1131,7 @@ describe("SelectFromSequence tag tests @group4", async () => {
     it("select numbers and sort", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
-    <p name="p1"><selectFromSequence numToSelect="20" sortResults="true" withReplacement="true" from="-20" to="20" /></p>
+    <p name="p1"><selectFromSequence numToSelect="20" sort="increasing" withReplacement="true" from="-20" to="20" /></p>
 
     <p extend="$p1" name="p2" />
     `,
@@ -1159,7 +1159,7 @@ describe("SelectFromSequence tag tests @group4", async () => {
     it("select letters and sort", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
-    <p name="p1"><selectFromSequence type="letters" numToSelect="20" sortResults="true" withReplacement="true" from="a" to="bz" /></p>
+    <p name="p1"><selectFromSequence type="letters" numToSelect="20" sort="increasing" withReplacement="true" from="a" to="bz" /></p>
 
     <p extend="$p1" name="p2" />
     `,
@@ -1819,7 +1819,7 @@ describe("SelectFromSequence tag tests @group4", async () => {
     });
 
     it("select two odd coprime numbers from 15 to 21, sort results", async () => {
-        const doenetML = `<selectFromSequence name="s" numToSelect="2" from="15" to="21" step="2" coprime sortResults />`;
+        const doenetML = `<selectFromSequence name="s" numToSelect="2" from="15" to="21" step="2" coprime sort="increasing" />`;
         const valid_combinations = [
             [15, 17],
             [15, 19],
@@ -1839,7 +1839,7 @@ describe("SelectFromSequence tag tests @group4", async () => {
     });
 
     it("select two odd coprime numbers from 15 to 21, sort results, with negative step", async () => {
-        const doenetML = `<selectFromSequence name="s" numToSelect="2" from="21" to="15" step="-2" coprime sortResults />`;
+        const doenetML = `<selectFromSequence name="s" numToSelect="2" from="21" to="15" step="-2" coprime sort="increasing" />`;
         const valid_combinations = [
             [15, 17],
             [15, 19],
@@ -1859,7 +1859,7 @@ describe("SelectFromSequence tag tests @group4", async () => {
     });
 
     it("select two coprime numbers from 21 to 27, excluding 23 and 25, sort results", async () => {
-        const doenetML = `<selectFromSequence name="s" numToSelect="2" from="21" to="27" exclude="23 25" coprime sortResults />`;
+        const doenetML = `<selectFromSequence name="s" numToSelect="2" from="21" to="27" exclude="23 25" coprime sort="increasing" />`;
         const valid_combinations = [
             [21, 22],
             [21, 26],
@@ -1878,7 +1878,7 @@ describe("SelectFromSequence tag tests @group4", async () => {
     });
 
     it("select four coprime numbers from 22 to 28, excluding 23 and 25, sort results", async () => {
-        const doenetML = `<selectFromSequence name="s" numToSelect="4" from="22" to="27" exclude="23 25" coprime sortResults />`;
+        const doenetML = `<selectFromSequence name="s" numToSelect="4" from="22" to="27" exclude="23 25" coprime sort="increasing" />`;
         const valid_combinations = [
             [22, 24, 26, 27],
             [22, 24, 27, 28],
@@ -1897,7 +1897,7 @@ describe("SelectFromSequence tag tests @group4", async () => {
     });
 
     it("select three coprime numbers from 4 to 6, with replacement, sort results", async () => {
-        const doenetML = `<selectFromSequence name="s" numToSelect="3" from="4" to="6" coprime  withReplacement sortResults />`;
+        const doenetML = `<selectFromSequence name="s" numToSelect="3" from="4" to="6" coprime  withReplacement sort="increasing" />`;
         const valid_combinations = [
             [4, 5, 6],
             [4, 4, 5],
@@ -2105,5 +2105,111 @@ describe("SelectFromSequence tag tests @group4", async () => {
             // Should not select a value close to zero
             expect(Math.abs(value)).greaterThan(0.5);
         }
+    });
+
+    it("sort with decreasing value", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p name="p1"><selectFromSequence numToSelect="10" sort="decreasing" from="1" to="10" /></p>
+    <p extend="$p1" name="p2" />
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        let originalNumbers = stateVariables[
+            await resolvePathToNodeIdx("p1")
+        ].activeChildren.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+        let secondNumbers = stateVariables[
+            await resolvePathToNodeIdx("p2")
+        ].activeChildren.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+
+        expect([...originalNumbers].sort((a, b) => b - a)).eqls(
+            originalNumbers,
+        );
+        expect(secondNumbers).eqls(originalNumbers);
+    });
+
+    it("sort with true value (backward compatibility)", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p name="p1"><selectFromSequence numToSelect="10" sort="true" from="1" to="10" /></p>
+    <p extend="$p1" name="p2" />
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        let originalNumbers = stateVariables[
+            await resolvePathToNodeIdx("p1")
+        ].activeChildren.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+        let secondNumbers = stateVariables[
+            await resolvePathToNodeIdx("p2")
+        ].activeChildren.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+
+        // sort="true" should convert to "increasing"
+        expect([...originalNumbers].sort((a, b) => a - b)).eqls(
+            originalNumbers,
+        );
+        expect(secondNumbers).eqls(originalNumbers);
+    });
+
+    it("sort with false value (backward compatibility)", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p name="p1"><selectFromSequence numToSelect="10" sort="false" from="1" to="10" /></p>
+    <p extend="$p1" name="p2" />
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        let originalNumbers = stateVariables[
+            await resolvePathToNodeIdx("p1")
+        ].activeChildren.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+        let secondNumbers = stateVariables[
+            await resolvePathToNodeIdx("p2")
+        ].activeChildren.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+
+        // sort="false" should convert to "unsorted"
+        // We just verify it doesn't crash and produces consistent results
+        expect(secondNumbers).eqls(originalNumbers);
+    });
+
+    it("sort with no value", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p name="p1"><selectFromSequence numToSelect="10" sort from="1" to="10" /></p>
+    <p extend="$p1" name="p2" />
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        let originalNumbers = stateVariables[
+            await resolvePathToNodeIdx("p1")
+        ].activeChildren.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+        let secondNumbers = stateVariables[
+            await resolvePathToNodeIdx("p2")
+        ].activeChildren.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+
+        // sort with no value should produce consistent results
+        expect(secondNumbers).eqls(originalNumbers);
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/selectfromsequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/selectfromsequence.test.ts
@@ -2110,12 +2110,16 @@ describe("SelectFromSequence tag tests @group4", async () => {
     it("sort with decreasing value", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
-    <p name="p1"><selectFromSequence numToSelect="10" sort="decreasing" from="1" to="10" /></p>
+    <p name="p1"><selectFromSequence name="s" numToSelect="10" sort="decreasing" from="1" to="10" /></p>
     <p extend="$p1" name="p2" />
     `,
         });
 
         let stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("s")].stateValues.sort,
+        ).eq("decreasing");
 
         let originalNumbers = stateVariables[
             await resolvePathToNodeIdx("p1")
@@ -2137,12 +2141,16 @@ describe("SelectFromSequence tag tests @group4", async () => {
     it("sort with true value", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
-    <p name="p1"><selectFromSequence numToSelect="10" sort="true" from="1" to="10" /></p>
+    <p name="p1"><selectFromSequence name="s" numToSelect="10" sort="true" from="1" to="10" /></p>
     <p extend="$p1" name="p2" />
     `,
         });
 
         let stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("s")].stateValues.sort,
+        ).eq("increasing");
 
         let originalNumbers = stateVariables[
             await resolvePathToNodeIdx("p1")
@@ -2165,12 +2173,16 @@ describe("SelectFromSequence tag tests @group4", async () => {
     it("sort with false value", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
-    <p name="p1"><selectFromSequence numToSelect="10" sort="false" from="1" to="10" /></p>
+    <p name="p1"><selectFromSequence name="s" numToSelect="10" sort="false" from="1" to="10" /></p>
     <p extend="$p1" name="p2" />
     `,
         });
 
         let stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("s")].stateValues.sort,
+        ).eq("unsorted");
 
         let originalNumbers = stateVariables[
             await resolvePathToNodeIdx("p1")
@@ -2188,15 +2200,19 @@ describe("SelectFromSequence tag tests @group4", async () => {
         expect(secondNumbers).eqls(originalNumbers);
     });
 
-    it("sort with no value", async () => {
+    it("sort with no value should be sorted increasing", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
-    <p name="p1"><selectFromSequence numToSelect="10" sort from="1" to="10" /></p>
+    <p name="p1"><selectFromSequence name="s" numToSelect="10" sort from="1" to="10" /></p>
     <p extend="$p1" name="p2" />
     `,
         });
 
         let stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("s")].stateValues.sort,
+        ).eq("increasing");
 
         let originalNumbers = stateVariables[
             await resolvePathToNodeIdx("p1")
@@ -2209,6 +2225,10 @@ describe("SelectFromSequence tag tests @group4", async () => {
             (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
+        // sort should convert to "increasing"
+        expect([...originalNumbers].sort((a, b) => a - b)).eqls(
+            originalNumbers,
+        );
         // sort with no value should produce consistent results
         expect(secondNumbers).eqls(originalNumbers);
     });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/selectfromsequence.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/selectfromsequence.test.ts
@@ -2134,7 +2134,7 @@ describe("SelectFromSequence tag tests @group4", async () => {
         expect(secondNumbers).eqls(originalNumbers);
     });
 
-    it("sort with true value (backward compatibility)", async () => {
+    it("sort with true value", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
     <p name="p1"><selectFromSequence numToSelect="10" sort="true" from="1" to="10" /></p>
@@ -2162,7 +2162,7 @@ describe("SelectFromSequence tag tests @group4", async () => {
         expect(secondNumbers).eqls(originalNumbers);
     });
 
-    it("sort with false value (backward compatibility)", async () => {
+    it("sort with false value", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
     <p name="p1"><selectFromSequence numToSelect="10" sort="false" from="1" to="10" /></p>

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/selectprimenumbers.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/selectprimenumbers.test.ts
@@ -926,7 +926,7 @@ describe("selectPrimeNumbers tag tests @group2", async () => {
     it("select prime numbers and sort", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
-    <p name="p1"><selectPrimeNumbers numToSelect="20" sortResults="true" withReplacement="true" to="100" /></p>
+    <p name="p1"><selectPrimeNumbers numToSelect="20" sort="increasing" withReplacement="true" to="100" /></p>
 
     <p extend="$p1" name="p2" />
     `,
@@ -959,7 +959,7 @@ describe("selectPrimeNumbers tag tests @group2", async () => {
 
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
-    <p name="p1"><selectPrimeNumbers numToSelect="3" sortResults="true" withReplacement="true" to="100" /></p>
+    <p name="p1"><selectPrimeNumbers numToSelect="3" sort="increasing" withReplacement="true" to="100" /></p>
 
     <p extend="$p1" name="p2" />
     `,
@@ -1162,5 +1162,111 @@ describe("selectPrimeNumbers tag tests @group2", async () => {
         expect(
             stateVariables[await resolvePathToNodeIdx("p5")].stateValues.text,
         ).eq(nums5.map((v, i) => `${l[i]}5=${v}`).join(", "));
+    });
+
+    it("sort with decreasing value", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p name="p1"><selectPrimeNumbers numToSelect="5" sort="decreasing" from="2" to="13" /></p>
+    <p extend="$p1" name="p2" />
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        let originalNumbers = stateVariables[
+            await resolvePathToNodeIdx("p1")
+        ].activeChildren.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+        let secondNumbers = stateVariables[
+            await resolvePathToNodeIdx("p2")
+        ].activeChildren.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+
+        expect([...originalNumbers].sort((a, b) => b - a)).eqls(
+            originalNumbers,
+        );
+        expect(secondNumbers).eqls(originalNumbers);
+    });
+
+    it("sort with true value (backward compatibility)", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p name="p1"><selectPrimeNumbers numToSelect="5" sort="true" from="2" to="13" /></p>
+    <p extend="$p1" name="p2" />
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        let originalNumbers = stateVariables[
+            await resolvePathToNodeIdx("p1")
+        ].activeChildren.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+        let secondNumbers = stateVariables[
+            await resolvePathToNodeIdx("p2")
+        ].activeChildren.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+
+        // sort="true" should convert to "increasing"
+        expect([...originalNumbers].sort((a, b) => a - b)).eqls(
+            originalNumbers,
+        );
+        expect(secondNumbers).eqls(originalNumbers);
+    });
+
+    it("sort with false value (backward compatibility)", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p name="p1"><selectPrimeNumbers numToSelect="5" sort="false" from="2" to="13" /></p>
+    <p extend="$p1" name="p2" />
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        let originalNumbers = stateVariables[
+            await resolvePathToNodeIdx("p1")
+        ].activeChildren.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+        let secondNumbers = stateVariables[
+            await resolvePathToNodeIdx("p2")
+        ].activeChildren.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+
+        // sort="false" should convert to "unsorted"
+        // We just verify it doesn't crash and produces consistent results
+        expect(secondNumbers).eqls(originalNumbers);
+    });
+
+    it("sort with no value", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p name="p1"><selectPrimeNumbers numToSelect="5" sort from="2" to="13" /></p>
+    <p extend="$p1" name="p2" />
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        let originalNumbers = stateVariables[
+            await resolvePathToNodeIdx("p1")
+        ].activeChildren.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+        let secondNumbers = stateVariables[
+            await resolvePathToNodeIdx("p2")
+        ].activeChildren.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+
+        // sort with no value should produce consistent results
+        expect(secondNumbers).eqls(originalNumbers);
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/selectprimenumbers.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/selectprimenumbers.test.ts
@@ -1257,6 +1257,34 @@ describe("selectPrimeNumbers tag tests @group2", async () => {
         expect(secondNumbers).eqls(originalNumbers);
     });
 
+    it("sort with whitespace and uppercase false value", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p name="p1"><selectPrimeNumbers name="s" numToSelect="5" sort="  FALSE  " from="2" to="13" /></p>
+    <p extend="$p1" name="p2" />
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("s")].stateValues.sort,
+        ).eq("unsorted");
+
+        let originalNumbers = stateVariables[
+            await resolvePathToNodeIdx("p1")
+        ].activeChildren.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+        let secondNumbers = stateVariables[
+            await resolvePathToNodeIdx("p2")
+        ].activeChildren.map(
+            (x) => stateVariables[x.componentIdx].stateValues.value,
+        );
+
+        expect(secondNumbers).eqls(originalNumbers);
+    });
+
     it("sort with no value should be sorted increasing", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/selectprimenumbers.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/selectprimenumbers.test.ts
@@ -1191,7 +1191,7 @@ describe("selectPrimeNumbers tag tests @group2", async () => {
         expect(secondNumbers).eqls(originalNumbers);
     });
 
-    it("sort with true value (backward compatibility)", async () => {
+    it("sort with true value", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
     <p name="p1"><selectPrimeNumbers numToSelect="5" sort="true" from="2" to="13" /></p>
@@ -1219,7 +1219,7 @@ describe("selectPrimeNumbers tag tests @group2", async () => {
         expect(secondNumbers).eqls(originalNumbers);
     });
 
-    it("sort with false value (backward compatibility)", async () => {
+    it("sort with false value", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
     <p name="p1"><selectPrimeNumbers numToSelect="5" sort="false" from="2" to="13" /></p>

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/selectprimenumbers.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/selectprimenumbers.test.ts
@@ -1167,12 +1167,16 @@ describe("selectPrimeNumbers tag tests @group2", async () => {
     it("sort with decreasing value", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
-    <p name="p1"><selectPrimeNumbers numToSelect="5" sort="decreasing" from="2" to="13" /></p>
+    <p name="p1"><selectPrimeNumbers name="s" numToSelect="5" sort="decreasing" from="2" to="13" /></p>
     <p extend="$p1" name="p2" />
     `,
         });
 
         let stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("s")].stateValues.sort,
+        ).eq("decreasing");
 
         let originalNumbers = stateVariables[
             await resolvePathToNodeIdx("p1")
@@ -1194,12 +1198,16 @@ describe("selectPrimeNumbers tag tests @group2", async () => {
     it("sort with true value", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
-    <p name="p1"><selectPrimeNumbers numToSelect="5" sort="true" from="2" to="13" /></p>
+    <p name="p1"><selectPrimeNumbers name="s" numToSelect="5" sort="true" from="2" to="13" /></p>
     <p extend="$p1" name="p2" />
     `,
         });
 
         let stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("s")].stateValues.sort,
+        ).eq("increasing");
 
         let originalNumbers = stateVariables[
             await resolvePathToNodeIdx("p1")
@@ -1222,12 +1230,16 @@ describe("selectPrimeNumbers tag tests @group2", async () => {
     it("sort with false value", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
-    <p name="p1"><selectPrimeNumbers numToSelect="5" sort="false" from="2" to="13" /></p>
+    <p name="p1"><selectPrimeNumbers name="s" numToSelect="5" sort="false" from="2" to="13" /></p>
     <p extend="$p1" name="p2" />
     `,
         });
 
         let stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("s")].stateValues.sort,
+        ).eq("unsorted");
 
         let originalNumbers = stateVariables[
             await resolvePathToNodeIdx("p1")
@@ -1245,15 +1257,19 @@ describe("selectPrimeNumbers tag tests @group2", async () => {
         expect(secondNumbers).eqls(originalNumbers);
     });
 
-    it("sort with no value", async () => {
+    it("sort with no value should be sorted increasing", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
-    <p name="p1"><selectPrimeNumbers numToSelect="5" sort from="2" to="13" /></p>
+    <p name="p1"><selectPrimeNumbers name="s" numToSelect="5" sort from="2" to="13" /></p>
     <p extend="$p1" name="p2" />
     `,
         });
 
         let stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("s")].stateValues.sort,
+        ).eq("increasing");
 
         let originalNumbers = stateVariables[
             await resolvePathToNodeIdx("p1")
@@ -1266,7 +1282,10 @@ describe("selectPrimeNumbers tag tests @group2", async () => {
             (x) => stateVariables[x.componentIdx].stateValues.value,
         );
 
-        // sort with no value should produce consistent results
+        // sort with no value should be increasing
+        expect([...originalNumbers].sort((a, b) => a - b)).eqls(
+            originalNumbers,
+        );
         expect(secondNumbers).eqls(originalNumbers);
     });
 });

--- a/packages/doenetml-worker-javascript/src/utils/variants.ts
+++ b/packages/doenetml-worker-javascript/src/utils/variants.ts
@@ -582,12 +582,12 @@ export function extractConstantSortAttribute(
             sortComponent.children?.length === 1 &&
             typeof sortComponent.children[0] === "string"
         ) {
-            sort = sortComponent.children[0].toLowerCase();
+            sort = sortComponent.children[0].trim().toLowerCase();
         } else if (
             (!sortComponent.children || sortComponent.children?.length === 0) &&
             typeof sortComponent.state?.value === "string"
         ) {
-            sort = sortComponent.state.value;
+            sort = sortComponent.state.value.trim().toLowerCase();
         } else {
             console.log(
                 `cannot determine unique variants of ${componentName} as sort isn't a constant.`,

--- a/packages/doenetml-worker-javascript/src/utils/variants.ts
+++ b/packages/doenetml-worker-javascript/src/utils/variants.ts
@@ -556,3 +556,54 @@ export function determineVariantsForSection({
 function indexToLowercaseLetters(index: number) {
     return numberToLetters(index, true);
 }
+
+/**
+ * Extract and validate a constant sort attribute from a serialized component.
+ * Used by selection components (selectFromSequence, selectPrimeNumbers) to ensure
+ * the sort attribute is a constant string value during variant determination.
+ *
+ * @param serializedComponent - The component to extract sort from
+ * @param componentName - The component type name (for error messages)
+ * @param numToSelect - The number of items being selected (determines if sort is valid)
+ * @returns Object with success flag and extracted sort value ("unsorted", "increasing", "decreasing")
+ */
+export function extractConstantSortAttribute(
+    serializedComponent: any,
+    componentName: string,
+    numToSelect: number,
+): { success: boolean; sort?: string } {
+    let sort;
+
+    let sortComponent = serializedComponent.attributes.sort?.component;
+    if (sortComponent) {
+        // only implemented if have a single string child
+
+        if (
+            sortComponent.children?.length === 1 &&
+            typeof sortComponent.children[0] === "string"
+        ) {
+            sort = sortComponent.children[0].toLowerCase();
+        } else if (
+            (!sortComponent.children || sortComponent.children?.length === 0) &&
+            typeof sortComponent.state?.value === "string"
+        ) {
+            sort = sortComponent.state.value;
+        } else {
+            console.log(
+                `cannot determine unique variants of ${componentName} as sort isn't a constant.`,
+            );
+            return { success: false };
+        }
+    } else {
+        sort = "unsorted";
+    }
+
+    if (sort !== "unsorted" && numToSelect > 1) {
+        console.log(
+            `have not implemented unique variants of a ${componentName} with sort`,
+        );
+        return { success: false };
+    }
+
+    return { success: true, sort };
+}

--- a/packages/lsp-tools/test/rust-resolver-integration.test.ts
+++ b/packages/lsp-tools/test/rust-resolver-integration.test.ts
@@ -767,7 +767,7 @@ describe.skipIf(!wasmAvailable)(
             // $sec.rep[1]. — the resolved terminal segment ("rep") is a
             // takesIndex composite AND carries an index.  This is an indirect
             // path (three segments: sec / rep[1] / <empty>), so rep is not
-            // the root of the ref.  The behaviour should be the same as the
+            // the root of the ref.  The behavior should be the same as the
             // direct case $rep[1].: the index means the cursor is after a
             // replacement child of unknown type, so descendant names should
             // be offered but schema properties of repeatForSequence should

--- a/packages/parser/src/dast-normalize/deprecations.ts
+++ b/packages/parser/src/dast-normalize/deprecations.ts
@@ -32,6 +32,15 @@ type DeprecationRegistry = {
 
 const DEPRECATION_REGISTRY: DeprecationRegistry = {
     attributeRenames: {
+        selectFromSequence: {
+            sortResults: {
+                to: "sort",
+                warningMessage:
+                    "[deprecation] Attribute `sortResults` on `<selectFromSequence>` is deprecated; use `sort` instead.",
+                conflictWarningMessage:
+                    "[deprecation] Attribute `sortResults` on `<selectFromSequence>` is deprecated and ignored because `sort` is also specified.",
+            },
+        },
         selectPrimeNumbers: {
             minValue: {
                 to: "from",
@@ -46,6 +55,13 @@ const DEPRECATION_REGISTRY: DeprecationRegistry = {
                     "[deprecation] Attribute `maxValue` on `<selectPrimeNumbers>` is deprecated; use `to` instead.",
                 conflictWarningMessage:
                     "[deprecation] Attribute `maxValue` on `<selectPrimeNumbers>` is deprecated and ignored because `to` is also specified.",
+            },
+            sortResults: {
+                to: "sort",
+                warningMessage:
+                    "[deprecation] Attribute `sortResults` on `<selectPrimeNumbers>` is deprecated; use `sort` instead.",
+                conflictWarningMessage:
+                    "[deprecation] Attribute `sortResults` on `<selectPrimeNumbers>` is deprecated and ignored because `sort` is also specified.",
             },
         },
         samplePrimeNumbers: {

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -113681,11 +113681,12 @@
                         "false"
                     ]
                 },
-                "sortResults": {
+                "sort": {
                     "optional": true,
                     "type": [
-                        "true",
-                        "false"
+                        "unsorted",
+                        "increasing",
+                        "decreasing"
                     ]
                 },
                 "excludeCombinations": {
@@ -113741,8 +113742,8 @@
                     "isArray": false
                 },
                 {
-                    "name": "sortResults",
-                    "type": "boolean",
+                    "name": "sort",
+                    "type": "text",
                     "isArray": false
                 },
                 {
@@ -116065,11 +116066,12 @@
                         "false"
                     ]
                 },
-                "sortResults": {
+                "sort": {
                     "optional": true,
                     "type": [
-                        "true",
-                        "false"
+                        "unsorted",
+                        "increasing",
+                        "decreasing"
                     ]
                 },
                 "excludeCombinations": {
@@ -116140,8 +116142,8 @@
                     "isArray": false
                 },
                 {
-                    "name": "sortResults",
-                    "type": "boolean",
+                    "name": "sort",
+                    "type": "text",
                     "isArray": false
                 },
                 {

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -70148,10 +70148,11 @@
                     ]
                 },
                 {
-                    "name": "sortResults",
+                    "name": "sort",
                     "values": [
-                        "true",
-                        "false"
+                        "unsorted",
+                        "increasing",
+                        "decreasing"
                     ]
                 },
                 {
@@ -70202,8 +70203,8 @@
                     "isArray": false
                 },
                 {
-                    "name": "sortResults",
-                    "type": "boolean",
+                    "name": "sort",
+                    "type": "text",
                     "isArray": false
                 },
                 {
@@ -71835,10 +71836,11 @@
                     ]
                 },
                 {
-                    "name": "sortResults",
+                    "name": "sort",
                     "values": [
-                        "true",
-                        "false"
+                        "unsorted",
+                        "increasing",
+                        "decreasing"
                     ]
                 },
                 {
@@ -71904,8 +71906,8 @@
                     "isArray": false
                 },
                 {
-                    "name": "sortResults",
-                    "type": "boolean",
+                    "name": "sort",
+                    "type": "text",
                     "isArray": false
                 },
                 {


### PR DESCRIPTION
## Changes

Replace the `sortResults` boolean attribute with a new `sort` text attribute for `selectFromSequence` and `selectPrimeNumbers` components.

### Implementation
- New `sort` attribute accepts: "unsorted", "increasing", "decreasing"
- Supports value shorthand: `sort` (becomes increasing), `sort="true"` (becomes increasing), `sort="false"` (becomes unsorted)
- Deprecation rules automatically convert old `sortResults` attribute to `sort` with equivalent behavior
- Works with both numeric and letter sequences (SelectFromSequence)
- Works with numeric prime numbers (SelectPrimeNumbers)
- Refactored duplicate sort attribute extraction logic into shared utility function

### Updates
- Component implementations with new sorting logic
- Component documentation
- Deprecation rules and tests
- Comprehensive test coverage for all sort variations

Resolves: #962