### PR TITLE
Race service and local WASM warmup in prefigure renderer

### DIFF
--- a/.changeset/prefigure-renderer-winner.md
+++ b/.changeset/prefigure-renderer-winner.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Fix PreFigure renderer so local WASM readiness cancels slow or failed service fallback.
+
+When the local WASM runtime is not yet warm, the renderer previously committed exclusively to the remote build service. Two flaws resulted: if the service failed the diagram was never rendered, and if WASM became ready during a slow service call the renderer still waited for the network round-trip.
+
+Both issues are resolved by racing the service request and the local warmup in parallel. When the WASM runtime becomes ready first, the in-flight service request is aborted and the diagram is compiled locally. When the service responds first its result is used immediately (existing behavior). If the service fails but warmup later succeeds, the diagram is still rendered locally instead of showing an error.

--- a/packages/doenetml/src/Viewer/renderers/prefigure.tsx
+++ b/packages/doenetml/src/Viewer/renderers/prefigure.tsx
@@ -22,6 +22,10 @@ type PrefigureBuildResult = {
     annotationsXml: string;
 };
 
+type PrefigureBuildWinner =
+    | { backend: "service"; data: PrefigureBuildResult }
+    | { backend: "local"; module: PrefigureModule };
+
 async function importPrefigureFromUrl(url: string): Promise<PrefigureModule> {
     return import(/* @vite-ignore */ url);
 }
@@ -88,6 +92,64 @@ async function buildWithPrefigureService(
     return data;
 }
 
