### PR TITLE
Add prefigure conversion support for curve and piecewise/interpolated functions

### DIFF
--- a/.changeset/curvy-oranges-repair.md
+++ b/.changeset/curvy-oranges-repair.md
@@ -1,0 +1,9 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Add initial PreFigure rendering support for `<curve>` elements.
+
+ It adds conversion for function, parameterized, and bezier curves, and includes support for piecewise and interpolated function definitions (including piecewise children that are interpolated). It also adds diagnostics for unsupported curve definitions.

--- a/.changeset/sleepy-cats-belong.md
+++ b/.changeset/sleepy-cats-belong.md
@@ -1,8 +1,7 @@
 ---
-"@doenet/doenetml": minor
-"@doenet/standalone": minor
-"@doenet/doenetml-iframe": minor
-"@doenet/v06-to-v07": minor
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
 ---
 
 Replace `sortResults` boolean attribute with `sort` text attribute for `selectFromSequence` and `selectPrimeNumbers` components. The new `sort` attribute accepts three values: "unsorted", "increasing", and "decreasing". Backward compatibility is maintained through deprecation shims that automatically convert `sort="true"` to `sort="increasing"` and `sort="false"` to `sort="unsorted"`.

--- a/packages/doenetml-worker-javascript/src/components/ControlVectors.js
+++ b/packages/doenetml-worker-javascript/src/components/ControlVectors.js
@@ -27,4 +27,22 @@ export default class ControlVectors extends VectorListComponent {
         };
         return attributes;
     }
+
+    static returnStateVariableDefinitions() {
+        let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        // Control vectors are interactive editing handles for jsxgraph and have
+        // no meaning in the prefigure (static) renderer. Overriding hidden to
+        // always be true ensures they propagate parentHidden=true to their
+        // vector children, causing the prefigure dispatcher to skip them.
+        // BezierControls reads controlVectors.hide (the raw attribute SV),
+        // not .hidden, for its hiddenControls array, so this override does
+        // not affect jsxgraph control handle visibility.
+        stateVariableDefinitions.hidden = {
+            returnDependencies: () => ({}),
+            definition: () => ({ setValue: { hidden: true } }),
+        };
+
+        return stateVariableDefinitions;
+    }
 }

--- a/packages/doenetml-worker-javascript/src/components/Function.js
+++ b/packages/doenetml-worker-javascript/src/components/Function.js
@@ -457,6 +457,11 @@ export default class Function extends InlineComponent {
             arrayDefinitionByKey({ globalDependencyValues }) {
                 if (globalDependencyValues.domainAttr !== null) {
                     let numInputs = globalDependencyValues.numInputs;
+                    // Function domains are stored as one interval per input
+                    // variable. For example, f(x,y) with
+                    // domain="(-1,2) (0,3)" becomes [(-1,2), (0,3)].
+                    // Multiple entries here represent different input
+                    // dimensions, not multiple pieces of a 1D domain.
                     let specifiedDomain =
                         globalDependencyValues.domainAttr.stateValues.intervals.slice(
                             0,
@@ -492,6 +497,9 @@ export default class Function extends InlineComponent {
                     if (
                         !specifiedDomain.every(
                             (interval) =>
+                                // At present, each input dimension must be a
+                                // single interval tree. Compound 1D domains
+                                // such as unions are not accepted here.
                                 Array.isArray(interval.tree) &&
                                 interval.tree[0] === "interval",
                         )

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
@@ -594,4 +594,64 @@ describe("Graph prefigure renderer core @group4", () => {
             ),
         ).eq(true);
     });
+
+    describe("hidden descendants", () => {
+        it("hidden point is excluded from prefigure XML", async () => {
+            const prefigureXML = await getPrefigureXML(
+                prefigureGraph('<point hide="true">(1,2)</point>'),
+            );
+
+            expect(prefigureXML).not.toContain(`<point `);
+            expect(prefigureXML).not.toContain(`p="(1,2)"`);
+        });
+
+        it("hidden line is excluded from prefigure XML", async () => {
+            const prefigureXML = await getPrefigureXML(
+                prefigureGraph('<line hide="true" through="(0,0) (1,1)" />'),
+            );
+
+            expect(prefigureXML).not.toContain(`<line `);
+        });
+
+        it("visible point is included while hidden point is excluded", async () => {
+            const prefigureXML = await getPrefigureXML(
+                prefigureGraph(
+                    '<point name="p1">(1,2)</point>\n  <point name="p2" hide="true">(3,4)</point>',
+                ),
+            );
+
+            expect(prefigureXML).toContain(`p="(1,2)"`);
+            expect(prefigureXML).not.toContain(`p="(3,4)"`);
+        });
+
+        it("hiding one of two points does not affect handle of the visible point", async () => {
+            const prefigureXML = await getPrefigureXML(
+                prefigureGraph(
+                    '<point name="p1">(1,2)</point>\n  <point name="p2" hide="true">(3,4)</point>',
+                ),
+            );
+
+            expect(prefigureXML).toContain(`at="point_`);
+            const matches = prefigureXML?.match(/at="point_(\d+)"/g) ?? [];
+            expect(matches.length).eq(1);
+        });
+
+        it("hidden component referenced by annotation produces target-not-found warning", async () => {
+            const doenetML = prefigureGraph(
+                '<point name="p" hide="true">(1,2)</point>\n  <annotations><annotation ref="$p" text="hidden point" /></annotations>',
+            );
+
+            const prefigureXML = await getPrefigureXML(doenetML);
+            expect(prefigureXML).not.toContain(`p="(1,2)"`);
+
+            const diagnosticsByType = await getWarnings(doenetML);
+            expect(
+                diagnosticsByType.warnings.some((x) =>
+                    x.message.includes(
+                        "target is not a supported graphical object",
+                    ),
+                ),
+            ).eq(true);
+        });
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
@@ -1302,6 +1302,18 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         expect(prefigureXML).not.toContain(`fill-opacity="`);
     });
 
+    it("renderer=prefigure normalizes parameter names across parametric coordinates", async () => {
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph(
+                '<curve><function variable="u">u^2</function><function variable="v">v^3</function></curve>',
+            ),
+        );
+
+        expect(prefigureXML).toContain(`<parametric-curve at="curve_0"`);
+        expect(prefigureXML).toContain(`function="curve_0_r(u)=(`);
+        expect(prefigureXML).not.toContain(`v^3`);
+    });
+
     it("renderer=prefigure maps bezier curve to PreFigure parametric-curve", async () => {
         const prefigureXML = await getPrefigureXML(
             prefigureGraph('<curve through="(0,0) (1,2) (2,1)" />'),
@@ -1441,6 +1453,19 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
                 ),
             ),
         ).eq(false);
+    });
+
+    it.skip("renderer=prefigure respects union-domain gaps on interpolated functions", async () => {
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph(
+                '<function through="(-3,1) (-2,0) (-1,1) (1,1) (2,0) (3,1)" domain="(-4,-1) union (1,4)" />',
+            ),
+        );
+
+        expect(prefigureXML).toContain(`<graph at="curve_0"`);
+        expect(prefigureXML).toContain(`domain="(-3,-2)"`);
+        expect(prefigureXML).toContain(`domain="(2,3)"`);
+        expect(prefigureXML).not.toContain(`domain="(-1,1)"`);
     });
 
     it("renderer=prefigure expands piecewise curve into graph pieces", async () => {

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { pointLabelAttributes } from "../../utils/prefigure/label";
+import { convertCurveToPrefigure } from "../../utils/prefigure/components/curve";
 import {
     getGraphRendererState,
     getPrefigureXML,
@@ -1504,6 +1505,48 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         expect(
             diagnosticsByType.warnings.some((x) =>
                 x.message.includes(
+                    "unsupported function definition type 'interpolated'",
+                ),
+            ),
+        ).eq(false);
+    });
+
+    it("renderer=prefigure emits parse-failure warning (not unsupported-type warning) for supported child that fails to build pieces", () => {
+        const diagnostics: import("@doenet/utils").DiagnosticRecord[] = [];
+        // Interpolated child whose xs contain Infinity — parsedInterpolatedDefinitionPieces
+        // returns null (parse failure), not because the type is unsupported.
+        const interpolatedChildWithBadXs = {
+            functionType: "interpolated",
+            xs: [Infinity, 1],
+            coeffs: [[1, 1, 1, 1]],
+            variables: [["variable", "x"]],
+        };
+        const piecewiseDefinition = {
+            functionType: "piecewise",
+            fDefinitionsOfChildren: [interpolatedChildWithBadXs],
+            numericalDomainsOfChildren: [null],
+        };
+        convertCurveToPrefigure({
+            sv: {
+                curveType: "function",
+                fDefinitions: piecewiseDefinition,
+                parMin: -1,
+                parMax: 1,
+            },
+            handle: "curve_0",
+            styleAttrs: [],
+            diagnostics,
+            warningPrefix: "curve_0",
+        });
+
+        const messages = diagnostics.map((d) => d.message);
+        // Should say "failed to build" not "unsupported function definition type"
+        expect(
+            messages.some((m) => m.includes("failed to build curve pieces")),
+        ).eq(true);
+        expect(
+            messages.some((m) =>
+                m.includes(
                     "unsupported function definition type 'interpolated'",
                 ),
             ),

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
@@ -1348,9 +1348,12 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
             ),
         );
 
-        const vectorDescendants = (
-            graphState.graphicalDescendants ?? []
-        ).filter((x) => x.componentType === "vector");
+        const descendants = (graphState.graphicalDescendants ?? []) as Array<{
+            componentType?: string;
+        }>;
+        const vectorDescendants = descendants.filter(
+            (x) => x.componentType === "vector",
+        );
 
         expect(vectorDescendants.length).toBeGreaterThan(0);
         expect(prefigureXML).not.toContain(`<vector `);
@@ -1488,6 +1491,25 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         expect(relevantWarnings.length).eq(1);
     });
 
+    it("renderer=prefigure does not report supported empty piecewise child as unsupported", async () => {
+        const doenetML = prefigureGraph(
+            '<curve parMin="-1" parMax="1"><piecewiseFunction><function through="(2,2) (3,3) (4,2)" domain="(2,4)" /><function domain="(-1,1)">x^2</function></piecewiseFunction></curve>',
+        );
+
+        const prefigureXML = await getPrefigureXML(doenetML);
+        expect(prefigureXML).toContain(`<graph at="curve_0"`);
+        expect(prefigureXML).toContain(`=x^2"`);
+
+        const diagnosticsByType = await getWarnings(doenetML);
+        expect(
+            diagnosticsByType.warnings.some((x) =>
+                x.message.includes(
+                    "unsupported function definition type 'interpolated'",
+                ),
+            ),
+        ).eq(false);
+    });
+
     it("renderer=prefigure expands piecewise curve into graph pieces", async () => {
         const prefigureXML = await getPrefigureXML(
             prefigureGraph(
@@ -1620,7 +1642,7 @@ describe("point label alignment overflow @group4", () => {
                 numericalXs: [9.5, 9.5],
                 // graphBounds intentionally omitted
             },
-            warnings: [],
+            diagnostics: [],
             warningPrefix: "test",
         });
         expect(result?.attrs).toContain(`alignment="ne"`);

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
@@ -1405,6 +1405,73 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
             ),
         ).eq(true);
     });
+
+    it("renderer=prefigure expands piecewise curve into graph pieces", async () => {
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph(
+                '<curve><piecewiseFunction><function domain="(-2,2)">x^3</function><function>x^2</function></piecewiseFunction></curve>',
+            ),
+        );
+
+        const pieceCount = (prefigureXML.match(/<graph at="curve_0/g) ?? [])
+            .length;
+        expect(pieceCount).toBeGreaterThan(1);
+        expect(prefigureXML).toContain(`function="curve_0_f(x)=x^3"`);
+        expect(prefigureXML).toContain(`=x^2"`);
+        expect(prefigureXML).not.toContain(`fill="`);
+        expect(prefigureXML).not.toContain(`fill-opacity="`);
+    });
+
+    it("renderer=prefigure warns that piecewise endpoint openness is approximated", async () => {
+        const doenetML = prefigureGraph(
+            '<curve><piecewiseFunction><function domain="(-2,2)">x^3</function><function>x^2</function></piecewiseFunction></curve>',
+        );
+
+        const diagnosticsByType = await getWarnings(doenetML);
+        expect(
+            diagnosticsByType.warnings.some((x) =>
+                x.message.includes(
+                    "piecewise open/closed endpoint semantics are approximated",
+                ),
+            ),
+        ).eq(true);
+    });
+
+    it("renderer=prefigure expands parameterized piecewise curves into parametric pieces", async () => {
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph(
+                '<curve><piecewiseFunction><function domain="(-2,2)">x^3/10</function><function>x^2</function></piecewiseFunction><piecewiseFunction><function domain="(-3,3)">x</function><function>x^3/10</function></piecewiseFunction></curve>',
+            ),
+        );
+
+        const pieceCount =
+            (prefigureXML.match(/<parametric-curve at="curve_0/g) ?? [])
+                .length +
+            (prefigureXML.match(/<parametric-curve at="curve_0_/g) ?? [])
+                .length;
+
+        expect(pieceCount).toBeGreaterThan(1);
+        expect(prefigureXML).toContain(`function="curve_0_r(`);
+        expect(prefigureXML).toContain(`(x^3)/10`);
+        expect(prefigureXML).toContain(`domain="`);
+        expect(prefigureXML).not.toContain(`fill="`);
+        expect(prefigureXML).not.toContain(`fill-opacity="`);
+    });
+
+    it("renderer=prefigure warns endpoint approximation for parameterized piecewise curves", async () => {
+        const doenetML = prefigureGraph(
+            '<curve><piecewiseFunction><function domain="(-2,2)">x^3/10</function><function>x^2</function></piecewiseFunction><piecewiseFunction><function domain="(-3,3)">x</function><function>x^3/10</function></piecewiseFunction></curve>',
+        );
+
+        const diagnosticsByType = await getWarnings(doenetML);
+        expect(
+            diagnosticsByType.warnings.some((x) =>
+                x.message.includes(
+                    "piecewise open/closed endpoint semantics are approximated",
+                ),
+            ),
+        ).eq(true);
+    });
 });
 
 // ─── point label alignment overflow ──────────────────────────────────────────

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
@@ -1455,17 +1455,37 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         ).eq(false);
     });
 
