### PR TITLE
Update prefigure runtime pins

### DIFF
--- a/.changeset/fair-schools-relate.md
+++ b/.changeset/fair-schools-relate.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Update the default PreFigure runtime pins used by the viewer.
+
+The published Doenet packages now default to `@doenet/prefigure@0.5.15` and
+`diagcess@1.4.1` for PreFigure rendering, aligning the built-in CDN defaults
+with the latest synchronized PreFigure runtime update.

--- a/.github/workflows/publish-prefigure.yml
+++ b/.github/workflows/publish-prefigure.yml
@@ -25,6 +25,7 @@ jobs:
     publish-prefigure:
         name: Publish Prefigure
         runs-on: ubuntu-latest
+        environment: production
         permissions:
             actions: read
             contents: read
@@ -57,6 +58,7 @@ jobs:
             - name: Build prefigure package
               run: npm run build -w packages/prefigure
               env:
+                  NODE_OPTIONS: "--max_old_space_size=6114"
                   WIREIT_CACHE: "local"
 
             - name: Verify wheel sync

--- a/.github/workflows/publish-prefigure.yml
+++ b/.github/workflows/publish-prefigure.yml
@@ -38,6 +38,14 @@ jobs:
               id: checked-sha
               run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+            - name: Verify commit is on main
+              run: |
+                  git fetch origin main
+                  if ! git merge-base --is-ancestor HEAD origin/main; then
+                      echo "Error: checked-out commit is not reachable from origin/main. Only commits on main may be published." >&2
+                      exit 1
+                  fi
+
             - name: Use Node.js 24
               uses: actions/setup-node@v4
               with:

--- a/.github/workflows/publish-prefigure.yml
+++ b/.github/workflows/publish-prefigure.yml
@@ -33,6 +33,8 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v3
+              with:
+                  fetch-depth: 0
 
             - name: Determine checked out commit SHA
               id: checked-sha

--- a/.github/workflows/publish-prefigure.yml
+++ b/.github/workflows/publish-prefigure.yml
@@ -1,0 +1,81 @@
+name: Publish Prefigure
+
+on:
+    workflow_dispatch:
+        inputs:
+            dry_run:
+                description: Skip npm publish
+                required: true
+                type: boolean
+                default: true
+            npm_tag:
+                description: npm dist-tag to publish under
+                required: true
+                type: string
+                default: latest
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+    cancel-in-progress: false
+
+env:
+    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+    publish-prefigure:
+        name: Publish Prefigure
+        runs-on: ubuntu-latest
+        permissions:
+            actions: read
+            contents: read
+            id-token: write
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+
+            - name: Determine checked out commit SHA
+              id: checked-sha
+              run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+            - name: Use Node.js 24
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 24.x
+                  registry-url: https://registry.npmjs.org
+                  cache: "npm"
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Verify CI succeeded for target commit
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+                  REPO: ${{ github.repository }}
+                  TARGET_SHA: ${{ steps.checked-sha.outputs.sha }}
+              run: node .github/scripts/verify-ci.mjs
+
+            - name: Build prefigure package
+              run: npm run build -w packages/prefigure
+              env:
+                  WIREIT_CACHE: "local"
+
+            - name: Verify wheel sync
+              run: npm run verify-wheel-sync -w @doenet/prefigure
+
+            - name: Publish prefigure package
+              if: ${{ !inputs.dry_run }}
+              env:
+                  NPM_TAG: ${{ inputs.npm_tag }}
+              run: |
+                  cd packages/prefigure/dist
+                  npm publish --tag "${NPM_TAG}"
+
+            - name: Purge jsDelivr cache
+              if: ${{ !inputs.dry_run }}
+              env:
+                  NPM_TAG: ${{ inputs.npm_tag }}
+              run: |
+                  echo "Waiting for npm package propagation before purging jsDelivr cache..."
+                  sleep 15
+                  curl -fv "https://purge.jsdelivr.net/npm/@doenet/prefigure@${NPM_TAG}" || exit 1
+                  curl -fv "https://purge.jsdelivr.net/npm/@doenet/prefigure@${NPM_TAG}/prefigure.js" || exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,6 +87,10 @@ jobs:
                   npm run build -w packages/doenetml -w packages/standalone -w packages/doenetml-iframe -w packages/v06-to-v07
               env:
                   WIREIT_CACHE: "local"
+                  # Dev builds use @latest so they remain functional even when a
+                  # prefigure version bump hasn't been published to npm yet.
+                  # Production builds (below) keep the exact pinned default.
+                  VITE_PREFIGURE_MODULE_URL: "https://cdn.jsdelivr.net/npm/@doenet/prefigure@latest/prefigure.js"
 
             - name: Publish dev release
               if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24773,7 +24773,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.11",
