### PR TITLE
Support function annotation refs in prefigure graphs

### DIFF
--- a/.changeset/clever-cameras-notice.md
+++ b/.changeset/clever-cameras-notice.md
@@ -1,0 +1,7 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Fix PreFigure annotation refs that target functions in graphs. An annotation like `<annotation ref="$f" />` now resolves when `f` is a `<function>` rendered via an adapted `<curve>`, while preserving existing behavior and warnings for invalid or out-of-graph refs.

--- a/packages/doenetml-worker-javascript/src/components/Graph.js
+++ b/packages/doenetml-worker-javascript/src/components/Graph.js
@@ -13,7 +13,7 @@ import {
 } from "../utils/rounding";
 // PreFigure conversion architecture and extension guide:
 // see src/utils/prefigure/README.md
-import { returnGraphPrefigureXMLStateVariableDefinition } from "../utils/prefigure/stateVariable";
+import { returnGraphPrefigureStateVariableDefinitions } from "../utils/prefigure/stateVariable";
 
 export default class Graph extends BlockComponent {
     constructor(args) {
@@ -551,8 +551,10 @@ export default class Graph extends BlockComponent {
             },
         };
 
-        stateVariableDefinitions.prefigureXML =
-            returnGraphPrefigureXMLStateVariableDefinition();
+        Object.assign(
+            stateVariableDefinitions,
+            returnGraphPrefigureStateVariableDefinitions(),
+        );
 
         stateVariableDefinitions.childIndicesToRender = {
             returnDependencies: () => ({

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
@@ -489,6 +489,23 @@ describe("Graph prefigure renderer core @group4", () => {
         expect(prefigureXML).toContain(`at="${annotationRef}"`);
     });
 
+    it("ref to multi-piece function resolves to grouped curve handle", async () => {
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph(
+                '<function name="f" through="(1,2) (-5,7) (4,3) (6,1)" />\n  <annotations><annotation ref="$f" text="function summary" /></annotations>',
+            ),
+        );
+
+        expect(prefigureXML).toContain(`<group at="curve_0">`);
+        expect(prefigureXML).toContain(`<graph at="curve_0_0"`);
+
+        const annotationRefMatch = prefigureXML.match(
+            /<annotation ref="([^"]+)" text="function summary"><\/annotation>/,
+        );
+        expect(annotationRefMatch).toBeTruthy();
+        expect(annotationRefMatch?.[1]).eq("curve_0");
+    });
+
     it("ref to function outside graph subtree omits annotation and emits warning", async () => {
         const doenetML = `
 <graph name="g" renderer="prefigure">

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
@@ -470,6 +470,43 @@ describe("Graph prefigure renderer core @group4", () => {
         ).eq(true);
     });
 
+    it("ref to function resolves through adapted curve handle", async () => {
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph(
+                '<function name="f">x^2</function>\n  <annotations><annotation ref="$f" text="function summary" /></annotations>',
+            ),
+        );
+
+        const annotationRefMatch = prefigureXML.match(
+            /<annotation ref="([^"]+)" text="function summary"><\/annotation>/,
+        );
+        expect(annotationRefMatch).toBeTruthy();
+
+        const annotationRef = annotationRefMatch?.[1] ?? "";
+        expect(annotationRef).not.toContain("annotation_");
+        expect(annotationRef).not.eq("figure");
+        expect(prefigureXML).toContain(`at="${annotationRef}"`);
+    });
+
+    it("ref to function outside graph subtree omits annotation and emits warning", async () => {
+        const doenetML = `
+<graph name="g" renderer="prefigure">
+  <annotations><annotation ref="$outsideFunction" text="outside function" /></annotations>
+</graph>
+<function name="outsideFunction">x^2</function>
+`;
+
+        const prefigureXML = await getPrefigureXML(doenetML);
+        expect(prefigureXML).not.toContain(`<annotations>`);
+
+        const diagnosticsByType = await getWarnings(doenetML);
+        expect(
+            diagnosticsByType.warnings.some((x) =>
+                x.message.includes("outside the containing graph"),
+            ),
+        ).eq(true);
+    });
+
     it("ref to unsupported graph child omits annotation and emits warning", async () => {
         const doenetML = prefigureGraph(
             '<textInput name="ti" />\n  <annotations><annotation ref="$ti" text="input summary" /></annotations>',

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
@@ -483,6 +483,7 @@ describe("Graph prefigure renderer core @group4", () => {
         expect(annotationRefMatch).toBeTruthy();
 
         const annotationRef = annotationRefMatch?.[1] ?? "";
+        expect(annotationRef).not.eq("");
         expect(annotationRef).not.toContain("annotation_");
         expect(annotationRef).not.eq("figure");
         expect(prefigureXML).toContain(`at="${annotationRef}"`);

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
@@ -1320,8 +1320,9 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
             prefigureGraph('<curve through="(0,0) (1,2) (2,1)" />'),
         );
 
-        expect(prefigureXML).toContain(`<parametric-curve at="curve_0"`);
-        expect(prefigureXML).toContain(`function="curve_0_r(`);
+        expect(prefigureXML).toContain(`<group at="curve_0">`);
+        expect(prefigureXML).toContain(`<parametric-curve at="curve_0_0"`);
+        expect(prefigureXML).toContain(`function="curve_0_0_r(`);
         expect(prefigureXML).toContain(`domain="(0,1)"`);
         expect(prefigureXML).toContain(`domain="(1,2)"`);
         expect(prefigureXML).not.toContain(`<spline `);
@@ -1334,8 +1335,9 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
             ),
         );
 
-        expect(prefigureXML).toContain(`<parametric-curve at="curve_0"`);
-        expect(prefigureXML).toContain(`function="curve_0_r(`);
+        expect(prefigureXML).toContain(`<group at="curve_0">`);
+        expect(prefigureXML).toContain(`<parametric-curve at="curve_0_0"`);
+        expect(prefigureXML).toContain(`function="curve_0_0_r(`);
         expect(prefigureXML).toContain(`domain="(0,1)"`);
         expect(prefigureXML).toContain(`domain="(1,2)"`);
         expect(prefigureXML).toContain(`domain="(2,3)"`);
@@ -1447,7 +1449,8 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
 
         const prefigureXML = await getPrefigureXML(doenetML);
         expect(prefigureXML).toContain(`<graph at="curve_1"`);
-        expect(prefigureXML).toContain(`<graph at="curve_0"`);
+        expect(prefigureXML).toContain(`<group at="curve_0">`);
+        expect(prefigureXML).toContain(`<graph at="curve_0_0"`);
 
         const diagnosticsByType = await getWarnings(doenetML);
         expect(
@@ -1560,10 +1563,11 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
             ),
         );
 
