### PR TITLE
Add dynamic prefigure annotations-skeleton autocomplete snippet

### DIFF
--- a/.changeset/brave-apples-smile.md
+++ b/.changeset/brave-apples-smile.md
@@ -1,0 +1,9 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Add a dynamic `annotations-skeleton` autocomplete snippet for prefigure graphs.
+
+When authoring inside a `<graph renderer="prefigure">`, autocomplete now offers `annotations-skeleton`, which inserts an `<annotations>` tree derived from authored graphical descendants. The generated author-facing annotation text now covers supported prefigure graphical component types (including authored `<function>`), uses explicit coordinate labels where appropriate for accessibility, and includes guidance when a referenced graphical component is unnamed.

--- a/.changeset/brave-apples-smile.md
+++ b/.changeset/brave-apples-smile.md
@@ -7,3 +7,5 @@
 Add a dynamic `annotations-skeleton` autocomplete snippet for prefigure graphs.
 
 When authoring inside a `<graph renderer="prefigure">`, autocomplete now offers `annotations-skeleton`, which inserts an `<annotations>` tree derived from authored graphical descendants. The generated author-facing annotation text now covers supported prefigure graphical component types (including authored `<function>`), uses explicit coordinate labels where appropriate for accessibility, and includes guidance when a referenced graphical component is unnamed.
+
+This change also aligns Ray coordinate aliases with generated annotation references by supporting `.endpoint.x/.y/.z` and `.through.x/.y/.z` access patterns in core state variables.

--- a/packages/doenetml-worker-javascript/src/components/Ray.js
+++ b/packages/doenetml-worker-javascript/src/components/Ray.js
@@ -1007,6 +1007,7 @@ export default class Ray extends GraphicalComponent {
             },
             isArray: true,
             entryPrefixes: ["throughX"],