+            "version": "0.7.13",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "dompurify": "^3.3.0"
@@ -24785,7 +24785,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.11",
+            "version": "0.7.13",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -25329,7 +25329,7 @@
         },
         "packages/prefigure": {
             "name": "@doenet/prefigure",
-            "version": "0.5.13",
+            "version": "0.5.15",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "@mathjax/src": "^4.0.0",
@@ -25341,7 +25341,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.11",
+            "version": "0.7.13",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },
@@ -25396,7 +25396,7 @@
         },
         "packages/v06-to-v07": {
             "name": "@doenet/v06-to-v07",
-            "version": "0.7.11",
+            "version": "0.7.13",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/packages/doenetml/src/Viewer/renderers/utils/prefigureConfig.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/prefigureConfig.ts
@@ -1,11 +1,11 @@
 const DEFAULT_PREFIGURE_BUILD_ENDPOINT = "https://prefigure.doenet.org/build";
 const DEFAULT_PREFIGURE_DIAGCESS_SCRIPT_URL =
-    "https://cdn.jsdelivr.net/npm/diagcess@1.4.0/dist/diagcess.js";
+    "https://cdn.jsdelivr.net/npm/diagcess@1.4.1/dist/diagcess.js";
 // This default pins a published @doenet/prefigure package tag for CDN loading.
 // It is intentionally managed independently from the wheel/runtime version
 // metadata in packages/prefigure/src/worker/compiler-metadata.ts.
 const DEFAULT_PREFIGURE_MODULE_URL =
-    "https://cdn.jsdelivr.net/npm/@doenet/prefigure@0.5.13/prefigure.js";
+    "https://cdn.jsdelivr.net/npm/@doenet/prefigure@0.5.15/prefigure.js";
 
 const env = (
     import.meta as ImportMeta & {

--- a/packages/doenetml/src/Viewer/renderers/utils/prefigureConfig.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/prefigureConfig.ts
@@ -2,8 +2,8 @@ const DEFAULT_PREFIGURE_BUILD_ENDPOINT = "https://prefigure.doenet.org/build";
 const DEFAULT_PREFIGURE_DIAGCESS_SCRIPT_URL =
     "https://cdn.jsdelivr.net/npm/diagcess@1.4.1/dist/diagcess.js";
 // This default pins a published @doenet/prefigure package tag for CDN loading.
-// It is intentionally managed independently from the wheel/runtime version
-// metadata in packages/prefigure/src/worker/compiler-metadata.ts.
+// It is configured here (not auto-derived from prefigure package metadata),
+// but should still be manually kept aligned with runtime version bumps.
 const DEFAULT_PREFIGURE_MODULE_URL =
     "https://cdn.jsdelivr.net/npm/@doenet/prefigure@0.5.15/prefigure.js";
 

--- a/packages/prefigure/README.md
+++ b/packages/prefigure/README.md
@@ -104,7 +104,9 @@ Before publishing or bumping the runtime, keep these in sync:
 - `pyodide_packages/prefig-<version>-py3-none-any.whl` via `npm run setup -w @doenet/prefigure`
 - `packages/doenetml/src/Viewer/renderers/utils/prefigureConfig.ts` default CDN URLs for `@doenet/prefigure` and `diagcess`
 
-At runtime, `initPrefigure()` defaults to loading wheel assets from `./assets/`.
+At runtime, `initPrefigure()` defaults to loading wheel assets from an `assets/`
+directory relative to the loaded `prefigure.js` module URL. Pass `indexURL` to
+`initPrefigure(indexURL)` to override this default.
 
 ## Repository Hygiene
 

--- a/packages/prefigure/README.md
+++ b/packages/prefigure/README.md
@@ -29,11 +29,14 @@ Or load from CDN:
 
 ```html
 <script type="module">
-  import * as prefigure from 'https://cdn.jsdelivr.net/npm/@doenet/prefigure@latest';
+	import * as prefigure from 'https://cdn.jsdelivr.net/npm/@doenet/prefigure@0.5.15/prefigure.js';
   await prefigure.initPrefigure();
   const result = await prefigure.compilePrefigure(diagramXml, { mode: 'svg' });
 </script>
 ```
+
+Pin a specific CDN version instead of using `@latest` so the browser runtime,
+vendored wheel, and downstream Doenet defaults stay reproducible.
 
 ## Global API
 
@@ -89,11 +92,19 @@ Current coverage includes API-level behavior tests for:
 The browser runtime check remains useful as a manual runtime check for real
 Pyodide+WASM execution.
 
-## Wheel Requirement
+## Runtime Version Sync
 
-Builds currently vendor wheels from `pyodide_packages/`. Before publishing,
-ensure a matching `prefig-<version>-py3-none-any.whl` is present there.
-At runtime, `initPrefigure()` defaults to loading from `./assets/`.
+Builds vendor wheels from `pyodide_packages/`, and the browser runtime is only
+consistent when all pinned PreFigure pieces move together.
+
+Before publishing or bumping the runtime, keep these in sync:
+
+- `packages/prefigure/package.json` version for the published `@doenet/prefigure` tag
+- `src/worker/compiler-metadata.ts` `PREFIG_VERSION` / `PREFIG_WHEEL_FILENAME`
+- `pyodide_packages/prefig-<version>-py3-none-any.whl` via `npm run setup -w @doenet/prefigure`
+- `packages/doenetml/src/Viewer/renderers/utils/prefigureConfig.ts` default CDN URLs for `@doenet/prefigure` and `diagcess`
+
+At runtime, `initPrefigure()` defaults to loading wheel assets from `./assets/`.
 
 ## Repository Hygiene
 
@@ -135,12 +146,16 @@ npm run verify-wheel-sync -w @doenet/prefigure
 `verify-wheel-sync` ensures `src/worker/compiler-metadata.ts` and
 `pyodide_packages/` reference the same `prefig` wheel.
 
-### Upgrade `prefig` wheel version
+### Upgrade PreFigure runtime version
 
-1. Update `PREFIG_WHEEL_FILENAME` in `src/worker/compiler-metadata.ts`.
-2. Run `npm run setup -w @doenet/prefigure`.
-3. Run `npm run verify-wheel-sync -w @doenet/prefigure`.
-4. Build and run the browser runtime check:
+1. Update `version` in `packages/prefigure/package.json`.
+2. Update `PREFIG_VERSION` in `src/worker/compiler-metadata.ts`.
+3. Update the default CDN module URL in `packages/doenetml/src/Viewer/renderers/utils/prefigureConfig.ts`.
+4. If the bundled accessibility runtime changed, update the default diagcess CDN URL there as well.
+5. Update `prefigure.doenet.org` outside this repository so the fallback build-service path matches the new runtime behavior before local WASM compilation warms up.
+6. Run `npm run setup -w @doenet/prefigure` to fetch the matching `prefig-<version>-py3-none-any.whl`.
+7. Run `npm run verify-wheel-sync -w @doenet/prefigure`.
+8. Build and run the browser runtime check:
 
 ```bash
 npm run build -w @doenet/prefigure

--- a/packages/prefigure/README.md
+++ b/packages/prefigure/README.md
@@ -29,7 +29,7 @@ Or load from CDN:
 
 ```html
 <script type="module">
-	import * as prefigure from 'https://cdn.jsdelivr.net/npm/@doenet/prefigure@0.5.15/prefigure.js';
+  import * as prefigure from 'https://cdn.jsdelivr.net/npm/@doenet/prefigure@0.5.15/prefigure.js';
   await prefigure.initPrefigure();
   const result = await prefigure.compilePrefigure(diagramXml, { mode: 'svg' });
 </script>
@@ -52,9 +52,9 @@ Both methods return promises.
 ```html
 <script type="module" src="./prefigure.js"></script>
 <script type="module">
-	await window.initPrefigure();
-	const result = await window.prefigure(`<diagram dimensions="(100,100)"></diagram>`);
-	console.log(result.svg, result.annotationsXml);
+  await window.initPrefigure();
+  const result = await window.prefigure(`<diagram dimensions="(100,100)"></diagram>`);
+  console.log(result.svg, result.annotationsXml);
 </script>
 ```
 

--- a/packages/prefigure/package.json
+++ b/packages/prefigure/package.json
@@ -2,7 +2,7 @@
     "name": "@doenet/prefigure",
     "type": "module",
     "description": "Standalone PreFigure WASM compiler for browser and CDN usage",
-    "version": "0.5.13",
+    "version": "0.5.15",
     "license": "AGPL-3.0-or-later",
     "homepage": "https://github.com/Doenet/DoenetML#readme",
     "private": true,

--- a/packages/prefigure/src/worker/compiler-metadata.ts
+++ b/packages/prefigure/src/worker/compiler-metadata.ts
@@ -13,5 +13,5 @@
  *
  * Keep this file free of imports so it tree-shakes to a tiny constant.
  */
-export const PREFIG_VERSION = "0.5.13";
+export const PREFIG_VERSION = "0.5.15";
 export const PREFIG_WHEEL_FILENAME = `prefig-${PREFIG_VERSION}-py3-none-any.whl`;


### PR DESCRIPTION
## Summary
- bump the packaged `@doenet/prefigure` runtime version to 0.5.15
- update the default viewer CDN pins for `@doenet/prefigure` and `diagcess`
- document the full runtime sync process in the prefigure README
- add a changeset for `@doenet/doenetml`, `@doenet/standalone`, and `@doenet/doenetml-iframe`
- add a separate manual GitHub Actions workflow for publishing `@doenet/prefigure`

## Verification
- `npm run build` in `packages/prefigure`
- `npm run verify-wheel-sync` in `packages/prefigure`
- verified `https://cdn.jsdelivr.net/npm/diagcess@1.4.1/dist/diagcess.js` returns HTTP 200