-    it.skip("renderer=prefigure respects union-domain gaps on interpolated functions", async () => {
-        const prefigureXML = await getPrefigureXML(
-            prefigureGraph(
-                '<function through="(-3,1) (-2,0) (-1,1) (1,1) (2,0) (3,1)" domain="(-4,-1) union (1,4)" />',
-            ),
+    it("renderer=prefigure respects supported single-interval domains on interpolated functions", async () => {
+        const doenetML = prefigureGraph(
+            '<function through="(1,1) (2,2) (3,1)" domain="(1,2)" />',
         );
 
+        const prefigureXML = await getPrefigureXML(doenetML);
         expect(prefigureXML).toContain(`<graph at="curve_0"`);
-        expect(prefigureXML).toContain(`domain="(-3,-2)"`);
-        expect(prefigureXML).toContain(`domain="(2,3)"`);
-        expect(prefigureXML).not.toContain(`domain="(-1,1)"`);
+        expect(prefigureXML).toContain(`domain="(1,2)"`);
+        expect(prefigureXML).not.toContain(`domain="(-12,1)"`);
+        expect(prefigureXML).not.toContain(`domain="(2,3)"`);
+    });
+
+    it("renderer=prefigure emits one warning when supported piecewise curve has no overlapping pieces", async () => {
+        const doenetML = prefigureGraph(
+            '<curve parMin="-1" parMax="1"><piecewiseFunction><function domain="(2,3)">x^2</function><function domain="(3,4)">x^3</function></piecewiseFunction></curve>',
+        );
+
+        const prefigureXML = await getPrefigureXML(doenetML);
+        expect(prefigureXML).not.toContain(`<graph at="curve_0"`);
+        expect(prefigureXML).not.toContain(`<parametric-curve at="curve_0"`);
+
+        const diagnosticsByType = await getWarnings(doenetML);
+        const relevantWarnings = diagnosticsByType.warnings.filter(
+            (x) =>
+                x.message.includes("unsupported curve function definition") ||
+                x.message.includes(
+                    "non-finite or incomplete geometry; descendant skipped",
+                ),
+        );
+
+        expect(relevantWarnings.length).eq(1);
     });
 
     it("renderer=prefigure expands piecewise curve into graph pieces", async () => {

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
@@ -1387,14 +1387,14 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         ).eq(true);
     });
 
-    it("renderer=prefigure warns when interpolated function curve cannot be serialized", async () => {
+    it("renderer=prefigure serializes interpolated function curves", async () => {
         const doenetML = prefigureGraph(
             '<function through="(1,1) (2,2) (3,1)" />\n  <function>x^2</function>',
         );
 
         const prefigureXML = await getPrefigureXML(doenetML);
         expect(prefigureXML).toContain(`<graph at="curve_1"`);
-        expect(prefigureXML).not.toContain(`<graph at="curve_0"`);
+        expect(prefigureXML).toContain(`<graph at="curve_0"`);
 
         const diagnosticsByType = await getWarnings(doenetML);
         expect(
@@ -1403,7 +1403,7 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
                     "unsupported curve function definition type 'interpolated'",
                 ),
             ),
-        ).eq(true);
+        ).eq(false);
     });
 
     it("renderer=prefigure expands piecewise curve into graph pieces", async () => {
@@ -1420,6 +1420,27 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         expect(prefigureXML).toContain(`=x^2"`);
         expect(prefigureXML).not.toContain(`fill="`);
         expect(prefigureXML).not.toContain(`fill-opacity="`);
+    });
+
+    it("renderer=prefigure supports interpolated pieces within piecewise curves", async () => {
+        const doenetML = prefigureGraph(
+            '<curve><piecewiseFunction><function through="(0,0) (1,1) (2,0)" domain="(-2,2)" /><function>x^2</function></piecewiseFunction></curve>',
+        );
+
+        const prefigureXML = await getPrefigureXML(doenetML);
+        const pieceCount = (prefigureXML.match(/<graph at="curve_0/g) ?? [])
+            .length;
+        expect(pieceCount).toBeGreaterThan(1);
+        expect(prefigureXML).toContain(`=x^2"`);
+
+        const diagnosticsByType = await getWarnings(doenetML);
+        expect(
+            diagnosticsByType.warnings.some((x) =>
+                x.message.includes(
+                    "unsupported curve function definition type 'interpolated'",
+                ),
+            ),
+        ).eq(false);
     });
 
     it("renderer=prefigure warns that piecewise endpoint openness is approximated", async () => {

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { pointLabelAttributes } from "../../utils/prefigure/label";
-import { getPrefigureXML, getWarnings } from "./graph-prefigure.helpers";
+import {
+    getGraphRendererState,
+    getPrefigureXML,
+    getWarnings,
+} from "./graph-prefigure.helpers";
 import {
     prefigureGraph,
     withStyleDefinitions,
@@ -1298,26 +1302,46 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         expect(prefigureXML).not.toContain(`fill-opacity="`);
     });
 
-    it("renderer=prefigure maps bezier curve to PreFigure spline", async () => {
+    it("renderer=prefigure maps bezier curve to PreFigure parametric-curve", async () => {
         const prefigureXML = await getPrefigureXML(
             prefigureGraph('<curve through="(0,0) (1,2) (2,1)" />'),
         );
 
-        expect(prefigureXML).toContain(`<spline at="curve_0"`);
-        expect(prefigureXML).toContain(`points="((0,0),(1,2),(2,1))"`);
-        expect(prefigureXML).toContain(`domain="(0,2)"`);
+        expect(prefigureXML).toContain(`<parametric-curve at="curve_0"`);
+        expect(prefigureXML).toContain(`function="curve_0_r(`);
+        expect(prefigureXML).toContain(`domain="(0,1)"`);
+        expect(prefigureXML).toContain(`domain="(1,2)"`);
+        expect(prefigureXML).not.toContain(`<spline `);
     });
 
-    it("renderer=prefigure maps periodic bezier to closed spline", async () => {
+    it("renderer=prefigure maps periodic bezier to matching parametric curve", async () => {
         const prefigureXML = await getPrefigureXML(
             prefigureGraph(
                 '<curve through="(0,0) (1,2) (2,1) (0,0)" periodic="true" />',
             ),
         );
 
-        expect(prefigureXML).toContain(`<spline at="curve_0"`);
-        expect(prefigureXML).toContain(`closed="yes"`);
-        expect(prefigureXML).not.toContain(`domain="`);
+        expect(prefigureXML).toContain(`<parametric-curve at="curve_0"`);
+        expect(prefigureXML).toContain(`function="curve_0_r(`);
+        expect(prefigureXML).toContain(`domain="(0,1)"`);
+        expect(prefigureXML).toContain(`domain="(1,2)"`);
+        expect(prefigureXML).toContain(`domain="(2,3)"`);
+        expect(prefigureXML).not.toContain(`<spline `);
+    });
+
+    it("renderer=prefigure currently leaks bezier control vectors from graph descendants", async () => {
+        const { graphState, prefigureXML } = await getGraphRendererState(
+            prefigureGraph(
+                '<curve through="(0,0) (1,2) (2,1)"><bezierControls alwaysVisible>(1,1) (-1,1) (1,-1) (-1,-1)</bezierControls></curve>',
+            ),
+        );
+
+        const vectorDescendants = (
+            graphState.graphicalDescendants ?? []
+        ).filter((x) => x.componentType === "vector");
+
+        expect(vectorDescendants.length).toBeGreaterThan(0);
+        expect(prefigureXML).not.toContain(`<vector `);
     });
 
     it("renderer=prefigure warns and omits curve labels", async () => {
@@ -1380,13 +1404,13 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         ).eq(true);
     });
 
-    it("renderer=prefigure warns when bezier points include non-finite coordinates", async () => {
+    it("renderer=prefigure warns when bezier curve cannot build finite geometry", async () => {
         const doenetML = prefigureGraph(
             '<curve through="(0,0) (a,2) (2,1)" />',
         );
 
         const prefigureXML = await getPrefigureXML(doenetML);
-        expect(prefigureXML).not.toContain(`<spline at="curve_0"`);
+        expect(prefigureXML).not.toContain(`<parametric-curve at="curve_0"`);
 
         const diagnosticsByType = await getWarnings(doenetML);
         expect(

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
@@ -1329,7 +1329,7 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         expect(prefigureXML).not.toContain(`<spline `);
     });
 
-    it("renderer=prefigure currently leaks bezier control vectors from graph descendants", async () => {
+    it("renderer=prefigure excludes bezier control vectors from graph descendants", async () => {
         const { graphState, prefigureXML } = await getGraphRendererState(
             prefigureGraph(
                 '<curve through="(0,0) (1,2) (2,1)"><bezierControls alwaysVisible>(1,1) (-1,1) (1,-1) (-1,-1)</bezierControls></curve>',

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { pointLabelAttributes } from "../../utils/prefigure/label";
-import { getPrefigureXML } from "./graph-prefigure.helpers";
+import { getPrefigureXML, getWarnings } from "./graph-prefigure.helpers";
 import {
     prefigureGraph,
     withStyleDefinitions,
@@ -1252,6 +1252,158 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
 
         expect(prefigureXML).toContain(`<arc `);
         expect(prefigureXML).toContain(`points="((0,1),(0,0),(1,0))"`);
+    });
+
+    it("renderer=prefigure maps function curve to PreFigure graph", async () => {
+        const prefigureXML = await getPrefigureXML(
+            withStyleDefinitions(
+                '    <styleDefinition styleNumber="7" lineColor="orange" lineWidth="6" />',
+                prefigureGraph(
+                    '<curve styleNumber="7"><function>x^2</function></curve>',
+                ),
+            ),
+        );
+
+        expect(prefigureXML).toContain(`<graph at="curve_0"`);
+        expect(prefigureXML).toContain(`function="curve_0_f(x)=x^2"`);
+        expect(prefigureXML).toContain(`domain="(-12,12)"`);
+        expect(prefigureXML).toContain(`stroke="orange"`);
+        expect(prefigureXML).toContain(`thickness="6"`);
+    });
+
+    it("renderer=prefigure maps parameterized curve to PreFigure parametric-curve", async () => {
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph(
+                '<curve parMin="-2" parMax="3"><function>3x</function><function>x^2</function></curve>',
+            ),
+        );
+
+        expect(prefigureXML).toContain(`<parametric-curve at="curve_0"`);
+        expect(prefigureXML).toContain(`function="curve_0_r(x)=(3 x,x^2)"`);
+        expect(prefigureXML).toContain(`domain="(-2,3)"`);
+        expect(prefigureXML).not.toContain(`fill="`);
+        expect(prefigureXML).not.toContain(`fill-opacity="`);
+    });
+
+    it("renderer=prefigure maps bezier curve to PreFigure spline", async () => {
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph('<curve through="(0,0) (1,2) (2,1)" />'),
+        );
+
+        expect(prefigureXML).toContain(`<spline at="curve_0"`);
+        expect(prefigureXML).toContain(`points="((0,0),(1,2),(2,1))"`);
+        expect(prefigureXML).toContain(`domain="(0,2)"`);
+    });
+
+    it("renderer=prefigure maps periodic bezier to closed spline", async () => {
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph(
+                '<curve through="(0,0) (1,2) (2,1) (0,0)" periodic="true" />',
+            ),
+        );
+
+        expect(prefigureXML).toContain(`<spline at="curve_0"`);
+        expect(prefigureXML).toContain(`closed="yes"`);
+        expect(prefigureXML).not.toContain(`domain="`);
+    });
+
+    it("renderer=prefigure warns and omits curve labels", async () => {
+        const doenetML = prefigureGraph(
+            "<curve><function>x^2</function><label>f</label></curve>",
+        );
+
+        const prefigureXML = await getPrefigureXML(doenetML);
+        expect(prefigureXML).toContain(`<graph at="curve_0"`);
+        expect(prefigureXML).not.toContain(`<label`);
+
+        const diagnosticsByType = await getWarnings(doenetML);
+        expect(
+            diagnosticsByType.warnings.some((x) =>
+                x.message.includes(
+                    "labels are not supported on converted curve elements",
+                ),
+            ),
+        ).eq(true);
+    });
+
+    it("renderer=prefigure warns when function curve cannot build finite domain for flipped rendering", async () => {
+        const doenetML = prefigureGraph(
+            '<curve flipFunction="true" parMin="a"><function>x^2</function></curve>',
+        );
+
+        const prefigureXML = await getPrefigureXML(doenetML);
+        expect(prefigureXML).not.toContain(`<graph at="curve_0"`);
+        expect(prefigureXML).not.toContain(`<parametric-curve at="curve_0"`);
+
+        const diagnosticsByType = await getWarnings(doenetML);
+        expect(
+            diagnosticsByType.warnings.some(
+                (x) =>
+                    x.message.includes("<curve>") &&
+                    x.message.includes(
+                        "non-finite or incomplete geometry; descendant skipped",
+                    ),
+            ),
+        ).eq(true);
+    });
+
+    it("renderer=prefigure warns when parameterized curve cannot build finite domain", async () => {
+        const doenetML = prefigureGraph(
+            '<curve parMax="a"><function>3x</function><function>x^2</function></curve>',
+        );
+
+        const prefigureXML = await getPrefigureXML(doenetML);
+        expect(prefigureXML).not.toContain(`<parametric-curve at="curve_0"`);
+
+        const diagnosticsByType = await getWarnings(doenetML);
+        expect(
+            diagnosticsByType.warnings.some(
+                (x) =>
+                    x.message.includes("<curve>") &&
+                    x.message.includes(
+                        "non-finite or incomplete geometry; descendant skipped",
+                    ),
+            ),
+        ).eq(true);
+    });
+
+    it("renderer=prefigure warns when bezier points include non-finite coordinates", async () => {
+        const doenetML = prefigureGraph(
+            '<curve through="(0,0) (a,2) (2,1)" />',
+        );
+
+        const prefigureXML = await getPrefigureXML(doenetML);
+        expect(prefigureXML).not.toContain(`<spline at="curve_0"`);
+
+        const diagnosticsByType = await getWarnings(doenetML);
+        expect(
+            diagnosticsByType.warnings.some(
+                (x) =>
+                    x.message.includes("<curve>") &&
+                    x.message.includes(
+                        "non-finite or incomplete geometry; descendant skipped",
+                    ),
+            ),
+        ).eq(true);
+    });
+
+    it("renderer=prefigure warns when interpolated function curve cannot be serialized", async () => {
+        const doenetML = prefigureGraph(
+            '<function through="(1,1) (2,2) (3,1)" />\n  <function>x^2</function>',
+        );
+
+        const prefigureXML = await getPrefigureXML(doenetML);
+        expect(prefigureXML).toContain(`<graph at="curve_1"`);
+        expect(prefigureXML).not.toContain(`<graph at="curve_0"`);
+
+        const diagnosticsByType = await getWarnings(doenetML);
+        expect(
+            diagnosticsByType.warnings.some((x) =>
+                x.message.includes(
+                    "unsupported curve function definition type 'interpolated'",
+                ),
+            ),
+        ).eq(true);
     });
 });
 

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
@@ -1271,6 +1271,19 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         expect(prefigureXML).toContain(`thickness="6"`);
     });
 
+    it("renderer=prefigure uses curve parameter bounds instead of child function domain", async () => {
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph(
+                '<curve parMin="-10" parMax="10"><function domain="(-1,1)">x^2</function></curve>',
+            ),
+        );
+
+        expect(prefigureXML).toContain(`<graph at="curve_0"`);
+        expect(prefigureXML).toContain(`function="curve_0_f(x)=x^2"`);
+        expect(prefigureXML).toContain(`domain="(-10,10)"`);
+        expect(prefigureXML).not.toContain(`domain="(-1,1)"`);
+    });
+
     it("renderer=prefigure maps parameterized curve to PreFigure parametric-curve", async () => {
         const prefigureXML = await getPrefigureXML(
             prefigureGraph(
@@ -1443,21 +1456,6 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         ).eq(false);
     });
 
-    it("renderer=prefigure warns that piecewise endpoint openness is approximated", async () => {
-        const doenetML = prefigureGraph(
-            '<curve><piecewiseFunction><function domain="(-2,2)">x^3</function><function>x^2</function></piecewiseFunction></curve>',
-        );
-
-        const diagnosticsByType = await getWarnings(doenetML);
-        expect(
-            diagnosticsByType.warnings.some((x) =>
-                x.message.includes(
-                    "piecewise open/closed endpoint semantics are approximated",
-                ),
-            ),
-        ).eq(true);
-    });
-
     it("renderer=prefigure expands parameterized piecewise curves into parametric pieces", async () => {
         const prefigureXML = await getPrefigureXML(
             prefigureGraph(
@@ -1477,21 +1475,6 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         expect(prefigureXML).toContain(`domain="`);
         expect(prefigureXML).not.toContain(`fill="`);
         expect(prefigureXML).not.toContain(`fill-opacity="`);
-    });
-
-    it("renderer=prefigure warns endpoint approximation for parameterized piecewise curves", async () => {
-        const doenetML = prefigureGraph(
-            '<curve><piecewiseFunction><function domain="(-2,2)">x^3/10</function><function>x^2</function></piecewiseFunction><piecewiseFunction><function domain="(-3,3)">x</function><function>x^3/10</function></piecewiseFunction></curve>',
-        );
-
-        const diagnosticsByType = await getWarnings(doenetML);
-        expect(
-            diagnosticsByType.warnings.some((x) =>
-                x.message.includes(
-                    "piecewise open/closed endpoint semantics are approximated",
-                ),
-            ),
-        ).eq(true);
     });
 });
 

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
@@ -1567,6 +1567,20 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         expect(prefigureXML).not.toContain(`fill="`);
         expect(prefigureXML).not.toContain(`fill-opacity="`);
     });
+
+    it("renderer=prefigure emits overlap-count pieces for large aligned parametric piecewise inputs", async () => {
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph(
+                '<curve><piecewiseFunction><function domain="(-8,-6)">x</function><function domain="(-6,-4)">x</function><function domain="(-4,-2)">x</function><function domain="(-2,0)">x</function><function domain="(0,2)">x</function><function domain="(2,4)">x</function><function domain="(4,6)">x</function><function domain="(6,8)">x</function></piecewiseFunction><piecewiseFunction><function domain="(-8,-6)">x^2</function><function domain="(-6,-4)">x^2</function><function domain="(-4,-2)">x^2</function><function domain="(-2,0)">x^2</function><function domain="(0,2)">x^2</function><function domain="(2,4)">x^2</function><function domain="(4,6)">x^2</function><function domain="(6,8)">x^2</function></piecewiseFunction></curve>',
+            ),
+        );
+
+        const pieceCount = (
+            prefigureXML.match(/<parametric-curve at="curve_0/g) ?? []
+        ).length;
+
+        expect(pieceCount).eq(8);
+    });
 });
 
 // ─── point label alignment overflow ──────────────────────────────────────────

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
@@ -97,6 +97,188 @@ function parseFormulaDefinition(
     };
 }
 
+function intervalFromCurveDefinitionDomain(
+    domain: unknown,
+): IntervalPiece | null {
+    if (!Array.isArray(domain) || domain.length === 0) {
+        return null;
+    }
+
+    const firstDomain = domain[0] as any;
+
+    if (firstDomain?.tree !== undefined) {
+        const pieces = intervalPiecesFromMathTree(firstDomain.tree);
+        return pieces[0] ?? null;
+    }
+
+    if (
+        Array.isArray(firstDomain) &&
+        firstDomain.length >= 2 &&
+        Array.isArray(firstDomain[0]) &&
+        Array.isArray(firstDomain[1])
+    ) {
+        const endpoints = firstDomain[0];
+        const closedFlags = firstDomain[1];
+
+        const min = Number(endpoints[0]);
+        const max = Number(endpoints[1]);
+        if (
+            (!Number.isFinite(min) && min !== -Infinity) ||
+            (!Number.isFinite(max) && max !== Infinity)
+        ) {
+            return null;
+        }
+        if (min > max) {
+            return null;
+        }
+
+        return {
+            min,
+            max,
+            openMin: !Boolean(closedFlags[0]),
+            openMax: !Boolean(closedFlags[1]),
+        };
+    }
+
+    return null;
+}
+
+function parsedInterpolatedDefinitionPieces({
+    definition,
+    fallbackVariableName,
+    curveBounds,
+}: {
+    definition: CurveFunctionDefinition;
+    fallbackVariableName: string;
+    curveBounds: { min: number; max: number };
+}): ParsedFormulaPiecesResult | null {
+    const xs = Array.isArray(definition.xs)
+        ? definition.xs.map((x) => Number(x))
+        : null;
+    const coeffs = Array.isArray(definition.coeffs) ? definition.coeffs : null;
+
+    if (
+        !xs ||
+        !coeffs ||
+        xs.length < 2 ||
+        coeffs.length < 1 ||
+        coeffs.length !== xs.length - 1 ||
+        xs.some((x) => !Number.isFinite(x)) ||
+        coeffs.some(
+            (c) =>
+                !Array.isArray(c) ||
+                c.length < 4 ||
+                c.slice(0, 4).some((v) => !Number.isFinite(v)),
+        )
+    ) {
+        return null;
+    }
+
+    const parsedVariable = Array.isArray(definition.variables)
+        ? astToExpressionString(definition.variables[0])
+        : null;
+    const variableName = parsedVariable || fallbackVariableName;
+
+    const domainInterval = intervalFromCurveDefinitionDomain(
+        definition.domain,
+    ) ?? {
+        min: -Infinity,
+        max: Infinity,
+        openMin: false,
+        openMax: false,
+    };
+
+    const makeExpression = (coeff: number[], baseX: number): string => {
+        const shiftedVar = `(${variableName}-(${baseX}))`;
+        return `(${coeff[0]}+(${coeff[1]})*${shiftedVar}+(${coeff[2]})*${shiftedVar}^2+(${coeff[3]})*${shiftedVar}^3)`;
+    };
+
+    const rawPieces: ParsedFormulaPiece[] = [];
+
+    // Left extrapolation: x <= xs[0]
+    rawPieces.push({
+        parsed: {
+            variableName,
+            expression: makeExpression(coeffs[0], xs[0]),
+        },
+        interval: {
+            min: -Infinity,
+            max: xs[0],
+            openMin: true,
+            openMax: false,
+        },
+    });
+
+    // Interior interpolation segments.
+    for (let i = 0; i < coeffs.length; i += 1) {
+        rawPieces.push({
+            parsed: {
+                variableName,
+                expression: makeExpression(coeffs[i], xs[i]),
+            },
+            interval: {
+                min: xs[i],
+                max: xs[i + 1],
+                openMin: false,
+                openMax: false,
+            },
+        });
+    }
+
+    // Right extrapolation: x >= xs[last]
+    rawPieces.push({
+        parsed: {
+            variableName,
+            expression: makeExpression(
+                coeffs[coeffs.length - 1],
+                xs[xs.length - 2],
+            ),
+        },
+        interval: {
+            min: xs[xs.length - 1],
+            max: Infinity,
+            openMin: false,
+            openMax: true,
+        },
+    });
+
+    const pieces: ParsedFormulaPiece[] = [];
+    let hasOpenEndpoints = false;
+
+    for (const piece of rawPieces) {
+        const withDefinitionDomain = intersectIntervals(
+            piece.interval,
+            domainInterval,
+        );
+        if (!withDefinitionDomain) {
+            continue;
+        }
+
+        const clipped = intersectIntervalWithBounds(
+            withDefinitionDomain,
+            curveBounds,
+        );
+        if (!clipped) {
+            continue;
+        }
+
+        if (clipped.openMin || clipped.openMax) {
+            hasOpenEndpoints = true;
+        }
+
+        pieces.push({
+            parsed: piece.parsed,
+            interval: clipped,
+        });
+    }
+
+    return {
+        sourceType: "interpolated",
+        hasOpenEndpoints,
+        pieces,
+    };
+}
+
 function formatDomainBound(value: unknown): string | null {
     if (value === Infinity) {
         return "inf";
@@ -348,6 +530,14 @@ function parsedFormulaPiecesFromDefinition({
         };
     }
 
+    if (definition.functionType === "interpolated") {
+        return parsedInterpolatedDefinitionPieces({
+            definition,
+            fallbackVariableName,
+            curveBounds,
+        });
+    }
+
     if (definition.functionType !== "piecewise") {
         return null;
     }
@@ -375,11 +565,17 @@ function parsedFormulaPiecesFromDefinition({
 
     for (let i = 0; i < childDefinitions.length; i += 1) {
         const childDefinition = childDefinitions[i] as CurveFunctionDefinition;
-        const parsed = parseFormulaDefinition(
-            childDefinition,
+        const childPiecesResult = parsedFormulaPiecesFromDefinition({
+            definition: childDefinition,
             fallbackVariableName,
-        );
-        if (!parsed) {
+            curveBounds,
+            diagnostics,
+            warningPrefix,
+            warningPosition,
+            pieceRole: `${pieceRole} piecewise child`,
+        });
+
+        if (!childPiecesResult || childPiecesResult.pieces.length === 0) {
             pushWarning({
                 diagnostics,
                 message: `${warningPrefix}: ${pieceRole} piecewise child ${i + 1} has unsupported function definition type '${definitionTypeLabel(childDefinition)}'; child skipped.`,
@@ -388,20 +584,42 @@ function parsedFormulaPiecesFromDefinition({
             continue;
         }
 
+        if (childPiecesResult.hasOpenEndpoints) {
+            hasOpenEndpoints = true;
+        }
+
         const domainTree =
             effectiveDomains?.[i]?.toMathExpression?.()?.tree ?? null;
 
         for (const interval of intervalPiecesFromMathTree(domainTree)) {
-            const clipped = intersectIntervalWithBounds(interval, curveBounds);
-            if (!clipped) {
+            const effectiveInterval = intersectIntervalWithBounds(
+                interval,
+                curveBounds,
+            );
+            if (!effectiveInterval) {
                 continue;
             }
 
-            if (clipped.openMin || clipped.openMax) {
+            if (effectiveInterval.openMin || effectiveInterval.openMax) {
                 hasOpenEndpoints = true;
             }
 
-            pieces.push({ parsed, interval: clipped });
+            for (const childPiece of childPiecesResult.pieces) {
+                const overlap = intersectIntervals(
+                    childPiece.interval,
+                    effectiveInterval,
+                );
+                if (!overlap) {
+                    continue;
+                }
+                if (overlap.openMin || overlap.openMax) {
+                    hasOpenEndpoints = true;
+                }
+                pieces.push({
+                    parsed: childPiece.parsed,
+                    interval: overlap,
+                });
+            }
         }
     }
 

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
@@ -4,11 +4,13 @@ import { escapeXml, formatPoint, pushWarning } from "../common";
 import { labelMarkup } from "../label";
 import type { ConverterArgs, CurveFunctionDefinition } from "../types";
 
+/** A parsed formula with its variable and expression in string form. */
 interface ParsedFormulaDefinition {
     variableName: string;
     expression: string;
 }
 
+/** An interval with explicit open/closed endpoint flags. */
 interface IntervalPiece {
     min: number;
     max: number;
@@ -16,17 +18,26 @@ interface IntervalPiece {
     openMax: boolean;
 }
 
+/** A single piece of a piecewise function: the parsed formula and its valid interval. */
 interface ParsedFormulaPiece {
     parsed: ParsedFormulaDefinition;
     interval: IntervalPiece;
 }
 
+/** Result of parsing a function definition into pieces. */
 interface ParsedFormulaPiecesResult {
     sourceType: string;
     hasOpenEndpoints: boolean;
     pieces: ParsedFormulaPiece[];
 }
 
+/**
+ * Get the label string (if any) for a curve definition type.
+ * Returns a string representation of the functionType field.
+ *
+ * @param definition - The function definition (may be null)
+ * @returns Type label string (e.g., "formula", "piecewise") or "unknown"
+ */
 function definitionTypeLabel(
     definition: CurveFunctionDefinition | null,
 ): string {
@@ -36,6 +47,28 @@ function definitionTypeLabel(
     return `${definition.functionType}`;
 }
 
+/**
+ * Generate a unique handle for a curve piece in the PreFigure output.
+ * The first piece (index 0) uses the base handle as-is; subsequent pieces
+ * append an underscore and index number to ensure uniqueness.
+ *
+ * @param baseHandle - The base identifier for the curve element
+ * @param index - The piece index (0 for first, 1 for second, etc.)
+ * @returns The formatted handle string
+ */
+function makePieceHandle(baseHandle: string, index: number): string {
+    return index === 0 ? baseHandle : `${baseHandle}_${index}`;
+}
+
+/**
+ * Extract a function definition at a given index from the fDefinitions object.
+ * Handles both array-based and object-based storage formats for definitions,
+ * accommodating the flexible internal representation of curve function data.
+ *
+ * @param fDefinitions - The function definitions (may be array, object, or single definition)
+ * @param index - The index to retrieve
+ * @returns The definition at the index, or null if not found or invalid
+ */
 function curveDefinitionAtIndex(
     fDefinitions: unknown,
     index: number,
@@ -63,6 +96,13 @@ function curveDefinitionAtIndex(
     return null;
 }
 
+/**
+ * Convert a math-expressions AST to a string representation.
+ * Safely handles invalid ASTs by catching exceptions.
+ *
+ * @param ast - The abstract syntax tree from math-expressions
+ * @returns String representation of the expression, or null if conversion fails
+ */
 function astToExpressionString(ast: unknown): string | null {
     try {
         return me.fromAst(ast as any).toString();
@@ -71,6 +111,15 @@ function astToExpressionString(ast: unknown): string | null {
     }
 }
 
+/**
+ * Parse a simple formula-based curve function definition.
+ * Extracts the expression and variable name; returns null if definition
+ * is not a formula type or expression conversion fails.
+ *
+ * @param definition - The curve function definition
+ * @param fallbackVariableName - Variable name to use if not specified (e.g., "x" or "t")
+ * @returns Parsed definition with variable and expression, or null
+ */
 function parseFormulaDefinition(
     definition: CurveFunctionDefinition | null,
     fallbackVariableName: string,
@@ -97,6 +146,14 @@ function parseFormulaDefinition(
     };
 }
 
+/**
+ * Extract a domain interval from a curve function definition's domain property.
+ * Parses various domain formats (tree, array-based endpoints, etc.).
+ * Returns the first component of compound domains (intervals, sets, unions).
+ *
+ * @param domain - The domain property from a function definition
+ * @returns Parsed interval with open/closed flags, or null if invalid
+ */
 function intervalFromCurveDefinitionDomain(
     domain: unknown,
 ): IntervalPiece | null {
@@ -143,6 +200,14 @@ function intervalFromCurveDefinitionDomain(
     return null;
 }
 
+/**
+ * Parse interpolated cubic spline pieces from a function definition.
+ * Decodes the coefficients array (cubic polynomial pieces) and extrapolation,
+ * then clips all pieces to specified curve bounds.
+ *
+ * @param params - Object containing definition, variable name, and bounds
+ * @returns Parsed pieces with interpolated cubic expressions, or null if invalid
+ */
 function parsedInterpolatedDefinitionPieces({
     definition,
     fallbackVariableName,
@@ -279,6 +344,14 @@ function parsedInterpolatedDefinitionPieces({
     };
 }
 
+/**
+ * Format a domain bound value for PreFigure output.
+ * Converts JavaScript infinities to "inf"/"-inf" strings and finite numbers
+ * to their string representation. Non-numeric or NaN values return null.
+ *
+ * @param value - The boundary value to format (number, Infinity, etc.)
+ * @returns Formatted string ("inf", "-inf", number string) or null if invalid
+ */
 function formatDomainBound(value: unknown): string | null {
     if (value === Infinity) {
         return "inf";
@@ -292,6 +365,33 @@ function formatDomainBound(value: unknown): string | null {
     return `${Number(value)}`;
 }
 
+/**
+ * Extract and validate a numeric boundary value from curve state.
+ * Handles infinity and finite values; returns null for non-numeric inputs.
+ * Used to normalize parMin/parMax properties into validated numbers.
+ *
+ * @param value - The state value (may be unknown type)
+ * @param defaultInf - Default infinity value (unused, for semantic clarity)
+ * @returns Numeric bound (including infinities) or null if invalid
+ */
+function numericBoundFromStateValue(
+    value: unknown,
+    defaultInf: number,
+): number | null {
+    if (value === -Infinity || value === Infinity) {
+        return value as number;
+    }
+    return Number.isFinite(value) ? Number(value) : null;
+}
+
+/**
+ * Format a potentially-infinite domain value range for PreFigure output.
+ * Used for parameter bounds (parMin, parMax) that may be infinite.
+ * Returns null if either bound is invalid or non-numeric.
+ *
+ * @param params - Object with parMin and parMax (may be any type)
+ * @returns Formatted domain string (e.g., "(-2,3)" or "(-inf,inf)") or null
+ */
 function prefigureDomainFromStateValues({
     parMin,
     parMax,
@@ -307,6 +407,14 @@ function prefigureDomainFromStateValues({
     return `(${min},${max})`;
 }
 
+/**
+ * Validate and extract numeric curve bounds from Doenet state values.
+ * Ensures parMin and parMax are valid numbers (including infinities)
+ * and that min ≤ max.
+ *
+ * @param params - Object with parMin and parMax
+ * @returns Object with numeric min/max fields, or null if validation fails
+ */
 function domainBoundsFromStateValues({
     parMin,
     parMax,
@@ -314,18 +422,8 @@ function domainBoundsFromStateValues({
     parMin: unknown;
     parMax: unknown;
 }): { min: number; max: number } | null {
-    const min =
-        parMin === -Infinity
-            ? -Infinity
-            : Number.isFinite(parMin)
-              ? Number(parMin)
-              : null;
-    const max =
-        parMax === Infinity
-            ? Infinity
-            : Number.isFinite(parMax)
-              ? Number(parMax)
-              : null;
+    const min = numericBoundFromStateValue(parMin, -Infinity);
+    const max = numericBoundFromStateValue(parMax, Infinity);
 
     if (min === null || max === null || min > max) {
         return null;
@@ -334,6 +432,14 @@ function domainBoundsFromStateValues({
     return { min, max };
 }
 
+/**
+ * Parse interval definitions from a math-expressions tree structure.
+ * Supports interval notation (e.g., [-2, 2)), single-point sets, and unions
+ * of intervals. Returns an array of normalized interval pieces.
+ *
+ * @param tree - The math-expressions tree (operator + operands array)
+ * @returns Array of parsed interval pieces (empty if tree is invalid/empty)
+ */
 function intervalPiecesFromMathTree(tree: unknown): IntervalPiece[] {
     if (!Array.isArray(tree) || tree.length === 0) {
         return [];
@@ -406,6 +512,58 @@ function intervalPiecesFromMathTree(tree: unknown): IntervalPiece[] {
     return [];
 }
 
+/**
+ * Determine which interval's open/closed endpoint flags should be used for
+ * the result of an interval intersection operation.
+ *
+ * When two intervals are intersected, the resulting endpoints may come from
+ * either interval depending on which bounds the result. This function applies
+ * the logical rules: if an endpoint moves from one interval, it becomes closed;
+ * if both intervals share the same endpoint, the result inherits the combined
+ * openness (open if either is open).
+ *
+ * @param interval1 - First interval with endpoint flags
+ * @param interval2 - Second interval with endpoint flags
+ * @param resultMin - The minimum endpoint of the intersection result
+ * @param resultMax - The maximum endpoint of the intersection result
+ * @returns Object with computed openMin and openMax flags
+ */
+function computeOpenEndpoints(
+    interval1: { min: number; max: number; openMin: boolean; openMax: boolean },
+    interval2: { min: number; max: number; openMin: boolean; openMax: boolean },
+    resultMin: number,
+    resultMax: number,
+): { openMin: boolean; openMax: boolean } {
+    let openMin: boolean;
+    if (interval1.min > interval2.min) {
+        openMin = interval1.openMin;
+    } else if (interval1.min < interval2.min) {
+        openMin = interval2.openMin;
+    } else {
+        openMin = interval1.openMin || interval2.openMin;
+    }
+
+    let openMax: boolean;
+    if (interval1.max < interval2.max) {
+        openMax = interval1.openMax;
+    } else if (interval1.max > interval2.max) {
+        openMax = interval2.openMax;
+    } else {
+        openMax = interval1.openMax || interval2.openMax;
+    }
+
+    return { openMin, openMax };
+}
+
+/**
+ * Clip an interval to fit within specified bounds.
+ * Preserves open/closed endpoint semantics: endpoints moving due to bounds
+ * become closed; others retain their original openness.
+ *
+ * @param interval - The interval to clip
+ * @param bounds - The bounding box (closed on both sides)
+ * @returns Clipped interval, or null if the result is empty
+ */
 function intersectIntervalWithBounds(
     interval: IntervalPiece,
     bounds: { min: number; max: number },
@@ -439,12 +597,29 @@ function intersectIntervalWithBounds(
     };
 }
 
+/**
+ * Convert an interval piece to a PreFigure domain string format.
+ * Output format: "(min,max)" with "inf" and "-inf" for infinities.
+ *
+ * @param interval - The interval to format
+ * @returns PreFigure domain string (e.g., "(-2,3)" or "(-inf,inf)")
+ */
 function domainFromIntervalPiece(interval: IntervalPiece): string {
     const min = formatDomainBound(interval.min) ?? "-inf";
     const max = formatDomainBound(interval.max) ?? "inf";
     return `(${min},${max})`;
 }
 
+/**
+ * Find the intersection of two intervals, preserving open/closed semantics.
+ * When both intervals share an endpoint, that endpoint inherits both openness
+ * flags (open if either is open). Otherwise, the endpoint's openness comes
+ * from whichever interval contributed that boundary.
+ *
+ * @param interval1 - First interval
+ * @param interval2 - Second interval
+ * @returns The intersection interval, or null if empty or invalid
+ */
 function intersectIntervals(
     interval1: IntervalPiece,
     interval2: IntervalPiece,
@@ -456,23 +631,12 @@ function intersectIntervals(
         return null;
     }
 
-    let openMin: boolean;
-    if (interval1.min > interval2.min) {
-        openMin = interval1.openMin;
-    } else if (interval1.min < interval2.min) {
-        openMin = interval2.openMin;
-    } else {
-        openMin = interval1.openMin || interval2.openMin;
-    }
-
-    let openMax: boolean;
-    if (interval1.max < interval2.max) {
-        openMax = interval1.openMax;
-    } else if (interval1.max > interval2.max) {
-        openMax = interval2.openMax;
-    } else {
-        openMax = interval1.openMax || interval2.openMax;
-    }
+    const { openMin, openMax } = computeOpenEndpoints(
+        interval1,
+        interval2,
+        min,
+        max,
+    );
 
     if (min === max && (openMin || openMax)) {
         return null;
@@ -486,6 +650,22 @@ function intersectIntervals(
     };
 }
 
+/**
+ * Recursively parse formula pieces from a function definition.
+ * Handles formulas, interpolated functions, and piecewise definitions.
+ * For piecewise definitions, recursively processes children and intersects
+ * their intervals with effective domains computed from the parent.
+ *
+ * @param params - Object containing:
+ *   - definition: The function definition to parse
+ *   - fallbackVariableName: Default variable name ("x", "t", etc.)
+ *   - curveBounds: Valid parameter bounds for clipping results
+ *   - diagnostics: Warning collector
+ *   - warningPrefix: Prefix for diagnostic messages
+ *   - warningPosition: Source position for diagnostics
+ *   - pieceRole: Role descriptor for nested errors (e.g., "x component")
+ * @returns Parsed pieces with open endpoint tracking, or null if definition is invalid
+ */
 function parsedFormulaPiecesFromDefinition({
     definition,
     fallbackVariableName,
@@ -630,6 +810,12 @@ function parsedFormulaPiecesFromDefinition({
     };
 }
 
+/**
+ * Emit a diagnostic warning that curve labels are not supported in PreFigure.
+ * Only warns if the curve actually has a label defined.
+ *
+ * @param params - Object containing label/labelHasLatex, diagnostics, and position
+ */
 function warnCurveLabelOmitted({
     label,
     labelHasLatex,
@@ -657,18 +843,68 @@ function warnCurveLabelOmitted({
     }
 }
 
-function emitFunctionGraph({
+/**
+ * Validate that a parsed formula pieces result has content.
+ * Emits a warning diagnostic if the result is missing or empty.
+ * Used to consolidate validation logic across multiple converter functions.
+ *
+ * @param result - The pieces result to validate
+ * @param diagnostics - Diagnostic collector for warning messages
+ * @param warningPrefix - Prefix for warning messages (e.g., curve handle)
+ * @param warningPosition - Source position for LSP diagnostics
+ * @param definitionTypeLabel - Label for the definition type in error messages
+ * @returns True if result is valid and non-empty; false otherwise
+ */
+function validatePiecesResult(
+    result: ParsedFormulaPiecesResult | null,
+    diagnostics: ConverterArgs["diagnostics"],
+    warningPrefix: string,
+    warningPosition: ConverterArgs["warningPosition"],
+    definitionTypeLabel: string,
+): boolean {
+    if (!result || result.pieces.length === 0) {
+        pushWarning({
+            diagnostics,
+            message: `${warningPrefix}: unsupported curve function definition type '${definitionTypeLabel}'; descendant skipped.`,
+            position: warningPosition,
+        });
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Generate a PreFigure XML element for a curve piece.
+ * Unifies emission of both <graph> (Cartesian) and <parametric-curve> elements
+ * by abstracting the tag type and function definition format.
+ *
+ * @param params - Object containing:
+ *   - handle: Unique identifier for this curve piece
+ *   - styleAttrs: Array of style attribute strings (stroke, thickness, etc.)
+ *   - parsed: Variable name and expression definition
+ *   - domain: Optional domain string; omitted for parametric curves
+ *   - isParametric: True for parametric curves, false for Cartesian functions
+ * @returns Complete XML element string (self-closing)
+ */
+function emitCurveElement({
     handle,
     styleAttrs,
     parsed,
     domain,
+    isParametric,
 }: {
     handle: string;
     styleAttrs: string[];
     parsed: ParsedFormulaDefinition;
     domain: string | null;
+    isParametric: boolean;
 }): string {
-    const functionDefinition = `${handle}_f(${parsed.variableName})=${parsed.expression}`;
+    const tagName = isParametric ? "parametric-curve" : "graph";
+    const prefix = isParametric ? "r" : "f";
+    const functionDefinition = isParametric
+        ? `${handle}_${prefix}(${parsed.variableName})=(${parsed.expression},${parsed.variableName})`
+        : `${handle}_${prefix}(${parsed.variableName})=${parsed.expression}`;
+
     const attrs = [
         `at="${escapeXml(handle)}"`,
         `function="${escapeXml(functionDefinition)}"`,
@@ -676,31 +912,17 @@ function emitFunctionGraph({
         ...styleAttrs,
     ];
 
-    return `<graph ${attrs.join(" ")} />`;
+    return `<${tagName} ${attrs.join(" ")} />`;
 }
 
-function emitFunctionAsParametric({
-    handle,
-    styleAttrs,
-    parsed,
-    domain,
-}: {
-    handle: string;
-    styleAttrs: string[];
-    parsed: ParsedFormulaDefinition;
-    domain: string;
-}): string {
-    const functionDefinition = `${handle}_r(${parsed.variableName})=(${parsed.expression},${parsed.variableName})`;
-    const attrs = [
-        `at="${escapeXml(handle)}"`,
-        `function="${escapeXml(functionDefinition)}"`,
-        `domain="${escapeXml(domain)}"`,
-        ...styleAttrs,
-    ];
-
-    return `<parametric-curve ${attrs.join(" ")} />`;
-}
-
+/**
+ * Convert a Doenet function curve to PreFigure <graph> or <parametric-curve>.
+ * Handles formula, interpolated, and piecewise function definitions.
+ * Optionally flips the function (swaps x and y) for inverted rendering.
+ *
+ * @param args - Standard converter arguments
+ * @returns PreFigure XML element(s) or null if conversion fails
+ */
 function convertFunctionCurve({
     sv,
     handle,
@@ -729,48 +951,43 @@ function convertFunctionCurve({
         pieceRole: "function",
     });
 
-    if (!result || result.pieces.length === 0) {
-        pushWarning({
+    if (
+        !validatePiecesResult(
+            result,
             diagnostics,
-            message: `${warningPrefix}: unsupported curve function definition type '${definitionTypeLabel(definition)}'; descendant skipped.`,
-            position: warningPosition,
-        });
+            warningPrefix,
+            warningPosition,
+            definitionTypeLabel(definition),
+        )
+    ) {
         return null;
     }
 
-    if (result.sourceType === "piecewise" && result.hasOpenEndpoints) {
-        pushWarning({
-            diagnostics,
-            message: `${warningPrefix}: piecewise open/closed endpoint semantics are approximated in prefigure output.`,
-            position: warningPosition,
-        });
-    }
+    // After validation check, result is guaranteed to be non-null
+    const validResult = result as ParsedFormulaPiecesResult;
 
-    if (sv.flipFunction) {
-        return result.pieces
-            .map(({ parsed, interval }, i) =>
-                emitFunctionAsParametric({
-                    handle: i === 0 ? handle : `${handle}_${i}`,
-                    styleAttrs,
-                    parsed,
-                    domain: domainFromIntervalPiece(interval),
-                }),
-            )
-            .join("");
-    }
-
-    return result.pieces
+    return validResult.pieces
         .map(({ parsed, interval }, i) =>
-            emitFunctionGraph({
-                handle: i === 0 ? handle : `${handle}_${i}`,
+            emitCurveElement({
+                handle: makePieceHandle(handle, i),
                 styleAttrs,
                 parsed,
                 domain: domainFromIntervalPiece(interval),
+                isParametric: Boolean(sv.flipFunction),
             }),
         )
         .join("");
 }
 
+/**
+ * Convert a Doenet parameterized (2D parametric) curve to PreFigure.
+ * Processes two function definitions (x and y) as separate dimensions.
+ * Generates one <parametric-curve> element for each distinct piece region
+ * where both x and y have valid definitions.
+ *
+ * @param args - Standard converter arguments
+ * @returns PreFigure XML element(s) or null if conversion fails
+ */
 function convertParametricCurve({
     sv,
     handle,
@@ -811,32 +1028,33 @@ function convertParametricCurve({
     });
 
     if (
-        !xPiecesResult ||
-        !yPiecesResult ||
-        xPiecesResult.pieces.length === 0 ||
-        yPiecesResult.pieces.length === 0
-    ) {
-        pushWarning({
+        !validatePiecesResult(
+            xPiecesResult,
             diagnostics,
-            message: `${warningPrefix}: unsupported parametric curve function definition types ('${definitionTypeLabel(xDefinition)}', '${definitionTypeLabel(yDefinition)}'); descendant skipped.`,
-            position: warningPosition,
-        });
+            warningPrefix,
+            warningPosition,
+            `${definitionTypeLabel(xDefinition)}, ${definitionTypeLabel(yDefinition)}`,
+        ) ||
+        !validatePiecesResult(
+            yPiecesResult,
+            diagnostics,
+            warningPrefix,
+            warningPosition,
+            `${definitionTypeLabel(xDefinition)}, ${definitionTypeLabel(yDefinition)}`,
+        )
+    ) {
         return null;
     }
 
-    if (xPiecesResult.hasOpenEndpoints || yPiecesResult.hasOpenEndpoints) {
-        pushWarning({
-            diagnostics,
-            message: `${warningPrefix}: piecewise open/closed endpoint semantics are approximated in prefigure output.`,
-            position: warningPosition,
-        });
-    }
+    // After validation checks, results are guaranteed to be non-null
+    const validXPiecesResult = xPiecesResult as ParsedFormulaPiecesResult;
+    const validYPiecesResult = yPiecesResult as ParsedFormulaPiecesResult;
 
     const pieceXml: string[] = [];
     let pieceCounter = 0;
 
-    for (const xPiece of xPiecesResult.pieces) {
-        for (const yPiece of yPiecesResult.pieces) {
+    for (const xPiece of validXPiecesResult.pieces) {
+        for (const yPiece of validYPiecesResult.pieces) {
             const overlap = intersectIntervals(
                 xPiece.interval,
                 yPiece.interval,
@@ -845,8 +1063,7 @@ function convertParametricCurve({
                 continue;
             }
 
-            const pieceHandle =
-                pieceCounter === 0 ? handle : `${handle}_${pieceCounter}`;
+            const pieceHandle = makePieceHandle(handle, pieceCounter);
             const functionDefinition = `${pieceHandle}_r(${xPiece.parsed.variableName})=(${xPiece.parsed.expression},${yPiece.parsed.expression})`;
             const attrs = [
                 `at="${escapeXml(pieceHandle)}"`,
@@ -867,6 +1084,13 @@ function convertParametricCurve({
     return pieceXml.join("");
 }
 
+/**
+ * Extract through-points array from numerical Bezier curve data.
+ * Validates that at least 2 points are present and all points format correctly.
+ *
+ * @param numericalThroughPoints - Array of point coordinates
+ * @returns Array of formatted point strings, or null if array is invalid
+ */
 function pointsFromNumericalThroughPoints(
     numericalThroughPoints: unknown,
 ): string[] | null {
@@ -885,6 +1109,14 @@ function pointsFromNumericalThroughPoints(
     return points;
 }
 
+/**
+ * Convert a Doenet Bezier curve (through points) to PreFigure <spline>.
+ * Handles both open and closed (periodic) splines.
+ * Domain is taken from curve parameter bounds if finite.
+ *
+ * @param args - Standard converter arguments
+ * @returns PreFigure <spline> element or null if conversion fails
+ */
 function convertBezierCurve({
     sv,
     handle,
@@ -928,6 +1160,17 @@ function convertBezierCurve({
 
 /**
  * Converts Doenet curve descendants into native PreFigure curve-family tags.
+ *
+ * Routes curve conversion based on curve type:
+ * - "function" → <graph> or <parametric-curve> (if flipped)
+ * - "parameterization" → <parametric-curve> (2D parametric)
+ * - "bezier" → <spline> (through-points curve)
+ *
+ * Also handles warnings for unsupported labels and diagnostics for incomplete
+ * geometry (non-finite domains, invalid data).
+ *
+ * @param args - Converter arguments containing state values, diagnostics, etc.
+ * @returns PreFigure XML element(s) or null if the curve cannot be converted
  */
 export function convertCurveToPrefigure(args: ConverterArgs): string | null {
     const { sv } = args;

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
@@ -48,6 +48,19 @@ function definitionTypeLabel(
 }
 
 /**
+ * Function types whose definitions the converter can process.
+ * Used both to gate the top-level unsupported-type warning
+ * and to produce a more accurate diagnostic when a supported type
+ * encounters a parse failure (e.g. non-finite interpolated points).
+ */
+const SUPPORTED_CURVE_FUNCTION_TYPES = new Set([
+    "formula",
+    "interpolated",
+    "bezier",
+    "piecewise",
+]);
+
+/**
  * Generate a unique handle for a curve piece in the PreFigure output.
  * The first piece (index 0) uses the base handle as-is; subsequent pieces
  * append an underscore and index number to ensure uniqueness.
@@ -945,11 +958,11 @@ function parsedFormulaPiecesFromDefinition({
         });
 
         if (!childPiecesResult) {
-            pushWarning({
-                diagnostics,
-                message: `${warningPrefix}: ${pieceRole} piecewise child ${i + 1} has unsupported function definition type '${definitionTypeLabel(childDefinition)}'; child skipped.`,
-                position: warningPosition,
-            });
+            const typeLabel = definitionTypeLabel(childDefinition);
+            const message = SUPPORTED_CURVE_FUNCTION_TYPES.has(typeLabel)
+                ? `${warningPrefix}: ${pieceRole} piecewise child ${i + 1} failed to build curve pieces (type '${typeLabel}'); child skipped.`
+                : `${warningPrefix}: ${pieceRole} piecewise child ${i + 1} has unsupported function definition type '${typeLabel}'; child skipped.`;
+            pushWarning({ diagnostics, message, position: warningPosition });
             continue;
         }
 
@@ -1060,17 +1073,10 @@ function validatePiecesResult(
     warningPosition: ConverterArgs["warningPosition"],
     definitionTypeLabel: string,
 ): boolean {
-    const supportedTypes = new Set([
-        "formula",
-        "interpolated",
-        "bezier",
-        "piecewise",
-    ]);
-
     const hasUnsupportedType = definitionTypeLabel
         .split(",")
         .map((x) => x.trim())
-        .some((x) => !supportedTypes.has(x));
+        .some((x) => !SUPPORTED_CURVE_FUNCTION_TYPES.has(x));
 
     if (!result || result.pieces.length === 0) {
         if (hasUnsupportedType) {

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
@@ -1,0 +1,354 @@
+import me from "math-expressions";
+import { escapeXml, formatPoint, pushWarning } from "../common";
+import { labelMarkup } from "../label";
+import type { ConverterArgs, CurveFunctionDefinition } from "../types";
+
+interface ParsedFormulaDefinition {
+    variableName: string;
+    expression: string;
+}
+
+function definitionTypeLabel(
+    definition: CurveFunctionDefinition | null,
+): string {
+    if (!definition || definition.functionType === undefined) {
+        return "unknown";
+    }
+    return `${definition.functionType}`;
+}
+
+function curveDefinitionAtIndex(
+    fDefinitions: unknown,
+    index: number,
+): CurveFunctionDefinition | null {
+    if (Array.isArray(fDefinitions)) {
+        const candidate = fDefinitions[index];
+        return candidate && typeof candidate === "object"
+            ? (candidate as CurveFunctionDefinition)
+            : null;
+    }
+
+    if (fDefinitions && typeof fDefinitions === "object") {
+        if ("functionType" in (fDefinitions as Record<string, unknown>)) {
+            return fDefinitions as CurveFunctionDefinition;
+        }
+
+        const byNumericKey = (fDefinitions as Record<string, unknown>)[
+            `${index}`
+        ];
+        if (byNumericKey && typeof byNumericKey === "object") {
+            return byNumericKey as CurveFunctionDefinition;
+        }
+    }
+
+    return null;
+}
+
+function astToExpressionString(ast: unknown): string | null {
+    try {
+        return me.fromAst(ast as any).toString();
+    } catch (_e) {
+        return null;
+    }
+}
+
+function parseFormulaDefinition(
+    definition: CurveFunctionDefinition | null,
+    fallbackVariableName: string,
+): ParsedFormulaDefinition | null {
+    if (!definition || definition.functionType !== "formula") {
+        return null;
+    }
+
+    const expression = astToExpressionString(definition.formula);
+    if (!expression) {
+        return null;
+    }
+
+    const variables = Array.isArray(definition.variables)
+        ? definition.variables
+        : [];
+    const variableExpression = variables.length
+        ? astToExpressionString(variables[0])
+        : null;
+
+    return {
+        variableName: variableExpression || fallbackVariableName,
+        expression,
+    };
+}
+
+function formatDomainBound(value: unknown): string | null {
+    if (value === Infinity) {
+        return "inf";
+    }
+    if (value === -Infinity) {
+        return "-inf";
+    }
+    if (!Number.isFinite(value)) {
+        return null;
+    }
+    return `${Number(value)}`;
+}
+
+function prefigureDomainFromStateValues({
+    parMin,
+    parMax,
+}: {
+    parMin: unknown;
+    parMax: unknown;
+}): string | null {
+    const min = formatDomainBound(parMin);
+    const max = formatDomainBound(parMax);
+    if (min === null || max === null) {
+        return null;
+    }
+    return `(${min},${max})`;
+}
+
+function warnCurveLabelOmitted({
+    label,
+    labelHasLatex,
+    diagnostics,
+    warningPrefix,
+    warningPosition,
+}: {
+    label: unknown;
+    labelHasLatex: unknown;
+    diagnostics: ConverterArgs["diagnostics"];
+    warningPrefix: string;
+    warningPosition?: ConverterArgs["warningPosition"];
+}): void {
+    if (
+        labelMarkup({
+            label,
+            labelHasLatex,
+        })
+    ) {
+        pushWarning({
+            diagnostics,
+            message: `${warningPrefix}: labels are not supported on converted curve elements; label omitted.`,
+            position: warningPosition,
+        });
+    }
+}
+
+function emitFunctionGraph({
+    handle,
+    styleAttrs,
+    parsed,
+    domain,
+}: {
+    handle: string;
+    styleAttrs: string[];
+    parsed: ParsedFormulaDefinition;
+    domain: string | null;
+}): string {
+    const functionDefinition = `${handle}_f(${parsed.variableName})=${parsed.expression}`;
+    const attrs = [
+        `at="${escapeXml(handle)}"`,
+        `function="${escapeXml(functionDefinition)}"`,
+        ...(domain ? [`domain="${escapeXml(domain)}"`] : []),
+        ...styleAttrs,
+    ];
+
+    return `<graph ${attrs.join(" ")} />`;
+}
+
+function emitFunctionAsParametric({
+    handle,
+    styleAttrs,
+    parsed,
+    domain,
+}: {
+    handle: string;
+    styleAttrs: string[];
+    parsed: ParsedFormulaDefinition;
+    domain: string;
+}): string {
+    const functionDefinition = `${handle}_r(${parsed.variableName})=(${parsed.expression},${parsed.variableName})`;
+    const attrs = [
+        `at="${escapeXml(handle)}"`,
+        `function="${escapeXml(functionDefinition)}"`,
+        `domain="${escapeXml(domain)}"`,
+        ...styleAttrs,
+    ];
+
+    return `<parametric-curve ${attrs.join(" ")} />`;
+}
+
+function convertFunctionCurve({
+    sv,
+    handle,
+    styleAttrs,
+    diagnostics,
+    warningPrefix,
+    warningPosition,
+}: ConverterArgs): string | null {
+    const definition = curveDefinitionAtIndex(sv.fDefinitions, 0);
+    const parsed = parseFormulaDefinition(definition, "x");
+    if (!parsed) {
+        pushWarning({
+            diagnostics,
+            message: `${warningPrefix}: unsupported curve function definition type '${definitionTypeLabel(definition)}'; descendant skipped.`,
+            position: warningPosition,
+        });
+        return null;
+    }
+
+    const domain = prefigureDomainFromStateValues({
+        parMin: sv.parMin,
+        parMax: sv.parMax,
+    });
+
+    if (sv.flipFunction) {
+        if (!domain) {
+            return null;
+        }
+        return emitFunctionAsParametric({
+            handle,
+            styleAttrs,
+            parsed,
+            domain,
+        });
+    }
+
+    return emitFunctionGraph({
+        handle,
+        styleAttrs,
+        parsed,
+        domain,
+    });
+}
+
+function convertParametricCurve({
+    sv,
+    handle,
+    styleAttrs,
+    diagnostics,
+    warningPrefix,
+    warningPosition,
+}: ConverterArgs): string | null {
+    const xDefinition = curveDefinitionAtIndex(sv.fDefinitions, 0);
+    const yDefinition = curveDefinitionAtIndex(sv.fDefinitions, 1);
+    const xFormula = parseFormulaDefinition(xDefinition, "t");
+    const yFormula = parseFormulaDefinition(
+        yDefinition,
+        xFormula?.variableName || "t",
+    );
+
+    if (!xFormula || !yFormula) {
+        pushWarning({
+            diagnostics,
+            message: `${warningPrefix}: unsupported parametric curve function definition types ('${definitionTypeLabel(xDefinition)}', '${definitionTypeLabel(yDefinition)}'); descendant skipped.`,
+            position: warningPosition,
+        });
+        return null;
+    }
+
+    const domain = prefigureDomainFromStateValues({
+        parMin: sv.parMin,
+        parMax: sv.parMax,
+    });
+    if (!domain) {
+        return null;
+    }
+
+    const functionDefinition = `${handle}_r(${xFormula.variableName})=(${xFormula.expression},${yFormula.expression})`;
+    const attrs = [
+        `at="${escapeXml(handle)}"`,
+        `function="${escapeXml(functionDefinition)}"`,
+        `domain="${escapeXml(domain)}"`,
+        ...styleAttrs,
+    ];
+
+    return `<parametric-curve ${attrs.join(" ")} />`;
+}
+
+function pointsFromNumericalThroughPoints(
+    numericalThroughPoints: unknown,
+): string[] | null {
+    if (!Array.isArray(numericalThroughPoints)) {
+        return null;
+    }
+
+    const points = numericalThroughPoints
+        .map((point) => formatPoint(point))
+        .filter((point): point is string => point !== null);
+
+    if (points.length < 2 || points.length !== numericalThroughPoints.length) {
+        return null;
+    }
+
+    return points;
+}
+
+function convertBezierCurve({
+    sv,
+    handle,
+    styleAttrs,
+    diagnostics,
+    warningPrefix,
+    warningPosition,
+}: ConverterArgs): string | null {
+    const points = pointsFromNumericalThroughPoints(sv.numericalThroughPoints);
+    if (!points) {
+        return null;
+    }
+
+    const attrs = [
+        `at="${escapeXml(handle)}"`,
+        `points="${escapeXml(`(${points.join(",")})`)}"`,
+        ...styleAttrs,
+    ];
+
+    if (sv.periodic) {
+        attrs.push('closed="yes"');
+    } else {
+        const domain = prefigureDomainFromStateValues({
+            parMin: sv.parMin,
+            parMax: sv.parMax,
+        });
+
+        if (domain) {
+            attrs.push(`domain="${escapeXml(domain)}"`);
+        } else if (sv.extrapolateBackward || sv.extrapolateForward) {
+            pushWarning({
+                diagnostics,
+                message: `${warningPrefix}: bezier extrapolation requested but parameter domain is non-finite; emitted spline without explicit domain.`,
+                position: warningPosition,
+            });
+        }
+    }
+
+    return `<spline ${attrs.join(" ")} />`;
+}
+
+/**
+ * Converts Doenet curve descendants into native PreFigure curve-family tags.
+ */
+export function convertCurveToPrefigure(args: ConverterArgs): string | null {
+    const { sv } = args;
+
+    warnCurveLabelOmitted({
+        label: sv.label,
+        labelHasLatex: sv.labelHasLatex,
+        diagnostics: args.diagnostics,
+        warningPrefix: args.warningPrefix,
+        warningPosition: args.warningPosition,
+    });
+
+    if (sv.curveType === "function") {
+        return convertFunctionCurve(args);
+    }
+
+    if (sv.curveType === "parameterization") {
+        return convertParametricCurve(args);
+    }
+
+    if (sv.curveType === "bezier") {
+        return convertBezierCurve(args);
+    }
+
+    return null;
+}

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
@@ -182,7 +182,12 @@ function parseFormulaDefinition(
 /**
  * Extract a domain interval from a curve function definition's domain property.
  * Parses various domain formats (tree, array-based endpoints, etc.).
- * Returns the first component of compound domains (intervals, sets, unions).
+ *
+ * Function definitions store domain as an array with one entry per input
+ * variable. For the single-input function definitions used here, this helper
+ * reads domain[0], i.e. the first input variable's domain interval. That does
+ * not mean "first union piece"; unions are not currently supported upstream
+ * for function domains and are rejected before reaching this conversion path.
  *
  * @param domain - The domain property from a function definition
  * @returns Parsed interval with open/closed flags, or null if invalid
@@ -198,6 +203,17 @@ function intervalFromCurveDefinitionDomain(
 
     if (firstDomain?.tree !== undefined) {
         const pieces = intervalPiecesFromMathTree(firstDomain.tree);
+        return pieces[0] ?? null;
+    }
+
+    // Interpolated/re-evaluated function definitions often store domain as raw
+    // math-expression trees (e.g. ["interval", ["tuple", ...], ["tuple", ...]]).
+    if (
+        Array.isArray(firstDomain) &&
+        firstDomain.length > 0 &&
+        typeof firstDomain[0] === "string"
+    ) {
+        const pieces = intervalPiecesFromMathTree(firstDomain);
         return pieces[0] ?? null;
     }
 
@@ -1049,12 +1065,26 @@ function validatePiecesResult(
     warningPosition: ConverterArgs["warningPosition"],
     definitionTypeLabel: string,
 ): boolean {
+    const supportedTypes = new Set([
+        "formula",
+        "interpolated",
+        "bezier",
+        "piecewise",
+    ]);
+
+    const hasUnsupportedType = definitionTypeLabel
+        .split(",")
+        .map((x) => x.trim())
+        .some((x) => !supportedTypes.has(x));
+
     if (!result || result.pieces.length === 0) {
-        pushWarning({
-            diagnostics,
-            message: `${warningPrefix}: unsupported curve function definition type '${definitionTypeLabel}'; descendant skipped.`,
-            position: warningPosition,
-        });
+        if (hasUnsupportedType) {
+            pushWarning({
+                diagnostics,
+                message: `${warningPrefix}: unsupported curve function definition type '${definitionTypeLabel}'; descendant skipped.`,
+                position: warningPosition,
+            });
+        }
         return false;
     }
     return true;

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
@@ -1271,23 +1271,35 @@ function convertParametricCurve({
     const validXPiecesResult = xPiecesResult as ParsedFormulaPiecesResult;
     const validYPiecesResult = yPiecesResult as ParsedFormulaPiecesResult;
 
+    const comparePiecesByIntervalStart = (
+        a: ParsedFormulaPiece,
+        b: ParsedFormulaPiece,
+    ) => {
+        if (a.interval.min !== b.interval.min) {
+            return a.interval.min - b.interval.min;
+        }
+        return a.interval.max - b.interval.max;
+    };
+
+    const xPieces = [...validXPiecesResult.pieces].sort(
+        comparePiecesByIntervalStart,
+    );
+    const yPieces = [...validYPiecesResult.pieces].sort(
+        comparePiecesByIntervalStart,
+    );
+
     const pieceXml: string[] = [];
     let pieceCounter = 0;
+    let xIndex = 0;
+    let yIndex = 0;
 
-    for (const xPiece of validXPiecesResult.pieces) {
-        for (const yPiece of validYPiecesResult.pieces) {
-            const overlap = intersectIntervals(
-                xPiece.interval,
-                yPiece.interval,
-            );
-            if (!overlap) {
-                continue;
-            }
+    // Sweep both sorted piece lists to emit only overlapping interval pairs.
+    while (xIndex < xPieces.length && yIndex < yPieces.length) {
+        const xPiece = xPieces[xIndex];
+        const yPiece = yPieces[yIndex];
 
-            if (overlap.min === overlap.max) {
-                continue;
-            }
-
+        const overlap = intersectIntervals(xPiece.interval, yPiece.interval);
+        if (overlap && overlap.min !== overlap.max) {
             const pieceHandle = makePieceHandle(handle, pieceCounter);
             const parameterVariable = xPiece.parsed.variableName;
             const xExpression = rewriteExpressionVariable({
@@ -1310,6 +1322,15 @@ function convertParametricCurve({
 
             pieceXml.push(`<parametric-curve ${attrs.join(" ")} />`);
             pieceCounter += 1;
+        }
+
+        if (xPiece.interval.max < yPiece.interval.max) {
+            xIndex += 1;
+        } else if (xPiece.interval.max > yPiece.interval.max) {
+            yIndex += 1;
+        } else {
+            xIndex += 1;
+            yIndex += 1;
         }
     }
 

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
@@ -384,9 +384,9 @@ function parsedBezierDefinitionPieces({
         if (!Array.isArray(segment) || !Array.isArray(segment[component])) {
             return null;
         }
-        const coeffs = segment[component].slice(0, 4).map((v: unknown) =>
-            Number(v),
-        );
+        const coeffs = segment[component]
+            .slice(0, 4)
+            .map((v: unknown) => Number(v));
         if (coeffs.length < 4 || coeffs.some((v) => !Number.isFinite(v))) {
             return null;
         }
@@ -410,9 +410,9 @@ function parsedBezierDefinitionPieces({
         if (!Array.isArray(componentCoeffs)) {
             return null;
         }
-        const coeffs = componentCoeffs.slice(0, 3).map((v: unknown) =>
-            Number(v),
-        );
+        const coeffs = componentCoeffs
+            .slice(0, 3)
+            .map((v: unknown) => Number(v));
         if (coeffs.length < 3 || coeffs.some((v) => !Number.isFinite(v))) {
             return null;
         }
@@ -488,7 +488,10 @@ function parsedBezierDefinitionPieces({
     let hasOpenEndpoints = false;
 
     for (const piece of rawPieces) {
-        const clipped = intersectIntervalWithBounds(piece.interval, curveBounds);
+        const clipped = intersectIntervalWithBounds(
+            piece.interval,
+            curveBounds,
+        );
         if (!clipped) {
             continue;
         }

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
@@ -1,4 +1,5 @@
 import me from "math-expressions";
+import { find_effective_domains_piecewise_children } from "@doenet/utils";
 import { escapeXml, formatPoint, pushWarning } from "../common";
 import { labelMarkup } from "../label";
 import type { ConverterArgs, CurveFunctionDefinition } from "../types";
@@ -6,6 +7,24 @@ import type { ConverterArgs, CurveFunctionDefinition } from "../types";
 interface ParsedFormulaDefinition {
     variableName: string;
     expression: string;
+}
+
+interface IntervalPiece {
+    min: number;
+    max: number;
+    openMin: boolean;
+    openMax: boolean;
+}
+
+interface ParsedFormulaPiece {
+    parsed: ParsedFormulaDefinition;
+    interval: IntervalPiece;
+}
+
+interface ParsedFormulaPiecesResult {
+    sourceType: string;
+    hasOpenEndpoints: boolean;
+    pieces: ParsedFormulaPiece[];
 }
 
 function definitionTypeLabel(
@@ -106,6 +125,293 @@ function prefigureDomainFromStateValues({
     return `(${min},${max})`;
 }
 
+function domainBoundsFromStateValues({
+    parMin,
+    parMax,
+}: {
+    parMin: unknown;
+    parMax: unknown;
+}): { min: number; max: number } | null {
+    const min =
+        parMin === -Infinity
+            ? -Infinity
+            : Number.isFinite(parMin)
+              ? Number(parMin)
+              : null;
+    const max =
+        parMax === Infinity
+            ? Infinity
+            : Number.isFinite(parMax)
+              ? Number(parMax)
+              : null;
+
+    if (min === null || max === null || min > max) {
+        return null;
+    }
+
+    return { min, max };
+}
+
+function intervalPiecesFromMathTree(tree: unknown): IntervalPiece[] {
+    if (!Array.isArray(tree) || tree.length === 0) {
+        return [];
+    }
+
+    const operator = tree[0];
+    if (operator === "interval") {
+        const endpoints = tree[1];
+        const closedFlags = tree[2];
+        if (
+            !Array.isArray(endpoints) ||
+            !Array.isArray(closedFlags) ||
+            endpoints.length < 3 ||
+            closedFlags.length < 3
+        ) {
+            return [];
+        }
+
+        const min = Number(endpoints[1]);
+        const max = Number(endpoints[2]);
+        const minClosed = Boolean(closedFlags[1]);
+        const maxClosed = Boolean(closedFlags[2]);
+
+        if (
+            (!Number.isFinite(min) && min !== -Infinity) ||
+            (!Number.isFinite(max) && max !== Infinity)
+        ) {
+            return [];
+        }
+
+        if (min > max || (min === max && (!minClosed || !maxClosed))) {
+            return [];
+        }
+
+        return [
+            {
+                min,
+                max,
+                openMin: !minClosed,
+                openMax: !maxClosed,
+            },
+        ];
+    }
+
+    if (operator === "set") {
+        if (tree.length < 2) {
+            return [];
+        }
+        const value = Number(tree[1]);
+        if (!Number.isFinite(value)) {
+            return [];
+        }
+
+        return [
+            {
+                min: value,
+                max: value,
+                openMin: false,
+                openMax: false,
+            },
+        ];
+    }
+
+    if (operator === "union") {
+        return tree
+            .slice(1)
+            .flatMap((piece) => intervalPiecesFromMathTree(piece));
+    }
+
+    return [];
+}
+
+function intersectIntervalWithBounds(
+    interval: IntervalPiece,
+    bounds: { min: number; max: number },
+): IntervalPiece | null {
+    const min = Math.max(interval.min, bounds.min);
+    const max = Math.min(interval.max, bounds.max);
+
+    if (min > max) {
+        return null;
+    }
+
+    let openMin = interval.openMin;
+    if (min === bounds.min && interval.min < bounds.min) {
+        openMin = false;
+    }
+
+    let openMax = interval.openMax;
+    if (max === bounds.max && interval.max > bounds.max) {
+        openMax = false;
+    }
+
+    if (min === max && (openMin || openMax)) {
+        return null;
+    }
+
+    return {
+        min,
+        max,
+        openMin,
+        openMax,
+    };
+}
+
+function domainFromIntervalPiece(interval: IntervalPiece): string {
+    const min = formatDomainBound(interval.min) ?? "-inf";
+    const max = formatDomainBound(interval.max) ?? "inf";
+    return `(${min},${max})`;
+}
+
+function intersectIntervals(
+    interval1: IntervalPiece,
+    interval2: IntervalPiece,
+): IntervalPiece | null {
+    const min = Math.max(interval1.min, interval2.min);
+    const max = Math.min(interval1.max, interval2.max);
+
+    if (min > max) {
+        return null;
+    }
+
+    let openMin: boolean;
+    if (interval1.min > interval2.min) {
+        openMin = interval1.openMin;
+    } else if (interval1.min < interval2.min) {
+        openMin = interval2.openMin;
+    } else {
+        openMin = interval1.openMin || interval2.openMin;
+    }
+
+    let openMax: boolean;
+    if (interval1.max < interval2.max) {
+        openMax = interval1.openMax;
+    } else if (interval1.max > interval2.max) {
+        openMax = interval2.openMax;
+    } else {
+        openMax = interval1.openMax || interval2.openMax;
+    }
+
+    if (min === max && (openMin || openMax)) {
+        return null;
+    }
+
+    return {
+        min,
+        max,
+        openMin,
+        openMax,
+    };
+}
+
+function parsedFormulaPiecesFromDefinition({
+    definition,
+    fallbackVariableName,
+    curveBounds,
+    diagnostics,
+    warningPrefix,
+    warningPosition,
+    pieceRole,
+}: {
+    definition: CurveFunctionDefinition | null;
+    fallbackVariableName: string;
+    curveBounds: { min: number; max: number };
+    diagnostics: ConverterArgs["diagnostics"];
+    warningPrefix: string;
+    warningPosition?: ConverterArgs["warningPosition"];
+    pieceRole: string;
+}): ParsedFormulaPiecesResult | null {
+    if (!definition) {
+        return null;
+    }
+
+    if (definition.functionType === "formula") {
+        const parsed = parseFormulaDefinition(definition, fallbackVariableName);
+        if (!parsed) {
+            return null;
+        }
+
+        return {
+            sourceType: "formula",
+            hasOpenEndpoints: false,
+            pieces: [
+                {
+                    parsed,
+                    interval: {
+                        min: curveBounds.min,
+                        max: curveBounds.max,
+                        openMin: false,
+                        openMax: false,
+                    },
+                },
+            ],
+        };
+    }
+
+    if (definition.functionType !== "piecewise") {
+        return null;
+    }
+
+    const childDefinitions = Array.isArray(definition.fDefinitionsOfChildren)
+        ? definition.fDefinitionsOfChildren
+        : null;
+    const numericalDomainsOfChildren = Array.isArray(
+        definition.numericalDomainsOfChildren,
+    )
+        ? definition.numericalDomainsOfChildren
+        : null;
+
+    if (!childDefinitions || !numericalDomainsOfChildren) {
+        return null;
+    }
+
+    const effectiveDomains = find_effective_domains_piecewise_children({
+        domain: definition.domain,
+        numericalDomainsOfChildren,
+    });
+
+    const pieces: ParsedFormulaPiece[] = [];
+    let hasOpenEndpoints = false;
+
+    for (let i = 0; i < childDefinitions.length; i += 1) {
+        const childDefinition = childDefinitions[i] as CurveFunctionDefinition;
+        const parsed = parseFormulaDefinition(
+            childDefinition,
+            fallbackVariableName,
+        );
+        if (!parsed) {
+            pushWarning({
+                diagnostics,
+                message: `${warningPrefix}: ${pieceRole} piecewise child ${i + 1} has unsupported function definition type '${definitionTypeLabel(childDefinition)}'; child skipped.`,
+                position: warningPosition,
+            });
+            continue;
+        }
+
+        const domainTree =
+            effectiveDomains?.[i]?.toMathExpression?.()?.tree ?? null;
+
+        for (const interval of intervalPiecesFromMathTree(domainTree)) {
+            const clipped = intersectIntervalWithBounds(interval, curveBounds);
+            if (!clipped) {
+                continue;
+            }
+
+            if (clipped.openMin || clipped.openMax) {
+                hasOpenEndpoints = true;
+            }
+
+            pieces.push({ parsed, interval: clipped });
+        }
+    }
+
+    return {
+        sourceType: "piecewise",
+        hasOpenEndpoints,
+        pieces,
+    };
+}
+
 function warnCurveLabelOmitted({
     label,
     labelHasLatex,
@@ -186,8 +492,26 @@ function convertFunctionCurve({
     warningPosition,
 }: ConverterArgs): string | null {
     const definition = curveDefinitionAtIndex(sv.fDefinitions, 0);
-    const parsed = parseFormulaDefinition(definition, "x");
-    if (!parsed) {
+
+    const curveBounds = domainBoundsFromStateValues({
+        parMin: sv.parMin,
+        parMax: sv.parMax,
+    });
+    if (!curveBounds) {
+        return null;
+    }
+
+    const result = parsedFormulaPiecesFromDefinition({
+        definition,
+        fallbackVariableName: "x",
+        curveBounds,
+        diagnostics,
+        warningPrefix,
+        warningPosition,
+        pieceRole: "function",
+    });
+
+    if (!result || result.pieces.length === 0) {
         pushWarning({
             diagnostics,
             message: `${warningPrefix}: unsupported curve function definition type '${definitionTypeLabel(definition)}'; descendant skipped.`,
@@ -196,29 +520,37 @@ function convertFunctionCurve({
         return null;
     }
 
-    const domain = prefigureDomainFromStateValues({
-        parMin: sv.parMin,
-        parMax: sv.parMax,
-    });
-
-    if (sv.flipFunction) {
-        if (!domain) {
-            return null;
-        }
-        return emitFunctionAsParametric({
-            handle,
-            styleAttrs,
-            parsed,
-            domain,
+    if (result.sourceType === "piecewise" && result.hasOpenEndpoints) {
+        pushWarning({
+            diagnostics,
+            message: `${warningPrefix}: piecewise open/closed endpoint semantics are approximated in prefigure output.`,
+            position: warningPosition,
         });
     }
 
-    return emitFunctionGraph({
-        handle,
-        styleAttrs,
-        parsed,
-        domain,
-    });
+    if (sv.flipFunction) {
+        return result.pieces
+            .map(({ parsed, interval }, i) =>
+                emitFunctionAsParametric({
+                    handle: i === 0 ? handle : `${handle}_${i}`,
+                    styleAttrs,
+                    parsed,
+                    domain: domainFromIntervalPiece(interval),
+                }),
+            )
+            .join("");
+    }
+
+    return result.pieces
+        .map(({ parsed, interval }, i) =>
+            emitFunctionGraph({
+                handle: i === 0 ? handle : `${handle}_${i}`,
+                styleAttrs,
+                parsed,
+                domain: domainFromIntervalPiece(interval),
+            }),
+        )
+        .join("");
 }
 
 function convertParametricCurve({
@@ -231,13 +563,41 @@ function convertParametricCurve({
 }: ConverterArgs): string | null {
     const xDefinition = curveDefinitionAtIndex(sv.fDefinitions, 0);
     const yDefinition = curveDefinitionAtIndex(sv.fDefinitions, 1);
-    const xFormula = parseFormulaDefinition(xDefinition, "t");
-    const yFormula = parseFormulaDefinition(
-        yDefinition,
-        xFormula?.variableName || "t",
-    );
 
-    if (!xFormula || !yFormula) {
+    const curveBounds = domainBoundsFromStateValues({
+        parMin: sv.parMin,
+        parMax: sv.parMax,
+    });
+    if (!curveBounds) {
+        return null;
+    }
+
+    const xPiecesResult = parsedFormulaPiecesFromDefinition({
+        definition: xDefinition,
+        fallbackVariableName: "t",
+        curveBounds,
+        diagnostics,
+        warningPrefix,
+        warningPosition,
+        pieceRole: "x",
+    });
+    const yPiecesResult = parsedFormulaPiecesFromDefinition({
+        definition: yDefinition,
+        fallbackVariableName:
+            xPiecesResult?.pieces?.[0]?.parsed.variableName ?? "t",
+        curveBounds,
+        diagnostics,
+        warningPrefix,
+        warningPosition,
+        pieceRole: "y",
+    });
+
+    if (
+        !xPiecesResult ||
+        !yPiecesResult ||
+        xPiecesResult.pieces.length === 0 ||
+        yPiecesResult.pieces.length === 0
+    ) {
         pushWarning({
             diagnostics,
             message: `${warningPrefix}: unsupported parametric curve function definition types ('${definitionTypeLabel(xDefinition)}', '${definitionTypeLabel(yDefinition)}'); descendant skipped.`,
@@ -246,23 +606,47 @@ function convertParametricCurve({
         return null;
     }
 
-    const domain = prefigureDomainFromStateValues({
-        parMin: sv.parMin,
-        parMax: sv.parMax,
-    });
-    if (!domain) {
+    if (xPiecesResult.hasOpenEndpoints || yPiecesResult.hasOpenEndpoints) {
+        pushWarning({
+            diagnostics,
+            message: `${warningPrefix}: piecewise open/closed endpoint semantics are approximated in prefigure output.`,
+            position: warningPosition,
+        });
+    }
+
+    const pieceXml: string[] = [];
+    let pieceCounter = 0;
+
+    for (const xPiece of xPiecesResult.pieces) {
+        for (const yPiece of yPiecesResult.pieces) {
+            const overlap = intersectIntervals(
+                xPiece.interval,
+                yPiece.interval,
+            );
+            if (!overlap) {
+                continue;
+            }
+
+            const pieceHandle =
+                pieceCounter === 0 ? handle : `${handle}_${pieceCounter}`;
+            const functionDefinition = `${pieceHandle}_r(${xPiece.parsed.variableName})=(${xPiece.parsed.expression},${yPiece.parsed.expression})`;
+            const attrs = [
+                `at="${escapeXml(pieceHandle)}"`,
+                `function="${escapeXml(functionDefinition)}"`,
+                `domain="${escapeXml(domainFromIntervalPiece(overlap))}"`,
+                ...styleAttrs,
+            ];
+
+            pieceXml.push(`<parametric-curve ${attrs.join(" ")} />`);
+            pieceCounter += 1;
+        }
+    }
+
+    if (pieceXml.length === 0) {
         return null;
     }
 
-    const functionDefinition = `${handle}_r(${xFormula.variableName})=(${xFormula.expression},${yFormula.expression})`;
-    const attrs = [
-        `at="${escapeXml(handle)}"`,
-        `function="${escapeXml(functionDefinition)}"`,
-        `domain="${escapeXml(domain)}"`,
-        ...styleAttrs,
-    ];
-
-    return `<parametric-curve ${attrs.join(" ")} />`;
+    return pieceXml.join("");
 }
 
 function pointsFromNumericalThroughPoints(

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
@@ -1,6 +1,6 @@
 import me from "math-expressions";
 import { find_effective_domains_piecewise_children } from "@doenet/utils";
-import { escapeXml, formatPoint, pushWarning } from "../common";
+import { escapeXml, pushWarning } from "../common";
 import { labelMarkup } from "../label";
 import type { ConverterArgs, CurveFunctionDefinition } from "../types";
 
@@ -345,6 +345,172 @@ function parsedInterpolatedDefinitionPieces({
 }
 
 /**
+ * Parse bezier curve definitions into explicit cubic pieces in the curve
+ * parameter. This mirrors Doenet's bezier evaluator: each segment is a cubic
+ * in local parameter (t-i), with optional quadratic extrapolation on each end.
+ */
+function parsedBezierDefinitionPieces({
+    definition,
+    fallbackVariableName,
+    curveBounds,
+}: {
+    definition: CurveFunctionDefinition;
+    fallbackVariableName: string;
+    curveBounds: { min: number; max: number };
+}): ParsedFormulaPiecesResult | null {
+    const parsedVariable = Array.isArray(definition.variables)
+        ? astToExpressionString(definition.variables[0])
+        : null;
+    const variableName = parsedVariable || fallbackVariableName;
+
+    const numThroughPoints = Number(definition.numThroughPoints);
+    if (!Number.isInteger(numThroughPoints) || numThroughPoints < 1) {
+        return null;
+    }
+
+    const segmentCount = numThroughPoints - 1;
+    const component = Number.isInteger(definition.component)
+        ? Number(definition.component)
+        : 0;
+
+    const rawSplineCoeffs = Array.isArray(definition.splineCoeffs)
+        ? definition.splineCoeffs
+        : null;
+    if (!rawSplineCoeffs || rawSplineCoeffs.length !== segmentCount) {
+        return null;
+    }
+
+    const splineCoeffs = rawSplineCoeffs.map((segment) => {
+        if (!Array.isArray(segment) || !Array.isArray(segment[component])) {
+            return null;
+        }
+        const coeffs = segment[component].slice(0, 4).map((v: unknown) =>
+            Number(v),
+        );
+        if (coeffs.length < 4 || coeffs.some((v) => !Number.isFinite(v))) {
+            return null;
+        }
+        return coeffs;
+    });
+
+    if (splineCoeffs.some((x) => x === null)) {
+        return null;
+    }
+
+    const forwardExtrapolation = Boolean(definition.extrapolateForward);
+    const backwardExtrapolation = Boolean(definition.extrapolateBackward);
+
+    const getExtrapolationCoeffs = (
+        coeffsByComponent: unknown,
+    ): number[] | null => {
+        if (!Array.isArray(coeffsByComponent)) {
+            return null;
+        }
+        const componentCoeffs = coeffsByComponent[component];
+        if (!Array.isArray(componentCoeffs)) {
+            return null;
+        }
+        const coeffs = componentCoeffs.slice(0, 3).map((v: unknown) =>
+            Number(v),
+        );
+        if (coeffs.length < 3 || coeffs.some((v) => !Number.isFinite(v))) {
+            return null;
+        }
+        return coeffs;
+    };
+
+    const backwardCoeffs = backwardExtrapolation
+        ? getExtrapolationCoeffs(definition.extrapolateBackwardCoeffs)
+        : null;
+    if (backwardExtrapolation && !backwardCoeffs) {
+        return null;
+    }
+
+    const forwardCoeffs = forwardExtrapolation
+        ? getExtrapolationCoeffs(definition.extrapolateForwardCoeffs)
+        : null;
+    if (forwardExtrapolation && !forwardCoeffs) {
+        return null;
+    }
+
+    const rawPieces: ParsedFormulaPiece[] = [];
+
+    if (backwardCoeffs) {
+        rawPieces.push({
+            parsed: {
+                variableName,
+                expression: `(${backwardCoeffs[0]}+(${backwardCoeffs[1]})*(${variableName})+(${backwardCoeffs[2]})*(${variableName})^2)`,
+            },
+            interval: {
+                min: -Infinity,
+                max: 0,
+                openMin: true,
+                openMax: false,
+            },
+        });
+    }
+
+    for (let i = 0; i < segmentCount; i += 1) {
+        const coeffs = splineCoeffs[i] as number[];
+        const shiftedVar = `(${variableName}-(${i}))`;
+        rawPieces.push({
+            parsed: {
+                variableName,
+                expression: `(${coeffs[0]}+(${coeffs[1]})*${shiftedVar}+(${coeffs[2]})*${shiftedVar}^2+(${coeffs[3]})*${shiftedVar}^3)`,
+            },
+            interval: {
+                min: i,
+                max: i + 1,
+                openMin: false,
+                openMax: false,
+            },
+        });
+    }
+
+    if (forwardCoeffs) {
+        const len = segmentCount;
+        const shiftedVar = `(${variableName}-(${len}))`;
+        rawPieces.push({
+            parsed: {
+                variableName,
+                expression: `(${forwardCoeffs[0]}+(${forwardCoeffs[1]})*${shiftedVar}+(${forwardCoeffs[2]})*${shiftedVar}^2)`,
+            },
+            interval: {
+                min: len,
+                max: Infinity,
+                openMin: false,
+                openMax: true,
+            },
+        });
+    }
+
+    const pieces: ParsedFormulaPiece[] = [];
+    let hasOpenEndpoints = false;
+
+    for (const piece of rawPieces) {
+        const clipped = intersectIntervalWithBounds(piece.interval, curveBounds);
+        if (!clipped) {
+            continue;
+        }
+
+        if (clipped.openMin || clipped.openMax) {
+            hasOpenEndpoints = true;
+        }
+
+        pieces.push({
+            parsed: piece.parsed,
+            interval: clipped,
+        });
+    }
+
+    return {
+        sourceType: "bezier",
+        hasOpenEndpoints,
+        pieces,
+    };
+}
+
+/**
  * Format a domain bound value for PreFigure output.
  * Converts JavaScript infinities to "inf"/"-inf" strings and finite numbers
  * to their string representation. Non-numeric or NaN values return null.
@@ -382,29 +548,6 @@ function numericBoundFromStateValue(
         return value as number;
     }
     return Number.isFinite(value) ? Number(value) : null;
-}
-
-/**
- * Format a potentially-infinite domain value range for PreFigure output.
- * Used for parameter bounds (parMin, parMax) that may be infinite.
- * Returns null if either bound is invalid or non-numeric.
- *
- * @param params - Object with parMin and parMax (may be any type)
- * @returns Formatted domain string (e.g., "(-2,3)" or "(-inf,inf)") or null
- */
-function prefigureDomainFromStateValues({
-    parMin,
-    parMax,
-}: {
-    parMin: unknown;
-    parMax: unknown;
-}): string | null {
-    const min = formatDomainBound(parMin);
-    const max = formatDomainBound(parMax);
-    if (min === null || max === null) {
-        return null;
-    }
-    return `(${min},${max})`;
 }
 
 /**
@@ -712,6 +855,14 @@ function parsedFormulaPiecesFromDefinition({
 
     if (definition.functionType === "interpolated") {
         return parsedInterpolatedDefinitionPieces({
+            definition,
+            fallbackVariableName,
+            curveBounds,
+        });
+    }
+
+    if (definition.functionType === "bezier") {
+        return parsedBezierDefinitionPieces({
             definition,
             fallbackVariableName,
             curveBounds,
@@ -1063,6 +1214,10 @@ function convertParametricCurve({
                 continue;
             }
 
+            if (overlap.min === overlap.max) {
+                continue;
+            }
+
             const pieceHandle = makePieceHandle(handle, pieceCounter);
             const functionDefinition = `${pieceHandle}_r(${xPiece.parsed.variableName})=(${xPiece.parsed.expression},${yPiece.parsed.expression})`;
             const attrs = [
@@ -1085,77 +1240,15 @@ function convertParametricCurve({
 }
 
 /**
- * Extract through-points array from numerical Bezier curve data.
- * Validates that at least 2 points are present and all points format correctly.
- *
- * @param numericalThroughPoints - Array of point coordinates
- * @returns Array of formatted point strings, or null if array is invalid
- */
-function pointsFromNumericalThroughPoints(
-    numericalThroughPoints: unknown,
-): string[] | null {
-    if (!Array.isArray(numericalThroughPoints)) {
-        return null;
-    }
-
-    const points = numericalThroughPoints
-        .map((point) => formatPoint(point))
-        .filter((point): point is string => point !== null);
-
-    if (points.length < 2 || points.length !== numericalThroughPoints.length) {
-        return null;
-    }
-
-    return points;
-}
-
-/**
- * Convert a Doenet Bezier curve (through points) to PreFigure <spline>.
- * Handles both open and closed (periodic) splines.
- * Domain is taken from curve parameter bounds if finite.
+ * Convert a Doenet Bezier curve using the same explicit parametric function
+ * definitions used by the Doenet renderer. This yields cubic piece geometry
+ * parity with Doenet rather than relying on a renderer-side spline fit.
  *
  * @param args - Standard converter arguments
- * @returns PreFigure <spline> element or null if conversion fails
+ * @returns PreFigure <parametric-curve> element(s) or null if conversion fails
  */
-function convertBezierCurve({
-    sv,
-    handle,
-    styleAttrs,
-    diagnostics,
-    warningPrefix,
-    warningPosition,
-}: ConverterArgs): string | null {
-    const points = pointsFromNumericalThroughPoints(sv.numericalThroughPoints);
-    if (!points) {
-        return null;
-    }
-
-    const attrs = [
-        `at="${escapeXml(handle)}"`,
-        `points="${escapeXml(`(${points.join(",")})`)}"`,
-        ...styleAttrs,
-    ];
-
-    if (sv.periodic) {
-        attrs.push('closed="yes"');
-    } else {
-        const domain = prefigureDomainFromStateValues({
-            parMin: sv.parMin,
-            parMax: sv.parMax,
-        });
-
-        if (domain) {
-            attrs.push(`domain="${escapeXml(domain)}"`);
-        } else if (sv.extrapolateBackward || sv.extrapolateForward) {
-            pushWarning({
-                diagnostics,
-                message: `${warningPrefix}: bezier extrapolation requested but parameter domain is non-finite; emitted spline without explicit domain.`,
-                position: warningPosition,
-            });
-        }
-    }
-
-    return `<spline ${attrs.join(" ")} />`;
+function convertBezierCurve(args: ConverterArgs): string | null {
+    return convertParametricCurve(args);
 }
 
 /**
@@ -1164,7 +1257,7 @@ function convertBezierCurve({
  * Routes curve conversion based on curve type:
  * - "function" → <graph> or <parametric-curve> (if flipped)
  * - "parameterization" → <parametric-curve> (2D parametric)
- * - "bezier" → <spline> (through-points curve)
+ * - "bezier" → <parametric-curve> piece(s) from explicit cubic definitions
  *
  * Also handles warnings for unsupported labels and diagnostics for incomplete
  * geometry (non-finite domains, invalid data).

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
@@ -714,15 +714,11 @@ function intervalPiecesFromMathTree(tree: unknown): IntervalPiece[] {
  *
  * @param interval1 - First interval with endpoint flags
  * @param interval2 - Second interval with endpoint flags
- * @param resultMin - The minimum endpoint of the intersection result
- * @param resultMax - The maximum endpoint of the intersection result
  * @returns Object with computed openMin and openMax flags
  */
 function computeOpenEndpoints(
     interval1: { min: number; max: number; openMin: boolean; openMax: boolean },
     interval2: { min: number; max: number; openMin: boolean; openMax: boolean },
-    resultMin: number,
-    resultMax: number,
 ): { openMin: boolean; openMax: boolean } {
     let openMin: boolean;
     if (interval1.min > interval2.min) {
@@ -821,12 +817,7 @@ function intersectIntervals(
         return null;
     }
 
-    const { openMin, openMax } = computeOpenEndpoints(
-        interval1,
-        interval2,
-        min,
-        max,
-    );
+    const { openMin, openMax } = computeOpenEndpoints(interval1, interval2);
 
     if (min === max && (openMin || openMax)) {
         return null;
@@ -1103,7 +1094,7 @@ function validatePiecesResult(
  *   - handle: Unique identifier for this curve piece
  *   - styleAttrs: Array of style attribute strings (stroke, thickness, etc.)
  *   - parsed: Variable name and expression definition
- *   - domain: Optional domain string; omitted for parametric curves
+ *   - domain: Optional domain string; included whenever non-null
  *   - isParametric: True for parametric curves, false for Cartesian functions
  * @returns Complete XML element string (self-closing)
  */

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
@@ -111,6 +111,39 @@ function astToExpressionString(ast: unknown): string | null {
     }
 }
 
+function escapeRegex(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Rewrite the variable symbol used in an expression string.
+ *
+ * This is used for parametric curves where x and y definitions may be authored
+ * with different variable names (for example, u and v), while PreFigure expects
+ * a single parameter in the emitted function signature.
+ */
+function rewriteExpressionVariable({
+    expression,
+    fromVariable,
+    toVariable,
+}: {
+    expression: string;
+    fromVariable: string;
+    toVariable: string;
+}): string {
+    if (!fromVariable || fromVariable === toVariable) {
+        return expression;
+    }
+
+    const escaped = escapeRegex(fromVariable);
+    const symbolPattern = new RegExp(
+        `(^|[^A-Za-z0-9_])(${escaped})(?=$|[^A-Za-z0-9_])`,
+        "g",
+    );
+
+    return expression.replace(symbolPattern, `$1${toVariable}`);
+}
+
 /**
  * Parse a simple formula-based curve function definition.
  * Extracts the expression and variable name; returns null if definition
@@ -1222,7 +1255,18 @@ function convertParametricCurve({
             }
 
             const pieceHandle = makePieceHandle(handle, pieceCounter);
-            const functionDefinition = `${pieceHandle}_r(${xPiece.parsed.variableName})=(${xPiece.parsed.expression},${yPiece.parsed.expression})`;
+            const parameterVariable = xPiece.parsed.variableName;
+            const xExpression = rewriteExpressionVariable({
+                expression: xPiece.parsed.expression,
+                fromVariable: xPiece.parsed.variableName,
+                toVariable: parameterVariable,
+            });
+            const yExpression = rewriteExpressionVariable({
+                expression: yPiece.parsed.expression,
+                fromVariable: yPiece.parsed.variableName,
+                toVariable: parameterVariable,
+            });
+            const functionDefinition = `${pieceHandle}_r(${parameterVariable})=(${xExpression},${yExpression})`;
             const attrs = [
                 `at="${escapeXml(pieceHandle)}"`,
                 `function="${escapeXml(functionDefinition)}"`,

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
@@ -589,13 +589,9 @@ function formatDomainBound(value: unknown): string | null {
  * Used to normalize parMin/parMax properties into validated numbers.
  *
  * @param value - The state value (may be unknown type)
- * @param defaultInf - Default infinity value (unused, for semantic clarity)
  * @returns Numeric bound (including infinities) or null if invalid
  */
-function numericBoundFromStateValue(
-    value: unknown,
-    defaultInf: number,
-): number | null {
+function numericBoundFromStateValue(value: unknown): number | null {
     if (value === -Infinity || value === Infinity) {
         return value as number;
     }
@@ -617,8 +613,8 @@ function domainBoundsFromStateValues({
     parMin: unknown;
     parMax: unknown;
 }): { min: number; max: number } | null {
-    const min = numericBoundFromStateValue(parMin, -Infinity);
-    const max = numericBoundFromStateValue(parMax, Infinity);
+    const min = numericBoundFromStateValue(parMin);
+    const max = numericBoundFromStateValue(parMax);
 
     if (min === null || max === null || min > max) {
         return null;
@@ -711,11 +707,10 @@ function intervalPiecesFromMathTree(tree: unknown): IntervalPiece[] {
  * Determine which interval's open/closed endpoint flags should be used for
  * the result of an interval intersection operation.
  *
- * When two intervals are intersected, the resulting endpoints may come from
- * either interval depending on which bounds the result. This function applies
- * the logical rules: if an endpoint moves from one interval, it becomes closed;
- * if both intervals share the same endpoint, the result inherits the combined
- * openness (open if either is open).
+ * When two intervals are intersected, each resulting endpoint inherits its
+ * open/closed flag from whichever interval contributes that boundary to the
+ * intersection. If both intervals share the same endpoint value, the result is
+ * open at that endpoint if either interval is open there.
  *
  * @param interval1 - First interval with endpoint flags
  * @param interval2 - Second interval with endpoint flags
@@ -958,10 +953,19 @@ function parsedFormulaPiecesFromDefinition({
             pieceRole: `${pieceRole} piecewise child`,
         });
 
-        if (!childPiecesResult || childPiecesResult.pieces.length === 0) {
+        if (!childPiecesResult) {
             pushWarning({
                 diagnostics,
                 message: `${warningPrefix}: ${pieceRole} piecewise child ${i + 1} has unsupported function definition type '${definitionTypeLabel(childDefinition)}'; child skipped.`,
+                position: warningPosition,
+            });
+            continue;
+        }
+
+        if (childPiecesResult.pieces.length === 0) {
+            pushWarning({
+                diagnostics,
+                message: `${warningPrefix}: ${pieceRole} piecewise child ${i + 1} has no pieces overlapping the active domain/bounds; child skipped.`,
                 position: warningPosition,
             });
             continue;

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/descendant.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/descendant.ts
@@ -17,6 +17,7 @@ import {
     convertPolygonToPrefigure,
 } from "./components/polygon";
 import { convertAngleToPrefigure } from "./components/angle";
+import { convertCurveToPrefigure } from "./components/curve";
 import type {
     Converter,
     Descendant,
@@ -33,7 +34,7 @@ const FILLED_COMPONENT_TYPES = new Set([
     "rectangle",
 ]);
 
-const NO_FILL_COMPONENT_TYPES = new Set(["polyline", "angle"]);
+const NO_FILL_COMPONENT_TYPES = new Set(["polyline", "angle", "curve"]);
 
 function styleIncludesFill(
     componentType: string,
@@ -56,6 +57,7 @@ const convertByComponentType: Record<string, Converter> = {
     polyline: convertPolylineToPrefigure,
     polygon: convertPolygonToPrefigure,
     angle: convertAngleToPrefigure,
+    curve: convertCurveToPrefigure,
     endpoint: convertPointToPrefigure,
     equilibriumPoint: convertPointToPrefigure,
     triangle: convertPolygonToPrefigure,

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/descendant.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/descendant.ts
@@ -121,6 +121,7 @@ export function convertGraphicalDescendantToPrefigure({
         return null;
     }
 
+    const diagnosticsCountBeforeConvert = diagnostics.length;
     const body = converter({
         sv,
         handle,
@@ -131,11 +132,15 @@ export function convertGraphicalDescendantToPrefigure({
     });
 
     if (!body) {
-        pushWarning({
-            diagnostics,
-            message: `${warningPrefix}: non-finite or incomplete geometry; descendant skipped.`,
-            position: warningPosition,
-        });
+        // If conversion failed and the failed converter call did not emit any
+        // diagnostics, add one generic fallback warning.
+        if (diagnostics.length === diagnosticsCountBeforeConvert) {
+            pushWarning({
+                diagnostics,
+                message: `${warningPrefix}: non-finite or incomplete geometry; descendant skipped.`,
+                position: warningPosition,
+            });
+        }
         return null;
     }
 

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/descendant.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/descendant.ts
@@ -95,6 +95,11 @@ export function convertGraphicalDescendantToPrefigure({
         graphBounds,
         graphDimensions,
     };
+
+    if (sv.hidden) {
+        return null;
+    }
+
     const warningPrefix = warningMessageForDescendant(descendant);
     const warningPosition = descendant?.position;
     const handle = createStableHandle(descendant, index, usedHandles);

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
@@ -256,7 +256,20 @@ function collectConfiguredDescendants(
         }
     }
 
-    return [...byComponentIdx.values()];
+    return [...byComponentIdx.values()].filter((descendant) => {
+        if (descendant.componentType !== "vector") {
+            return true;
+        }
+
+        const componentName = descendant.componentName?.toLowerCase() ?? "";
+
+        // Bezier control vectors are implementation details of curve editing
+        // and should not be rendered as standalone vectors in PreFigure.
+        return (
+            !componentName.includes("beziercontrols") &&
+            !componentName.includes("controlvectors")
+        );
+    });
 }
 
 /**

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
@@ -26,6 +26,7 @@ const GRAPHICAL_DESCENDANT_CONFIGS = [
             "labelHasLatex",
             "labelPosition",
             "open",
+            "hidden",
         ],
         variablesOptional: true,
     },
@@ -38,6 +39,7 @@ const GRAPHICAL_DESCENDANT_CONFIGS = [
             "label",
             "labelHasLatex",
             "labelPosition",
+            "hidden",
         ],
     },
     {
@@ -49,6 +51,7 @@ const GRAPHICAL_DESCENDANT_CONFIGS = [
             "label",
             "labelHasLatex",
             "labelPosition",
+            "hidden",
         ],
     },
     {
@@ -61,6 +64,7 @@ const GRAPHICAL_DESCENDANT_CONFIGS = [
             "label",
             "labelHasLatex",
             "labelPosition",
+            "hidden",
         ],
     },
     {
@@ -72,6 +76,7 @@ const GRAPHICAL_DESCENDANT_CONFIGS = [
             "label",
             "labelHasLatex",
             "labelPosition",
+            "hidden",
         ],
     },
     {
@@ -84,6 +89,7 @@ const GRAPHICAL_DESCENDANT_CONFIGS = [
             "label",
             "labelHasLatex",
             "swapPointOrder",
+            "hidden",
         ],
     },
     {
@@ -102,6 +108,7 @@ const GRAPHICAL_DESCENDANT_CONFIGS = [
             "selectedStyle",
             "label",
             "labelHasLatex",
+            "hidden",
         ],
         variablesOptional: true,
     },
@@ -113,17 +120,23 @@ const GRAPHICAL_DESCENDANT_CONFIGS = [
             "numericalRadius",
             "selectedStyle",
             "filled",
+            "hidden",
         ],
     },
     {
         key: "polylineDescendants",
         componentType: "polyline",
-        variableNames: ["numericalVertices", "selectedStyle"],
+        variableNames: ["numericalVertices", "selectedStyle", "hidden"],
     },
     {
         key: "polygonDescendants",
         componentType: "polygon",
-        variableNames: ["numericalVertices", "selectedStyle", "filled"],
+        variableNames: [
+            "numericalVertices",
+            "selectedStyle",
+            "filled",
+            "hidden",
+        ],
     },
 ];
 

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
@@ -87,6 +87,25 @@ const GRAPHICAL_DESCENDANT_CONFIGS = [
         ],
     },
     {
+        key: "curveDescendants",
+        componentType: "curve",
+        variableNames: [
+            "curveType",
+            "fDefinitions",
+            "parMin",
+            "parMax",
+            "flipFunction",
+            "numericalThroughPoints",
+            "periodic",
+            "extrapolateBackward",
+            "extrapolateForward",
+            "selectedStyle",
+            "label",
+            "labelHasLatex",
+        ],
+        variablesOptional: true,
+    },
+    {
         key: "circleDescendants",
         componentType: "circle",
         variableNames: [

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
@@ -269,20 +269,7 @@ function collectConfiguredDescendants(
         }
     }
 
-    return [...byComponentIdx.values()].filter((descendant) => {
-        if (descendant.componentType !== "vector") {
-            return true;
-        }
-
-        const componentName = descendant.componentName?.toLowerCase() ?? "";
-
-        // Bezier control vectors are implementation details of curve editing
-        // and should not be rendered as standalone vectors in PreFigure.
-        return (
-            !componentName.includes("beziercontrols") &&
-            !componentName.includes("controlvectors")
-        );
-    });
+    return [...byComponentIdx.values()];
 }
 
 /**

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/types.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/types.ts
@@ -55,6 +55,7 @@ export interface PrefigureStateValues extends Record<string, unknown> {
     label?: string;
     labelHasLatex?: boolean;
     labelPosition?: string;
+    hidden?: boolean;
     open?: boolean;
     filled?: boolean;
     swapPointOrder?: boolean;

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/types.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/types.ts
@@ -43,6 +43,13 @@ export interface SelectedStyle {
     [key: string]: unknown;
 }
 
+export interface CurveFunctionDefinition {
+    functionType?: unknown;
+    formula?: unknown;
+    variables?: unknown;
+    [key: string]: unknown;
+}
+
 export interface PrefigureStateValues extends Record<string, unknown> {
     selectedStyle?: SelectedStyle;
     label?: string;
@@ -59,6 +66,15 @@ export interface PrefigureStateValues extends Record<string, unknown> {
     numericalCenter?: unknown;
     numericalRadius?: unknown;
     numericalVertices?: unknown;
+    curveType?: unknown;
+    fDefinitions?: unknown;
+    parMin?: unknown;
+    parMax?: unknown;
+    flipFunction?: unknown;
+    numericalThroughPoints?: unknown;
+    periodic?: unknown;
+    extrapolateBackward?: unknown;
+    extrapolateForward?: unknown;
     graphBounds?: GraphBounds;
     graphDimensions?: GraphDimensions;
     lineLabelLocationOverride?: number;

--- a/packages/utils/src/components/function.ts
+++ b/packages/utils/src/components/function.ts
@@ -1164,6 +1164,9 @@ export function returnInterpolatedFunction({
     let openMin = false,
         openMax = false;
     if (domain !== null) {
+        // Function domains are represented as one interval per input variable.
+        // Interpolated functions here are single-input, so domain[0] is the
+        // x-domain interval, not the first piece of a union domain.
         let domain0 = domain[0];
         if (domain0 !== undefined) {
             minx = me


### PR DESCRIPTION
## Summary
- add worker-side PreFigure conversion for curve descendants
- support function, parameterized, and bezier curve mappings
- add piecewise expansion for function and parameterized curves
- add interpolated function support, including piecewise children that are interpolated
- add non-fatal diagnostics for unsupported case