-        const pieceCount = (prefigureXML.match(/<graph at="curve_0/g) ?? [])
+        const pieceCount = (prefigureXML.match(/<graph at="curve_0_/g) ?? [])
             .length;
         expect(pieceCount).toBeGreaterThan(1);
-        expect(prefigureXML).toContain(`function="curve_0_f(x)=x^3"`);
+        expect(prefigureXML).toContain(`<group at="curve_0">`);
+        expect(prefigureXML).toContain(`function="curve_0_0_f(x)=x^3"`);
         expect(prefigureXML).toContain(`=x^2"`);
         expect(prefigureXML).not.toContain(`fill="`);
         expect(prefigureXML).not.toContain(`fill-opacity="`);
@@ -1575,9 +1579,10 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         );
 
         const prefigureXML = await getPrefigureXML(doenetML);
-        const pieceCount = (prefigureXML.match(/<graph at="curve_0/g) ?? [])
+        const pieceCount = (prefigureXML.match(/<graph at="curve_0_/g) ?? [])
             .length;
         expect(pieceCount).toBeGreaterThan(1);
+        expect(prefigureXML).toContain(`<group at="curve_0">`);
         expect(prefigureXML).toContain(`=x^2"`);
 
         const diagnosticsByType = await getWarnings(doenetML);
@@ -1597,14 +1602,13 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
             ),
         );
 
-        const pieceCount =
-            (prefigureXML.match(/<parametric-curve at="curve_0/g) ?? [])
-                .length +
-            (prefigureXML.match(/<parametric-curve at="curve_0_/g) ?? [])
-                .length;
+        const pieceCount = (
+            prefigureXML.match(/<parametric-curve at="curve_0_/g) ?? []
+        ).length;
 
         expect(pieceCount).toBeGreaterThan(1);
-        expect(prefigureXML).toContain(`function="curve_0_r(`);
+        expect(prefigureXML).toContain(`<group at="curve_0">`);
+        expect(prefigureXML).toContain(`function="curve_0_0_r(`);
         expect(prefigureXML).toContain(`(x^3)/10`);
         expect(prefigureXML).toContain(`domain="`);
         expect(prefigureXML).not.toContain(`fill="`);
@@ -1619,9 +1623,10 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         );
 
         const pieceCount = (
-            prefigureXML.match(/<parametric-curve at="curve_0/g) ?? []
+            prefigureXML.match(/<parametric-curve at="curve_0_/g) ?? []
         ).length;
 
+        expect(prefigureXML).toContain(`<group at="curve_0">`);
         expect(pieceCount).eq(8);
     });
 });

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/annotations.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/annotations.ts
@@ -189,26 +189,20 @@ function resolveAnnotationRef(
         return "figure";
     }
 
-    let annotationRefTargetComponentIdx = targetComponentIdx;
+    let resolvedIdx = targetComponentIdx;
 
-    const directHandle = state.handleByComponentIdx.get(
-        annotationRefTargetComponentIdx,
-    );
+    const directHandle = state.handleByComponentIdx.get(resolvedIdx);
 
     if (!directHandle) {
         const aliasedTargetComponentIdx =
-            state.functionToCurveComponentIdx[annotationRefTargetComponentIdx];
+            state.functionToCurveComponentIdx[resolvedIdx];
 
         if (Number.isFinite(aliasedTargetComponentIdx)) {
-            annotationRefTargetComponentIdx = aliasedTargetComponentIdx;
+            resolvedIdx = aliasedTargetComponentIdx;
         }
     }
 
-    if (
-        !state.graphDescendantComponentIndices.has(
-            annotationRefTargetComponentIdx,
-        )
-    ) {
+    if (!state.graphDescendantComponentIndices.has(resolvedIdx)) {
         pushAnnotationWarning({
             diagnostics: state.diagnostics,
             annotation,
@@ -218,9 +212,7 @@ function resolveAnnotationRef(
         return null;
     }
 
-    const handle =
-        directHandle ??
-        state.handleByComponentIdx.get(annotationRefTargetComponentIdx);
+    const handle = directHandle ?? state.handleByComponentIdx.get(resolvedIdx);
     if (!handle) {
         pushAnnotationWarning({
             diagnostics: state.diagnostics,

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/annotations.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/annotations.ts
@@ -12,6 +12,7 @@ interface AnnotationXmlBuildState {
     handleByComponentIdx: Map<number, string>;
     graphComponentIdx: number;
     graphDescendantComponentIndices: Set<number>;
+    functionToCurveComponentIdx: Record<number, number>;
     conceptualRefCounter: number;
     usedAnnotationRefs: Set<string>;
 }
@@ -25,6 +26,7 @@ interface BuildAnnotationsXmlParams {
     handleByComponentIdx: Map<number, string>;
     graphComponentIdx: number;
     graphDescendantComponentIndices: Set<number>;
+    functionToCurveComponentIdx?: Record<number, number>;
 }
 
 const INVALID_REF_WARNING =
@@ -85,6 +87,7 @@ export function convertDoenetMLAnnotationsToPreFigureXml({
     handleByComponentIdx,
     graphComponentIdx,
     graphDescendantComponentIndices,
+    functionToCurveComponentIdx,
 }: BuildAnnotationsXmlParams): string {
     if (!Array.isArray(annotations) || annotations.length === 0) {
         return "";
@@ -95,6 +98,7 @@ export function convertDoenetMLAnnotationsToPreFigureXml({
         handleByComponentIdx,
         graphComponentIdx,
         graphDescendantComponentIndices,
+        functionToCurveComponentIdx: functionToCurveComponentIdx ?? {},
         conceptualRefCounter: 1,
         usedAnnotationRefs: new Set(handleByComponentIdx.values()),
     };
@@ -185,7 +189,26 @@ function resolveAnnotationRef(
         return "figure";
     }
 
-    if (!state.graphDescendantComponentIndices.has(targetComponentIdx)) {
+    let annotationRefTargetComponentIdx = targetComponentIdx;
+
+    const directHandle = state.handleByComponentIdx.get(
+        annotationRefTargetComponentIdx,
+    );
+
+    if (!directHandle) {
+        const aliasedTargetComponentIdx =
+            state.functionToCurveComponentIdx[annotationRefTargetComponentIdx];
+
+        if (Number.isFinite(aliasedTargetComponentIdx)) {
+            annotationRefTargetComponentIdx = aliasedTargetComponentIdx;
+        }
+    }
+
+    if (
+        !state.graphDescendantComponentIndices.has(
+            annotationRefTargetComponentIdx,
+        )
+    ) {
         pushAnnotationWarning({
             diagnostics: state.diagnostics,
             annotation,
@@ -195,7 +218,9 @@ function resolveAnnotationRef(
         return null;
     }
 
-    const handle = state.handleByComponentIdx.get(targetComponentIdx);
+    const handle =
+        directHandle ??
+        state.handleByComponentIdx.get(annotationRefTargetComponentIdx);
     if (!handle) {
         pushAnnotationWarning({
             diagnostics: state.diagnostics,

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
@@ -31,6 +31,13 @@ interface ParsedFormulaPiecesResult {
     pieces: ParsedFormulaPiece[];
 }
 
+interface ParametricCurvePieceDefinition {
+    parameterVariable: string;
+    xExpression: string;
+    yExpression: string;
+    domain: string;
+}
+
 /**
  * Get the label string (if any) for a curve definition type.
  * Returns a string representation of the functionType field.
@@ -62,15 +69,44 @@ const SUPPORTED_CURVE_FUNCTION_TYPES = new Set([
 
 /**
  * Generate a unique handle for a curve piece in the PreFigure output.
- * The first piece (index 0) uses the base handle as-is; subsequent pieces
- * append an underscore and index number to ensure uniqueness.
  *
- * @param baseHandle - The base identifier for the curve element
+ * Single-piece curves keep the base handle on the piece itself. When a curve
+ * emits multiple pieces, the base handle is reserved for an outer `<group>` so
+ * each child piece gets a suffixed handle starting at `_0`.
+ *
+ * @param baseHandle - The base identifier for the logical curve element
  * @param index - The piece index (0 for first, 1 for second, etc.)
+ * @param reserveBaseHandle - Whether the base handle is owned by an outer group
  * @returns The formatted handle string
  */
-function makePieceHandle(baseHandle: string, index: number): string {
-    return index === 0 ? baseHandle : `${baseHandle}_${index}`;
+function makePieceHandle(
+    baseHandle: string,
+    index: number,
+    reserveBaseHandle = false,
+): string {
+    if (!reserveBaseHandle && index === 0) {
+        return baseHandle;
+    }
+
+    return `${baseHandle}_${index}`;
+}
+
+function wrapCurvePieces({
+    handle,
+    pieces,
+}: {
+    handle: string;
+    pieces: string[];
+}): string | null {
+    if (pieces.length === 0) {
+        return null;
+    }
+
+    if (pieces.length === 1) {
+        return pieces[0];
+    }
+
+    return `<group at="${escapeXml(handle)}">${pieces.join("")}</group>`;
 }
 
 /**
@@ -1184,17 +1220,18 @@ function convertFunctionCurve({
     // After validation check, result is guaranteed to be non-null
     const validResult = result as ParsedFormulaPiecesResult;
 
-    return validResult.pieces
-        .map(({ parsed, interval }, i) =>
-            emitCurveElement({
-                handle: makePieceHandle(handle, i),
-                styleAttrs,
-                parsed,
-                domain: domainFromIntervalPiece(interval),
-                isParametric: Boolean(sv.flipFunction),
-            }),
-        )
-        .join("");
+    const reserveBaseHandle = validResult.pieces.length > 1;
+    const pieces = validResult.pieces.map(({ parsed, interval }, i) =>
+        emitCurveElement({
+            handle: makePieceHandle(handle, i, reserveBaseHandle),
+            styleAttrs,
+            parsed,
+            domain: domainFromIntervalPiece(interval),
+            isParametric: Boolean(sv.flipFunction),
+        }),
+    );
+
+    return wrapCurvePieces({ handle, pieces });
 }
 
 /**
@@ -1285,7 +1322,7 @@ function convertParametricCurve({
         comparePiecesByIntervalStart,
     );
 
-    const pieceXml: string[] = [];
+    const pieceDefinitions: ParametricCurvePieceDefinition[] = [];
     let pieceCounter = 0;
     let xIndex = 0;
     let yIndex = 0;
@@ -1297,7 +1334,6 @@ function convertParametricCurve({
 
         const overlap = intersectIntervals(xPiece.interval, yPiece.interval);
         if (overlap && overlap.min !== overlap.max) {
-            const pieceHandle = makePieceHandle(handle, pieceCounter);
             const parameterVariable = xPiece.parsed.variableName;
             const xExpression = rewriteExpressionVariable({
                 expression: xPiece.parsed.expression,
@@ -1309,15 +1345,12 @@ function convertParametricCurve({
                 fromVariable: yPiece.parsed.variableName,
                 toVariable: parameterVariable,
             });
-            const functionDefinition = `${pieceHandle}_r(${parameterVariable})=(${xExpression},${yExpression})`;
-            const attrs = [
-                `at="${escapeXml(pieceHandle)}"`,
-                `function="${escapeXml(functionDefinition)}"`,
-                `domain="${escapeXml(domainFromIntervalPiece(overlap))}"`,
-                ...styleAttrs,
-            ];
-
-            pieceXml.push(`<parametric-curve ${attrs.join(" ")} />`);
+            pieceDefinitions.push({
+                parameterVariable,
+                xExpression,
+                yExpression,
+                domain: domainFromIntervalPiece(overlap),
+            });
             pieceCounter += 1;
         }
 
@@ -1331,11 +1364,34 @@ function convertParametricCurve({
         }
     }
 
-    if (pieceXml.length === 0) {
+    if (pieceDefinitions.length === 0) {
         return null;
     }
 
-    return pieceXml.join("");
+    const reserveBaseHandle = pieceDefinitions.length > 1;
+    const pieces = pieceDefinitions.map(
+        ({ parameterVariable, xExpression, yExpression, domain }, index) => {
+            const pieceHandle = makePieceHandle(
+                handle,
+                index,
+                reserveBaseHandle,
+            );
+            const functionDefinition = `${pieceHandle}_r(${parameterVariable})=(${xExpression},${yExpression})`;
+            const attrs = [
+                `at="${escapeXml(pieceHandle)}"`,
+                `function="${escapeXml(functionDefinition)}"`,
+                `domain="${escapeXml(domain)}"`,
+                ...styleAttrs,
+            ];
+
+            return `<parametric-curve ${attrs.join(" ")} />`;
+        },
+    );
+
+    return wrapCurvePieces({
+        handle,
+        pieces,
+    });
 }
 
 /**

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
@@ -1323,7 +1323,6 @@ function convertParametricCurve({
     );
 
     const pieceDefinitions: ParametricCurvePieceDefinition[] = [];
-    let pieceCounter = 0;
     let xIndex = 0;
     let yIndex = 0;
 
@@ -1351,7 +1350,6 @@ function convertParametricCurve({
                 yExpression,
                 domain: domainFromIntervalPiece(overlap),
             });
-            pieceCounter += 1;
         }
 
         if (xPiece.interval.max < yPiece.interval.max) {

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/graph.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/graph.ts
@@ -107,12 +107,14 @@ export function createPrefigureXML({
     unsupported,
     annotations,
     graphComponentIdx,
+    functionToCurveComponentIdx,
 }: {
     dependencyValues: GraphDependencyValues;
     descendants: Descendant[];
     unsupported: Descendant[];
     annotations: AnnotationNode[] | null;
     graphComponentIdx: number;
+    functionToCurveComponentIdx?: Record<number, number>;
 }): { xml: string; diagnostics: DiagnosticRecord[] } {
     const diagnostics: DiagnosticRecord[] = [];
     const usedHandles = new Set<string>();
@@ -222,6 +224,7 @@ export function createPrefigureXML({
         handleByComponentIdx,
         graphComponentIdx,
         graphDescendantComponentIndices,
+        functionToCurveComponentIdx,
     });
 
     const xml = `<diagram dimensions="${escapeXml(dimensions)}"><coordinates bbox="${escapeXml(bbox)}">${axesElement}${elements.join("")}</coordinates>${annotationsElement}</diagram>`;

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
@@ -263,9 +263,12 @@ function prefigureDescendantDependencies(): Record<string, unknown> {
  * Computes a stable ordered list of curve component indices for this graph.
  *
  * Relationship to other helpers:
- * - this list is consumed by functionCurveAliasMap to create one adapterSource
+ * - this list is consumed by functionToCurveComponentIdx to create one adapterSource
  *   dependency per curve descendant.
- * - prefigureXML depends on functionCurveAliasMap (not directly on this list).
+ * - prefigureXML depends on functionToCurveComponentIdx (not directly on this list).
+ *
+ * `variableNames: []` is intentional: only component indices are needed here,
+ * avoiding redundant variable fetching that the prefigureXML query already does.
  */
 function returnGraphCurveDescendantComponentIndicesStateVariableDefinition() {
     return {
@@ -337,7 +340,7 @@ function returnGraphFunctionCurveAliasMapStateVariableDefinition() {
         }: {
             dependencyValues: GraphDependencyValues;
         }) {
-            const functionCurveAliasMap: Record<number, number> = {};
+            const functionToCurveComponentIdx: Record<number, number> = {};
 
             const curveDescendantComponentIndices =
                 dependencyValues.curveDescendantComponentIndices;
@@ -352,18 +355,17 @@ function returnGraphFunctionCurveAliasMapStateVariableDefinition() {
                     ] as Descendant | undefined;
 
                     if (
-                        Number.isFinite(curveComponentIdx) &&
                         Number.isFinite(adapterSource?.componentIdx) &&
                         adapterSource?.componentType === "function"
                     ) {
-                        functionCurveAliasMap[
+                        functionToCurveComponentIdx[
                             adapterSource.componentIdx as number
                         ] = curveComponentIdx;
                     }
                 }
             }
 
-            return { setValue: { functionCurveAliasMap } };
+            return { setValue: { functionToCurveComponentIdx } };
         },
     };
 }
@@ -410,9 +412,9 @@ function returnGraphPrefigureXMLStateVariableDefinition() {
         returnDependencies: () => ({
             ...prefigureBaseDependencies(),
             ...prefigureDescendantDependencies(),
-            functionCurveAliasMap: {
+            functionToCurveComponentIdx: {
                 dependencyType: "stateVariable",
-                variableName: "functionCurveAliasMap",
+                variableName: "functionToCurveComponentIdx",
             },
             annotationsChildren: {
                 dependencyType: "child",
@@ -494,9 +496,7 @@ function returnGraphPrefigureXMLStateVariableDefinition() {
                 annotations,
                 graphComponentIdx: componentIdx,
                 functionToCurveComponentIdx:
-                    (dependencyValues.functionCurveAliasMap as
-                        | Record<number, number>
-                        | undefined) ?? {},
+                    dependencyValues.functionToCurveComponentIdx ?? {},
             });
 
             if (
@@ -524,13 +524,17 @@ function returnGraphPrefigureXMLStateVariableDefinition() {
     };
 }
 
+/**
+ * Returns all Graph state-variable definitions needed for prefigure conversion.
+ *
+ * This is the canonical mapping between state-variable names and their
+ * definitions; extend here when adding new prefigure-related state variables.
+ */
 export function returnGraphPrefigureStateVariableDefinitions() {
-    // Keep this object as the canonical relationship map between Graph state
-    // variable names and their prefigure definitions.
     return {
         curveDescendantComponentIndices:
             returnGraphCurveDescendantComponentIndicesStateVariableDefinition(),
-        functionCurveAliasMap:
+        functionToCurveComponentIdx:
             returnGraphFunctionCurveAliasMapStateVariableDefinition(),
         prefigureXML: returnGraphPrefigureXMLStateVariableDefinition(),
     };

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
@@ -168,6 +168,13 @@ function descendantDependency({
     return dependency;
 }
 
+/**
+ * Returns the graph-level state-variable dependencies shared by prefigureXML.
+ *
+ * These dependencies describe graph framing and axis metadata (bounds,
+ * dimensions, labels, renderer context) and are intentionally separated from
+ * descendant dependencies so conversion inputs are easier to reason about.
+ */
 function prefigureBaseDependencies() {
     return {
         effectiveRenderer: {
@@ -237,6 +244,12 @@ function prefigureBaseDependencies() {
     };
 }
 
+/**
+ * Materializes configured descendant dependency entries keyed by config key.
+ *
+ * This function is the single place where GRAPHICAL_DESCENDANT_CONFIGS become
+ * graph dependencies, which keeps descendant wiring declarative and centralized.
+ */
 function prefigureDescendantDependencies(): Record<string, unknown> {
     return Object.fromEntries(
         GRAPHICAL_DESCENDANT_CONFIGS.map((config) => [
@@ -244,6 +257,115 @@ function prefigureDescendantDependencies(): Record<string, unknown> {
             descendantDependency(config),
         ]),
     );
+}
+
+/**
+ * Computes a stable ordered list of curve component indices for this graph.
+ *
+ * Relationship to other helpers:
+ * - this list is consumed by functionCurveAliasMap to create one adapterSource
+ *   dependency per curve descendant.
+ * - prefigureXML depends on functionCurveAliasMap (not directly on this list).
+ */
+function returnGraphCurveDescendantComponentIndicesStateVariableDefinition() {
+    return {
+        returnDependencies: () => ({
+            curveDescendants: descendantDependency({
+                componentType: "curve",
+                variableNames: [],
+            }),
+        }),
+        definition({
+            dependencyValues,
+        }: {
+            dependencyValues: GraphDependencyValues;
+        }) {
+            const curveDescendantComponentIndices = (
+                dependencyValues.curveDescendants ?? []
+            )
+                .map((x) => x.componentIdx)
+                .filter((x): x is number => Number.isFinite(x));
+
+            return { setValue: { curveDescendantComponentIndices } };
+        },
+    };
+}
+
+/**
+ * Inverts curve adapter-source links into a function->curve alias map.
+ *
+ * Functions render via adapted curves in prefigure conversion. This map bridges
+ * annotation refs authored against function components to the concrete rendered
+ * curve handles, without changing curve conversion behavior.
+ */
+function returnGraphFunctionCurveAliasMapStateVariableDefinition() {
+    return {
+        stateVariablesDeterminingDependencies: [
+            "curveDescendantComponentIndices",
+        ],
+        returnDependencies: ({
+            stateValues,
+        }: {
+            stateValues: GraphDependencyValues;
+        }) => {
+            const dependencies: Record<string, unknown> = {
+                curveDescendantComponentIndices: {
+                    dependencyType: "stateVariable",
+                    variableName: "curveDescendantComponentIndices",
+                },
+            };
+
+            const curveDescendantComponentIndices =
+                stateValues.curveDescendantComponentIndices;
+
+            if (Array.isArray(curveDescendantComponentIndices)) {
+                for (const [
+                    index,
+                    curveComponentIdx,
+                ] of curveDescendantComponentIndices.entries()) {
+                    dependencies[`curveAdapterSource${index}`] = {
+                        dependencyType: "adapterSource",
+                        componentIdx: curveComponentIdx,
+                    };
+                }
+            }
+
+            return dependencies;
+        },
+        definition({
+            dependencyValues,
+        }: {
+            dependencyValues: GraphDependencyValues;
+        }) {
+            const functionCurveAliasMap: Record<number, number> = {};
+
+            const curveDescendantComponentIndices =
+                dependencyValues.curveDescendantComponentIndices;
+
+            if (Array.isArray(curveDescendantComponentIndices)) {
+                for (const [
+                    index,
+                    curveComponentIdx,
+                ] of curveDescendantComponentIndices.entries()) {
+                    const adapterSource = dependencyValues[
+                        `curveAdapterSource${index}`
+                    ] as Descendant | undefined;
+
+                    if (
+                        Number.isFinite(curveComponentIdx) &&
+                        Number.isFinite(adapterSource?.componentIdx) &&
+                        adapterSource?.componentType === "function"
+                    ) {
+                        functionCurveAliasMap[
+                            adapterSource.componentIdx as number
+                        ] = curveComponentIdx;
+                    }
+                }
+            }
+
+            return { setValue: { functionCurveAliasMap } };
+        },
+    };
 }
 
 /**
@@ -278,7 +400,7 @@ function collectConfiguredDescendants(
  * This builder keeps dependency wiring and conversion orchestration outside
  * of `Graph.js`, while preserving conversion behavior in utility modules.
  */
-export function returnGraphPrefigureXMLStateVariableDefinition() {
+function returnGraphPrefigureXMLStateVariableDefinition() {
     return {
         public: true,
         forRenderer: true,
@@ -288,6 +410,10 @@ export function returnGraphPrefigureXMLStateVariableDefinition() {
         returnDependencies: () => ({
             ...prefigureBaseDependencies(),
             ...prefigureDescendantDependencies(),
+            functionCurveAliasMap: {
+                dependencyType: "stateVariable",
+                variableName: "functionCurveAliasMap",
+            },
             annotationsChildren: {
                 dependencyType: "child",
                 childGroups: ["annotations"],
@@ -367,6 +493,10 @@ export function returnGraphPrefigureXMLStateVariableDefinition() {
                 unsupported,
                 annotations,
                 graphComponentIdx: componentIdx,
+                functionToCurveComponentIdx:
+                    (dependencyValues.functionCurveAliasMap as
+                        | Record<number, number>
+                        | undefined) ?? {},
             });
 
             if (
@@ -391,5 +521,17 @@ export function returnGraphPrefigureXMLStateVariableDefinition() {
                 sendDiagnostics: diagnostics,
             };
         },
+    };
+}
+
+export function returnGraphPrefigureStateVariableDefinitions() {
+    // Keep this object as the canonical relationship map between Graph state
+    // variable names and their prefigure definitions.
+    return {
+        curveDescendantComponentIndices:
+            returnGraphCurveDescendantComponentIndicesStateVariableDefinition(),
+        functionCurveAliasMap:
+            returnGraphFunctionCurveAliasMapStateVariableDefinition(),
+        prefigureXML: returnGraphPrefigureXMLStateVariableDefinition(),
     };
 }

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
@@ -273,9 +273,19 @@ function prefigureDescendantDependencies(): Record<string, unknown> {
  */
 function returnGraphCurveDescendantsStateVariableDefinition() {
     return {
-        returnDependencies: () => ({
-            curveDescendants: descendantDependency(CURVE_DESCENDANT_CONFIG),
-        }),
+        stateVariablesDeterminingDependencies: ["effectiveRenderer"],
+        returnDependencies: ({
+            stateValues,
+        }: {
+            stateValues: GraphDependencyValues;
+        }) => {
+            if (stateValues.effectiveRenderer !== "prefigure") {
+                return {};
+            }
+            return {
+                curveDescendants: descendantDependency(CURVE_DESCENDANT_CONFIG),
+            };
+        },
         definition({
             dependencyValues,
         }: {
@@ -442,34 +452,49 @@ function returnGraphPrefigureXMLStateVariableDefinition() {
     return {
         public: true,
         forRenderer: true,
+        stateVariablesDeterminingDependencies: ["effectiveRenderer"],
         shadowingInstructions: {
             createComponentOfType: "text",
         },
-        returnDependencies: () => ({
-            ...prefigureBaseDependencies(),
-            ...prefigureDescendantDependencies(),
-            curveDescendants: {
-                dependencyType: "stateVariable",
-                variableName: "curveDescendants",
-            },
-            functionToCurveComponentIdx: {
-                dependencyType: "stateVariable",
-                variableName: "functionToCurveComponentIdx",
-            },
-            annotationsChildren: {
-                dependencyType: "child",
-                childGroups: ["annotations"],
-                variableNames: ["annotationSubtrees"],
-            },
-            allGraphicalDescendants: {
-                dependencyType: "descendant",
-                componentTypes: ["_graphical"],
-            },
-            allDescendants: {
-                dependencyType: "descendant",
-                componentTypes: ["_base"],
-            },
-        }),
+        returnDependencies: ({
+            stateValues,
+        }: {
+            stateValues: GraphDependencyValues;
+        }) => {
+            const annotationsChildren = {
+                annotationsChildren: {
+                    dependencyType: "child",
+                    childGroups: ["annotations"],
+                    variableNames: ["annotationSubtrees"],
+                },
+            };
+
+            if (stateValues.effectiveRenderer !== "prefigure") {
+                return annotationsChildren;
+            }
+
+            return {
+                ...prefigureBaseDependencies(),
+                ...prefigureDescendantDependencies(),
+                curveDescendants: {
+                    dependencyType: "stateVariable",
+                    variableName: "curveDescendants",
+                },
+                functionToCurveComponentIdx: {
+                    dependencyType: "stateVariable",
+                    variableName: "functionToCurveComponentIdx",
+                },
+                ...annotationsChildren,
+                allGraphicalDescendants: {
+                    dependencyType: "descendant",
+                    componentTypes: ["_graphical"],
+                },
+                allDescendants: {
+                    dependencyType: "descendant",
+                    componentTypes: ["_base"],
+                },
+            };
+        },
         definition({
             dependencyValues,
             componentIdx,

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
@@ -12,9 +12,35 @@ interface DescendantDependency {
 // PreFigure conversion architecture and extension guide:
 // see src/utils/prefigure/README.md
 
+// Curve descendants are pulled into a dedicated shared state variable so the
+// descendant traversal happens once and its results are reused by both
+// prefigureXML and curveDescendantComponentIndices.
+const CURVE_DESCENDANT_CONFIG = {
+    key: "curveDescendants",
+    componentType: "curve",
+    variableNames: [
+        "curveType",
+        "fDefinitions",
+        "parMin",
+        "parMax",
+        "flipFunction",
+        "numericalThroughPoints",
+        "periodic",
+        "extrapolateBackward",
+        "extrapolateForward",
+        "selectedStyle",
+        "label",
+        "labelHasLatex",
+        "hidden",
+    ],
+    variablesOptional: true,
+};
+
 // Ordered from broader base types to narrower types where relevant.
 // If a component matches multiple configs via inheritance, the later match
 // wins after componentIdx dedupe in collectConfiguredDescendants().
+// curveDescendants is intentionally excluded here; it is fetched once via
+// the curveDescendants state variable and threaded in as a stateVariable dep.
 const GRAPHICAL_DESCENDANT_CONFIGS = [
     {
         key: "pointDescendants",
@@ -91,26 +117,6 @@ const GRAPHICAL_DESCENDANT_CONFIGS = [
             "swapPointOrder",
             "hidden",
         ],
-    },
-    {
-        key: "curveDescendants",
-        componentType: "curve",
-        variableNames: [
-            "curveType",
-            "fDefinitions",
-            "parMin",
-            "parMax",
-            "flipFunction",
-            "numericalThroughPoints",
-            "periodic",
-            "extrapolateBackward",
-            "extrapolateForward",
-            "selectedStyle",
-            "label",
-            "labelHasLatex",
-            "hidden",
-        ],
-        variablesOptional: true,
     },
     {
         key: "circleDescendants",
@@ -249,6 +255,8 @@ function prefigureBaseDependencies() {
  *
  * This function is the single place where GRAPHICAL_DESCENDANT_CONFIGS become
  * graph dependencies, which keeps descendant wiring declarative and centralized.
+ * curveDescendants is excluded here and referenced via a stateVariable dep so
+ * the traversal happens only once per graph.
  */
 function prefigureDescendantDependencies(): Record<string, unknown> {
     return Object.fromEntries(
@@ -260,6 +268,29 @@ function prefigureDescendantDependencies(): Record<string, unknown> {
 }
 
 /**
+ * Single traversal for curve descendants, shared by curveDescendantComponentIndices
+ * and prefigureXML via a stateVariable dependency.
+ */
+function returnGraphCurveDescendantsStateVariableDefinition() {
+    return {
+        returnDependencies: () => ({
+            curveDescendants: descendantDependency(CURVE_DESCENDANT_CONFIG),
+        }),
+        definition({
+            dependencyValues,
+        }: {
+            dependencyValues: GraphDependencyValues;
+        }) {
+            return {
+                setValue: {
+                    curveDescendants: dependencyValues.curveDescendants ?? [],
+                },
+            };
+        },
+    };
+}
+
+/**
  * Computes a stable ordered list of curve component indices for this graph.
  *
  * Relationship to other helpers:
@@ -267,16 +298,16 @@ function prefigureDescendantDependencies(): Record<string, unknown> {
  *   dependency per curve descendant.
  * - prefigureXML depends on functionToCurveComponentIdx (not directly on this list).
  *
- * `variableNames: []` is intentional: only component indices are needed here,
- * avoiding redundant variable fetching that the prefigureXML query already does.
+ * Curve data is sourced from the shared curveDescendants state variable to
+ * avoid a second descendant traversal.
  */
 function returnGraphCurveDescendantComponentIndicesStateVariableDefinition() {
     return {
         returnDependencies: () => ({
-            curveDescendants: descendantDependency({
-                componentType: "curve",
-                variableNames: [],
-            }),
+            curveDescendants: {
+                dependencyType: "stateVariable",
+                variableName: "curveDescendants",
+            },
         }),
         definition({
             dependencyValues,
@@ -382,7 +413,12 @@ function collectConfiguredDescendants(
 ): Descendant[] {
     const byComponentIdx = new Map<number, Descendant>();
 
-    for (const config of GRAPHICAL_DESCENDANT_CONFIGS) {
+    // CURVE_DESCENDANT_CONFIG is listed first so later configs can override
+    // if a curve componentIdx also matches a narrower graphical type.
+    for (const config of [
+        CURVE_DESCENDANT_CONFIG,
+        ...GRAPHICAL_DESCENDANT_CONFIGS,
+    ]) {
         for (const descendant of (dependencyValues[config.key] as
             | Descendant[]
             | undefined) ?? []) {
@@ -412,6 +448,10 @@ function returnGraphPrefigureXMLStateVariableDefinition() {
         returnDependencies: () => ({
             ...prefigureBaseDependencies(),
             ...prefigureDescendantDependencies(),
+            curveDescendants: {
+                dependencyType: "stateVariable",
+                variableName: "curveDescendants",
+            },
             functionToCurveComponentIdx: {
                 dependencyType: "stateVariable",
                 variableName: "functionToCurveComponentIdx",
@@ -532,6 +572,7 @@ function returnGraphPrefigureXMLStateVariableDefinition() {
  */
 export function returnGraphPrefigureStateVariableDefinitions() {
     return {
+        curveDescendants: returnGraphCurveDescendantsStateVariableDefinition(),
         curveDescendantComponentIndices:
             returnGraphCurveDescendantComponentIndicesStateVariableDefinition(),
         functionToCurveComponentIdx:

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/types.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/types.ts
@@ -151,4 +151,7 @@ export interface GraphDependencyValues extends Record<string, unknown> {
     allGraphicalDescendants?: Descendant[];
     allDescendants?: Descendant[];
     annotationsChildren?: AnnotationContainerChild[];
+    curveDescendants?: Descendant[];
+    curveDescendantComponentIndices?: number[];
+    functionCurveAliasMap?: Record<number, number>;
 }

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/types.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/types.ts
@@ -153,5 +153,5 @@ export interface GraphDependencyValues extends Record<string, unknown> {
     annotationsChildren?: AnnotationContainerChild[];
     curveDescendants?: Descendant[];
     curveDescendantComponentIndices?: number[];
-    functionCurveAliasMap?: Record<number, number>;
+    functionToCurveComponentIdx?: Record<number, number>;
 }


### PR DESCRIPTION
## Summary
- add function-to-curve alias resolution for prefigure annotation refs so `<annotation ref="$f" />` works when `f` is a function rendered via an adapted curve
- refactor prefigure graph state-variable wiring into a single exported object map in `stateVariable.ts` for maintainability
- add/clarify docstrings for prefigure state-variable helper relationships
- add tests covering function ref resolution and outside-graph rejection behavior

## Validation
- `npm run test -w @doenet/doenetml-worker-javascript -- --run src/test/prefigure/graph-prefigure-core.test.ts`