+function createAbortError(): Error {
+    try {
+        return new DOMException("The operation was aborted.", "AbortError");
+    } catch (_error) {
+        const error = new Error("The operation was aborted.");
+        error.name = "AbortError";
+        return error;
+    }
+}
+
+function isAbortError(error: unknown): boolean {
+    return error instanceof Error && error.name === "AbortError";
+}
+
+function resolveBuildRaceError(error: unknown): unknown {
+    if (!Array.isArray(error)) {
+        return error;
+    }
+
+    const allErrors = error;
+    if (allErrors.length === 0) {
+        return error;
+    }
+
+    const nonAbortError = allErrors.find((candidate) => {
+        return !isAbortError(candidate);
+    });
+
+    return nonAbortError ?? allErrors[0];
+}
+
+function firstSuccessful<T>(promises: Array<Promise<T>>): Promise<T> {
+    return new Promise((resolve, reject) => {
+        let remaining = promises.length;
+        const errors: unknown[] = [];
+
+        if (remaining === 0) {
+            reject(new Error("No promises were provided."));
+            return;
+        }
+
+        for (const promise of promises) {
+            promise
+                .then((value) => {
+                    resolve(value);
+                })
+                .catch((error) => {
+                    errors.push(error);
+                    remaining -= 1;
+
+                    if (remaining === 0) {
+                        reject(errors);
+                    }
+                });
+        }
+    });
+}
+
 /**
  * Build diagram content via whichever backend is currently available.
  * Prefers local WASM when warm; otherwise uses the build service.
@@ -103,12 +165,68 @@ async function buildPrefigureDiagram(
         });
     }
 
-    const data = await buildWithPrefigureService(diagramXML, signal);
+    if (signal.aborted) {
+        throw createAbortError();
+    }
 
-    // Keep warmup alive for future renders.
-    warmupPrefigureInBackground();
+    const serviceAbortController = new AbortController();
+    const abortServiceRequest = () => {
+        serviceAbortController.abort();
+    };
 
-    return data;
+    signal.addEventListener("abort", abortServiceRequest, { once: true });
+
+    const outerAbortPromise = new Promise<never>((_resolve, reject) => {
+        const rejectForAbort = () => {
+            reject(createAbortError());
+        };
+
+        if (signal.aborted) {
+            rejectForAbort();
+            return;
+        }
+
+        signal.addEventListener("abort", rejectForAbort, { once: true });
+    });
+
+    try {
+        const serviceBuildPromise: Promise<PrefigureBuildWinner> =
+            buildWithPrefigureService(
+                diagramXML,
+                serviceAbortController.signal,
+            ).then((data) => {
+                return { backend: "service", data };
+            });
+
+        const localReadyPromise: Promise<PrefigureBuildWinner> =
+            startPrefigureWarmup().then((module) => {
+                return { backend: "local", module };
+            });
+
+        const winner = await Promise.race([
+            firstSuccessful([serviceBuildPromise, localReadyPromise]),
+            outerAbortPromise,
+        ]);
+
+        if (winner.backend === "service") {
+            return winner.data;
+        }
+
+        // WASM became ready before the service response, so stop waiting on the
+        // slower network fallback and compile locally.
+        if (!serviceAbortController.signal.aborted) {
+            serviceAbortController.abort();
+        }
+
+        return winner.module.compilePrefigure(diagramXML, {
+            mode: "svg",
+            indexURL: PREFIGURE_INDEX_URL || undefined,
+        });
+    } catch (error) {
+        throw resolveBuildRaceError(error);
+    } finally {
+        signal.removeEventListener("abort", abortServiceRequest);
+    }
 }
 
 type DiagcessApi = {

--- a/packages/doenetml/src/Viewer/renderers/prefigure.tsx
+++ b/packages/doenetml/src/Viewer/renderers/prefigure.tsx
@@ -229,9 +229,14 @@ async function buildPrefigureDiagram(
             });
 
         const localReadyPromise: Promise<PrefigureBuildWinner> =
-            startPrefigureWarmup().then((module) => {
-                return { backend: "local", module };
-            });
+            startPrefigureWarmup()
+                .then((module) => {
+                    return { backend: "local" as const, module };
+                })
+                .catch((error) => {
+                    logWarmupFailure(error);
+                    throw error;
+                });
 
         const winner = await Promise.race([
             firstSuccessful([serviceBuildPromise, localReadyPromise]),

--- a/packages/doenetml/src/Viewer/renderers/prefigure.tsx
+++ b/packages/doenetml/src/Viewer/renderers/prefigure.tsx
@@ -109,10 +109,22 @@ function createAbortError(): Error {
 
 /**
  * Returns true if `error` is an AbortError regardless of whether it came from
- * a DOMException or from the plain-Error fallback in {@link createAbortError}.
+ * a DOMException, from the plain-Error fallback in {@link createAbortError},
+ * or from environment-specific abort object shapes.
  */
 function isAbortError(error: unknown): boolean {
-    return error instanceof Error && error.name === "AbortError";
+    if (
+        error === null ||
+        (typeof error !== "object" && typeof error !== "function")
+    ) {
+        return false;
+    }
+
+    if (!("name" in error)) {
+        return false;
+    }
+
+    return error.name === "AbortError";
 }
 
 /**
@@ -234,10 +246,13 @@ async function buildPrefigureDiagram(
         // slower network fallback and compile locally.
         serviceAbortController.abort();
 
-        return winner.module.compilePrefigure(diagramXML, {
-            mode: "svg",
-            indexURL: PREFIGURE_INDEX_URL || undefined,
-        });
+        return await Promise.race([
+            winner.module.compilePrefigure(diagramXML, {
+                mode: "svg",
+                indexURL: PREFIGURE_INDEX_URL || undefined,
+            }),
+            outerAbortPromise,
+        ]);
     } catch (error) {
         throw resolveBuildRaceError(error);
     } finally {

--- a/packages/doenetml/src/Viewer/renderers/prefigure.tsx
+++ b/packages/doenetml/src/Viewer/renderers/prefigure.tsx
@@ -92,6 +92,11 @@ async function buildWithPrefigureService(
     return data;
 }
 
+/**
+ * Creates a DOMException-compatible AbortError for programmatic cancellation.
+ * Falls back to a plain Error with `name === "AbortError"` in environments
+ * where DOMException is not constructible (e.g. older WebViews).
+ */
 function createAbortError(): Error {
     try {
         return new DOMException("The operation was aborted.", "AbortError");
@@ -102,27 +107,37 @@ function createAbortError(): Error {
     }
 }
 
+/**
+ * Returns true if `error` is an AbortError regardless of whether it came from
+ * a DOMException or from the plain-Error fallback in {@link createAbortError}.
+ */
 function isAbortError(error: unknown): boolean {
     return error instanceof Error && error.name === "AbortError";
 }
 
+/**
+ * Unwraps a multi-error array produced by {@link firstSuccessful} into a
+ * single throwable value.  Prefers the first non-AbortError so that a real
+ * failure surfaces even when one of the two backends was intentionally
+ * cancelled.
+ */
 function resolveBuildRaceError(error: unknown): unknown {
     if (!Array.isArray(error)) {
         return error;
     }
 
-    const allErrors = error;
-    if (allErrors.length === 0) {
-        return error;
-    }
-
-    const nonAbortError = allErrors.find((candidate) => {
-        return !isAbortError(candidate);
-    });
-
-    return nonAbortError ?? allErrors[0];
+    const nonAbortError = error.find((candidate) => !isAbortError(candidate));
+    return nonAbortError ?? error[0];
 }
 
+/**
+ * Resolves with the value of the first promise that fulfills.
+ * Rejects with an array of all errors only when every promise has rejected.
+ *
+ * Semantically equivalent to `Promise.any()`, but compatible with the
+ * `ES2021.String` lib subset used in this package (which lacks `ES2021.Promise`
+ * and therefore lacks the `AggregateError` type).
+ */
 function firstSuccessful<T>(promises: Array<Promise<T>>): Promise<T> {
     return new Promise((resolve, reject) => {
         let remaining = promises.length;
@@ -134,18 +149,13 @@ function firstSuccessful<T>(promises: Array<Promise<T>>): Promise<T> {
         }
 
         for (const promise of promises) {
-            promise
-                .then((value) => {
-                    resolve(value);
-                })
-                .catch((error) => {
-                    errors.push(error);
-                    remaining -= 1;
-
-                    if (remaining === 0) {
-                        reject(errors);
-                    }
-                });
+            promise.then(resolve, (error: unknown) => {
+                errors.push(error);
+                remaining -= 1;
+                if (remaining === 0) {
+                    reject(errors);
+                }
+            });
         }
     });
 }
@@ -176,6 +186,11 @@ async function buildPrefigureDiagram(
 
     signal.addEventListener("abort", abortServiceRequest, { once: true });
 
+    // cleanupOuterAbort removes the abort listener added inside the promise
+    // constructor below so it does not linger on the signal after the race
+    // settles normally.
+    let cleanupOuterAbort: () => void = () => {};
+
     const outerAbortPromise = new Promise<never>((_resolve, reject) => {
         const rejectForAbort = () => {
             reject(createAbortError());
@@ -187,6 +202,9 @@ async function buildPrefigureDiagram(
         }
 
         signal.addEventListener("abort", rejectForAbort, { once: true });
+        cleanupOuterAbort = () => {
+            signal.removeEventListener("abort", rejectForAbort);
+        };
     });
 
     try {
@@ -214,9 +232,7 @@ async function buildPrefigureDiagram(
 
         // WASM became ready before the service response, so stop waiting on the
         // slower network fallback and compile locally.
-        if (!serviceAbortController.signal.aborted) {
-            serviceAbortController.abort();
-        }
+        serviceAbortController.abort();
 
         return winner.module.compilePrefigure(diagramXML, {
             mode: "svg",
@@ -226,6 +242,7 @@ async function buildPrefigureDiagram(
         throw resolveBuildRaceError(error);
     } finally {
         signal.removeEventListener("abort", abortServiceRequest);
+        cleanupOuterAbort();
     }
 }
 
@@ -722,10 +739,7 @@ export default React.memo(function Prefigure({
                     setCmlContent,
                 });
             } catch (error) {
-                if (
-                    error instanceof DOMException &&
-                    error.name === "AbortError"
-                ) {
+                if (isAbortError(error)) {
                     return;
                 }
 

--- a/packages/doenetml/src/Viewer/renderers/prefigure.tsx
+++ b/packages/doenetml/src/Viewer/renderers/prefigure.tsx
@@ -198,6 +198,12 @@ async function buildPrefigureDiagram(
 
     signal.addEventListener("abort", abortServiceRequest, { once: true });
 
+    // Close the check/listen race: the outer signal may have aborted after the
+    // earlier guard but before this listener was attached.
+    if (signal.aborted) {
+        serviceAbortController.abort();
+    }
+
     // cleanupOuterAbort removes the abort listener added inside the promise
     // constructor below so it does not linger on the signal after the race
     // settles normally.

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureWinner.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureWinner.cy.js
@@ -76,7 +76,7 @@ describe(
                 modulePath: "/mock-prefigure-abort-during-compile.js",
                 initDelayMs: 40,
                 compileDelayMs: 450,
-                renderLabel: "local-should-not-render-after-abort",
+                renderLabel: "local-replacement-render-after-abort",
             });
 
             cy.intercept("POST", PREFIGURE_BUILD_URL_PATTERN, {
@@ -117,7 +117,7 @@ describe(
             cy.wait(550);
             cy.get(cesc("#prefig2"), { timeout: 2000 }).should(
                 "contain.text",
-                "local-should-not-render-after-abort",
+                "local-replacement-render-after-abort",
             );
             cy.get(cesc("#prefig2")).should("not.contain.text", "Error:");
         });

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureWinner.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureWinner.cy.js
@@ -1,0 +1,73 @@
+import { cesc } from "@doenet/utils";
+import {
+    installMockPrefigureModule,
+    postDebounceTestDoenetML,
+    visitWithMockPrefigureModule,
+} from "../../support/prefigure";
+
+describe(
+    "PreFigure backend winner behavior @group4",
+    { tags: ["@group4"] },
+    () => {
+        beforeEach(() => {
+            cy.clearIndexedDB();
+        });
+
+        it("uses local WASM when it becomes ready before a slow service response", () => {
+            const modulePath = installMockPrefigureModule({
+                modulePath: "/mock-prefigure-fast-local.js",
+                initDelayMs: 120,
+                renderLabel: "local-winner",
+            });
+
+            cy.intercept("POST", "**/build", {
+                statusCode: 200,
+                headers: { "content-type": "application/json" },
+                delay: 4500,
+                body: {
+                    svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>service-slow</text></svg>',
+                    annotationsXml:
+                        "<diagram><annotation>service-slow</annotation></diagram>",
+                },
+            });
+
+            visitWithMockPrefigureModule(modulePath);
+            postDebounceTestDoenetML(cesc);
+
+            cy.get(cesc("#prefig"), { timeout: 1800 }).should(
+                "contain.text",
+                "local-winner",
+            );
+            cy.get(cesc("#prefig")).should("not.contain.text", "service-slow");
+
+            // Even after the delayed service response eventually settles, the
+            // local winner should remain rendered.
+            cy.wait(4700);
+            cy.get(cesc("#prefig")).should("contain.text", "local-winner");
+            cy.get(cesc("#prefig")).should("not.contain.text", "service-slow");
+        });
+
+        it("recovers from service failure once local WASM warmup completes", () => {
+            const modulePath = installMockPrefigureModule({
+                modulePath: "/mock-prefigure-after-failure.js",
+                initDelayMs: 350,
+                renderLabel: "local-after-service-error",
+            });
+
+            cy.intercept("POST", "**/build", {
+                statusCode: 503,
+                headers: { "content-type": "application/json" },
+                body: { message: "service unavailable" },
+            });
+
+            visitWithMockPrefigureModule(modulePath);
+            postDebounceTestDoenetML(cesc);
+
+            cy.get(cesc("#prefig"), { timeout: 3000 }).should(
+                "contain.text",
+                "local-after-service-error",
+            );
+            cy.get(cesc("#prefig")).should("not.contain.text", "Error:");
+        });
+    },
+);

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureWinner.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureWinner.cy.js
@@ -71,7 +71,7 @@ describe(
             cy.get(cesc("#prefig")).should("not.contain.text", "Error:");
         });
 
-        it("cancels local compile when request is aborted after warmup wins", () => {
+        it("suppresses stale local compile result when request is aborted after warmup wins", () => {
             const modulePath = installMockPrefigureModule({
                 modulePath: "/mock-prefigure-abort-during-compile.js",
                 initDelayMs: 40,

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureWinner.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureWinner.cy.js
@@ -70,5 +70,56 @@ describe(
             );
             cy.get(cesc("#prefig")).should("not.contain.text", "Error:");
         });
+
+        it("cancels local compile when request is aborted after warmup wins", () => {
+            const modulePath = installMockPrefigureModule({
+                modulePath: "/mock-prefigure-abort-during-compile.js",
+                initDelayMs: 40,
+                compileDelayMs: 1200,
+                renderLabel: "local-should-not-render-after-abort",
+            });
+
+            cy.intercept("POST", PREFIGURE_BUILD_URL_PATTERN, {
+                statusCode: 200,
+                headers: { "content-type": "application/json" },
+                delay: 4500,
+                body: {
+                    svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>service-slow</text></svg>',
+                    annotationsXml:
+                        "<diagram><annotation>service-slow</annotation></diagram>",
+                },
+            });
+
+            visitWithMockPrefigureModule(modulePath);
+            postDebounceTestDoenetML(cesc);
+
+            // Trigger a new payload while the first local compile is still in
+            // flight, which should abort and suppress the stale result.
+            cy.window().then(async (win) => {
+                win.postMessage(
+                    {
+                        doenetML: `
+<text name="ready">ready</text>
+<graph name="g2">
+  <point name="Q">(1,1)</point>
+</graph>
+<graph name="prefig2" renderer="prefigure" extend="$g2" />
+`,
+                    },
+                    "*",
+                );
+            });
+
+            // The second payload replaces the first graph, so #prefig is
+            // removed from the DOM. The key assertion is that this unmount-time
+            // abort does not surface stale output or an error.
+            cy.get(cesc("#prefig")).should("not.exist");
+            cy.wait(1400);
+            cy.get(cesc("#prefig2"), { timeout: 3500 }).should(
+                "contain.text",
+                "local-should-not-render-after-abort",
+            );
+            cy.get(cesc("#prefig2")).should("not.contain.text", "Error:");
+        });
     },
 );

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureWinner.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureWinner.cy.js
@@ -17,14 +17,14 @@ describe(
         it("uses local WASM when it becomes ready before a slow service response", () => {
             const modulePath = installMockPrefigureModule({
                 modulePath: "/mock-prefigure-fast-local.js",
-                initDelayMs: 120,
+                initDelayMs: 40,
                 renderLabel: "local-winner",
             });
 
             cy.intercept("POST", PREFIGURE_BUILD_URL_PATTERN, {
                 statusCode: 200,
                 headers: { "content-type": "application/json" },
-                delay: 4500,
+                delay: 800,
                 body: {
                     svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>service-slow</text></svg>',
                     annotationsXml:
@@ -35,7 +35,7 @@ describe(
             visitWithMockPrefigureModule(modulePath);
             postDebounceTestDoenetML(cesc);
 
-            cy.get(cesc("#prefig"), { timeout: 1800 }).should(
+            cy.get(cesc("#prefig"), { timeout: 1400 }).should(
                 "contain.text",
                 "local-winner",
             );
@@ -43,7 +43,7 @@ describe(
 
             // Even after the delayed service response eventually settles, the
             // local winner should remain rendered.
-            cy.wait(4700);
+            cy.wait(900);
             cy.get(cesc("#prefig")).should("contain.text", "local-winner");
             cy.get(cesc("#prefig")).should("not.contain.text", "service-slow");
         });
@@ -51,7 +51,7 @@ describe(
         it("recovers from service failure once local WASM warmup completes", () => {
             const modulePath = installMockPrefigureModule({
                 modulePath: "/mock-prefigure-after-failure.js",
-                initDelayMs: 350,
+                initDelayMs: 120,
                 renderLabel: "local-after-service-error",
             });
 
@@ -64,7 +64,7 @@ describe(
             visitWithMockPrefigureModule(modulePath);
             postDebounceTestDoenetML(cesc);
 
-            cy.get(cesc("#prefig"), { timeout: 3000 }).should(
+            cy.get(cesc("#prefig"), { timeout: 2000 }).should(
                 "contain.text",
                 "local-after-service-error",
             );
@@ -75,14 +75,14 @@ describe(
             const modulePath = installMockPrefigureModule({
                 modulePath: "/mock-prefigure-abort-during-compile.js",
                 initDelayMs: 40,
-                compileDelayMs: 1200,
+                compileDelayMs: 450,
                 renderLabel: "local-should-not-render-after-abort",
             });
 
             cy.intercept("POST", PREFIGURE_BUILD_URL_PATTERN, {
                 statusCode: 200,
                 headers: { "content-type": "application/json" },
-                delay: 4500,
+                delay: 900,
                 body: {
                     svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>service-slow</text></svg>',
                     annotationsXml:
@@ -114,8 +114,8 @@ describe(
             // removed from the DOM. The key assertion is that this unmount-time
             // abort does not surface stale output or an error.
             cy.get(cesc("#prefig")).should("not.exist");
-            cy.wait(1400);
-            cy.get(cesc("#prefig2"), { timeout: 3500 }).should(
+            cy.wait(550);
+            cy.get(cesc("#prefig2"), { timeout: 2000 }).should(
                 "contain.text",
                 "local-should-not-render-after-abort",
             );

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureWinner.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureWinner.cy.js
@@ -3,6 +3,7 @@ import {
     installMockPrefigureModule,
     postDebounceTestDoenetML,
     visitWithMockPrefigureModule,
+    PREFIGURE_BUILD_URL_PATTERN,
 } from "../../support/prefigure";
 
 describe(
@@ -20,7 +21,7 @@ describe(
                 renderLabel: "local-winner",
             });
 
-            cy.intercept("POST", "**/build", {
+            cy.intercept("POST", PREFIGURE_BUILD_URL_PATTERN, {
                 statusCode: 200,
                 headers: { "content-type": "application/json" },
                 delay: 4500,
@@ -54,7 +55,7 @@ describe(
                 renderLabel: "local-after-service-error",
             });
 
-            cy.intercept("POST", "**/build", {
+            cy.intercept("POST", PREFIGURE_BUILD_URL_PATTERN, {
                 statusCode: 503,
                 headers: { "content-type": "application/json" },
                 body: { message: "service unavailable" },

--- a/packages/test-cypress/cypress/support/prefigure.js
+++ b/packages/test-cypress/cypress/support/prefigure.js
@@ -56,3 +56,49 @@ export function postDebounceTestDoenetML(cesc) {
 
     cy.get(cesc("#ready")).should("have.text", "ready");
 }
+
+export function installMockPrefigureModule({
+    modulePath = "/mock-prefigure-module.js",
+    initDelayMs = 0,
+    renderLabel = "local-render",
+} = {}) {
+    const moduleBody = `
+let isReady = false;
+
+export async function initPrefigure() {
+  await new Promise((resolve) => setTimeout(resolve, ${initDelayMs}));
+  isReady = true;
+}
+
+export async function compilePrefigure(_diagramXML, _options) {
+  if (!isReady) {
+    throw new Error("compilePrefigure called before initPrefigure");
+  }
+
+  return {
+    svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>${renderLabel}</text></svg>',
+    annotationsXml: '<diagram><annotation>${renderLabel}-cml</annotation></diagram>',
+  };
+}
+`;
+
+    cy.intercept("GET", `**${modulePath}*`, {
+        statusCode: 200,
+        headers: { "content-type": "application/javascript" },
+        body: moduleBody,
+    });
+
+    return modulePath;
+}
+
+export function visitWithMockPrefigureModule(modulePath) {
+    cy.visit("/", {
+        onBeforeLoad(win) {
+            win.__DOENET_PREFIGURE_MODULE_URL__ = new URL(
+                modulePath,
+                win.location.href,
+            ).toString();
+            win.__DOENET_PREFIGURE_INDEX_URL__ = "";
+        },
+    });
+}

--- a/packages/test-cypress/cypress/support/prefigure.js
+++ b/packages/test-cypress/cypress/support/prefigure.js
@@ -60,6 +60,7 @@ export function postDebounceTestDoenetML(cesc) {
 export function installMockPrefigureModule({
     modulePath = "/mock-prefigure-module.js",
     initDelayMs = 0,
+    compileDelayMs = 0,
     renderLabel = "local-render",
 } = {}) {
     const moduleBody = `
@@ -74,6 +75,8 @@ export async function compilePrefigure(_diagramXML, _options) {
   if (!isReady) {
     throw new Error("compilePrefigure called before initPrefigure");
   }
+
+    await new Promise((resolve) => setTimeout(resolve, ${compileDelayMs}));
 
   return {
     svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>${renderLabel}</text></svg>',

--- a/packages/test-cypress/cypress/support/prefigure.js
+++ b/packages/test-cypress/cypress/support/prefigure.js
@@ -1,6 +1,6 @@
 export const PREFIGURE_BUILD_DEBOUNCE_MS = 1000;
 export const REQUEST_SETTLE_BUFFER_MS = 300;
-const PREFIGURE_BUILD_URL_PATTERN = "**/build";
+export const PREFIGURE_BUILD_URL_PATTERN = "**/build";
 
 export function installPrefigureBuildIntercept(responseForRequest) {
     const tracker = { count: 0 };

--- a/packages/test-cypress/cypress/support/prefigure.js
+++ b/packages/test-cypress/cypress/support/prefigure.js
@@ -63,8 +63,11 @@ export function installMockPrefigureModule({
     compileDelayMs = 0,
     renderLabel = "local-render",
 } = {}) {
+    const serializedRenderLabel = JSON.stringify(renderLabel);
+
     const moduleBody = `
 let isReady = false;
+const renderLabelValue = ${serializedRenderLabel};
 
 export async function initPrefigure() {
   await new Promise((resolve) => setTimeout(resolve, ${initDelayMs}));
@@ -79,8 +82,8 @@ export async function compilePrefigure(_diagramXML, _options) {
     await new Promise((resolve) => setTimeout(resolve, ${compileDelayMs}));
 
   return {
-    svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>${renderLabel}</text></svg>',
-    annotationsXml: '<diagram><annotation>${renderLabel}-cml</annotation></diagram>',
+        svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>' + renderLabelValue + '</text></svg>',
+        annotationsXml: '<diagram><annotation>' + renderLabelValue + '-cml</annotation></diagram>',
   };
 }
 `;


### PR DESCRIPTION
## Summary

When the renderer starts cold, the previous code committed exclusively to the remote build service, causing two flaws:

1. If the service failed, the diagram was never rendered even after local WASM became ready.
2. If WASM became ready during a slow service call, the renderer still waited for the full network round-trip.

## Changes

**`packages/doenetml/src/Viewer/renderers/prefigure.tsx`**

Refactors `buildPrefigureDiagram` so that in cold mode the service request and the local WASM warmup run in parallel via a `firstSuccessful()` helper. Whichever resolves first wins:

- Local WASM ready first -> abort the in-flight service request, compile locally.
- Service responds first -> return its result immediately (existing behavior).
- Service fails, warmup later succeeds -> render locally instead of surfacing an error.
- Both fail -> propagate the most informative error through the existing UI error path.

The outer `AbortSignal` (component unmount / stale request) still cancels everything promptly. Existing staleness guards (`requestSequenceRef`, `fetchAbortControllerRef`) in the component effect are unchanged.

**`packages/test-cypress/cypress/support/prefigure.js`**

Adds `installMockPrefigureModule` and `visitWithMockPrefigureModule` helpers that serve a synthetic ES-module prefigure implementation via Cypress intercept and wire the `__DOENET_PREFIGURE_MODULE_URL__` global so warmup timing is fully controllable in tests.

**`packages/test-cypress/cypress/e2e/prefigure/prefigureWinner.cy.js`** *(new file)*

Three Cypress tests:
- Local WASM wins over a slow service response: local output appears quickly; slow service result never replaces it.
- Service 503 failure recovers via local warmup: diagram renders locally, no error text shown.
- Abort during local compile after warmup wins does not surface stale output and the replacement render succeeds.