+            indexAliases: [["x", "y", "z"]],
             set: convertValueToMathExpression,
             stateVariablesDeterminingDependencies: ["basedOnThrough"],
             returnArraySizeDependencies: () => ({
@@ -1228,6 +1229,7 @@ export default class Ray extends GraphicalComponent {
             },
             isArray: true,
             entryPrefixes: ["endpointX"],
+            indexAliases: [["x", "y", "z"]],
             hasEssential: true,
             defaultValueByArrayKey: () => me.fromAst(0),
             essentialVarName: "endpoint2", // since endpointShadow uses "endpoint"

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { DastElement, lezerToDast } from "@doenet/parser";
+import { lezerToDast } from "@doenet/parser";
+import type { DastElement } from "@doenet/parser";
 import { createTestCore } from "../utils/test-core";
 import { getDiagnosticsByType } from "../utils/diagnostics";
 import {

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { DastElement, lezerToDast } from "@doenet/parser";
 import { createTestCore } from "../utils/test-core";
 import { getDiagnosticsByType } from "../utils/diagnostics";
 import {
@@ -6,11 +7,43 @@ import {
     getPrefigureXML,
     getWarnings,
 } from "./graph-prefigure.helpers";
+import { generateAnnotationSkeletonSnippet } from "../../../../lsp-tools/src/auto-completer/methods/generate-annotation-skeleton";
 import { nextAvailableConceptualAnnotationRef } from "../../utils/prefigure/annotations";
 import {
     prefigureGraph,
     withStyleDefinitions,
 } from "./graph-prefigure.fixtures";
+
+function getFirstGraphElement(source: string): DastElement {
+    const dast = lezerToDast(source);
+    const graphElement = dast.children.find(
+        (child) => child.type === "element" && child.name === "graph",
+    );
+
+    if (!graphElement || graphElement.type !== "element") {
+        throw new Error("Expected source to contain a <graph> element.");
+    }
+
+    return graphElement;
+}
+
+async function expectGeneratedAnnotationTextResolves(
+    componentDoenetML: string,
+    expectedText: string,
+) {
+    const graphSourceForSnippet = `<graph renderer="prefigure">${componentDoenetML}</graph>`;
+    const graphElement = getFirstGraphElement(graphSourceForSnippet);
+    const snippet = generateAnnotationSkeletonSnippet(graphElement);
+
+    expect(snippet).toBeTruthy();
+
+    const prefigureXML = await getPrefigureXML(
+        prefigureGraph(`${componentDoenetML}\n  ${snippet!.snippet}`),
+    );
+
+    expect(prefigureXML).toContain(`<annotations>`);
+    expect(prefigureXML).toContain(expectedText);
+}
 
 describe("Graph prefigure renderer core @group4", () => {
     it("renderer=doenet leaves prefigureXML null", async () => {
@@ -359,6 +392,81 @@ describe("Graph prefigure renderer core @group4", () => {
         expect(prefigureXML).toContain(
             `<annotation ref="${pointHandle}" text="point summary"></annotation>`,
         );
+    });
+
+    it("generated annotations-skeleton text resolves for all supported component types", async () => {
+        const cases: Array<{
+            componentDoenetML: string;
+            expectedText: string;
+        }> = [
+            {
+                componentDoenetML: `<point name="p">(2,5)</point>`,
+                expectedText: `A point with x-coordinate 2 and y-coordinate 5.`,
+            },
+            {
+                componentDoenetML: `<line name="ln" through="(0,0) (1,1)" />`,
+                expectedText: `A line.`,
+            },
+            {
+                componentDoenetML: `<lineSegment name="seg" endpoints="(1,2) (3,4)" />`,
+                expectedText: `A line segment from a point with x-coordinate 1 and y-coordinate 2 to a point with x-coordinate 3 and y-coordinate 4.`,
+            },
+            {
+                componentDoenetML: `<ray name="r" endpoint="(1,2)" through="(5,8)" />`,
+                expectedText: `A ray starting at a point with x-coordinate 1 and y-coordinate 2, passing through a point with x-coordinate 5 and y-coordinate 8.`,
+            },
+            {
+                componentDoenetML: `<vector name="v" tail="(1,2)" head="(4,6)" />`,
+                expectedText: `A vector with tail at x-coordinate 1 and y-coordinate 2, and head at x-coordinate 4 and y-coordinate 6.`,
+            },
+            {
+                componentDoenetML: `<circle name="c" center="(0,0)" radius="3" />`,
+                expectedText: `A circle with radius 3 centered at x-coordinate 0 and y-coordinate 0.`,
+            },
+            {
+                componentDoenetML: `<function name="f">x^2</function>`,
+                expectedText: `A function.`,
+            },
+            {
+                componentDoenetML: `<polyline name="pl" vertices="(0,0) (2,0) (1,1)" />`,
+                expectedText: `A polyline with 3 vertices.`,
+            },
+            {
+                componentDoenetML: `<polygon name="poly" vertices="(0,0) (2,0) (1,1)" />`,
+                expectedText: `A polygon with 3 vertices.`,
+            },
+            {
+                componentDoenetML: `<angle name="a" through="(1,0) (0,0) (0,1)" />`,
+                expectedText: `An angle.`,
+            },
+            {
+                componentDoenetML: `<curve name="cv" through="(0,0) (1,2) (2,3)" />`,
+                expectedText: `A curve.`,
+            },
+            {
+                componentDoenetML: `<endpoint name="ep">(1,4)</endpoint>`,
+                expectedText: `An endpoint with x-coordinate 1 and y-coordinate 4.`,
+            },
+            {
+                componentDoenetML: `<equilibriumPoint name="eq">(3,7)</equilibriumPoint>`,
+                expectedText: `An equilibrium point with x-coordinate 3 and y-coordinate 7.`,
+            },
+            {
+                componentDoenetML: `<triangle name="tri" vertices="(0,0) (2,0) (1,1)" />`,
+                expectedText: `A triangle.`,
+            },
+            {
+                componentDoenetML: `<rectangle name="rect" center="(4,0.5)" width="2" height="1" />`,
+                expectedText: `A rectangle of width 2 and height 1.`,
+            },
+        ];
+
+        for (const c of cases) {
+            await expectGeneratedAnnotationTextResolves(
+                c.componentDoenetML,
+                c.expectedText,
+            );
+        }
     });
 
     it("serializes speech, sonify, and circular annotation attributes", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/ray.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/ray.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { Expression, Tree } from "math-expressions";
 import { createTestCore, ResolvePathToNodeIdx } from "../utils/test-core";
 import { PublicDoenetMLCore } from "../../CoreWorker";
 import { getDiagnosticsByType } from "../utils/diagnostics";
@@ -16,6 +17,14 @@ import {
 const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);
 vi.mock("hyperformula");
+
+function toTree(value: { tree: Tree }): Tree {
+    return value.tree;
+}
+
+function toSimplifiedTree(value: Expression): Tree {
+    return value.simplify().tree;
+}
 
 describe("Ray Tag Tests @group1", function () {
     /**
@@ -39,20 +48,45 @@ describe("Ray Tag Tests @group1", function () {
     }) {
         expect(
             stateVariables[componentIdx].stateValues.endpoint.map(
-                (x) => x.simplify().tree,
+                toSimplifiedTree,
             ),
         ).eqls(t);
         expect(
             stateVariables[componentIdx].stateValues.through.map(
-                (x) => x.simplify().tree,
+                toSimplifiedTree,
             ),
         ).eqls(h);
         expect(
             stateVariables[componentIdx].stateValues.direction.map(
-                (x) => x.simplify().tree,
+                toSimplifiedTree,
             ),
         ).eqls(d);
     }
+
+    it("ray endpoint and through support x/y aliases", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<graph>
+    <ray name="r" endpoint="(1,2)" through="(5,8)" />
+    <point name="endpointCoords">($r.endpoint.x, $r.endpoint.y)</point>
+    <point name="throughCoords">($r.through.x, $r.through.y)</point>
+</graph>
+`,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[
+                await resolvePathToNodeIdx("endpointCoords")
+            ].stateValues.xs.map(toTree),
+        ).eqls([1, 2]);
+        expect(
+            stateVariables[
+                await resolvePathToNodeIdx("throughCoords")
+            ].stateValues.xs.map(toTree),
+        ).eqls([5, 8]);
+    });
 
     async function testRayCopiedHTD({
         throughx,
@@ -67,6 +101,19 @@ describe("Ray Tag Tests @group1", function () {
         directionName = "direction",
         core,
         resolvePathToNodeIdx,
+    }: {
+        throughx: number;
+        throughy: number;
+        endpointx: number;
+        endpointy: number;
+        directionEndpointShiftx?: number;
+        directionEndpointShifty?: number;
+        rayName?: string;
+        endpointName?: string;
+        throughName?: string;
+        directionName?: string;
+        core: PublicDoenetMLCore;
+        resolvePathToNodeIdx: ResolvePathToNodeIdx;
     }) {
         function check_vec_htd({
             componentIdx,
@@ -83,17 +130,17 @@ describe("Ray Tag Tests @group1", function () {
         }) {
             expect(
                 stateVariables[componentIdx].stateValues.tail.map(
-                    (x) => x.simplify().tree,
+                    toSimplifiedTree,
                 ),
             ).eqls(t);
             expect(
                 stateVariables[componentIdx].stateValues.head.map(
-                    (x) => x.simplify().tree,
+                    toSimplifiedTree,
                 ),
             ).eqls(h);
             expect(
                 stateVariables[componentIdx].stateValues.displacement.map(
-                    (x) => x.simplify().tree,
+                    toSimplifiedTree,
                 ),
             ).eqls(d);
         }
@@ -113,12 +160,12 @@ describe("Ray Tag Tests @group1", function () {
         expect(
             stateVariables[
                 await resolvePathToNodeIdx(endpointName)
-            ].stateValues.xs.map((v) => v.tree),
+            ].stateValues.xs.map(toTree),
         ).eqls([endpointx, endpointy]);
         expect(
             stateVariables[
                 await resolvePathToNodeIdx(throughName)
-            ].stateValues.xs.map((v) => v.tree),
+            ].stateValues.xs.map(toTree),
         ).eqls([throughx, throughy]);
 
         check_vec_htd({
@@ -559,36 +606,36 @@ describe("Ray Tag Tests @group1", function () {
                 expect(
                     stateVariables[
                         await resolvePathToNodeIdx(name)
-                    ].stateValues.endpoint.map((v) => v.tree),
+                    ].stateValues.endpoint.map(toTree),
                 ).eqls([v1tx, v1ty]);
                 expect(
                     stateVariables[
                         await resolvePathToNodeIdx(name)
-                    ].stateValues.through.map((v) => v.tree),
+                    ].stateValues.through.map(toTree),
                 ).eqls([v1hx, v1hy]);
             }
             for (let name of ray2s) {
                 expect(
                     stateVariables[
                         await resolvePathToNodeIdx(name)
-                    ].stateValues.endpoint.map((v) => v.tree),
+                    ].stateValues.endpoint.map(toTree),
                 ).eqls([v2tx, v2ty]);
                 expect(
                     stateVariables[
                         await resolvePathToNodeIdx(name)
-                    ].stateValues.through.map((v) => v.tree),
+                    ].stateValues.through.map(toTree),
                 ).eqls([v2hx, v2hy]);
             }
             for (let name of ray3s) {
                 expect(
                     stateVariables[
                         await resolvePathToNodeIdx(name)
-                    ].stateValues.endpoint.map((v) => v.tree),
+                    ].stateValues.endpoint.map(toTree),
                 ).eqls([v3tx, v3ty]);
                 expect(
                     stateVariables[
                         await resolvePathToNodeIdx(name)
-                    ].stateValues.through.map((v) => v.tree),
+                    ].stateValues.through.map(toTree),
                 ).eqls([v3hx, v3hy]);
             }
         }
@@ -757,17 +804,17 @@ describe("Ray Tag Tests @group1", function () {
                 expect(
                     stateVariables[
                         await resolvePathToNodeIdx(name)
-                    ].stateValues.endpoint.map((v) => v.tree),
+                    ].stateValues.endpoint.map(toTree),
                 ).eqls([ray_tx, ray_ty]);
                 expect(
                     stateVariables[
                         await resolvePathToNodeIdx(name)
-                    ].stateValues.through.map((v) => v.tree),
+                    ].stateValues.through.map(toTree),
                 ).eqls([ray_hx, ray_hy]);
                 expect(
                     stateVariables[
                         await resolvePathToNodeIdx(name)
-                    ].stateValues.direction.map((v) => v.tree),
+                    ].stateValues.direction.map(toTree),
                 ).eqls([direction_x, direction_y]);
             }
 
@@ -776,17 +823,17 @@ describe("Ray Tag Tests @group1", function () {
                 expect(
                     stateVariables[
                         await resolvePathToNodeIdx(name)
-                    ].stateValues.tail.map((v) => v.tree),
+                    ].stateValues.tail.map(toTree),
                 ).eqls([dtail_xs[i], dtail_ys[i]]);
                 expect(
                     stateVariables[
                         await resolvePathToNodeIdx(name)
-                    ].stateValues.head.map((v) => v.tree),
+                    ].stateValues.head.map(toTree),
                 ).eqls([dhead_xs[i], dhead_ys[i]]);
                 expect(
                     stateVariables[
                         await resolvePathToNodeIdx(name)
-                    ].stateValues.displacement.map((v) => v.tree),
+                    ].stateValues.displacement.map(toTree),
                 ).eqls([direction_x, direction_y]);
             }
         }
@@ -871,12 +918,12 @@ describe("Ray Tag Tests @group1", function () {
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("ray1")
-                ].stateValues.endpoint.map((v) => v.tree),
+                ].stateValues.endpoint.map(toTree),
             ).eqls([tx, ty]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("ray1")
-                ].stateValues.through.map((v) => v.tree),
+                ].stateValues.through.map(toTree),
             ).eqls([hx, hy]);
             expect(
                 stateVariables[await resolvePathToNodeIdx("point3")].stateValues
@@ -896,7 +943,10 @@ describe("Ray Tag Tests @group1", function () {
         hy = -4;
         let pxOrig = -5;
         let pyOrig = 2;
-        function calc_snap_45_deg(pxOrig, pyOrig) {
+        function calc_snap_45_deg(
+            pxOrig: number,
+            pyOrig: number,
+        ): [number, number] {
             let temp = (pxOrig - pyOrig) / 2;
             temp = Math.max(-4, temp); // No upper bound since ray continues
             const px = temp;
@@ -980,12 +1030,12 @@ describe("Ray Tag Tests @group1", function () {
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("ray1")
-                ].stateValues.endpoint.map((v) => v.tree),
+                ].stateValues.endpoint.map(toTree),
             ).eqls([tx, ty]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("ray1")
-                ].stateValues.through.map((v) => v.tree),
+                ].stateValues.through.map(toTree),
             ).eqls([hx, hy]);
             expect(
                 stateVariables[await resolvePathToNodeIdx("point3")].stateValues
@@ -1015,7 +1065,10 @@ describe("Ray Tag Tests @group1", function () {
         let pxOrig = 3.3;
         let pyOrig = -3.6;
 
-        function calc_snap_45_deg(pxOrig, pyOrig) {
+        function calc_snap_45_deg(
+            pxOrig: number,
+            pyOrig: number,
+        ): [number, number] {
             let temp = (pxOrig - pyOrig) / 2;
             temp = Math.max(-4, temp); // No upper bound since ray continues
             const px = temp;
@@ -1171,22 +1224,22 @@ describe("Ray Tag Tests @group1", function () {
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("original")
-                ].stateValues.endpoint.map((v) => v.tree),
+                ].stateValues.endpoint.map(toTree),
             ).eqls([0, 0]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("original")
-                ].stateValues.through.map((v) => v.tree),
+                ].stateValues.through.map(toTree),
             ).eqls([ohx, ohy]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("multiplied")
-                ].stateValues.endpoint.map((v) => v.tree),
+                ].stateValues.endpoint.map(toTree),
             ).eqls([0, 0]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("multiplied")
-                ].stateValues.through.map((v) => v.tree),
+                ].stateValues.through.map(toTree),
             ).eqls([mhx, mhy]);
         }
         await check_items();
@@ -1269,47 +1322,47 @@ describe("Ray Tag Tests @group1", function () {
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("u")
-                ].stateValues.endpoint.map((v) => v.tree),
+                ].stateValues.endpoint.map(toTree),
             ).eqls([...uEndpoint]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("u")
-                ].stateValues.through.map((v) => v.tree),
+                ].stateValues.through.map(toTree),
             ).eqls([...uThrough]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("u")
-                ].stateValues.direction.map((v) => v.tree),
+                ].stateValues.direction.map(toTree),
             ).eqls([...u]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("v")
-                ].stateValues.endpoint.map((v) => v.tree),
+                ].stateValues.endpoint.map(toTree),
             ).eqls([...vEndpoint]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("v")
-                ].stateValues.through.map((v) => v.tree),
+                ].stateValues.through.map(toTree),
             ).eqls([...vThrough]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("v")
-                ].stateValues.direction.map((v) => v.tree),
+                ].stateValues.direction.map(toTree),
             ).eqls([...v]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("w")
-                ].stateValues.endpoint.map((v) => v.tree),
+                ].stateValues.endpoint.map(toTree),
             ).eqls([...wEndpoint]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("w")
-                ].stateValues.through.map((v) => v.tree),
+                ].stateValues.through.map(toTree),
             ).eqls([...wThrough]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("w")
-                ].stateValues.direction.map((v) => v.tree),
+                ].stateValues.direction.map(toTree),
             ).eqls([...w]);
         }
         await check_items();
@@ -1417,17 +1470,17 @@ describe("Ray Tag Tests @group1", function () {
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("v")
-                ].stateValues.endpoint.map((v) => v.tree),
+                ].stateValues.endpoint.map(toTree),
             ).eqls([tx, ty]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("v")
-                ].stateValues.through.map((v) => v.tree),
+                ].stateValues.through.map(toTree),
             ).eqls([hx, hy]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("v")
-                ].stateValues.direction.map((v) => v.tree),
+                ].stateValues.direction.map(toTree),
             ).eqls([hx - tx, hy - ty]);
 
             expect(
@@ -1623,7 +1676,7 @@ describe("Ray Tag Tests @group1", function () {
                 expect(
                     stateVariables[
                         await resolvePathToNodeIdx(name)
-                    ].stateValues.displacement.map((x) => x.simplify().tree),
+                    ].stateValues.displacement.map(toSimplifiedTree),
                 ).eqls(disp);
             }
 
@@ -2435,32 +2488,32 @@ describe("Ray Tag Tests @group1", function () {
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("ray1")
-                ].stateValues.endpoint.map((v) => v.tree),
+                ].stateValues.endpoint.map(toTree),
             ).eqls([x1, y1]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("ray1")
-                ].stateValues.through.map((v) => v.tree),
+                ].stateValues.through.map(toTree),
             ).eqls([x2, y2]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("ray2")
-                ].stateValues.endpoint.map((v) => v.tree),
+                ].stateValues.endpoint.map(toTree),
             ).eqls([x3, y3]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("ray2")
-                ].stateValues.through.map((v) => v.tree),
+                ].stateValues.through.map(toTree),
             ).eqls([x2, y2]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("ray3")
-                ].stateValues.endpoint.map((v) => v.tree),
+                ].stateValues.endpoint.map(toTree),
             ).eqls([x3, y3]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("ray3")
-                ].stateValues.through.map((v) => v.tree),
+                ].stateValues.through.map(toTree),
             ).eqls([x1, y1]);
         }
 
@@ -2555,17 +2608,17 @@ describe("Ray Tag Tests @group1", function () {
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("ray1")
-                ].stateValues.endpoint.map((v) => v.tree),
+                ].stateValues.endpoint.map(toTree),
             ).eqls([endpointx, endpointy]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("ray1")
-                ].stateValues.through.map((v) => v.tree),
+                ].stateValues.through.map(toTree),
             ).eqls([throughx, throughy]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("ray1")
-                ].stateValues.direction.map((v) => v.tree),
+                ].stateValues.direction.map(toTree),
             ).eqls([directionx, directiony]);
         }
         await check_items();
@@ -2608,17 +2661,17 @@ describe("Ray Tag Tests @group1", function () {
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("ray1")
-                ].stateValues.endpoint.map((v) => v.tree),
+                ].stateValues.endpoint.map(toTree),
             ).eqls([endpointx, endpointy]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("ray1")
-                ].stateValues.through.map((v) => v.tree),
+                ].stateValues.through.map(toTree),
             ).eqls([throughx, throughy]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("ray1")
-                ].stateValues.direction.map((v) => v.tree),
+                ].stateValues.direction.map(toTree),
             ).eqls([directionx, directiony]);
         }
 
@@ -2661,17 +2714,17 @@ describe("Ray Tag Tests @group1", function () {
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("ray1")
-                ].stateValues.endpoint.map((v) => v.tree),
+                ].stateValues.endpoint.map(toTree),
             ).eqls([endpointx, endpointy]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("ray1")
-                ].stateValues.through.map((v) => v.tree),
+                ].stateValues.through.map(toTree),
             ).eqls([throughx, throughy]);
             expect(
                 stateVariables[
                     await resolvePathToNodeIdx("ray1")
-                ].stateValues.direction.map((v) => v.tree),
+                ].stateValues.direction.map(toTree),
             ).eqls([directionx, directiony]);
         }
 
@@ -2938,17 +2991,17 @@ describe("Ray Tag Tests @group1", function () {
                     expect(
                         stateVariables[
                             await resolvePathToNodeIdx(`g${j}.v${i}`)
-                        ].stateValues.endpoint.map((v) => v.tree),
+                        ].stateValues.endpoint.map(toTree),
                     ).eqls(endpoints[i]);
                     expect(
                         stateVariables[
                             await resolvePathToNodeIdx(`g${j}.v${i}`)
-                        ].stateValues.through.map((v) => v.tree),
+                        ].stateValues.through.map(toTree),
                     ).eqls(throughs[i]);
                     expect(
                         stateVariables[
                             await resolvePathToNodeIdx(`g${j}.v${i}`)
-                        ].stateValues.direction.map((v) => v.tree),
+                        ].stateValues.direction.map(toTree),
                     ).eqls(directions[i]);
                 }
             }

--- a/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
@@ -311,7 +311,7 @@ export function renderAnnotationNodeToSnippetXml(
 }
 
 /**
- * Generate the dynamic annotation-skeleton snippet for a prefigure graph.
+ * Generate the dynamic annotations-skeleton snippet for a prefigure graph.
  */
 export function generateAnnotationSkeletonSnippet(
     graphElement: DastElement,
@@ -328,7 +328,7 @@ export function generateAnnotationSkeletonSnippet(
     const snippet = snippetWithCursorMarker.replace(CURSOR_MARKER, "");
 
     return {
-        key: "annotation-skeleton",
+        key: "annotations-skeleton",
         element: "annotations",
         snippet,
         description: "Auto-generated annotation structure for graph components",

--- a/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
@@ -149,7 +149,7 @@ export function getDescriptionTemplate(
         case "polygon":
             return `A polygon with $${componentName}.numVertices vertices.${unnamedHint}`;
         case "triangle":
-            return `A triangle with $${componentName}.numVertices vertices.${unnamedHint}`;
+            return `A triangle.${unnamedHint}`;
         case "rectangle":
             return `A rectangle of width $${componentName}.width and height $${componentName}.height.${unnamedHint}`;
         case "angle":

--- a/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
@@ -260,11 +260,9 @@ export function buildAnnotationTree(
                 componentName = component.name;
             } else {
                 isUnnamed = true;
-                const nextCount = (unnamedCounters.get(component.type) ?? 0) + 1;
-                unnamedCounters.set(
-                    component.type,
-                    nextCount,
-                );
+                const nextCount =
+                    (unnamedCounters.get(component.type) ?? 0) + 1;
+                unnamedCounters.set(component.type, nextCount);
                 componentName = `unnamed${capitalize(component.type)}${nextCount}`;
             }
 

--- a/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
@@ -3,7 +3,23 @@ import { DastElement, toXml } from "@doenet/parser";
 
 const CURSOR_MARKER = "__ANNOTATION_SKELETON_CURSOR__";
 
-const GRAPHICAL_COMPONENT_TYPES = new Set(["point", "circle", "line"]);
+const GRAPHICAL_COMPONENT_TYPES = new Set([
+    "point",
+    "line",
+    "linesegment",
+    "ray",
+    "vector",
+    "circle",
+    "polyline",
+    "polygon",
+    "angle",
+    "curve",
+    // Aliases that map to primary converters
+    "endpoint",
+    "equilibriumpoint",
+    "triangle",
+    "rectangle",
+]);
 
 export interface GraphicalComponent {
     type: string;
@@ -109,13 +125,41 @@ export function getDescriptionTemplate(
         ? ` (${componentLabel} requires a name for the ref to work.)`
         : "";
 
-    switch (componentType) {
+    // Map aliases to their primary types for description purposes
+    let descriptionType = componentType.toLowerCase();
+    if (
+        descriptionType === "endpoint" ||
+        descriptionType === "equilibriumpoint"
+    ) {
+        descriptionType = "point";
+    } else if (
+        descriptionType === "triangle" ||
+        descriptionType === "rectangle"
+    ) {
+        descriptionType = "polygon";
+    }
+
+    switch (descriptionType) {
         case "point":
             return `A point with x-coordinate $${componentName}.x and y-coordinate $${componentName}.y.${unnamedHint}`;
         case "circle":
             return `A circle with radius $${componentName}.r centered at ($${componentName}.center.x, $${componentName}.center.y).${unnamedHint}`;
         case "line":
             return `A line.${unnamedHint}`;
+        case "linesegment":
+            return `A line segment with endpoints at ($${componentName}.point1.x, $${componentName}.point1.y) and ($${componentName}.point2.x, $${componentName}.point2.y).${unnamedHint}`;
+        case "ray":
+            return `A ray starting at ($${componentName}.point1.x, $${componentName}.point1.y) passing through ($${componentName}.point2.x, $${componentName}.point2.y).${unnamedHint}`;
+        case "vector":
+            return `A vector with tail at ($${componentName}.point1.x, $${componentName}.point1.y) and endpoint at ($${componentName}.point2.x, $${componentName}.point2.y).${unnamedHint}`;
+        case "polyline":
+            return `A polyline with vertices at positions defined by $${componentName}.points.${unnamedHint}`;
+        case "polygon":
+            return `A polygon with $${componentName}.numVertices vertices.${unnamedHint}`;
+        case "angle":
+            return `An angle formed by a vertex at ($${componentName}.vertex.x, $${componentName}.vertex.y).${unnamedHint}`;
+        case "curve":
+            return `A curve.${unnamedHint}`;
         default:
             return `${componentLabel}.${unnamedHint || " (Add a name for this component to enable annotation refs.)"}`;
     }

--- a/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
@@ -71,6 +71,17 @@ function capitalize(value: string) {
     return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
+// Keep aligned with parser macro grammar in `packages/parser/src/macros/macros.peggy`.
+const SIMPLE_IDENTIFIER_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * Return the macro prefix for a component name: `$name` for SimpleIdent names
+ * and `$(name)` for names that contain hyphens, start with a digit, etc.
+ */
+function macroBase(name: string): string {
+    return SIMPLE_IDENTIFIER_REGEX.test(name) ? `$${name}` : `$(${name})`;
+}
+
 type ComponentLabelInfo = {
     singular: string;
     refStem: string;
@@ -149,33 +160,35 @@ export function getDescriptionTemplate(
 
     const normalizedType = componentType.toLowerCase();
 
+    const m = macroBase(componentName);
+
     switch (normalizedType) {
         case "point":
-            return `A point with x-coordinate $${componentName}.x and y-coordinate $${componentName}.y.${unnamedHint}`;
+            return `A point with x-coordinate ${m}.x and y-coordinate ${m}.y.${unnamedHint}`;
         case "endpoint":
-            return `An endpoint with x-coordinate $${componentName}.x and y-coordinate $${componentName}.y.${unnamedHint}`;
+            return `An endpoint with x-coordinate ${m}.x and y-coordinate ${m}.y.${unnamedHint}`;
         case "equilibriumpoint":
-            return `An equilibrium point with x-coordinate $${componentName}.x and y-coordinate $${componentName}.y.${unnamedHint}`;
+            return `An equilibrium point with x-coordinate ${m}.x and y-coordinate ${m}.y.${unnamedHint}`;
         case "circle":
-            return `A circle with radius $${componentName}.radius centered at x-coordinate $${componentName}.center.x and y-coordinate $${componentName}.center.y.${unnamedHint}`;
+            return `A circle with radius ${m}.radius centered at x-coordinate ${m}.center.x and y-coordinate ${m}.center.y.${unnamedHint}`;
         case "function":
             return `A function.${unnamedHint}`;
         case "line":
             return `A line.${unnamedHint}`;
         case "linesegment":
-            return `A line segment from a point with x-coordinate $${componentName}.endpoints[1].x and y-coordinate $${componentName}.endpoints[1].y to a point with x-coordinate $${componentName}.endpoints[2].x and y-coordinate $${componentName}.endpoints[2].y.${unnamedHint}`;
+            return `A line segment from a point with x-coordinate ${m}.endpoints[1].x and y-coordinate ${m}.endpoints[1].y to a point with x-coordinate ${m}.endpoints[2].x and y-coordinate ${m}.endpoints[2].y.${unnamedHint}`;
         case "ray":
-            return `A ray starting at a point with x-coordinate $${componentName}.endpoint.x and y-coordinate $${componentName}.endpoint.y, passing through a point with x-coordinate $${componentName}.through.x and y-coordinate $${componentName}.through.y.${unnamedHint}`;
+            return `A ray starting at a point with x-coordinate ${m}.endpoint.x and y-coordinate ${m}.endpoint.y, passing through a point with x-coordinate ${m}.through.x and y-coordinate ${m}.through.y.${unnamedHint}`;
         case "vector":
-            return `A vector with tail at x-coordinate $${componentName}.tail.x and y-coordinate $${componentName}.tail.y, and head at x-coordinate $${componentName}.head.x and y-coordinate $${componentName}.head.y.${unnamedHint}`;
+            return `A vector with tail at x-coordinate ${m}.tail.x and y-coordinate ${m}.tail.y, and head at x-coordinate ${m}.head.x and y-coordinate ${m}.head.y.${unnamedHint}`;
         case "polyline":
-            return `A polyline with $${componentName}.numVertices vertices.${unnamedHint}`;
+            return `A polyline with ${m}.numVertices vertices.${unnamedHint}`;
         case "polygon":
-            return `A polygon with $${componentName}.numVertices vertices.${unnamedHint}`;
+            return `A polygon with ${m}.numVertices vertices.${unnamedHint}`;
         case "triangle":
             return `A triangle.${unnamedHint}`;
         case "rectangle":
-            return `A rectangle of width $${componentName}.width and height $${componentName}.height.${unnamedHint}`;
+            return `A rectangle of width ${m}.width and height ${m}.height.${unnamedHint}`;
         case "angle":
             return `An angle.${unnamedHint}`;
         case "curve":
@@ -293,7 +306,7 @@ export function buildAnnotationTree(
 
             return {
                 type: "annotation",
-                ref: `$${componentName}`,
+                ref: macroBase(componentName),
                 text: getDescriptionTemplate(
                     component.type,
                     componentName,

--- a/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
@@ -70,6 +70,28 @@ function capitalize(value: string) {
     return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
+type ComponentLabelInfo = {
+    singular: string;
+    refStem: string;
+};
+
+const COMPONENT_LABELS: Record<string, ComponentLabelInfo> = {
+    linesegment: { singular: "line segment", refStem: "LineSegment" },
+    equilibriumpoint: {
+        singular: "equilibrium point",
+        refStem: "EquilibriumPoint",
+    },
+};
+
+function getComponentLabelInfo(componentType: string): ComponentLabelInfo {
+    return (
+        COMPONENT_LABELS[componentType] ?? {
+            singular: componentType,
+            refStem: capitalize(componentType),
+        }
+    );
+}
+
 /**
  * Recursively extract graphical descendants from a graph element.
  * Existing `<annotations>` subtrees are intentionally ignored.
@@ -117,7 +139,9 @@ export function getDescriptionTemplate(
     componentName: string,
     isUnnamed = false,
 ): string {
-    const componentLabel = capitalize(componentType);
+    const componentLabel = capitalize(
+        getComponentLabelInfo(componentType).singular,
+    );
     const unnamedHint = isUnnamed
         ? ` (${componentLabel} requires a name for the ref to work.)`
         : "";
@@ -263,7 +287,7 @@ export function buildAnnotationTree(
                 const nextCount =
                     (unnamedCounters.get(component.type) ?? 0) + 1;
                 unnamedCounters.set(component.type, nextCount);
-                componentName = `unnamed${capitalize(component.type)}${nextCount}`;
+                componentName = `unnamed${getComponentLabelInfo(component.type).refStem}${nextCount}`;
             }
 
             return {

--- a/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
@@ -125,23 +125,15 @@ export function getDescriptionTemplate(
         ? ` (${componentLabel} requires a name for the ref to work.)`
         : "";
 
-    // Map aliases to their primary types for description purposes
-    let descriptionType = componentType.toLowerCase();
-    if (
-        descriptionType === "endpoint" ||
-        descriptionType === "equilibriumpoint"
-    ) {
-        descriptionType = "point";
-    } else if (
-        descriptionType === "triangle" ||
-        descriptionType === "rectangle"
-    ) {
-        descriptionType = "polygon";
-    }
+    const normalizedType = componentType.toLowerCase();
 
-    switch (descriptionType) {
+    switch (normalizedType) {
         case "point":
             return `A point with x-coordinate $${componentName}.x and y-coordinate $${componentName}.y.${unnamedHint}`;
+        case "endpoint":
+            return `An endpoint with x-coordinate $${componentName}.x and y-coordinate $${componentName}.y.${unnamedHint}`;
+        case "equilibriumpoint":
+            return `An equilibrium point with x-coordinate $${componentName}.x and y-coordinate $${componentName}.y.${unnamedHint}`;
         case "circle":
             return `A circle with radius $${componentName}.r centered at ($${componentName}.center.x, $${componentName}.center.y).${unnamedHint}`;
         case "line":
@@ -156,6 +148,10 @@ export function getDescriptionTemplate(
             return `A polyline with vertices at positions defined by $${componentName}.points.${unnamedHint}`;
         case "polygon":
             return `A polygon with $${componentName}.numVertices vertices.${unnamedHint}`;
+        case "triangle":
+            return `A triangle with $${componentName}.numVertices vertices.${unnamedHint}`;
+        case "rectangle":
+            return `A rectangle of width $${componentName}.width and height $${componentName}.height.${unnamedHint}`;
         case "angle":
             return `An angle formed by a vertex at ($${componentName}.vertex.x, $${componentName}.vertex.y).${unnamedHint}`;
         case "curve":

--- a/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
@@ -135,15 +135,15 @@ export function getDescriptionTemplate(
         case "equilibriumpoint":
             return `An equilibrium point with x-coordinate $${componentName}.x and y-coordinate $${componentName}.y.${unnamedHint}`;
         case "circle":
-            return `A circle with radius $${componentName}.r centered at ($${componentName}.center.x, $${componentName}.center.y).${unnamedHint}`;
+            return `A circle with radius $${componentName}.r centered at x-coordinate $${componentName}.center.x and y-coordinate $${componentName}.center.y.${unnamedHint}`;
         case "line":
             return `A line.${unnamedHint}`;
         case "linesegment":
-            return `A line segment with endpoints at ($${componentName}.point1.x, $${componentName}.point1.y) and ($${componentName}.point2.x, $${componentName}.point2.y).${unnamedHint}`;
+            return `A line segment with endpoints at first point with x-coordinate $${componentName}.point1.x and y-coordinate $${componentName}.point1.y, and second point with x-coordinate $${componentName}.point2.x and y-coordinate $${componentName}.point2.y.${unnamedHint}`;
         case "ray":
-            return `A ray starting at ($${componentName}.point1.x, $${componentName}.point1.y) passing through ($${componentName}.point2.x, $${componentName}.point2.y).${unnamedHint}`;
+            return `A ray starting at x-coordinate $${componentName}.point1.x and y-coordinate $${componentName}.point1.y, passing through x-coordinate $${componentName}.point2.x and y-coordinate $${componentName}.point2.y.${unnamedHint}`;
         case "vector":
-            return `A vector with tail at ($${componentName}.point1.x, $${componentName}.point1.y) and endpoint at ($${componentName}.point2.x, $${componentName}.point2.y).${unnamedHint}`;
+            return `A vector with tail at x-coordinate $${componentName}.point1.x and y-coordinate $${componentName}.point1.y, and endpoint at x-coordinate $${componentName}.point2.x and y-coordinate $${componentName}.point2.y.${unnamedHint}`;
         case "polyline":
             return `A polyline with vertices at positions defined by $${componentName}.points.${unnamedHint}`;
         case "polygon":
@@ -153,7 +153,7 @@ export function getDescriptionTemplate(
         case "rectangle":
             return `A rectangle of width $${componentName}.width and height $${componentName}.height.${unnamedHint}`;
         case "angle":
-            return `An angle formed by a vertex at ($${componentName}.vertex.x, $${componentName}.vertex.y).${unnamedHint}`;
+            return `An angle formed by a vertex at x-coordinate $${componentName}.vertex.x and y-coordinate $${componentName}.vertex.y.${unnamedHint}`;
         case "curve":
             return `A curve.${unnamedHint}`;
         default:

--- a/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
@@ -25,8 +25,6 @@ const GRAPHICAL_COMPONENT_TYPES = new Set([
 export interface GraphicalComponent {
     type: string;
     name?: string;
-    elementIndex: number;
-    dastElement: DastElement;
 }
 
 export interface AnnotationNode {
@@ -81,7 +79,7 @@ export function extractGraphicalChildren(
 ): GraphicalComponent[] {
     const graphicalComponents: GraphicalComponent[] = [];
 
-    function visitElement(element: DastElement, elementIndex: number) {
+    function visitElement(element: DastElement) {
         const normalizedType = element.name.toLowerCase();
 
         if (normalizedType === "annotations") {
@@ -92,21 +90,19 @@ export function extractGraphicalChildren(
             graphicalComponents.push({
                 type: normalizedType,
                 name: getAttributeValue(element, "name"),
-                elementIndex,
-                dastElement: element,
             });
         }
 
-        element.children.forEach((child, index) => {
+        element.children.forEach((child) => {
             if (child.type === "element") {
-                visitElement(child, index);
+                visitElement(child);
             }
         });
     }
 
-    graphElement.children.forEach((child, index) => {
+    graphElement.children.forEach((child) => {
         if (child.type === "element") {
-            visitElement(child, index);
+            visitElement(child);
         }
     });
 
@@ -136,17 +132,17 @@ export function getDescriptionTemplate(
         case "equilibriumpoint":
             return `An equilibrium point with x-coordinate $${componentName}.x and y-coordinate $${componentName}.y.${unnamedHint}`;
         case "circle":
-            return `A circle with radius $${componentName}.r centered at x-coordinate $${componentName}.center.x and y-coordinate $${componentName}.center.y.${unnamedHint}`;
+            return `A circle with radius $${componentName}.radius centered at x-coordinate $${componentName}.center.x and y-coordinate $${componentName}.center.y.${unnamedHint}`;
         case "function":
             return `A function.${unnamedHint}`;
         case "line":
             return `A line.${unnamedHint}`;
         case "linesegment":
-            return `A line segment from a point with x-coordinate $${componentName}.point1.x and y-coordinate $${componentName}.point1.y to a point with x-coordinate $${componentName}.point2.x and y-coordinate $${componentName}.point2.y.${unnamedHint}`;
+            return `A line segment from a point with x-coordinate $${componentName}.endpoints[1].x and y-coordinate $${componentName}.endpoints[1].y to a point with x-coordinate $${componentName}.endpoints[2].x and y-coordinate $${componentName}.endpoints[2].y.${unnamedHint}`;
         case "ray":
-            return `A ray starting at a point with x-coordinate $${componentName}.point1.x and y-coordinate $${componentName}.point1.y, passing through a point with x-coordinate $${componentName}.point2.x and y-coordinate $${componentName}.point2.y.${unnamedHint}`;
+            return `A ray starting at a point with x-coordinate $${componentName}.endpoint.x and y-coordinate $${componentName}.endpoint.y, passing through a point with x-coordinate $${componentName}.through.x and y-coordinate $${componentName}.through.y.${unnamedHint}`;
         case "vector":
-            return `A vector with tail at x-coordinate $${componentName}.point1.x and y-coordinate $${componentName}.point1.y, and endpoint at x-coordinate $${componentName}.point2.x and y-coordinate $${componentName}.point2.y.${unnamedHint}`;
+            return `A vector with tail at x-coordinate $${componentName}.tail.x and y-coordinate $${componentName}.tail.y, and head at x-coordinate $${componentName}.head.x and y-coordinate $${componentName}.head.y.${unnamedHint}`;
         case "polyline":
             return `A polyline with $${componentName}.numVertices vertices.${unnamedHint}`;
         case "polygon":
@@ -178,6 +174,35 @@ const NUMBER_WORDS = [
     "ten",
 ];
 
+function getGraphLevelTypeDescriptor(type: string, count: number): string {
+    switch (type) {
+        case "line":
+            return count === 1 ? "a line" : `${countAsWord(count)} lines`;
+        case "linesegment":
+            return count === 1
+                ? "a line segment"
+                : `${countAsWord(count)} line segments`;
+        case "endpoint":
+            return count === 1
+                ? "an endpoint"
+                : `${countAsWord(count)} endpoints`;
+        case "equilibriumpoint":
+            return count === 1
+                ? "an equilibrium point"
+                : `${countAsWord(count)} equilibrium points`;
+        case "angle":
+            return count === 1 ? "an angle" : `${countAsWord(count)} angles`;
+        default: {
+            const noun = count === 1 ? type : `${type}s`;
+            return count === 1 ? `a ${noun}` : `${countAsWord(count)} ${noun}`;
+        }
+    }
+}
+
+function countAsWord(count: number): string {
+    return count < NUMBER_WORDS.length ? NUMBER_WORDS[count] : String(count);
+}
+
 /**
  * Build the text for the top-level graph annotation describing its graphical
  * contents, e.g. "A graph of a line and two points."
@@ -201,10 +226,7 @@ function buildGraphLevelAnnotationText(
 
     const parts = typeOrder.map((type) => {
         const count = typeCounts.get(type) ?? 1;
-        const noun = count === 1 ? type : `${type}s`;
-        const numWord =
-            count < NUMBER_WORDS.length ? NUMBER_WORDS[count] : String(count);
-        return `${numWord} ${noun}`;
+        return getGraphLevelTypeDescriptor(type, count);
     });
 
     if (parts.length === 0) {
@@ -230,14 +252,20 @@ export function buildAnnotationTree(
 
     const childAnnotations: AnnotationNode[] = graphicalComponents.map(
         (component) => {
-            let componentName = component.name;
-            let isUnnamed = false;
-            if (!componentName) {
-                const priorCount = unnamedCounters.get(component.type) ?? 0;
-                const nextCount = priorCount + 1;
-                unnamedCounters.set(component.type, nextCount);
-                componentName = `unnamed${capitalize(component.type)}${nextCount}`;
+            let componentName: string;
+            let isUnnamed: boolean;
+
+            if (component.name) {
+                isUnnamed = false;
+                componentName = component.name;
+            } else {
                 isUnnamed = true;
+                const nextCount = (unnamedCounters.get(component.type) ?? 0) + 1;
+                unnamedCounters.set(
+                    component.type,
+                    nextCount,
+                );
+                componentName = `unnamed${capitalize(component.type)}${nextCount}`;
             }
 
             return {

--- a/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
@@ -1,5 +1,6 @@
 import type { CompletionSnippetCursor } from "@doenet/static-assets/completion-snippet-protocol";
-import { DastElement, toXml } from "@doenet/parser";
+import { toXml } from "@doenet/parser";
+import type { DastElement } from "@doenet/parser";
 
 const CURSOR_MARKER = "__ANNOTATION_SKELETON_CURSOR__";
 

--- a/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
@@ -10,6 +10,7 @@ const GRAPHICAL_COMPONENT_TYPES = new Set([
     "ray",
     "vector",
     "circle",
+    "function",
     "polyline",
     "polygon",
     "angle",
@@ -136,16 +137,18 @@ export function getDescriptionTemplate(
             return `An equilibrium point with x-coordinate $${componentName}.x and y-coordinate $${componentName}.y.${unnamedHint}`;
         case "circle":
             return `A circle with radius $${componentName}.r centered at x-coordinate $${componentName}.center.x and y-coordinate $${componentName}.center.y.${unnamedHint}`;
+        case "function":
+            return `A function.${unnamedHint}`;
         case "line":
             return `A line.${unnamedHint}`;
         case "linesegment":
-            return `A line segment with endpoints at first point with x-coordinate $${componentName}.point1.x and y-coordinate $${componentName}.point1.y, and second point with x-coordinate $${componentName}.point2.x and y-coordinate $${componentName}.point2.y.${unnamedHint}`;
+            return `A line segment from a point with x-coordinate $${componentName}.point1.x and y-coordinate $${componentName}.point1.y to a point with x-coordinate $${componentName}.point2.x and y-coordinate $${componentName}.point2.y.${unnamedHint}`;
         case "ray":
-            return `A ray starting at x-coordinate $${componentName}.point1.x and y-coordinate $${componentName}.point1.y, passing through x-coordinate $${componentName}.point2.x and y-coordinate $${componentName}.point2.y.${unnamedHint}`;
+            return `A ray starting at a point with x-coordinate $${componentName}.point1.x and y-coordinate $${componentName}.point1.y, passing through a point with x-coordinate $${componentName}.point2.x and y-coordinate $${componentName}.point2.y.${unnamedHint}`;
         case "vector":
             return `A vector with tail at x-coordinate $${componentName}.point1.x and y-coordinate $${componentName}.point1.y, and endpoint at x-coordinate $${componentName}.point2.x and y-coordinate $${componentName}.point2.y.${unnamedHint}`;
         case "polyline":
-            return `A polyline with vertices at positions defined by $${componentName}.points.${unnamedHint}`;
+            return `A polyline with $${componentName}.numVertices vertices.${unnamedHint}`;
         case "polygon":
             return `A polygon with $${componentName}.numVertices vertices.${unnamedHint}`;
         case "triangle":
@@ -153,7 +156,7 @@ export function getDescriptionTemplate(
         case "rectangle":
             return `A rectangle of width $${componentName}.width and height $${componentName}.height.${unnamedHint}`;
         case "angle":
-            return `An angle formed by a vertex at x-coordinate $${componentName}.vertex.x and y-coordinate $${componentName}.vertex.y.${unnamedHint}`;
+            return `An angle.${unnamedHint}`;
         case "curve":
             return `A curve.${unnamedHint}`;
         default:

--- a/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/generate-annotation-skeleton.ts
@@ -1,0 +1,299 @@
+import type { CompletionSnippetCursor } from "@doenet/static-assets/completion-snippet-protocol";
+import { DastElement, toXml } from "@doenet/parser";
+
+const CURSOR_MARKER = "__ANNOTATION_SKELETON_CURSOR__";
+
+const GRAPHICAL_COMPONENT_TYPES = new Set(["point", "circle", "line"]);
+
+export interface GraphicalComponent {
+    type: string;
+    name?: string;
+    elementIndex: number;
+    dastElement: DastElement;
+}
+
+export interface AnnotationNode {
+    type: "annotations" | "annotation";
+    ref?: string;
+    text?: string;
+    children?: AnnotationNode[];
+}
+
+export type ProcessedSnippet = {
+    key: string;
+    element: string;
+    snippet: string;
+    description: string;
+    cursor?: CompletionSnippetCursor;
+};
+
+function getAttributeValue(
+    element: DastElement,
+    attributeName: string,
+): string | undefined {
+    const attr = element.attributes[attributeName];
+    if (!attr) {
+        return undefined;
+    }
+
+    const value = toXml(attr.children).trim();
+    return value.length > 0 ? value : undefined;
+}
+
+function escapeXmlAttributeValue(value: string): string {
+    return value
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/\"/g, "&quot;");
+}
+
+function capitalize(value: string) {
+    if (value.length === 0) {
+        return value;
+    }
+    return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+/**
+ * Recursively extract graphical descendants from a graph element.
+ * Existing `<annotations>` subtrees are intentionally ignored.
+ */
+export function extractGraphicalChildren(
+    graphElement: DastElement,
+): GraphicalComponent[] {
+    const graphicalComponents: GraphicalComponent[] = [];
+
+    function visitElement(element: DastElement, elementIndex: number) {
+        const normalizedType = element.name.toLowerCase();
+
+        if (normalizedType === "annotations") {
+            return;
+        }
+
+        if (GRAPHICAL_COMPONENT_TYPES.has(normalizedType)) {
+            graphicalComponents.push({
+                type: normalizedType,
+                name: getAttributeValue(element, "name"),
+                elementIndex,
+                dastElement: element,
+            });
+        }
+
+        element.children.forEach((child, index) => {
+            if (child.type === "element") {
+                visitElement(child, index);
+            }
+        });
+    }
+
+    graphElement.children.forEach((child, index) => {
+        if (child.type === "element") {
+            visitElement(child, index);
+        }
+    });
+
+    return graphicalComponents;
+}
+
+/**
+ * Get the default annotation text template for a graphical component.
+ */
+export function getDescriptionTemplate(
+    componentType: string,
+    componentName: string,
+    isUnnamed = false,
+): string {
+    const componentLabel = capitalize(componentType);
+    const unnamedHint = isUnnamed
+        ? ` (${componentLabel} requires a name for the ref to work.)`
+        : "";
+
+    switch (componentType) {
+        case "point":
+            return `A point with x-coordinate $${componentName}.x and y-coordinate $${componentName}.y.${unnamedHint}`;
+        case "circle":
+            return `A circle with radius $${componentName}.r centered at ($${componentName}.center.x, $${componentName}.center.y).${unnamedHint}`;
+        case "line":
+            return `A line.${unnamedHint}`;
+        default:
+            return `${componentLabel}.${unnamedHint || " (Add a name for this component to enable annotation refs.)"}`;
+    }
+}
+
+const NUMBER_WORDS = [
+    "",
+    "a",
+    "two",
+    "three",
+    "four",
+    "five",
+    "six",
+    "seven",
+    "eight",
+    "nine",
+    "ten",
+];
+
+/**
+ * Build the text for the top-level graph annotation describing its graphical
+ * contents, e.g. "A graph of a line and two points."
+ */
+function buildGraphLevelAnnotationText(
+    graphicalComponents: GraphicalComponent[],
+): string {
+    const typeCounts = new Map<string, number>();
+    const typeOrder: string[] = [];
+
+    for (const component of graphicalComponents) {
+        if (!typeCounts.has(component.type)) {
+            typeOrder.push(component.type);
+            typeCounts.set(component.type, 0);
+        }
+        typeCounts.set(
+            component.type,
+            (typeCounts.get(component.type) ?? 0) + 1,
+        );
+    }
+
+    const parts = typeOrder.map((type) => {
+        const count = typeCounts.get(type) ?? 1;
+        const noun = count === 1 ? type : `${type}s`;
+        const numWord =
+            count < NUMBER_WORDS.length ? NUMBER_WORDS[count] : String(count);
+        return `${numWord} ${noun}`;
+    });
+
+    if (parts.length === 0) {
+        return "A graph.";
+    } else if (parts.length === 1) {
+        return `A graph of ${parts[0]}.`;
+    } else if (parts.length === 2) {
+        return `A graph of ${parts[0]} and ${parts[1]}.`;
+    } else {
+        const last = parts[parts.length - 1];
+        const rest = parts.slice(0, -1).join(", ");
+        return `A graph of ${rest}, and ${last}.`;
+    }
+}
+
+/**
+ * Build annotations tree with one graph-level annotation and nested children.
+ */
+export function buildAnnotationTree(
+    graphicalComponents: GraphicalComponent[],
+): AnnotationNode {
+    const unnamedCounters = new Map<string, number>();
+
+    const childAnnotations: AnnotationNode[] = graphicalComponents.map(
+        (component) => {
+            let componentName = component.name;
+            let isUnnamed = false;
+            if (!componentName) {
+                const priorCount = unnamedCounters.get(component.type) ?? 0;
+                const nextCount = priorCount + 1;
+                unnamedCounters.set(component.type, nextCount);
+                componentName = `unnamed${capitalize(component.type)}${nextCount}`;
+                isUnnamed = true;
+            }
+
+            return {
+                type: "annotation",
+                ref: `$${componentName}`,
+                text: getDescriptionTemplate(
+                    component.type,
+                    componentName,
+                    isUnnamed,
+                ),
+            };
+        },
+    );
+
+    const graphLevelText = buildGraphLevelAnnotationText(graphicalComponents);
+
+    return {
+        type: "annotations",
+        children: [
+            {
+                type: "annotation",
+                text: `${graphLevelText}${CURSOR_MARKER}`,
+                children: childAnnotations,
+            },
+        ],
+    };
+}
+
+/**
+ * Render annotation tree to DoenetML snippet XML.
+ */
+export function renderAnnotationNodeToSnippetXml(
+    annotationNode: AnnotationNode,
+    indentLevel = 0,
+): string {
+    const indent = "  ".repeat(indentLevel);
+
+    if (annotationNode.type === "annotations") {
+        const renderedChildren = (annotationNode.children ?? []).map((child) =>
+            renderAnnotationNodeToSnippetXml(child, indentLevel + 1),
+        );
+        return [
+            `${indent}<annotations>`,
+            ...renderedChildren,
+            `${indent}</annotations>`,
+        ].join("\n");
+    }
+
+    const attrs: string[] = [];
+    if (annotationNode.ref) {
+        attrs.push(`ref=\"${escapeXmlAttributeValue(annotationNode.ref)}\"`);
+    }
+    if (annotationNode.text) {
+        attrs.push(`text=\"${escapeXmlAttributeValue(annotationNode.text)}\"`);
+    }
+
+    const renderedAttributes = attrs.length ? ` ${attrs.join(" ")}` : "";
+    const children = annotationNode.children ?? [];
+    if (children.length === 0) {
+        return `${indent}<annotation${renderedAttributes} />`;
+    }
+
+    const renderedChildren = children.map((child) =>
+        renderAnnotationNodeToSnippetXml(child, indentLevel + 1),
+    );
+    return [
+        `${indent}<annotation${renderedAttributes}>`,
+        ...renderedChildren,
+        `${indent}</annotation>`,
+    ].join("\n");
+}
+
+/**
+ * Generate the dynamic annotation-skeleton snippet for a prefigure graph.
+ */
+export function generateAnnotationSkeletonSnippet(
+    graphElement: DastElement,
+): ProcessedSnippet | null {
+    const graphicalComponents = extractGraphicalChildren(graphElement);
+    if (graphicalComponents.length === 0) {
+        return null;
+    }
+
+    const annotationTree = buildAnnotationTree(graphicalComponents);
+    const snippetWithCursorMarker =
+        renderAnnotationNodeToSnippetXml(annotationTree);
+    const caretOffset = snippetWithCursorMarker.indexOf(CURSOR_MARKER);
+    const snippet = snippetWithCursorMarker.replace(CURSOR_MARKER, "");
+
+    return {
+        key: "annotation-skeleton",
+        element: "annotations",
+        snippet,
+        description: "Auto-generated annotation structure for graph components",
+        cursor:
+            caretOffset >= 0
+                ? {
+                      caretOffset,
+                  }
+                : undefined,
+    };
+}

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -220,7 +220,7 @@ function isPrefigureGraphElement(
     );
 }
 
-function isPreFigureGraph(
+function isPrefigureGraph(
     autoCompleter: AutoCompleter,
     contextElement: DastElement | null,
 ): contextElement is DastElement {
@@ -242,7 +242,7 @@ function createDynamicSnippetCompletionItems(
         return [];
     }
 
-    if (!isPreFigureGraph(autoCompleter, contextElement)) {
+    if (!isPrefigureGraph(autoCompleter, contextElement)) {
         return [];
     }
 

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -6,7 +6,9 @@ import type {
     CompletionSnippetCompletionItemData,
     CompletionSnippetCursor,
 } from "@doenet/static-assets/completion-snippet-protocol";
+import { DastElement, toXml } from "@doenet/parser";
 import { AutoCompleter } from "../index";
+import { generateAnnotationSkeletonSnippet } from "./generate-annotation-skeleton";
 
 // Keep these aligned with parser grammar in `packages/parser/src/macros/macros.peggy`:
 // - SimpleIdent = [a-zA-Z_][a-zA-Z0-9_]*
@@ -193,6 +195,76 @@ function createSnippetCompletionItems(
     });
 }
 
+function getElementAttributeValue(
+    element: DastElement,
+    attributeName: string,
+): string | undefined {
+    const attr = element.attributes[attributeName];
+    if (!attr) {
+        return undefined;
+    }
+
+    const value = toXml(attr.children).trim();
+    return value.length > 0 ? value : undefined;
+}
+
+function isPrefigureGraphElement(
+    autoCompleter: AutoCompleter,
+    element: DastElement,
+): boolean {
+    return (
+        autoCompleter.normalizeElementName(element.name) === "graph" &&
+        getElementAttributeValue(element, "renderer")?.toLowerCase() ===
+            "prefigure"
+    );
+}
+
+function isPreFigureGraph(
+    autoCompleter: AutoCompleter,
+    contextElement: DastElement | null,
+): contextElement is DastElement {
+    return (
+        contextElement !== null &&
+        isPrefigureGraphElement(autoCompleter, contextElement)
+    );
+}
+
+function createDynamicSnippetCompletionItems(
+    autoCompleter: AutoCompleter,
+    allowedElementNames: string[],
+    contextElement: DastElement | null,
+    startOffset: number,
+    endOffset: number,
+    typedPrefix = "",
+): CompletionItem[] {
+    if (!allowedElementNames.includes("annotations")) {
+        return [];
+    }
+
+    if (!isPreFigureGraph(autoCompleter, contextElement)) {
+        return [];
+    }
+
+    const dynamicSnippet = generateAnnotationSkeletonSnippet(contextElement);
+    if (!dynamicSnippet) {
+        return [];
+    }
+
+    if (
+        typedPrefix &&
+        !dynamicSnippet.key.toLowerCase().startsWith(typedPrefix.toLowerCase())
+    ) {
+        return [];
+    }
+
+    return createSnippetCompletionItems(
+        autoCompleter.sourceObj,
+        [dynamicSnippet],
+        startOffset,
+        endOffset,
+    );
+}
+
 /**
  * Create schema element and snippet completion items for a set of allowed elements.
  */
@@ -202,6 +274,7 @@ function createElementAndSnippetCompletionItems(
     startOffset: number,
     endOffset: number,
     typedPrefix = "",
+    contextElement: DastElement | null = null,
 ): CompletionItem[] {
     const prefixLower = typedPrefix.toLowerCase();
     const schemaItems = allowedElementNames
@@ -224,7 +297,16 @@ function createElementAndSnippetCompletionItems(
         endOffset,
     );
 
-    return [...schemaItems, ...snippetItems];
+    const dynamicSnippetItems = createDynamicSnippetCompletionItems(
+        autoCompleter,
+        allowedElementNames,
+        contextElement,
+        startOffset,
+        endOffset,
+        typedPrefix,
+    );
+
+    return [...schemaItems, ...snippetItems, ...dynamicSnippetItems];
 }
 
 /**
@@ -613,6 +695,8 @@ export function getCompletionItems(
             allowedChildrenNames,
             offset - 1,
             offset,
+            "",
+            containingElement.node,
         );
 
         if (closed) {
@@ -671,6 +755,7 @@ export function getCompletionItems(
             tagStartOffset,
             offset,
             currentText,
+            parent?.type === "element" ? parent : null,
         );
     }
 

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -6,7 +6,8 @@ import type {
     CompletionSnippetCompletionItemData,
     CompletionSnippetCursor,
 } from "@doenet/static-assets/completion-snippet-protocol";
-import { DastElement, toXml } from "@doenet/parser";
+import { toXml } from "@doenet/parser";
+import type { DastElement } from "@doenet/parser";
 import { AutoCompleter } from "../index";
 import { generateAnnotationSkeletonSnippet } from "./generate-annotation-skeleton";
 

--- a/packages/lsp-tools/test/annotation-skeleton-snippet.test.ts
+++ b/packages/lsp-tools/test/annotation-skeleton-snippet.test.ts
@@ -98,6 +98,7 @@ describe("Annotation skeleton snippet generation", () => {
 
     it("generates descriptions for all supported graphical components", () => {
         const source = `<graph renderer="prefigure">
+  <function name="f" />
   <lineSegment name="seg" />
   <ray name="r" />
   <vector name="v" />
@@ -111,6 +112,7 @@ describe("Annotation skeleton snippet generation", () => {
         const snippet = generateAnnotationSkeletonSnippet(graph);
 
         expect(snippet).toBeTruthy();
+        expect(snippet?.snippet).toContain('ref="$f"');
         expect(snippet?.snippet).toContain('ref="$seg"');
         expect(snippet?.snippet).toContain('ref="$r"');
         expect(snippet?.snippet).toContain('ref="$v"');
@@ -119,6 +121,7 @@ describe("Annotation skeleton snippet generation", () => {
         expect(snippet?.snippet).toContain('ref="$a"');
         expect(snippet?.snippet).toContain('ref="$curv"');
         // Verify descriptions mention relevant properties
+        expect(snippet?.snippet).toContain("function");
         expect(snippet?.snippet).toContain("line segment");
         expect(snippet?.snippet).toContain("ray");
         expect(snippet?.snippet).toContain("vector");
@@ -170,6 +173,7 @@ describe("Annotation skeleton autocomplete integration", () => {
                 children: [
                     "point",
                     "circle",
+                    "function",
                     "line",
                     "lineSegment",
                     "ray",
@@ -194,6 +198,7 @@ describe("Annotation skeleton autocomplete integration", () => {
                 children: [
                     "point",
                     "circle",
+                    "function",
                     "line",
                     "lineSegment",
                     "ray",
@@ -231,6 +236,13 @@ describe("Annotation skeleton autocomplete integration", () => {
             },
             {
                 name: "circle",
+                children: [],
+                attributes: [{ name: "name" }],
+                top: false,
+                acceptsStringChildren: false,
+            },
+            {
+                name: "function",
                 children: [],
                 attributes: [{ name: "name" }],
                 top: false,

--- a/packages/lsp-tools/test/annotation-skeleton-snippet.test.ts
+++ b/packages/lsp-tools/test/annotation-skeleton-snippet.test.ts
@@ -98,6 +98,7 @@ describe("Annotation skeleton snippet generation", () => {
 
     it("generates descriptions for all supported graphical components", () => {
         const source = `<graph renderer="prefigure">
+  <circle name="c" />
   <function name="f" />
   <lineSegment name="seg" />
   <ray name="r" />
@@ -112,7 +113,7 @@ describe("Annotation skeleton snippet generation", () => {
         const snippet = generateAnnotationSkeletonSnippet(graph);
 
         expect(snippet).toBeTruthy();
-        expect(snippet?.snippet).toContain('ref="$f"');
+        expect(snippet?.snippet).toContain('ref="$c"');
         expect(snippet?.snippet).toContain('ref="$seg"');
         expect(snippet?.snippet).toContain('ref="$r"');
         expect(snippet?.snippet).toContain('ref="$v"');
@@ -129,6 +130,39 @@ describe("Annotation skeleton snippet generation", () => {
         expect(snippet?.snippet).toContain("polyline");
         expect(snippet?.snippet).toContain("angle");
         expect(snippet?.snippet).toContain("curve");
+
+        // Verify component property paths match the published schema names
+        expect(snippet?.snippet).toContain("$c.radius");
+        expect(snippet?.snippet).toContain("$c.center.x");
+        expect(snippet?.snippet).toContain("$c.center.y");
+        expect(snippet?.snippet).toContain("$seg.endpoints[1].x");
+        expect(snippet?.snippet).toContain("$seg.endpoints[1].y");
+        expect(snippet?.snippet).toContain("$seg.endpoints[2].x");
+        expect(snippet?.snippet).toContain("$seg.endpoints[2].y");
+        expect(snippet?.snippet).toContain("$r.endpoint.x");
+        expect(snippet?.snippet).toContain("$r.endpoint.y");
+        expect(snippet?.snippet).toContain("$r.through.x");
+        expect(snippet?.snippet).toContain("$r.through.y");
+        expect(snippet?.snippet).toContain("$v.tail.x");
+        expect(snippet?.snippet).toContain("$v.tail.y");
+        expect(snippet?.snippet).toContain("$v.head.x");
+        expect(snippet?.snippet).toContain("$v.head.y");
+        expect(snippet?.snippet).toContain(
+            "A vector with tail at x-coordinate $v.tail.x and y-coordinate $v.tail.y, and head at x-coordinate $v.head.x and y-coordinate $v.head.y.",
+        );
+        expect(snippet?.snippet).toContain("A function.");
+        expect(snippet?.snippet).toContain('ref="$f"');
+        expect(snippet?.snippet).not.toContain("$seg.endpoints[1][1]");
+        expect(snippet?.snippet).not.toContain("$r.endpoint[1]");
+
+        // Ensure old invalid path suggestions are not emitted
+        expect(snippet?.snippet).not.toMatch(/\$c\.r(\W|$)/);
+        expect(snippet?.snippet).not.toContain("$seg.point1");
+        expect(snippet?.snippet).not.toContain("$seg.point2");
+        expect(snippet?.snippet).not.toContain("$r.point1");
+        expect(snippet?.snippet).not.toContain("$r.point2");
+        expect(snippet?.snippet).not.toContain("$v.point1");
+        expect(snippet?.snippet).not.toContain("$v.point2");
     });
 
     it("handles component aliases (endpoint, equilibriumPoint, triangle, rectangle)", () => {
@@ -152,6 +186,22 @@ describe("Annotation skeleton snippet generation", () => {
         expect(snippet?.snippet).toContain("An equilibrium point"); // equilibriumPoint description
         expect(snippet?.snippet).toContain("A triangle."); // triangle description (simple, no vertices count)
         expect(snippet?.snippet).toContain("A rectangle"); // rectangle description
+    });
+
+    it("uses readable graph-level wording for special component names", () => {
+        const source = `<graph renderer="prefigure">
+  <endpoint name="ep" />
+  <angle name="a" />
+  <lineSegment name="s1" />
+  <lineSegment name="s2" />
+</graph>`;
+        const graph = getFirstGraphElement(source);
+
+        const snippet = generateAnnotationSkeletonSnippet(graph);
+
+        expect(snippet?.snippet).toContain(
+            '<annotation text="A graph of an endpoint, an angle, and two line segments.">',
+        );
     });
 
     it("returns null when graph has no supported graphical descendants", () => {

--- a/packages/lsp-tools/test/annotation-skeleton-snippet.test.ts
+++ b/packages/lsp-tools/test/annotation-skeleton-snippet.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "vitest";
+import type { DastElement } from "@doenet/parser";
+import { CompletionItemKind } from "vscode-languageserver/browser";
+
+import { DoenetSourceObject } from "../src/doenet-source-object";
+import { AutoCompleter } from "../src";
+import {
+    extractGraphicalChildren,
+    generateAnnotationSkeletonSnippet,
+} from "../src/auto-completer/methods/generate-annotation-skeleton";
+
+function getFirstGraphElement(source: string): DastElement {
+    const sourceObj = new DoenetSourceObject();
+    sourceObj.setSource(source);
+    const graphElement = sourceObj.dast.children.find(
+        (child) => child.type === "element" && child.name === "graph",
+    );
+    if (!graphElement || graphElement.type !== "element") {
+        throw new Error("Expected source to contain a <graph> element.");
+    }
+    return graphElement;
+}
+
+describe("Annotation skeleton snippet generation", () => {
+    it("extracts graphical descendants in document order and ignores <annotations>", () => {
+        const source = `<graph renderer="prefigure">
+  <point name="P" />
+  <group>
+    <line name="L" />
+  </group>
+  <annotations>
+    <annotation text="ignore me" />
+  </annotations>
+  <circle name="c" />
+</graph>`;
+        const graph = getFirstGraphElement(source);
+        const components = extractGraphicalChildren(graph);
+
+        expect(components.map((component) => component.type)).toEqual([
+            "point",
+            "line",
+            "circle",
+        ]);
+        expect(components.map((component) => component.name)).toEqual([
+            "P",
+            "L",
+            "c",
+        ]);
+    });
+
+    it("generates a skeleton snippet with graph-level annotation and nested refs", () => {
+        const source = `<graph renderer="prefigure">
+  <point name="P" />
+  <circle name="c" />
+  <line name="L" />
+</graph>`;
+        const graph = getFirstGraphElement(source);
+
+        const snippet = generateAnnotationSkeletonSnippet(graph);
+
+        expect(snippet).toBeTruthy();
+        expect(snippet?.key).toBe("annotation-skeleton");
+        expect(snippet?.snippet).toContain("<annotations>");
+        expect(snippet?.snippet).toContain(
+            '<annotation text="A graph of a point, a circle, and a line.">',
+        );
+        expect(snippet?.snippet).toContain('ref="$P"');
+        expect(snippet?.snippet).toContain('ref="$c"');
+        expect(snippet?.snippet).toContain('ref="$L"');
+        expect(snippet?.cursor).toBeTruthy();
+    });
+
+    it("uses synthetic names and guidance for unnamed graphical components", () => {
+        const source = `<graph renderer="prefigure">
+  <point />
+  <point />
+  <circle />
+  <line />
+</graph>`;
+        const graph = getFirstGraphElement(source);
+
+        const snippet = generateAnnotationSkeletonSnippet(graph);
+
+        expect(snippet?.snippet).toContain('ref="$unnamedPoint1"');
+        expect(snippet?.snippet).toContain('ref="$unnamedPoint2"');
+        expect(snippet?.snippet).toContain('ref="$unnamedCircle1"');
+        expect(snippet?.snippet).toContain('ref="$unnamedLine1"');
+        expect(snippet?.snippet).toContain(
+            "Point requires a name for the ref to work.",
+        );
+        expect(snippet?.snippet).toContain(
+            "Circle requires a name for the ref to work.",
+        );
+        expect(snippet?.snippet).toContain(
+            "Line requires a name for the ref to work.",
+        );
+    });
+
+    it("returns null when graph has no supported graphical descendants", () => {
+        const source = `<graph renderer="prefigure">
+  <text>Nothing graphical here</text>
+  <annotations><annotation text="old" /></annotations>
+</graph>`;
+        const graph = getFirstGraphElement(source);
+
+        expect(generateAnnotationSkeletonSnippet(graph)).toBeNull();
+    });
+});
+
+describe("Annotation skeleton autocomplete integration", () => {
+    const integrationSchema = {
+        elements: [
+            {
+                name: "graph",
+                children: ["point", "circle", "line", "group", "annotations"],
+                attributes: [{ name: "renderer" }, { name: "name" }],
+                top: true,
+                acceptsStringChildren: false,
+            },
+            {
+                name: "group",
+                children: ["point", "circle", "line", "annotations"],
+                attributes: [{ name: "name" }],
+                top: false,
+                acceptsStringChildren: false,
+            },
+            {
+                name: "annotations",
+                children: ["annotation"],
+                attributes: [],
+                top: false,
+                acceptsStringChildren: false,
+            },
+            {
+                name: "annotation",
+                children: ["annotation"],
+                attributes: [{ name: "ref" }, { name: "text" }],
+                top: false,
+                acceptsStringChildren: true,
+            },
+            {
+                name: "point",
+                children: [],
+                attributes: [{ name: "name" }],
+                top: false,
+                acceptsStringChildren: false,
+            },
+            {
+                name: "circle",
+                children: [],
+                attributes: [{ name: "name" }],
+                top: false,
+                acceptsStringChildren: false,
+            },
+            {
+                name: "line",
+                children: [],
+                attributes: [{ name: "name" }],
+                top: false,
+                acceptsStringChildren: false,
+            },
+        ],
+    };
+
+    it("offers annotation-skeleton snippet when typing < inside prefigure graph body", () => {
+        const source = `<graph renderer="prefigure">
+  <point name="P" />
+  <
+</graph>`;
+        const autoCompleter = new AutoCompleter(
+            source,
+            integrationSchema.elements,
+        );
+        const offset = source.indexOf("  <\n") + 3;
+
+        const items = autoCompleter.getCompletionItems(offset);
+        const annotationSnippetItem = items.find(
+            (item) => item.label === "annotation-skeleton",
+        );
+
+        expect(annotationSnippetItem).toBeTruthy();
+        expect(annotationSnippetItem?.kind).toBe(CompletionItemKind.Snippet);
+        const textEdit = annotationSnippetItem?.textEdit;
+        if (textEdit && "newText" in textEdit) {
+            expect(textEdit.newText).toContain("<annotations>");
+            expect(textEdit.newText).toContain('ref="$P"');
+        }
+    });
+
+    it("does not offer annotation-skeleton snippet in non-prefigure graph", () => {
+        const source = `<graph renderer="doenet">
+  <point name="P" />
+  <
+</graph>`;
+        const autoCompleter = new AutoCompleter(
+            source,
+            integrationSchema.elements,
+        );
+        const offset = source.indexOf("  <\n") + 3;
+
+        const items = autoCompleter.getCompletionItems(offset);
+        expect(items.some((item) => item.label === "annotation-skeleton")).toBe(
+            false,
+        );
+    });
+
+    it("does not offer annotation-skeleton snippet when immediate parent is not graph", () => {
+        const source = `<graph renderer="prefigure">
+  <group>
+    <point name="P" />
+    <
+  </group>
+</graph>`;
+        const autoCompleter = new AutoCompleter(
+            source,
+            integrationSchema.elements,
+        );
+        const offset = source.indexOf("    <\n") + 5;
+
+        const items = autoCompleter.getCompletionItems(offset);
+        expect(items.some((item) => item.label === "annotation-skeleton")).toBe(
+            false,
+        );
+    });
+});

--- a/packages/lsp-tools/test/annotation-skeleton-snippet.test.ts
+++ b/packages/lsp-tools/test/annotation-skeleton-snippet.test.ts
@@ -214,6 +214,29 @@ describe("Annotation skeleton snippet generation", () => {
         );
     });
 
+    it("uses parenthesized macro syntax for non-SimpleIdent component names", () => {
+        const source = `<graph renderer="prefigure">
+  <lineSegment name="my-seg" />
+  <point name="1stPoint" />
+</graph>`;
+        const graph = getFirstGraphElement(source);
+
+        const snippet = generateAnnotationSkeletonSnippet(graph);
+
+        expect(snippet).toBeTruthy();
+        // ref attributes use parenthesized form
+        expect(snippet?.snippet).toContain('ref="$(my-seg)"');
+        expect(snippet?.snippet).toContain('ref="$(1stPoint)"');
+        // text macros use parenthesized form with property paths
+        expect(snippet?.snippet).toContain("$(my-seg).endpoints[1].x");
+        expect(snippet?.snippet).toContain("$(my-seg).endpoints[2].y");
+        expect(snippet?.snippet).toContain("$(1stPoint).x");
+        expect(snippet?.snippet).toContain("$(1stPoint).y");
+        // bare $ form must not appear for these names
+        expect(snippet?.snippet).not.toContain("$my-seg");
+        expect(snippet?.snippet).not.toContain("$1stPoint");
+    });
+
     it("returns null when graph has no supported graphical descendants", () => {
         const source = `<graph renderer="prefigure">
   <text>Nothing graphical here</text>

--- a/packages/lsp-tools/test/annotation-skeleton-snippet.test.ts
+++ b/packages/lsp-tools/test/annotation-skeleton-snippet.test.ts
@@ -96,6 +96,59 @@ describe("Annotation skeleton snippet generation", () => {
         );
     });
 
+    it("generates descriptions for all supported graphical components", () => {
+        const source = `<graph renderer="prefigure">
+  <lineSegment name="seg" />
+  <ray name="r" />
+  <vector name="v" />
+  <polygon name="poly" />
+  <polyline name="pline" />
+  <angle name="a" />
+  <curve name="curv" />
+</graph>`;
+        const graph = getFirstGraphElement(source);
+
+        const snippet = generateAnnotationSkeletonSnippet(graph);
+
+        expect(snippet).toBeTruthy();
+        expect(snippet?.snippet).toContain('ref="$seg"');
+        expect(snippet?.snippet).toContain('ref="$r"');
+        expect(snippet?.snippet).toContain('ref="$v"');
+        expect(snippet?.snippet).toContain('ref="$poly"');
+        expect(snippet?.snippet).toContain('ref="$pline"');
+        expect(snippet?.snippet).toContain('ref="$a"');
+        expect(snippet?.snippet).toContain('ref="$curv"');
+        // Verify descriptions mention relevant properties
+        expect(snippet?.snippet).toContain("line segment");
+        expect(snippet?.snippet).toContain("ray");
+        expect(snippet?.snippet).toContain("vector");
+        expect(snippet?.snippet).toContain("polygon");
+        expect(snippet?.snippet).toContain("polyline");
+        expect(snippet?.snippet).toContain("angle");
+        expect(snippet?.snippet).toContain("curve");
+    });
+
+    it("handles component aliases (endpoint, equilibriumPoint, triangle, rectangle)", () => {
+        const source = `<graph renderer="prefigure">
+  <endpoint name="ep" />
+  <equilibriumPoint name="eq" />
+  <triangle name="tri" />
+  <rectangle name="rect" />
+</graph>`;
+        const graph = getFirstGraphElement(source);
+
+        const snippet = generateAnnotationSkeletonSnippet(graph);
+
+        expect(snippet).toBeTruthy();
+        expect(snippet?.snippet).toContain('ref="$ep"');
+        expect(snippet?.snippet).toContain('ref="$eq"');
+        expect(snippet?.snippet).toContain('ref="$tri"');
+        expect(snippet?.snippet).toContain('ref="$rect"');
+        // Aliases should use descriptions based on their primary types
+        expect(snippet?.snippet).toContain("A point"); // endpoint and equilibriumPoint are points
+        expect(snippet?.snippet).toContain("polygon"); // triangle and rectangle are polygons
+    });
+
     it("returns null when graph has no supported graphical descendants", () => {
         const source = `<graph renderer="prefigure">
   <text>Nothing graphical here</text>
@@ -112,14 +165,43 @@ describe("Annotation skeleton autocomplete integration", () => {
         elements: [
             {
                 name: "graph",
-                children: ["point", "circle", "line", "group", "annotations"],
+                children: [
+                    "point",
+                    "circle",
+                    "line",
+                    "lineSegment",
+                    "ray",
+                    "vector",
+                    "polygon",
+                    "polyline",
+                    "angle",
+                    "curve",
+                    "endpoint",
+                    "equilibriumPoint",
+                    "triangle",
+                    "rectangle",
+                    "group",
+                    "annotations",
+                ],
                 attributes: [{ name: "renderer" }, { name: "name" }],
                 top: true,
                 acceptsStringChildren: false,
             },
             {
                 name: "group",
-                children: ["point", "circle", "line", "annotations"],
+                children: [
+                    "point",
+                    "circle",
+                    "line",
+                    "lineSegment",
+                    "ray",
+                    "vector",
+                    "polygon",
+                    "polyline",
+                    "angle",
+                    "curve",
+                    "annotations",
+                ],
                 attributes: [{ name: "name" }],
                 top: false,
                 acceptsStringChildren: false,
@@ -154,6 +236,83 @@ describe("Annotation skeleton autocomplete integration", () => {
             },
             {
                 name: "line",
+                children: [],
+                attributes: [{ name: "name" }],
+                top: false,
+                acceptsStringChildren: false,
+            },
+            {
+                name: "lineSegment",
+                children: [],
+                attributes: [{ name: "name" }],
+                top: false,
+                acceptsStringChildren: false,
+            },
+            {
+                name: "ray",
+                children: [],
+                attributes: [{ name: "name" }],
+                top: false,
+                acceptsStringChildren: false,
+            },
+            {
+                name: "vector",
+                children: [],
+                attributes: [{ name: "name" }],
+                top: false,
+                acceptsStringChildren: false,
+            },
+            {
+                name: "polygon",
+                children: [],
+                attributes: [{ name: "name" }],
+                top: false,
+                acceptsStringChildren: false,
+            },
+            {
+                name: "polyline",
+                children: [],
+                attributes: [{ name: "name" }],
+                top: false,
+                acceptsStringChildren: false,
+            },
+            {
+                name: "angle",
+                children: [],
+                attributes: [{ name: "name" }],
+                top: false,
+                acceptsStringChildren: false,
+            },
+            {
+                name: "curve",
+                children: [],
+                attributes: [{ name: "name" }],
+                top: false,
+                acceptsStringChildren: false,
+            },
+            {
+                name: "endpoint",
+                children: [],
+                attributes: [{ name: "name" }],
+                top: false,
+                acceptsStringChildren: false,
+            },
+            {
+                name: "equilibriumPoint",
+                children: [],
+                attributes: [{ name: "name" }],
+                top: false,
+                acceptsStringChildren: false,
+            },
+            {
+                name: "triangle",
+                children: [],
+                attributes: [{ name: "name" }],
+                top: false,
+                acceptsStringChildren: false,
+            },
+            {
+                name: "rectangle",
                 children: [],
                 attributes: [{ name: "name" }],
                 top: false,

--- a/packages/lsp-tools/test/annotation-skeleton-snippet.test.ts
+++ b/packages/lsp-tools/test/annotation-skeleton-snippet.test.ts
@@ -59,7 +59,7 @@ describe("Annotation skeleton snippet generation", () => {
         const snippet = generateAnnotationSkeletonSnippet(graph);
 
         expect(snippet).toBeTruthy();
-        expect(snippet?.key).toBe("annotation-skeleton");
+        expect(snippet?.key).toBe("annotations-skeleton");
         expect(snippet?.snippet).toContain("<annotations>");
         expect(snippet?.snippet).toContain(
             '<annotation text="A graph of a point, a circle, and a line.">',
@@ -335,7 +335,7 @@ describe("Annotation skeleton autocomplete integration", () => {
         ],
     };
 
-    it("offers annotation-skeleton snippet when typing < inside prefigure graph body", () => {
+    it("offers annotations-skeleton snippet when typing < inside prefigure graph body", () => {
         const source = `<graph renderer="prefigure">
   <point name="P" />
   <
@@ -348,7 +348,7 @@ describe("Annotation skeleton autocomplete integration", () => {
 
         const items = autoCompleter.getCompletionItems(offset);
         const annotationSnippetItem = items.find(
-            (item) => item.label === "annotation-skeleton",
+            (item) => item.label === "annotations-skeleton",
         );
 
         expect(annotationSnippetItem).toBeTruthy();
@@ -360,7 +360,7 @@ describe("Annotation skeleton autocomplete integration", () => {
         }
     });
 
-    it("does not offer annotation-skeleton snippet in non-prefigure graph", () => {
+    it("does not offer annotations-skeleton snippet in non-prefigure graph", () => {
         const source = `<graph renderer="doenet">
   <point name="P" />
   <
@@ -372,12 +372,12 @@ describe("Annotation skeleton autocomplete integration", () => {
         const offset = source.indexOf("  <\n") + 3;
 
         const items = autoCompleter.getCompletionItems(offset);
-        expect(items.some((item) => item.label === "annotation-skeleton")).toBe(
-            false,
-        );
+        expect(
+            items.some((item) => item.label === "annotations-skeleton"),
+        ).toBe(false);
     });
 
-    it("does not offer annotation-skeleton snippet when immediate parent is not graph", () => {
+    it("does not offer annotations-skeleton snippet when immediate parent is not graph", () => {
         const source = `<graph renderer="prefigure">
   <group>
     <point name="P" />
@@ -391,8 +391,8 @@ describe("Annotation skeleton autocomplete integration", () => {
         const offset = source.indexOf("    <\n") + 5;
 
         const items = autoCompleter.getCompletionItems(offset);
-        expect(items.some((item) => item.label === "annotation-skeleton")).toBe(
-            false,
-        );
+        expect(
+            items.some((item) => item.label === "annotations-skeleton"),
+        ).toBe(false);
     });
 });

--- a/packages/lsp-tools/test/annotation-skeleton-snippet.test.ts
+++ b/packages/lsp-tools/test/annotation-skeleton-snippet.test.ts
@@ -76,6 +76,8 @@ describe("Annotation skeleton snippet generation", () => {
   <point />
   <circle />
   <line />
+  <lineSegment />
+  <equilibriumPoint />
 </graph>`;
         const graph = getFirstGraphElement(source);
 
@@ -85,6 +87,8 @@ describe("Annotation skeleton snippet generation", () => {
         expect(snippet?.snippet).toContain('ref="$unnamedPoint2"');
         expect(snippet?.snippet).toContain('ref="$unnamedCircle1"');
         expect(snippet?.snippet).toContain('ref="$unnamedLine1"');
+        expect(snippet?.snippet).toContain('ref="$unnamedLineSegment1"');
+        expect(snippet?.snippet).toContain('ref="$unnamedEquilibriumPoint1"');
         expect(snippet?.snippet).toContain(
             "Point requires a name for the ref to work.",
         );
@@ -93,6 +97,12 @@ describe("Annotation skeleton snippet generation", () => {
         );
         expect(snippet?.snippet).toContain(
             "Line requires a name for the ref to work.",
+        );
+        expect(snippet?.snippet).toContain(
+            "Line segment requires a name for the ref to work.",
+        );
+        expect(snippet?.snippet).toContain(
+            "Equilibrium point requires a name for the ref to work.",
         );
     });
 

--- a/packages/lsp-tools/test/annotation-skeleton-snippet.test.ts
+++ b/packages/lsp-tools/test/annotation-skeleton-snippet.test.ts
@@ -144,9 +144,11 @@ describe("Annotation skeleton snippet generation", () => {
         expect(snippet?.snippet).toContain('ref="$eq"');
         expect(snippet?.snippet).toContain('ref="$tri"');
         expect(snippet?.snippet).toContain('ref="$rect"');
-        // Aliases should use descriptions based on their primary types
-        expect(snippet?.snippet).toContain("A point"); // endpoint and equilibriumPoint are points
-        expect(snippet?.snippet).toContain("polygon"); // triangle and rectangle are polygons
+        // Aliases use their own descriptions
+        expect(snippet?.snippet).toContain("An endpoint"); // endpoint description
+        expect(snippet?.snippet).toContain("An equilibrium point"); // equilibriumPoint description
+        expect(snippet?.snippet).toContain("A triangle"); // triangle description
+        expect(snippet?.snippet).toContain("A rectangle"); // rectangle description
     });
 
     it("returns null when graph has no supported graphical descendants", () => {

--- a/packages/lsp-tools/test/annotation-skeleton-snippet.test.ts
+++ b/packages/lsp-tools/test/annotation-skeleton-snippet.test.ts
@@ -147,7 +147,7 @@ describe("Annotation skeleton snippet generation", () => {
         // Aliases use their own descriptions
         expect(snippet?.snippet).toContain("An endpoint"); // endpoint description
         expect(snippet?.snippet).toContain("An equilibrium point"); // equilibriumPoint description
-        expect(snippet?.snippet).toContain("A triangle"); // triangle description
+        expect(snippet?.snippet).toContain("A triangle."); // triangle description (simple, no vertices count)
         expect(snippet?.snippet).toContain("A rectangle"); // rectangle description
     });
 


### PR DESCRIPTION
## Summary
- add a dynamic `annotations-skeleton` completion item when typing inside a prefigure graph body
- generate nested `<annotations><annotation>...</annotation></annotations>` content from authored graphical descendants
- ignore existing `<annotations>` subtrees while extracting graphical descendants
- support authored prefigure graphical types including `point`, `line`, `lineSegment`, `ray`, `vector`, `circle`, `function`, `polyline`, `polygon`, `angle`, `curve`, `endpoint`, `equilibriumPoint`, `triangle`, and `rectangle`
- use authored component types in generated author-facing descriptions
- improve readability for unnamed multi-word component refs and guidance text (for example, `lineSegment` and `equilibriumPoint`)
- improve accessibility wording with explicit `x-coordinate` and `y-coordinate` labels where applicable
- align runtime behavior for ray references by supporting `.endpoint.x/.y/.z` and `.through.x/.y/.z` aliases in core state variables

## Notes on generated text
- keep concise fallback text for components where richer property descriptions are not obvious (for example: `angle`, `function`, `curve`, `triangle`)
- use synthetic names with guidance text when a referenced graphical component is unnamed

## Testing
- `npm run test -w @doenet/lsp-tools -- --run test/annotation-skeleton-snippet.test.ts`
- `npm run test -w @doenet/doenetml-worker-javascript -- --run src/test/prefigure/ray.test.ts src/test/prefigure/graph-prefigure-core.test.ts`

## Scope
- includes `lsp-tools` autocomplete/snippet generation plus worker-core runtime/test alignment needed for generated ray endpoint/through references
