### PR TITLE
test: remove unnecessary cesc wrappers in Cypress

### DIFF
--- a/packages/test-cypress/cypress/e2e/DocViewer/docViewerAttributes.cy.js
+++ b/packages/test-cypress/cypress/e2e/DocViewer/docViewerAttributes.cy.js
@@ -1,4 +1,4 @@
-import { cesc, deepCompare } from "@doenet/utils";
+import { deepCompare } from "@doenet/utils";
 
 describe("DocViewer Attribute Tests", { tags: ["@group5"] }, function () {
     beforeEach(() => {
@@ -60,7 +60,7 @@ describe("DocViewer Attribute Tests", { tags: ["@group5"] }, function () {
             });
         });
 
-        cy.get(cesc("#t")).should("not.exist");
+        cy.get("#t").should("not.exist");
 
         cy.log("Core has not been initialized");
         cy.window().then(async (win) => {

--- a/packages/test-cypress/cypress/e2e/answerValidation/pointlocation.cy.js
+++ b/packages/test-cypress/cypress/e2e/answerValidation/pointlocation.cy.js
@@ -1,5 +1,3 @@
-import { cesc } from "@doenet/utils";
-
 describe("Point location validation tests", { tags: ["@group5"] }, function () {
     beforeEach(() => {
         cy.clearIndexedDB();
@@ -35,7 +33,7 @@ describe("Point location validation tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); // to wait for page to load
+        cy.get("#a").should("have.text", "a"); // to wait for page to load
 
         cy.log("Move point to correct quadrant and move again");
         // for some reason, have to move point twice to trigger bug
@@ -54,11 +52,11 @@ describe("Point location validation tests", { tags: ["@group5"] }, function () {
             });
         });
 
-        cy.get(cesc("#answer1_button")).should("contain.text", "Check Work");
+        cy.get("#answer1_button").should("contain.text", "Check Work");
 
         cy.log("Submit answer");
-        cy.get(cesc("#answer1_button")).click();
-        cy.get(cesc("#answer1_button")).should("contain.text", "Correct");
+        cy.get("#answer1_button").click();
+        cy.get("#answer1_button").should("contain.text", "Correct");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -85,7 +83,7 @@ describe("Point location validation tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+        cy.get("#a").should("have.text", "a"); //wait for page to load
 
         // wait until core is loaded
         cy.waitUntil(() =>
@@ -95,7 +93,7 @@ describe("Point location validation tests", { tags: ["@group5"] }, function () {
             }),
         );
 
-        cy.get(cesc("#answer1_button")).should("contain.text", "Correct");
+        cy.get("#answer1_button").should("contain.text", "Correct");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -122,10 +120,10 @@ describe("Point location validation tests", { tags: ["@group5"] }, function () {
             ).eq(1);
         });
 
-        cy.get(cesc("#answer1_button")).should("contain.text", "Check Work");
+        cy.get("#answer1_button").should("contain.text", "Check Work");
 
-        cy.get(cesc("#answer1_button")).click();
-        cy.get(cesc("#answer1_button")).should("contain.text", "Incorrect");
+        cy.get("#answer1_button").click();
+        cy.get("#answer1_button").should("contain.text", "Incorrect");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -152,7 +150,7 @@ describe("Point location validation tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+        cy.get("#a").should("have.text", "a"); //wait for page to load
 
         // wait until core is loaded
         cy.waitUntil(() =>
@@ -162,7 +160,7 @@ describe("Point location validation tests", { tags: ["@group5"] }, function () {
             }),
         );
 
-        cy.get(cesc("#answer1_button")).should("contain.text", "Incorrect");
+        cy.get("#answer1_button").should("contain.text", "Incorrect");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -194,10 +192,10 @@ describe("Point location validation tests", { tags: ["@group5"] }, function () {
             ).eq(0);
         });
 
-        cy.get(cesc("#answer1_button")).should("contain.text", "Check Work");
+        cy.get("#answer1_button").should("contain.text", "Check Work");
 
-        cy.get(cesc("#answer1_button")).click();
-        cy.get(cesc("#answer1_button")).should("contain.text", "Incorrect");
+        cy.get("#answer1_button").click();
+        cy.get("#answer1_button").should("contain.text", "Incorrect");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -224,7 +222,7 @@ describe("Point location validation tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+        cy.get("#a").should("have.text", "a"); //wait for page to load
 
         // wait until core is loaded
         cy.waitUntil(() =>
@@ -234,7 +232,7 @@ describe("Point location validation tests", { tags: ["@group5"] }, function () {
             }),
         );
 
-        cy.get(cesc("#answer1_button")).should("contain.text", "Incorrect");
+        cy.get("#answer1_button").should("contain.text", "Incorrect");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();

--- a/packages/test-cypress/cypress/e2e/answerValidation/videoProgress.cy.js
+++ b/packages/test-cypress/cypress/e2e/answerValidation/videoProgress.cy.js
@@ -1,5 +1,3 @@
-import { cesc } from "@doenet/utils";
-
 describe("Video progress tests", { tags: ["@group3"] }, function () {
     beforeEach(() => {
         cy.clearIndexedDB();
@@ -48,170 +46,161 @@ describe("Video progress tests", { tags: ["@group3"] }, function () {
             // Wait for the YouTube iframe to exist and be visible
             cy.get('iframe[src*="youtube.com"]').should("be.visible");
 
-            cy.get(cesc("#pDuration")).should("have.text", "Duration: 300");
-            cy.get(cesc("#seconds")).should("have.text", "0");
-            cy.get(cesc("#progress")).should("have.text", "0");
-            cy.get(cesc("#credit")).should("have.text", "0");
+            cy.get("#pDuration").should("have.text", "Duration: 300");
+            cy.get("#seconds").should("have.text", "0");
+            cy.get("#progress").should("have.text", "0");
+            cy.get("#credit").should("have.text", "0");
 
-            cy.get(cesc("#play")).click();
+            cy.get("#play").click();
 
-            cy.get(cesc("#time")).contains("5");
-            cy.get(cesc("#pause")).click();
+            cy.get("#time").contains("5");
+            cy.get("#pause").click();
 
-            cy.get(cesc("#seconds")).should("have.text", "5");
-            cy.get(cesc("#credit")).should("not.have.text", "0");
+            cy.get("#seconds").should("have.text", "5");
+            cy.get("#credit").should("not.have.text", "0");
 
-            cy.get(cesc("#credit"))
+            cy.get("#credit")
                 .invoke("text")
                 .then((text) => {
                     credit = Number(text);
                     expect(credit).gte(0.016).lte(0.018);
                 });
 
-            cy.get(cesc("#progress"))
+            cy.get("#progress")
                 .invoke("text")
                 .then((text) => {
                     expect(Number(text)).eq(Math.round(credit * 1000) / 10);
                 });
 
-            cy.get(cesc("#play")).click();
+            cy.get("#play").click();
 
-            cy.get(cesc("#time")).contains("7");
-            cy.get(cesc("#pause")).click();
+            cy.get("#time").contains("7");
+            cy.get("#pause").click();
 
-            cy.get(cesc("#seconds"))
+            cy.get("#seconds")
                 .should("have.text", "7")
                 .then(() => {
                     // put inside then so that get updated value of local variable credit
-                    cy.get(cesc("#credit")).should(
-                        "not.have.text",
-                        `${credit}`,
-                    );
+                    cy.get("#credit").should("not.have.text", `${credit}`);
                 });
 
-            cy.get(cesc("#credit"))
+            cy.get("#credit")
                 .invoke("text")
                 .then((text) => {
                     credit = Number(text);
                     expect(credit).gte(0.023).lte(0.025);
                 });
 
-            cy.get(cesc("#progress"))
+            cy.get("#progress")
                 .invoke("text")
                 .then((text) => {
                     expect(Number(text)).eq(Math.round(credit * 1000) / 10);
                 });
 
-            cy.get(cesc("#skip1")).click();
-            cy.get(cesc("#time")).contains("157");
+            cy.get("#skip1").click();
+            cy.get("#time").contains("157");
 
-            cy.get(cesc("#seconds")).should("have.text", "7");
+            cy.get("#seconds").should("have.text", "7");
 
-            cy.get(cesc("#credit"))
+            cy.get("#credit")
                 .invoke("text")
                 .then((text) => {
                     expect(Number(text)).eq(credit);
                 });
 
-            cy.get(cesc("#progress"))
+            cy.get("#progress")
                 .invoke("text")
                 .then((text) => {
                     expect(Number(text)).eq(Math.round(credit * 1000) / 10);
                 });
 
-            cy.get(cesc("#play")).click();
+            cy.get("#play").click();
 
-            cy.get(cesc("#time")).contains("160");
-            cy.get(cesc("#skip2")).click();
+            cy.get("#time").contains("160");
+            cy.get("#skip2").click();
 
-            cy.get(cesc("#time")).contains("59");
+            cy.get("#time").contains("59");
 
-            cy.get(cesc("#pause")).click();
+            cy.get("#pause").click();
 
-            cy.get(cesc("#seconds"))
+            cy.get("#seconds")
                 .contains(/1(2|3)/)
                 .then(() => {
                     // put inside then so that get updated value of local variable credit
-                    cy.get(cesc("#credit")).should(
-                        "not.have.text",
-                        `${credit}`,
-                    );
-                    cy.get(cesc("#credit")).should("not.contain", `3`); // should contain a 3 after the intermediate skip
+                    cy.get("#credit").should("not.have.text", `${credit}`);
+                    cy.get("#credit").should("not.contain", `3`); // should contain a 3 after the intermediate skip
                 });
 
-            cy.get(cesc("#credit"))
+            cy.get("#credit")
                 .invoke("text")
                 .then((text) => {
                     credit = Number(text);
                     expect(credit).gte(0.04).lte(0.045);
                 });
 
-            cy.get(cesc("#progress"))
+            cy.get("#progress")
                 .invoke("text")
                 .then((text) => {
                     expect(Number(text)).eq(Math.round(credit * 1000) / 10);
                 });
 
-            cy.get(cesc("#skip1")).click();
-            cy.get(cesc("#time")).contains("157");
+            cy.get("#skip1").click();
+            cy.get("#time").contains("157");
 
-            cy.get(cesc("#seconds")).contains(/1(2|3)/);
+            cy.get("#seconds").contains(/1(2|3)/);
 
-            cy.get(cesc("#credit"))
+            cy.get("#credit")
                 .invoke("text")
                 .then((text) => {
                     expect(Number(text)).eq(credit);
                 });
 
-            cy.get(cesc("#progress"))
+            cy.get("#progress")
                 .invoke("text")
                 .then((text) => {
                     expect(Number(text)).eq(Math.round(credit * 1000) / 10);
                 });
 
-            cy.get(cesc("#play")).click();
+            cy.get("#play").click();
 
-            cy.get(cesc("#time")).contains("159");
-            cy.get(cesc("#pause")).click();
-            cy.get(cesc("#state")).contains("stopped");
+            cy.get("#time").contains("159");
+            cy.get("#pause").click();
+            cy.get("#state").contains("stopped");
 
-            cy.get(cesc("#seconds")).contains(/1(2|3)/);
-            cy.get(cesc("#credit"))
+            cy.get("#seconds").contains(/1(2|3)/);
+            cy.get("#credit")
                 .invoke("text")
                 .then((text) => {
                     expect(Number(text)).eq(credit);
                 });
 
-            cy.get(cesc("#progress"))
+            cy.get("#progress")
                 .invoke("text")
                 .then((text) => {
                     expect(Number(text)).eq(Math.round(credit * 1000) / 10);
                 });
 
             cy.wait(200); // for some reason seems to occasionally miss clicking play
-            cy.get(cesc("#play")).click();
+            cy.get("#play").click();
 
-            cy.get(cesc("#time")).contains("162");
-            cy.get(cesc("#pause")).click();
+            cy.get("#time").contains("162");
+            cy.get("#pause").click();
 
-            cy.get(cesc("#seconds"))
+            cy.get("#seconds")
                 .contains(/1(4|5)/)
                 .then(() => {
                     // put inside then so that get updated value of local variable credit
-                    cy.get(cesc("#credit")).should(
-                        "not.have.text",
-                        `${credit}`,
-                    );
+                    cy.get("#credit").should("not.have.text", `${credit}`);
                 });
 
-            cy.get(cesc("#credit"))
+            cy.get("#credit")
                 .invoke("text")
                 .then((text) => {
                     credit = Number(text);
                     expect(credit).gte(0.046).lte(0.052);
                 });
 
-            cy.get(cesc("#progress"))
+            cy.get("#progress")
                 .invoke("text")
                 .then((text) => {
                     expect(Number(text)).eq(Math.round(credit * 1000) / 10);

--- a/packages/test-cypress/cypress/e2e/baseComponent/renderCommas.cy.js
+++ b/packages/test-cypress/cypress/e2e/baseComponent/renderCommas.cy.js
@@ -71,53 +71,41 @@ $fi.iterates
             );
         });
 
-        cy.get(cesc("#_id_0")).should(
-            "contain.text",
-            "In document: yes, no, maybe",
-        );
-        cy.get(cesc("#in_alert")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_blockQuote")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_c")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_caption")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_cell")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_choice")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_span")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_em")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_feedback")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_footnote")).click();
-        cy.get(cesc("#in_footnote")).should("contain.text", "yes, no, maybe");
-        cy.get(cesc("#in_hint_w_title")).click();
-        cy.get(cesc("#in_hint_w_title")).should(
-            "contain.text",
-            "yes, no, maybe",
-        );
-        cy.get(cesc("#in_hint_wo_title")).click();
-        cy.get(cesc("#in_hint_wo_title")).should(
-            "contain.text",
-            "yes, no, maybe",
-        );
-        cy.get(cesc("#in_label")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_li")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_li2")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_p")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_pre")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_q")).should("have.text", "“yes, no, maybe”");
-        cy.get(cesc("#in_section_w_title")).should(
+        cy.get("#_id_0").should("contain.text", "In document: yes, no, maybe");
+        cy.get("#in_alert").should("have.text", "yes, no, maybe");
+        cy.get("#in_blockQuote").should("have.text", "yes, no, maybe");
+        cy.get("#in_c").should("have.text", "yes, no, maybe");
+        cy.get("#in_caption").should("have.text", "yes, no, maybe");
+        cy.get("#in_cell").should("have.text", "yes, no, maybe");
+        cy.get("#in_choice").should("have.text", "yes, no, maybe");
+        cy.get("#in_span").should("have.text", "yes, no, maybe");
+        cy.get("#in_em").should("have.text", "yes, no, maybe");
+        cy.get("#in_feedback").should("have.text", "yes, no, maybe");
+        cy.get("#in_footnote").click();
+        cy.get("#in_footnote").should("contain.text", "yes, no, maybe");
+        cy.get("#in_hint_w_title").click();
+        cy.get("#in_hint_w_title").should("contain.text", "yes, no, maybe");
+        cy.get("#in_hint_wo_title").click();
+        cy.get("#in_hint_wo_title").should("contain.text", "yes, no, maybe");
+        cy.get("#in_label").should("have.text", "yes, no, maybe");
+        cy.get("#in_li").should("have.text", "yes, no, maybe");
+        cy.get("#in_li2").should("have.text", "yes, no, maybe");
+        cy.get("#in_p").should("have.text", "yes, no, maybe");
+        cy.get("#in_pre").should("have.text", "yes, no, maybe");
+        cy.get("#in_q").should("have.text", "“yes, no, maybe”");
+        cy.get("#in_section_w_title").should(
             "contain.text",
             "Title: yes, no, maybe",
         );
-        cy.get(cesc("#in_section_w_title")).should(
+        cy.get("#in_section_w_title").should(
             "contain.text",
             "Text: yes, no, maybe",
         );
-        cy.get(cesc("#in_section_wo_title")).should(
-            "contain.text",
-            "yes, no, maybe",
-        );
-        cy.get(cesc("#in_solution")).click();
-        cy.get(cesc("#in_solution")).should("contain.text", "yes, no, maybe");
-        cy.get(cesc("#in_sq")).should("have.text", "‘yes, no, maybe’");
-        cy.get(cesc("#in_text")).should("have.text", "yes, no, maybe");
+        cy.get("#in_section_wo_title").should("contain.text", "yes, no, maybe");
+        cy.get("#in_solution").click();
+        cy.get("#in_solution").should("contain.text", "yes, no, maybe");
+        cy.get("#in_sq").should("have.text", "‘yes, no, maybe’");
+        cy.get("#in_text").should("have.text", "yes, no, maybe");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -329,7 +317,7 @@ $fi.iterates
             );
         });
 
-        cy.get(cesc("#s")).should(
+        cy.get("#s").should(
             "contain.text",
             toMathJaxString("a, b, c\n\n    2a, 2b, 2c"),
         );
@@ -354,7 +342,7 @@ $fi.iterates
             );
         });
 
-        cy.get(cesc("#p")).should(
+        cy.get("#p").should(
             "contain.text",
             toMathJaxString("a, b, c\n\n    2a, 2b, 2c"),
         );
@@ -410,49 +398,40 @@ $fi.iterates
             "contain.text",
             "In document: yes, no, maybe",
         );
-        cy.get(cesc("#in_alert")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_blockquote")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_c")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_caption")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_cell")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_choice")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_span")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_em")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_feedback")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_footnote")).click();
-        cy.get(cesc("#in_footnote")).should("contain.text", "yes, no, maybe");
-        cy.get(cesc("#in_hint_w_title")).click();
-        cy.get(cesc("#in_hint_w_title")).should(
-            "contain.text",
-            "yes, no, maybe",
-        );
-        cy.get(cesc("#in_hint_wo_title")).click();
-        cy.get(cesc("#in_hint_wo_title")).should(
-            "contain.text",
-            "yes, no, maybe",
-        );
-        cy.get(cesc("#in_label")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_li")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_li2")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_p")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_pre")).should("have.text", "yes, no, maybe");
-        cy.get(cesc("#in_q")).should("have.text", "“yes, no, maybe”");
-        cy.get(cesc("#in_section_w_title")).should(
+        cy.get("#in_alert").should("have.text", "yes, no, maybe");
+        cy.get("#in_blockquote").should("have.text", "yes, no, maybe");
+        cy.get("#in_c").should("have.text", "yes, no, maybe");
+        cy.get("#in_caption").should("have.text", "yes, no, maybe");
+        cy.get("#in_cell").should("have.text", "yes, no, maybe");
+        cy.get("#in_choice").should("have.text", "yes, no, maybe");
+        cy.get("#in_span").should("have.text", "yes, no, maybe");
+        cy.get("#in_em").should("have.text", "yes, no, maybe");
+        cy.get("#in_feedback").should("have.text", "yes, no, maybe");
+        cy.get("#in_footnote").click();
+        cy.get("#in_footnote").should("contain.text", "yes, no, maybe");
+        cy.get("#in_hint_w_title").click();
+        cy.get("#in_hint_w_title").should("contain.text", "yes, no, maybe");
+        cy.get("#in_hint_wo_title").click();
+        cy.get("#in_hint_wo_title").should("contain.text", "yes, no, maybe");
+        cy.get("#in_label").should("have.text", "yes, no, maybe");
+        cy.get("#in_li").should("have.text", "yes, no, maybe");
+        cy.get("#in_li2").should("have.text", "yes, no, maybe");
+        cy.get("#in_p").should("have.text", "yes, no, maybe");
+        cy.get("#in_pre").should("have.text", "yes, no, maybe");
+        cy.get("#in_q").should("have.text", "“yes, no, maybe”");
+        cy.get("#in_section_w_title").should(
             "contain.text",
             "Title: yes, no, maybe",
         );
-        cy.get(cesc("#in_section_w_title")).should(
+        cy.get("#in_section_w_title").should(
             "contain.text",
             "Text: yes, no, maybe",
         );
-        cy.get(cesc("#in_section_wo_title")).should(
-            "contain.text",
-            "yes, no, maybe",
-        );
-        cy.get(cesc("#in_solution")).click();
-        cy.get(cesc("#in_solution")).should("contain.text", "yes, no, maybe");
-        cy.get(cesc("#in_sq")).should("have.text", "‘yes, no, maybe’");
-        cy.get(cesc("#in_text")).should("have.text", "yes, no, maybe");
+        cy.get("#in_section_wo_title").should("contain.text", "yes, no, maybe");
+        cy.get("#in_solution").click();
+        cy.get("#in_solution").should("contain.text", "yes, no, maybe");
+        cy.get("#in_sq").should("have.text", "‘yes, no, maybe’");
+        cy.get("#in_text").should("have.text", "yes, no, maybe");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();

--- a/packages/test-cypress/cypress/e2e/chemistry/atom.cy.js
+++ b/packages/test-cypress/cypress/e2e/chemistry/atom.cy.js
@@ -1,4 +1,3 @@
-import { cesc } from "@doenet/utils";
 import { toMathJaxString } from "../../../src/util/mathDisplay";
 
 describe("Atom tests", { tags: ["@group2"] }, function () {

--- a/packages/test-cypress/cypress/e2e/dynamicalsystem/cobwebpolyline.cy.js
+++ b/packages/test-cypress/cypress/e2e/dynamicalsystem/cobwebpolyline.cy.js
@@ -1067,7 +1067,7 @@ describe("CobwebPolyline Tag Tests", { tags: ["@group2"] }, function () {
 
         let f = (x) => 2 * x - x ** 2 / 3;
 
-        cy.get(cesc("#ca")).should("have.text", "0");
+        cy.get("#ca").should("have.text", "0");
         cy.get(cesc("#cobwebTutorial.next_button")).click();
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
         cy.get(cesc("#cobwebTutorial.cc0.cc1.addPoint1_button")).click();
@@ -1085,9 +1085,9 @@ describe("CobwebPolyline Tag Tests", { tags: ["@group2"] }, function () {
         });
 
         cy.get(cesc("#cobwebTutorial.next_button")).should("not.be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "0");
+        cy.get("#ca").should("have.text", "0");
         cy.get(cesc("#cobwebTutorial.next_button")).click();
-        cy.get(cesc("#ca")).should("have.text", "0.167");
+        cy.get("#ca").should("have.text", "0.167");
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
 
         cy.get(cesc("#cobwebTutorial.cc0.cc2.addVline1_button")).click();
@@ -1108,10 +1108,10 @@ describe("CobwebPolyline Tag Tests", { tags: ["@group2"] }, function () {
         });
 
         cy.get(cesc("#cobwebTutorial.next_button")).should("not.be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "0.167");
+        cy.get("#ca").should("have.text", "0.167");
         cy.get(cesc("#cobwebTutorial.next_button")).click();
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "0.333");
+        cy.get("#ca").should("have.text", "0.333");
 
         cy.get(cesc("#cobwebTutorial.cc0.cc3.addHline1_button")).click();
         cy.get(cesc("#cobwebTutorial.cc0.cc3.addHline1_button")).should(
@@ -1132,7 +1132,7 @@ describe("CobwebPolyline Tag Tests", { tags: ["@group2"] }, function () {
         cy.get(cesc("#cobwebTutorial.cc0.cc3.addPoint2_button")).should(
             "be.visible",
         );
-        cy.get(cesc("#ca")).should("have.text", "0.333");
+        cy.get("#ca").should("have.text", "0.333");
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
         cy.get(cesc("#cobwebTutorial.cc0.cc3.addPoint2_button")).click();
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
@@ -1146,10 +1146,10 @@ describe("CobwebPolyline Tag Tests", { tags: ["@group2"] }, function () {
         });
 
         cy.get(cesc("#cobwebTutorial.next_button")).should("not.be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "0.333");
+        cy.get("#ca").should("have.text", "0.333");
         cy.get(cesc("#cobwebTutorial.next_button")).click();
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "0.5");
+        cy.get("#ca").should("have.text", "0.5");
 
         cy.get(cesc("#cobwebTutorial.cc0.cc4.addPoint3_button")).click();
         cy.get(cesc("#cobwebTutorial.cc0.cc4.addPoint3_button")).should(
@@ -1166,10 +1166,10 @@ describe("CobwebPolyline Tag Tests", { tags: ["@group2"] }, function () {
         });
 
         cy.get(cesc("#cobwebTutorial.next_button")).should("not.be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "0.5");
+        cy.get("#ca").should("have.text", "0.5");
         cy.get(cesc("#cobwebTutorial.next_button")).click();
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "0.667");
+        cy.get("#ca").should("have.text", "0.667");
 
         cy.get(cesc("#cobwebTutorial.cc0.cc5.addVline2_button")).click();
         cy.get(cesc("#cobwebTutorial.cc0.cc5addVline2_button")).should(
@@ -1189,10 +1189,10 @@ describe("CobwebPolyline Tag Tests", { tags: ["@group2"] }, function () {
         });
 
         cy.get(cesc("#cobwebTutorial.next_button")).should("not.be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "0.667");
+        cy.get("#ca").should("have.text", "0.667");
         cy.get(cesc("#cobwebTutorial.next_button")).click();
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "0.833");
+        cy.get("#ca").should("have.text", "0.833");
 
         cy.get(cesc("#cobwebTutorial.cc0.cc6.addHline2_button")).click();
         cy.get(cesc("#cobwebTutorial.cc0.cc6.addHline2_button")).should(
@@ -1214,7 +1214,7 @@ describe("CobwebPolyline Tag Tests", { tags: ["@group2"] }, function () {
         cy.get(cesc("#cobwebTutorial.cc0.cc6.addPoint4_button")).should(
             "be.visible",
         );
-        cy.get(cesc("#ca")).should("have.text", "0.833");
+        cy.get("#ca").should("have.text", "0.833");
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
         cy.get(cesc("#cobwebTutorial.cc0.cc6.addPoint4_button")).click();
         cy.get(cesc("#cobwebTutorial.cc0.cc6.addPoint4_button")).should(
@@ -1231,21 +1231,21 @@ describe("CobwebPolyline Tag Tests", { tags: ["@group2"] }, function () {
         });
 
         cy.get(cesc("#cobwebTutorial.next_button")).should("not.be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "0.833");
+        cy.get("#ca").should("have.text", "0.833");
         cy.get(cesc("#cobwebTutorial.next_button")).click();
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "1");
+        cy.get("#ca").should("have.text", "1");
 
         cy.get(cesc("#cobwebTutorial.cc0.cc7.shortcutButton_button")).click();
         cy.get(cesc("#cobwebTutorial.cc0.cc7.shortcutButton_button")).should(
             "not.exist",
         );
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "1");
+        cy.get("#ca").should("have.text", "1");
 
         cy.get(cesc("#cobwebTutorial.resetTutorial_button")).click();
 
-        cy.get(cesc("#ca")).should("have.text", "0");
+        cy.get("#ca").should("have.text", "0");
         cy.get(cesc("#cobwebTutorial.next_button")).click();
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
         cy.get(cesc("#cobwebTutorial.cc0.cc1.addPoint1_button")).click();
@@ -1263,9 +1263,9 @@ describe("CobwebPolyline Tag Tests", { tags: ["@group2"] }, function () {
         });
 
         cy.get(cesc("#cobwebTutorial.next_button")).should("not.be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "0");
+        cy.get("#ca").should("have.text", "0");
         cy.get(cesc("#cobwebTutorial.next_button")).click();
-        cy.get(cesc("#ca")).should("have.text", "0.167");
+        cy.get("#ca").should("have.text", "0.167");
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
 
         cy.get(cesc("#cobwebTutorial.cc0.cc2.addVline1_button")).click();
@@ -1286,10 +1286,10 @@ describe("CobwebPolyline Tag Tests", { tags: ["@group2"] }, function () {
         });
 
         cy.get(cesc("#cobwebTutorial.next_button")).should("not.be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "0.167");
+        cy.get("#ca").should("have.text", "0.167");
         cy.get(cesc("#cobwebTutorial.next_button")).click();
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "0.333");
+        cy.get("#ca").should("have.text", "0.333");
 
         cy.get(cesc("#cobwebTutorial.cc0.cc3.addHline1_button")).click();
         cy.get(cesc("#cobwebTutorial.cc0.cc3.addHline1_button")).should(
@@ -1311,7 +1311,7 @@ describe("CobwebPolyline Tag Tests", { tags: ["@group2"] }, function () {
         cy.get(cesc("#cobwebTutorial.cc0.cc3.addPoint2_button")).should(
             "be.visible",
         );
-        cy.get(cesc("#ca")).should("have.text", "0.333");
+        cy.get("#ca").should("have.text", "0.333");
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
         cy.get(cesc("#cobwebTutorial.cc0.cc3.addPoint2_button")).click();
         cy.get(cesc("#cobwebTutorial.cc0.cc3.addPoint2_button")).should(
@@ -1328,10 +1328,10 @@ describe("CobwebPolyline Tag Tests", { tags: ["@group2"] }, function () {
         });
 
         cy.get(cesc("#cobwebTutorial.next_button")).should("not.be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "0.333");
+        cy.get("#ca").should("have.text", "0.333");
         cy.get(cesc("#cobwebTutorial.next_button")).click();
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "0.5");
+        cy.get("#ca").should("have.text", "0.5");
 
         cy.get(cesc("#cobwebTutorial.cc0.cc4.addPoint3_button")).click();
         cy.get(cesc("#cobwebTutorial.cc0.cc4.addPoint3_button")).should(
@@ -1348,10 +1348,10 @@ describe("CobwebPolyline Tag Tests", { tags: ["@group2"] }, function () {
         });
 
         cy.get(cesc("#cobwebTutorial.next_button")).should("not.be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "0.5");
+        cy.get("#ca").should("have.text", "0.5");
         cy.get(cesc("#cobwebTutorial.next_button")).click();
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "0.667");
+        cy.get("#ca").should("have.text", "0.667");
 
         cy.get(cesc("#cobwebTutorial.cc0.cc5.addVline2_button")).click();
         cy.get(cesc("#cobwebTutorial.cc0.cc5.addVline2_button")).should(
@@ -1371,10 +1371,10 @@ describe("CobwebPolyline Tag Tests", { tags: ["@group2"] }, function () {
         });
 
         cy.get(cesc("#cobwebTutorial.next_button")).should("not.be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "0.667");
+        cy.get("#ca").should("have.text", "0.667");
         cy.get(cesc("#cobwebTutorial.next_button")).click();
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "0.833");
+        cy.get("#ca").should("have.text", "0.833");
 
         cy.get(cesc("#cobwebTutorial.cc0.cc6.addHline2_button")).click();
         cy.get(cesc("#cobwebTutorial.cc0.cc6.addHline2_button")).should(
@@ -1396,7 +1396,7 @@ describe("CobwebPolyline Tag Tests", { tags: ["@group2"] }, function () {
         cy.get(cesc("#cobwebTutorial.cc0.cc6.addPoint4_button")).should(
             "be.visible",
         );
-        cy.get(cesc("#ca")).should("have.text", "0.833");
+        cy.get("#ca").should("have.text", "0.833");
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
         cy.get(cesc("#cobwebTutorial.cc0.cc6.addPoint4_button")).click();
         cy.get(cesc("#cobwebTutorial.cc0.cc6.addPoint4_button")).should(
@@ -1413,16 +1413,16 @@ describe("CobwebPolyline Tag Tests", { tags: ["@group2"] }, function () {
         });
 
         cy.get(cesc("#cobwebTutorial.next_button")).should("not.be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "0.833");
+        cy.get("#ca").should("have.text", "0.833");
         cy.get(cesc("#cobwebTutorial.next_button")).click();
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "1");
+        cy.get("#ca").should("have.text", "1");
 
         cy.get(cesc("#cobwebTutorial.cc0.cc7.shortcutButton_button")).click();
         cy.get(cesc("#cobwebTutorial.cc0.cc7.shortcutButton_button")).should(
             "not.exist",
         );
         cy.get(cesc("#cobwebTutorial.next_button")).should("be.disabled");
-        cy.get(cesc("#ca")).should("have.text", "1");
+        cy.get("#ca").should("have.text", "1");
     });
 });

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureAnnotationsAccessibility.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureAnnotationsAccessibility.cy.js
@@ -1,4 +1,3 @@
-import { cesc } from "@doenet/utils";
 import { installPrefigureBuildIntercept } from "../../support/prefigure";
 
 describe(
@@ -66,7 +65,7 @@ describe(
                 );
             });
 
-            cy.get(cesc("#ready")).should("have.text", "ready");
+            cy.get("#ready").should("have.text", "ready");
             cy.wait("@prefigureBuild");
             cy.wait(450);
 
@@ -75,17 +74,13 @@ describe(
                 expect(requestBodies[0]).to.include(`text="point summary"`);
             });
 
-            cy.get(cesc("#prefig"))
-                .find(".svg")
-                .should("contain.text", "svg-1");
-            cy.get(cesc("#prefig"))
-                .find(".cml")
-                .should("contain.text", "safe-cml-1");
-            cy.get(cesc("#prefig"))
+            cy.get("#prefig").find(".svg").should("contain.text", "svg-1");
+            cy.get("#prefig").find(".cml").should("contain.text", "safe-cml-1");
+            cy.get("#prefig")
                 .find(".cml [onclick], .cml [style]")
                 .should("not.exist");
             cy.window().its("__diagcessInitCount").should("eq", 1);
-            cy.get(cesc("#prefig"))
+            cy.get("#prefig")
                 .children("p.cacc-message")
                 .should("have.length", 1)
                 .and("contain.text", "diagcess init 1");
@@ -107,17 +102,13 @@ describe(
                 expect(requestBodies[1]).to.include(`text="point summary"`);
             });
 
-            cy.get(cesc("#prefig"))
-                .find(".svg")
-                .should("contain.text", "svg-2");
-            cy.get(cesc("#prefig"))
-                .find(".cml")
-                .should("contain.text", "safe-cml-2");
-            cy.get(cesc("#prefig"))
+            cy.get("#prefig").find(".svg").should("contain.text", "svg-2");
+            cy.get("#prefig").find(".cml").should("contain.text", "safe-cml-2");
+            cy.get("#prefig")
                 .find(".cml [onclick], .cml [style]")
                 .should("not.exist");
             cy.window().its("__diagcessInitCount").should("eq", 2);
-            cy.get(cesc("#prefig"))
+            cy.get("#prefig")
                 .children("p.cacc-message")
                 .should("have.length", 1)
                 .and("contain.text", "diagcess init 2");
@@ -159,7 +150,7 @@ describe(
                 "not.have.attr",
                 "open",
             );
-            cy.get(cesc("#prefig")).find(".svg").should("exist");
+            cy.get("#prefig").find(".svg").should("exist");
         });
     },
 );

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureDebounce.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureDebounce.cy.js
@@ -20,7 +20,7 @@ describe(
 
         it("sends initial PreFigure build request immediately", () => {
             requestTracker = installPrefigureBuildIntercept();
-            postDebounceTestDoenetML(cesc);
+            postDebounceTestDoenetML();
 
             cy.wait(250);
             expectBuildRequestCount(requestTracker, 1);
@@ -31,7 +31,7 @@ describe(
 
         it("coalesces rapid point updates into one additional build", () => {
             requestTracker = installPrefigureBuildIntercept();
-            postDebounceTestDoenetML(cesc);
+            postDebounceTestDoenetML();
 
             waitPastDebounceWindow();
             expectBuildRequestCount(requestTracker, 1);
@@ -81,7 +81,7 @@ describe(
                 };
             });
 
-            postDebounceTestDoenetML(cesc);
+            postDebounceTestDoenetML();
 
             waitPastDebounceWindow();
             expectBuildRequestCount(requestTracker, 1);
@@ -104,7 +104,7 @@ describe(
         it("reintroduced prefigure graph builds immediately after being absent", () => {
             requestTracker = installPrefigureBuildIntercept();
 
-            postDebounceTestDoenetML(cesc);
+            postDebounceTestDoenetML();
             cy.wait(250);
             expectBuildRequestCount(requestTracker, 1);
 

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureDebounce.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureDebounce.cy.js
@@ -1,4 +1,3 @@
-import { cesc } from "@doenet/utils";
 import {
     PREFIGURE_BUILD_DEBOUNCE_MS,
     REQUEST_SETTLE_BUFFER_MS,
@@ -98,11 +97,8 @@ describe(
             waitPastDebounceWindow();
             expectBuildRequestCount(requestTracker, 2);
 
-            cy.get(cesc("#prefig")).should("contain.text", "latest-response");
-            cy.get(cesc("#prefig")).should(
-                "not.contain.text",
-                "older-response",
-            );
+            cy.get("#prefig").should("contain.text", "latest-response");
+            cy.get("#prefig").should("not.contain.text", "older-response");
         });
 
         it("reintroduced prefigure graph builds immediately after being absent", () => {
@@ -126,7 +122,7 @@ describe(
                 );
             });
 
-            cy.get(cesc("#ready")).should("have.text", "ready");
+            cy.get("#ready").should("have.text", "ready");
             cy.wait(PREFIGURE_BUILD_DEBOUNCE_MS + REQUEST_SETTLE_BUFFER_MS);
             expectBuildRequestCount(requestTracker, 1);
 
@@ -145,7 +141,7 @@ describe(
                 );
             });
 
-            cy.get(cesc("#ready")).should("have.text", "ready");
+            cy.get("#ready").should("have.text", "ready");
             cy.wait(250);
             expectBuildRequestCount(requestTracker, 2);
         });

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureDiagcessScript.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureDiagcessScript.cy.js
@@ -1,4 +1,3 @@
-import { cesc } from "@doenet/utils";
 import { installPrefigureBuildIntercept } from "../../support/prefigure";
 
 describe(
@@ -32,7 +31,7 @@ describe(
                 );
             });
 
-            cy.get(cesc("#ready")).should("have.text", "ready");
+            cy.get("#ready").should("have.text", "ready");
 
             cy.get(diagcessScriptSelector).should("have.length", 1);
 
@@ -50,7 +49,7 @@ describe(
                 );
             });
 
-            cy.get(cesc("#ready")).should("have.text", "ready");
+            cy.get("#ready").should("have.text", "ready");
 
             cy.get(diagcessScriptSelector).should("have.length", 1);
 
@@ -68,7 +67,7 @@ describe(
                 );
             });
 
-            cy.get(cesc("#ready")).should("have.text", "ready");
+            cy.get("#ready").should("have.text", "ready");
             cy.wait(300);
 
             // Script remains in place after all PreFigure instances unmount.

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureNoRuntimeOnNonPrefigurePage.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureNoRuntimeOnNonPrefigurePage.cy.js
@@ -1,5 +1,3 @@
-import { cesc } from "@doenet/utils";
-
 describe(
     "PreFigure stays unloaded on non-prefigure pages @group4",
     { tags: ["@group4"] },
@@ -68,11 +66,8 @@ describe(
                 );
             });
 
-            cy.get(cesc("#ready")).should("have.text", "ready");
-            cy.get(cesc("#status")).should(
-                "have.text",
-                "no prefigure renderer",
-            );
+            cy.get("#ready").should("have.text", "ready");
+            cy.get("#status").should("have.text", "no prefigure renderer");
 
             cy.wait(500);
 

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureSanitize.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureSanitize.cy.js
@@ -15,7 +15,7 @@ describe("PreFigure sanitization guards @group4", { tags: ["@group4"] }, () => {
             annotationsXml: `<?xml version="1.0"?><annotations onclick="alert('xss')" style="color:red"><annotation href="javascript:alert(3)" style="color:blue" onclick="alert(4)">safe-cml</annotation></annotations>`,
         }));
 
-        postDebounceTestDoenetML(cesc);
+        postDebounceTestDoenetML();
 
         cy.get("#prefig").find(".svg").should("contain.text", "safe-svg");
         cy.get("#prefig")
@@ -53,7 +53,7 @@ describe("PreFigure sanitization guards @group4", { tags: ["@group4"] }, () => {
             annotationsXml: "<annotations></annotations>",
         }));
 
-        postDebounceTestDoenetML(cesc);
+        postDebounceTestDoenetML();
 
         // Ensure the tick label text is present somewhere in the SVG.
         cy.get("#prefig").find(".svg").should("contain.text", "-1");
@@ -84,7 +84,7 @@ describe("PreFigure sanitization guards @group4", { tags: ["@group4"] }, () => {
             annotationsXml: "<annotations></annotations>",
         }));
 
-        postDebounceTestDoenetML(cesc);
+        postDebounceTestDoenetML();
 
         cy.get("#prefig").find(".svg").should("contain.text", "x_1 + y^2");
         cy.get("#prefig")
@@ -98,7 +98,7 @@ describe("PreFigure sanitization guards @group4", { tags: ["@group4"] }, () => {
             annotationsXml: "<annotations></annotations>",
         }));
 
-        postDebounceTestDoenetML(cesc);
+        postDebounceTestDoenetML();
 
         // Expected policy: only fragment-local <use> targets should survive sanitization.
         cy.get("#prefig").find(".svg").should("contain.text", "local-label");

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureSanitize.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureSanitize.cy.js
@@ -1,4 +1,3 @@
-import { cesc } from "@doenet/utils";
 import {
     installPrefigureBuildIntercept,
     postDebounceTestDoenetML,
@@ -18,11 +17,11 @@ describe("PreFigure sanitization guards @group4", { tags: ["@group4"] }, () => {
 
         postDebounceTestDoenetML(cesc);
 
-        cy.get(cesc("#prefig")).find(".svg").should("contain.text", "safe-svg");
-        cy.get(cesc("#prefig"))
+        cy.get("#prefig").find(".svg").should("contain.text", "safe-svg");
+        cy.get("#prefig")
             .find(".svg [xlink\\:href^='javascript:']")
             .should("not.exist");
-        cy.get(cesc("#prefig"))
+        cy.get("#prefig")
             .find(".svg")
             .invoke("html")
             .then((html) => {
@@ -32,12 +31,12 @@ describe("PreFigure sanitization guards @group4", { tags: ["@group4"] }, () => {
                 expect(html).not.to.include("javascript:alert(2)");
             });
 
-        cy.get(cesc("#prefig")).find(".cml [onclick]").should("not.exist");
-        cy.get(cesc("#prefig")).find(".cml [style]").should("not.exist");
-        cy.get(cesc("#prefig"))
+        cy.get("#prefig").find(".cml [onclick]").should("not.exist");
+        cy.get("#prefig").find(".cml [style]").should("not.exist");
+        cy.get("#prefig")
             .find(".cml [href^='javascript:']")
             .should("not.exist");
-        cy.get(cesc("#prefig"))
+        cy.get("#prefig")
             .find(".cml")
             .invoke("html")
             .then((html) => {
@@ -57,13 +56,13 @@ describe("PreFigure sanitization guards @group4", { tags: ["@group4"] }, () => {
         postDebounceTestDoenetML(cesc);
 
         // Ensure the tick label text is present somewhere in the SVG.
-        cy.get(cesc("#prefig")).find(".svg").should("contain.text", "-1");
-        cy.get(cesc("#prefig")).find(".svg").should("contain.text", "0");
-        cy.get(cesc("#prefig")).find(".svg").should("contain.text", "1");
+        cy.get("#prefig").find(".svg").should("contain.text", "-1");
+        cy.get("#prefig").find(".svg").should("contain.text", "0");
+        cy.get("#prefig").find(".svg").should("contain.text", "1");
 
         // Critically, ensure local fragment references survive sanitization.
         // Browsers may normalize xlink:href into href in the live DOM.
-        cy.get(cesc("#prefig"))
+        cy.get("#prefig")
             .find(".svg use")
             .then(($uses) => {
                 const refs = [...$uses].map(
@@ -87,10 +86,8 @@ describe("PreFigure sanitization guards @group4", { tags: ["@group4"] }, () => {
 
         postDebounceTestDoenetML(cesc);
 
-        cy.get(cesc("#prefig"))
-            .find(".svg")
-            .should("contain.text", "x_1 + y^2");
-        cy.get(cesc("#prefig"))
+        cy.get("#prefig").find(".svg").should("contain.text", "x_1 + y^2");
+        cy.get("#prefig")
             .find(".svg use[href='#point-label-math']")
             .should("exist");
     });
@@ -104,13 +101,9 @@ describe("PreFigure sanitization guards @group4", { tags: ["@group4"] }, () => {
         postDebounceTestDoenetML(cesc);
 
         // Expected policy: only fragment-local <use> targets should survive sanitization.
-        cy.get(cesc("#prefig"))
-            .find(".svg")
-            .should("contain.text", "local-label");
-        cy.get(cesc("#prefig"))
-            .find(".svg use[href='#local-label']")
-            .should("exist");
-        cy.get(cesc("#prefig"))
+        cy.get("#prefig").find(".svg").should("contain.text", "local-label");
+        cy.get("#prefig").find(".svg use[href='#local-label']").should("exist");
+        cy.get("#prefig")
             .find(
                 ".svg use[href^='https://'], .svg use[xlink\\:href^='https://']",
             )

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureSliders.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureSliders.cy.js
@@ -232,7 +232,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 <p>Py: <number name="Py">$P.y</number></p>
 `);
 
-        cy.get(cesc("#ready")).should("have.text", "ready");
+        cy.get("#ready").should("have.text", "ready");
 
         cy.get('[aria-label="x coordinate for P"]').should("have.value", "0");
         cy.get('[aria-label="y coordinate for P"]').should("have.value", "0");
@@ -252,8 +252,8 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         // While x remains transient and displays the dragged value, y should still
         // synchronize to the latest non-transient core value from constraints.
         cy.get('[aria-label="x coordinate for P"]').should("have.value", "4");
-        cy.get(cesc("#Px")).should("have.text", "2");
-        cy.get(cesc("#Py")).should("have.text", "2");
+        cy.get("#Px").should("have.text", "2");
+        cy.get("#Py").should("have.text", "2");
         cy.get('[aria-label="y coordinate for P"]').should("have.value", "2");
 
         cy.wait(500);
@@ -266,8 +266,8 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         cy.get('[aria-label="x coordinate for P"]').should("have.value", "2");
         cy.get('[aria-label="y coordinate for P"]').should("have.value", "2");
-        cy.get(cesc("#Px")).should("have.text", "2");
-        cy.get(cesc("#Py")).should("have.text", "2");
+        cy.get("#Px").should("have.text", "2");
+        cy.get("#Py").should("have.text", "2");
     });
 
     it("normalizes slider min and max for reversed graph bounds", () => {
@@ -584,7 +584,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 <p>Py: <number name="Py">$P.y</number></p>
 `);
 
-        cy.get(cesc("#ready")).should("have.text", "ready");
+        cy.get("#ready").should("have.text", "ready");
 
         cy.get('[aria-label="x coordinate for P"]').should("have.value", "0");
 
@@ -604,14 +604,14 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         // Slider handle should show the accumulated value (1.0) while core still shows 0.
         cy.get(xSlider).should("have.value", "1");
-        cy.get(cesc("#Px")).should("have.text", "0");
+        cy.get("#Px").should("have.text", "0");
 
         // Blurring triggers the final non-transient commit.
         cy.get(xSlider).blur();
 
         // Core evaluates constrainToGrid once against 1.0 → snaps to 1.
         cy.get(xSlider).should("have.value", "1");
-        cy.get(cesc("#Px")).should("have.text", "1");
+        cy.get("#Px").should("have.text", "1");
     });
 
     it("keyboard blur on constrained point does not send another movePoint", () => {
@@ -630,7 +630,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 <p>Py: <number name="Py">$P.y</number></p>
 `);
 
-        cy.get(cesc("#ready")).should("have.text", "ready");
+        cy.get("#ready").should("have.text", "ready");
 
         cy.get('[aria-label="x coordinate for P"]').should("have.value", "0");
         cy.get('[aria-label="y coordinate for P"]').should("have.value", "0");
@@ -645,8 +645,8 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         keyboardStepRangeRight(xSlider);
 
         // Now check that core has constrained the point to (0.1, 0.1).
-        cy.get(cesc("#Px")).should("have.text", "0.1");
-        cy.get(cesc("#Py")).should("have.text", "0.1");
+        cy.get("#Px").should("have.text", "0.1");
+        cy.get("#Py").should("have.text", "0.1");
 
         // The x-slider shows the transient value (what user entered), while
         // the visible y-slider label reflects the constrained core value.
@@ -664,8 +664,8 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         // updated, so assert the user-visible slider labels and core values here.
         cy.get(xSlider).should("have.attr", "value", "0.1");
         cy.get(ySlider).should("have.attr", "value", "0.1");
-        cy.get(cesc("#Px")).should("have.text", "0.1");
-        cy.get(cesc("#Py")).should("have.text", "0.1");
+        cy.get("#Px").should("have.text", "0.1");
+        cy.get("#Py").should("have.text", "0.1");
     });
 
     it("addSliders false on point is equivalent to none", () => {

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureSliders.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureSliders.cy.js
@@ -1,4 +1,3 @@
-import { cesc } from "@doenet/utils";
 import { installPrefigureBuildIntercept } from "../../support/prefigure";
 
 describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
@@ -44,7 +43,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 <p>Py: <number name="Py">$P.y</number></p>
 `);
 
-        cy.get(cesc("#ready")).should("have.text", "ready");
+        cy.get("#ready").should("have.text", "ready");
 
         cy.get('[aria-label="x coordinate for Point 1"]').should(
             "have.value",
@@ -66,16 +65,16 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
             "have.value",
             "5.6",
         );
-        cy.get(cesc("#Qx")).should("have.text", "5.6");
-        cy.get(cesc("#Qy")).should("have.text", "4");
+        cy.get("#Qx").should("have.text", "5.6");
+        cy.get("#Qy").should("have.text", "4");
 
         cy.get('[aria-label="x coordinate for Point 1"]').trigger("mouseup");
         cy.get('[aria-label="x coordinate for Point 1"]').should(
             "have.value",
             "5.6",
         );
-        cy.get(cesc("#Qx")).should("have.text", "5.6");
-        cy.get(cesc("#Qy")).should("have.text", "4");
+        cy.get("#Qx").should("have.text", "5.6");
+        cy.get("#Qy").should("have.text", "4");
     });
 
     it("snaps a constrained point slider to the core value on mouseup", () => {
@@ -97,10 +96,10 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 <p>Py: <number name="Py">$P.y</number></p>
 `);
 
-        cy.get(cesc("#ready")).should("have.text", "ready");
+        cy.get("#ready").should("have.text", "ready");
 
         cy.get('[aria-label="x coordinate for P"]').should("have.value", "3");
-        cy.get(cesc("#Px")).should("have.text", "3");
+        cy.get("#Px").should("have.text", "3");
 
         cy.get('[aria-label="x coordinate for P"]').trigger("mousedown");
         cy.get('[aria-label="x coordinate for P"]')
@@ -108,13 +107,13 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
             .trigger("input");
 
         cy.get('[aria-label="x coordinate for P"]').should("have.value", "3.6");
-        cy.get(cesc("#Px")).should("have.text", "4");
+        cy.get("#Px").should("have.text", "4");
 
         cy.get('[aria-label="x coordinate for P"]').trigger("mouseup");
 
         cy.get('[aria-label="x coordinate for P"]').should("have.value", "4");
-        cy.get(cesc("#Px")).should("have.text", "4");
-        cy.get(cesc("#Py")).should("have.text", "4");
+        cy.get("#Px").should("have.text", "4");
+        cy.get("#Py").should("have.text", "4");
     });
 
     it("keeps transient local value on first pointer drag input, then snaps on pointerup", () => {
@@ -134,10 +133,10 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 <p>Px: <number name="Px">$P.x</number></p>
 `);
 
-        cy.get(cesc("#ready")).should("have.text", "ready");
+        cy.get("#ready").should("have.text", "ready");
 
         cy.get('[aria-label="x coordinate for P"]').should("have.value", "3");
-        cy.get(cesc("#Px")).should("have.text", "3");
+        cy.get("#Px").should("have.text", "3");
 
         cy.get('[aria-label="x coordinate for P"]').trigger("pointerdown", {
             pointerId: 1,
@@ -153,7 +152,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         // During the active drag, the UI should keep the transient local value
         // even though the constrained core value has already snapped.
         cy.get('[aria-label="x coordinate for P"]').should("have.value", "3.6");
-        cy.get(cesc("#Px")).should("have.text", "4");
+        cy.get("#Px").should("have.text", "4");
 
         cy.get('[aria-label="x coordinate for P"]').trigger("pointerup", {
             pointerId: 1,
@@ -162,7 +161,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         });
 
         cy.get('[aria-label="x coordinate for P"]').should("have.value", "4");
-        cy.get(cesc("#Px")).should("have.text", "4");
+        cy.get("#Px").should("have.text", "4");
     });
 
     it("preserves latest other-axis value across rapid slider interactions", () => {
@@ -180,7 +179,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 <p>Py: <number name="Py">$P.y</number></p>
 `);
 
-        cy.get(cesc("#ready")).should("have.text", "ready");
+        cy.get("#ready").should("have.text", "ready");
 
         cy.get('[aria-label="x coordinate for P"]').trigger("pointerdown", {
             pointerId: 1,
@@ -202,8 +201,8 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
             .invoke("val", "6.4")
             .trigger("input", { force: true });
 
-        cy.get(cesc("#Px")).should("have.text", "4.2");
-        cy.get(cesc("#Py")).should("have.text", "6.4");
+        cy.get("#Px").should("have.text", "4.2");
+        cy.get("#Py").should("have.text", "6.4");
 
         cy.get('[aria-label="x coordinate for P"]').trigger("pointerup", {
             pointerId: 1,
@@ -285,7 +284,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 <p>Px: <number name="Px">$P.x</number></p>
 `);
 
-        cy.get(cesc("#ready")).should("have.text", "ready");
+        cy.get("#ready").should("have.text", "ready");
 
         cy.get('[aria-label="x coordinate for P"]')
             .should("have.attr", "min", "-10")
@@ -298,7 +297,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         cy.get('[aria-label="x coordinate for P"]')
             .invoke("val", "7")
             .trigger("input");
-        cy.get(cesc("#Px")).should("have.text", "7");
+        cy.get("#Px").should("have.text", "7");
         cy.get('[aria-label="x coordinate for P"]').trigger("mouseup");
     });
 
@@ -317,7 +316,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 </graph>
 `);
 
-        cy.get(cesc("#ready")).should("have.text", "ready");
+        cy.get("#ready").should("have.text", "ready");
 
         cy.get('input[type="range"]').should("have.length", 2);
         cy.get('[aria-label="x coordinate for Point 1"]').should("exist");
@@ -344,7 +343,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 </graph>
 `);
 
-        cy.get(cesc("#ready")).should("have.text", "ready");
+        cy.get("#ready").should("have.text", "ready");
 
         cy.get('[aria-label="x coordinate for Point 1"]').should("exist");
         cy.get('[aria-label="x coordinate for Point 2"]').should("exist");
@@ -379,11 +378,11 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 <p>R.x: <number name="refRx">$R.x</number></p>
 `);
 
-        cy.get(cesc("#ready")).should("have.text", "ready");
+        cy.get("#ready").should("have.text", "ready");
 
         // Verify slider labels match reference number display values
         // P with displayDecimals="1" should display 1.6 (rounded from 1.555)
-        cy.get(cesc("#refPx")).then(($refPx) => {
+        cy.get("#refPx").then(($refPx) => {
             const refValue = $refPx.text();
             // Check that slider label contains the same value
             cy.get('input[aria-label="x coordinate for P"]')
@@ -394,7 +393,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         });
 
         // Q with displayDigits="2" should display 3.5 (rounded to 2 significant digits)
-        cy.get(cesc("#refQx")).then(($refQx) => {
+        cy.get("#refQx").then(($refQx) => {
             const refValue = $refQx.text();
             cy.get('input[aria-label="x coordinate for Q"]')
                 .parent()
@@ -404,7 +403,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         });
 
         // R with default display should show coordinate with 3 decimal places
-        cy.get(cesc("#refRx")).then(($refRx) => {
+        cy.get("#refRx").then(($refRx) => {
             const refValue = $refRx.text();
             cy.get('input[aria-label="x coordinate for R"]')
                 .parent()
@@ -430,11 +429,11 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 <p>Q.x: <number name="refQx" displayDigits="3" padZeros="true">$Q.x</number></p>
 `);
 
-        cy.get(cesc("#ready")).should("have.text", "ready");
+        cy.get("#ready").should("have.text", "ready");
 
         // Verify slider labels match reference number display with padding
         // P with displayDecimals="2" and padZeros should display "1.50"
-        cy.get(cesc("#refPx")).then(($refPx) => {
+        cy.get("#refPx").then(($refPx) => {
             const refValue = $refPx.text();
             cy.get('input[aria-label="x coordinate for P"]')
                 .parent()
@@ -444,7 +443,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         });
 
         // Q with displayDigits="3" and padZeros
-        cy.get(cesc("#refQx")).then(($refQx) => {
+        cy.get("#refQx").then(($refQx) => {
             const refValue = $refQx.text();
             cy.get('input[aria-label="x coordinate for Q"]')
                 .parent()
@@ -469,7 +468,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 </graph>
 `);
 
-        cy.get(cesc("#ready")).should("have.text", "ready");
+        cy.get("#ready").should("have.text", "ready");
 
         cy.get('input[type="range"]').should("have.length", 4);
         cy.get('[aria-label="x coordinate for Point 1"]').should("exist");
@@ -496,7 +495,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 <p>Py: <number name="Py">$P.y</number></p>
 `);
 
-        cy.get(cesc("#ready")).should("have.text", "ready");
+        cy.get("#ready").should("have.text", "ready");
 
         cy.get('[aria-label="x coordinate for P"]').should("exist");
         cy.get('[aria-label="y coordinate for P"]').should("not.exist");
@@ -509,10 +508,10 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         cy.get('[aria-label="x coordinate for P"]')
             .invoke("val", "5")
             .trigger("input");
-        cy.get(cesc("#Px")).should("have.text", "5");
-        cy.get(cesc("#Py")).should("have.text", "4");
+        cy.get("#Px").should("have.text", "5");
+        cy.get("#Py").should("have.text", "4");
         cy.get('[aria-label="x coordinate for P"]').trigger("mouseup");
-        cy.get(cesc("#Px")).should("have.text", "5");
+        cy.get("#Px").should("have.text", "5");
     });
 
     it("addSliders='yOnly' on a point renders only the y slider", () => {
@@ -531,7 +530,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 <p>Py: <number name="Py">$P.y</number></p>
 `);
 
-        cy.get(cesc("#ready")).should("have.text", "ready");
+        cy.get("#ready").should("have.text", "ready");
 
         cy.get('[aria-label="x coordinate for P"]').should("not.exist");
         cy.get('[aria-label="y coordinate for P"]').should("exist");
@@ -544,10 +543,10 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         cy.get('[aria-label="y coordinate for P"]')
             .invoke("val", "7")
             .trigger("input");
-        cy.get(cesc("#Px")).should("have.text", "3");
-        cy.get(cesc("#Py")).should("have.text", "7");
+        cy.get("#Px").should("have.text", "3");
+        cy.get("#Py").should("have.text", "7");
         cy.get('[aria-label="y coordinate for P"]').trigger("mouseup");
-        cy.get(cesc("#Py")).should("have.text", "7");
+        cy.get("#Py").should("have.text", "7");
     });
 
     it("addSliders defaults to 'both' when graph-level addSliders is set", () => {
@@ -563,7 +562,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 </graph>
 `);
 
-        cy.get(cesc("#ready")).should("have.text", "ready");
+        cy.get("#ready").should("have.text", "ready");
 
         cy.get('[aria-label="x coordinate for P"]').should("exist");
         cy.get('[aria-label="y coordinate for P"]').should("exist");
@@ -683,7 +682,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 </graph>
 `);
 
-        cy.get(cesc("#ready")).should("have.text", "ready");
+        cy.get("#ready").should("have.text", "ready");
 
         cy.get('[aria-label="x coordinate for P"]').should("not.exist");
         cy.get('[aria-label="y coordinate for P"]').should("not.exist");

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureViewport.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureViewport.cy.js
@@ -1,4 +1,3 @@
-import { cesc } from "@doenet/utils";
 import {
     installPrefigureBuildIntercept,
     postDebounceTestDoenetML,
@@ -21,7 +20,7 @@ describe(
 
             postDebounceTestDoenetML(cesc);
 
-            cy.get(cesc("#prefig"))
+            cy.get("#prefig")
                 .find(".svg")
                 .as("svgWrapper")
                 .invoke("css", "width", "120px")

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureViewport.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureViewport.cy.js
@@ -18,7 +18,7 @@ describe(
                 annotationsXml: "<annotations></annotations>",
             }));
 
-            postDebounceTestDoenetML(cesc);
+            postDebounceTestDoenetML();
 
             cy.get("#prefig")
                 .find(".svg")

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureWinner.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureWinner.cy.js
@@ -1,4 +1,3 @@
-import { cesc } from "@doenet/utils";
 import {
     installMockPrefigureModule,
     postDebounceTestDoenetML,
@@ -33,19 +32,19 @@ describe(
             });
 
             visitWithMockPrefigureModule(modulePath);
-            postDebounceTestDoenetML(cesc);
+            postDebounceTestDoenetML();
 
-            cy.get(cesc("#prefig"), { timeout: 1400 }).should(
+            cy.get("#prefig", { timeout: 1400 }).should(
                 "contain.text",
                 "local-winner",
             );
-            cy.get(cesc("#prefig")).should("not.contain.text", "service-slow");
+            cy.get("#prefig").should("not.contain.text", "service-slow");
 
             // Even after the delayed service response eventually settles, the
             // local winner should remain rendered.
             cy.wait(900);
-            cy.get(cesc("#prefig")).should("contain.text", "local-winner");
-            cy.get(cesc("#prefig")).should("not.contain.text", "service-slow");
+            cy.get("#prefig").should("contain.text", "local-winner");
+            cy.get("#prefig").should("not.contain.text", "service-slow");
         });
 
         it("recovers from service failure once local WASM warmup completes", () => {
@@ -62,13 +61,13 @@ describe(
             });
 
             visitWithMockPrefigureModule(modulePath);
-            postDebounceTestDoenetML(cesc);
+            postDebounceTestDoenetML();
 
-            cy.get(cesc("#prefig"), { timeout: 2000 }).should(
+            cy.get("#prefig", { timeout: 2000 }).should(
                 "contain.text",
                 "local-after-service-error",
             );
-            cy.get(cesc("#prefig")).should("not.contain.text", "Error:");
+            cy.get("#prefig").should("not.contain.text", "Error:");
         });
 
         it("suppresses stale local compile result when request is aborted after warmup wins", () => {
@@ -91,7 +90,7 @@ describe(
             });
 
             visitWithMockPrefigureModule(modulePath);
-            postDebounceTestDoenetML(cesc);
+            postDebounceTestDoenetML();
 
             // Trigger a new payload while the first local compile is still in
             // flight, which should abort and suppress the stale result.
@@ -113,13 +112,13 @@ describe(
             // The second payload replaces the first graph, so #prefig is
             // removed from the DOM. The key assertion is that this unmount-time
             // abort does not surface stale output or an error.
-            cy.get(cesc("#prefig")).should("not.exist");
+            cy.get("#prefig").should("not.exist");
             cy.wait(550);
-            cy.get(cesc("#prefig2"), { timeout: 2000 }).should(
+            cy.get("#prefig2", { timeout: 2000 }).should(
                 "contain.text",
                 "local-replacement-render-after-abort",
             );
-            cy.get(cesc("#prefig2")).should("not.contain.text", "Error:");
+            cy.get("#prefig2").should("not.contain.text", "Error:");
         });
     },
 );

--- a/packages/test-cypress/cypress/e2e/tagSpecific/animatefromsequence.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/animatefromsequence.cy.js
@@ -1833,9 +1833,9 @@ describe("AnimateFromSequence Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#n1")).should("have.text", "1");
-        cy.get(cesc("#n2")).should("have.text", "2");
-        cy.get(cesc("#n3")).should("have.text", "3");
+        cy.get("#n1").should("have.text", "1");
+        cy.get("#n2").should("have.text", "2");
+        cy.get("#n3").should("have.text", "3");
         cy.get(cesc("#c2.n1")).should("have.text", "1");
         cy.get(cesc("#c2.n2")).should("have.text", "2");
         cy.get(cesc("#c2.n3")).should("have.text", "3");
@@ -1877,27 +1877,27 @@ describe("AnimateFromSequence Tag Tests", { tags: ["@group4"] }, function () {
         });
 
         cy.get("#b").click();
-        cy.get(cesc("#n1")).should("have.text", "2");
+        cy.get("#n1").should("have.text", "2");
         cy.get(cesc("#c2.n1")).should("have.text", "2");
-        cy.get(cesc("#n1")).should("have.text", "3");
+        cy.get("#n1").should("have.text", "3");
         cy.get(cesc("#c2.n1")).should("have.text", "3");
-        cy.get(cesc("#n1")).should("have.text", "4");
+        cy.get("#n1").should("have.text", "4");
         cy.get(cesc("#c2.n1")).should("have.text", "4");
-        cy.get(cesc("#n1")).should("have.text", "5");
+        cy.get("#n1").should("have.text", "5");
         cy.get(cesc("#c2.n1")).should("have.text", "5");
-        cy.get(cesc("#n1")).should("have.text", "6");
+        cy.get("#n1").should("have.text", "6");
         cy.get(cesc("#c2.n1")).should("have.text", "6");
-        cy.get(cesc("#n1")).should("have.text", "7");
+        cy.get("#n1").should("have.text", "7");
         cy.get(cesc("#c2.n1")).should("have.text", "7");
-        cy.get(cesc("#n1")).should("have.text", "8");
+        cy.get("#n1").should("have.text", "8");
         cy.get(cesc("#c2.n1")).should("have.text", "8");
-        cy.get(cesc("#n1")).should("have.text", "9");
+        cy.get("#n1").should("have.text", "9");
         cy.get(cesc("#c2.n1")).should("have.text", "9");
-        cy.get(cesc("#n1")).should("have.text", "10");
+        cy.get("#n1").should("have.text", "10");
         cy.get(cesc("#c2.n1")).should("have.text", "10");
-        cy.get(cesc("#n1")).should("have.text", "1");
+        cy.get("#n1").should("have.text", "1");
         cy.get(cesc("#c2.n1")).should("have.text", "1");
-        cy.get(cesc("#n1")).should("have.text", "2");
+        cy.get("#n1").should("have.text", "2");
         cy.get(cesc("#c2.n1")).should("have.text", "2");
 
         cy.get("#b").click();
@@ -1913,7 +1913,7 @@ describe("AnimateFromSequence Tag Tests", { tags: ["@group4"] }, function () {
         );
 
         // should stop at 2 or 3
-        cy.get(cesc("#n1")).contains(/2|3/);
+        cy.get("#n1").contains(/2|3/);
 
         let lastValue1;
 
@@ -1953,9 +1953,9 @@ describe("AnimateFromSequence Tag Tests", { tags: ["@group4"] }, function () {
                     .animationOn,
             ).eq(false);
 
-            cy.get(cesc("#n1")).should("have.text", `${lastValue1}`);
-            cy.get(cesc("#n2")).should("have.text", "2");
-            cy.get(cesc("#n3")).should("have.text", "3");
+            cy.get("#n1").should("have.text", `${lastValue1}`);
+            cy.get("#n2").should("have.text", "2");
+            cy.get("#n3").should("have.text", "3");
             cy.get(cesc("#c2.n1")).should("have.text", `${lastValue1}`);
             cy.get(cesc("#c2.n2")).should("have.text", "2");
             cy.get(cesc("#c2.n3")).should("have.text", "3");
@@ -1968,17 +1968,17 @@ describe("AnimateFromSequence Tag Tests", { tags: ["@group4"] }, function () {
         });
 
         cy.get("#b").click();
-        cy.get(cesc("#n2")).should("have.text", "3");
+        cy.get("#n2").should("have.text", "3");
         cy.get(cesc("#c2.n2")).should("have.text", "3");
-        cy.get(cesc("#n2")).should("have.text", "4");
+        cy.get("#n2").should("have.text", "4");
         cy.get(cesc("#c2.n2")).should("have.text", "4");
-        cy.get(cesc("#n2")).should("have.text", "5");
+        cy.get("#n2").should("have.text", "5");
         cy.get(cesc("#c2.n2")).should("have.text", "5");
-        cy.get(cesc("#n2")).should("have.text", "6");
+        cy.get("#n2").should("have.text", "6");
         cy.get(cesc("#c2.n2")).should("have.text", "6");
-        cy.get(cesc("#n2")).should("have.text", "7");
+        cy.get("#n2").should("have.text", "7");
         cy.get(cesc("#c2.n2")).should("have.text", "7");
-        cy.get(cesc("#n2")).should("have.text", "8");
+        cy.get("#n2").should("have.text", "8");
         cy.get(cesc("#c2.n2")).should("have.text", "8");
 
         cy.get("#b").click();
@@ -1994,7 +1994,7 @@ describe("AnimateFromSequence Tag Tests", { tags: ["@group4"] }, function () {
         );
 
         // should stop at 9 or 0
-        cy.get(cesc("#n2")).contains(/8|9/);
+        cy.get("#n2").contains(/8|9/);
 
         let lastValue2;
 
@@ -2034,9 +2034,9 @@ describe("AnimateFromSequence Tag Tests", { tags: ["@group4"] }, function () {
                     .animationOn,
             ).eq(false);
 
-            cy.get(cesc("#n1")).should("have.text", `${lastValue1}`);
-            cy.get(cesc("#n2")).should("have.text", `${lastValue2}`);
-            cy.get(cesc("#n3")).should("have.text", "3");
+            cy.get("#n1").should("have.text", `${lastValue1}`);
+            cy.get("#n2").should("have.text", `${lastValue2}`);
+            cy.get("#n3").should("have.text", "3");
             cy.get(cesc("#c2.n1")).should("have.text", `${lastValue1}`);
             cy.get(cesc("#c2.n2")).should("have.text", `${lastValue2}`);
             cy.get(cesc("#c2.n3")).should("have.text", "3");
@@ -2045,22 +2045,22 @@ describe("AnimateFromSequence Tag Tests", { tags: ["@group4"] }, function () {
         cy.log("Switch to animate index 3 while animating");
 
         cy.get("#b").click();
-        cy.get(cesc("#n2")).should("have.text", "10");
+        cy.get("#n2").should("have.text", "10");
         cy.get(cesc("#c2.n2")).should("have.text", "10");
-        cy.get(cesc("#n2")).should("have.text", "1");
+        cy.get("#n2").should("have.text", "1");
         cy.get(cesc("#c2.n2")).should("have.text", "1");
 
         cy.get("#ind" + " textarea").type("{end}{backspace}3{enter}", {
             force: true,
         });
 
-        cy.get(cesc("#n3")).should("have.text", "4");
+        cy.get("#n3").should("have.text", "4");
         cy.get(cesc("#c2.n3")).should("have.text", "4");
-        cy.get(cesc("#n3")).should("have.text", "5");
+        cy.get("#n3").should("have.text", "5");
         cy.get(cesc("#c2.n3")).should("have.text", "5");
-        cy.get(cesc("#n3")).should("have.text", "6");
+        cy.get("#n3").should("have.text", "6");
         cy.get(cesc("#c2.n3")).should("have.text", "6");
-        cy.get(cesc("#n3")).should("have.text", "7");
+        cy.get("#n3").should("have.text", "7");
         cy.get(cesc("#c2.n3")).should("have.text", "7");
 
         cy.get("#b").click();
@@ -2076,10 +2076,10 @@ describe("AnimateFromSequence Tag Tests", { tags: ["@group4"] }, function () {
         );
 
         // should stop at 7 or 8
-        cy.get(cesc("#n3")).contains(/7|8/);
+        cy.get("#n3").contains(/7|8/);
 
         // previous should have stopped at 1 or 2
-        cy.get(cesc("#n2")).contains(/1|2/);
+        cy.get("#n2").contains(/1|2/);
 
         let lastValue3;
 
@@ -2119,9 +2119,9 @@ describe("AnimateFromSequence Tag Tests", { tags: ["@group4"] }, function () {
                     .animationOn,
             ).eq(false);
 
-            cy.get(cesc("#n1")).should("have.text", `${lastValue1}`);
-            cy.get(cesc("#n2")).should("have.text", `${lastValue2}`);
-            cy.get(cesc("#n3")).should("have.text", `${lastValue3}`);
+            cy.get("#n1").should("have.text", `${lastValue1}`);
+            cy.get("#n2").should("have.text", `${lastValue2}`);
+            cy.get("#n3").should("have.text", `${lastValue3}`);
             cy.get(cesc("#c2.n1")).should("have.text", `${lastValue1}`);
             cy.get(cesc("#c2.n2")).should("have.text", `${lastValue2}`);
             cy.get(cesc("#c2.n3")).should("have.text", `${lastValue3}`);
@@ -2156,7 +2156,7 @@ describe("AnimateFromSequence Tag Tests", { tags: ["@group4"] }, function () {
         });
 
         cy.get(cesc("#p1.n1")).should("have.text", "1");
-        cy.get(cesc("#n2")).should("have.text", "2");
+        cy.get("#n2").should("have.text", "2");
         cy.get(cesc("#p2.n1")).should("have.text", "3");
         cy.get(cesc("#c2.p1.n1")).should("have.text", "1");
         cy.get(cesc("#c2.n2")).should("have.text", "2");
@@ -2282,7 +2282,7 @@ describe("AnimateFromSequence Tag Tests", { tags: ["@group4"] }, function () {
             ).eq(false);
 
             cy.get(cesc("#p1.n1")).should("have.text", `${lastValue1}`);
-            cy.get(cesc("#n2")).should("have.text", "2");
+            cy.get("#n2").should("have.text", "2");
             cy.get(cesc("#p2.n1")).should("have.text", "3");
             cy.get(cesc("#c2.p1.n1")).should("have.text", `${lastValue1}`);
             cy.get(cesc("#c2.n2")).should("have.text", "2");
@@ -2292,17 +2292,17 @@ describe("AnimateFromSequence Tag Tests", { tags: ["@group4"] }, function () {
         cy.log("Animate second number");
 
         cy.get(cesc(`#b2`)).click();
-        cy.get(cesc("#n2")).should("have.text", "3");
+        cy.get("#n2").should("have.text", "3");
         cy.get(cesc("#c2.n2")).should("have.text", "3");
-        cy.get(cesc("#n2")).should("have.text", "4");
+        cy.get("#n2").should("have.text", "4");
         cy.get(cesc("#c2.n2")).should("have.text", "4");
-        cy.get(cesc("#n2")).should("have.text", "5");
+        cy.get("#n2").should("have.text", "5");
         cy.get(cesc("#c2.n2")).should("have.text", "5");
-        cy.get(cesc("#n2")).should("have.text", "6");
+        cy.get("#n2").should("have.text", "6");
         cy.get(cesc("#c2.n2")).should("have.text", "6");
-        cy.get(cesc("#n2")).should("have.text", "7");
+        cy.get("#n2").should("have.text", "7");
         cy.get(cesc("#c2.n2")).should("have.text", "7");
-        cy.get(cesc("#n2")).should("have.text", "8");
+        cy.get("#n2").should("have.text", "8");
         cy.get(cesc("#c2.n2")).should("have.text", "8");
 
         cy.get(cesc(`#b2`)).click();
@@ -2318,7 +2318,7 @@ describe("AnimateFromSequence Tag Tests", { tags: ["@group4"] }, function () {
         );
 
         // should stop at 9 or 0
-        cy.get(cesc("#n2")).contains(/8|9/);
+        cy.get("#n2").contains(/8|9/);
 
         let lastValue2;
 
@@ -2361,7 +2361,7 @@ describe("AnimateFromSequence Tag Tests", { tags: ["@group4"] }, function () {
             ).eq(false);
 
             cy.get(cesc("#p1.n1")).should("have.text", `${lastValue1}`);
-            cy.get(cesc("#n2")).should("have.text", `${lastValue2}`);
+            cy.get("#n2").should("have.text", `${lastValue2}`);
             cy.get(cesc("#p2.n1")).should("have.text", "3");
             cy.get(cesc("#c2.p1.n1")).should("have.text", `${lastValue1}`);
             cy.get(cesc("#c2.n2")).should("have.text", `${lastValue2}`);
@@ -2440,7 +2440,7 @@ describe("AnimateFromSequence Tag Tests", { tags: ["@group4"] }, function () {
             ).eq(false);
 
             cy.get(cesc("#p1.n1")).should("have.text", `${lastValue1}`);
-            cy.get(cesc("#n2")).should("have.text", `${lastValue2}`);
+            cy.get("#n2").should("have.text", `${lastValue2}`);
             cy.get(cesc("#p2.n1")).should("have.text", `${lastValue3}`);
             cy.get(cesc("#c2.p1.n1")).should("have.text", `${lastValue1}`);
             cy.get(cesc("#c2.n2")).should("have.text", `${lastValue2}`);

--- a/packages/test-cypress/cypress/e2e/tagSpecific/circle.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/circle.cy.js
@@ -39,7 +39,7 @@ describe("Circle Tag Tests", { tags: ["@group3"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); // to wait for page to load
+        cy.get("#a").should("have.text", "a"); // to wait for page to load
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -82,7 +82,7 @@ describe("Circle Tag Tests", { tags: ["@group3"] }, function () {
         });
 
         cy.log("change radius");
-        cy.get(cesc("#r") + " textarea").type("{end}{backspace}3{enter}", {
+        cy.get("#r" + " textarea").type("{end}{backspace}3{enter}", {
             force: true,
         });
         cy.get(cesc(`#r`) + ` .mq-editable-field`).should("contain.text", "3");
@@ -113,7 +113,7 @@ describe("Circle Tag Tests", { tags: ["@group3"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+        cy.get("#a").should("have.text", "a"); //wait for page to load
 
         // wait until core is loaded
         cy.waitUntil(() =>

--- a/packages/test-cypress/cypress/e2e/tagSpecific/codeeditor.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/codeeditor.cy.js
@@ -20,8 +20,8 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#p1")).should("have.text", "");
-        cy.get(cesc("#p2")).should("have.text", "");
+        cy.get("#p1").should("have.text", "");
+        cy.get("#p2").should("have.text", "");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -36,10 +36,10 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
         });
 
         cy.log("type text in editor");
-        cy.get(cesc("#editor") + " .cm-activeLine").invoke("text", "Hello!");
+        cy.get("#editor" + " .cm-activeLine").invoke("text", "Hello!");
 
-        cy.get(cesc("#p1")).should("have.text", "Hello!");
-        cy.get(cesc("#p2")).should("have.text", "");
+        cy.get("#p1").should("have.text", "Hello!");
+        cy.get("#p2").should("have.text", "");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -55,8 +55,8 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
 
         cy.log("wait for debounce to update value");
         cy.wait(1500);
-        cy.get(cesc("#p1")).should("have.text", "Hello!");
-        cy.get(cesc("#p2")).should("have.text", "Hello!");
+        cy.get("#p1").should("have.text", "Hello!");
+        cy.get("#p2").should("have.text", "Hello!");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -71,14 +71,11 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
         });
 
         cy.log("type more in editor");
-        cy.get(cesc("#editor") + " .cm-activeLine").type("{enter}");
-        cy.get(cesc("#editor") + " .cm-activeLine").invoke(
-            "text",
-            "More here.",
-        );
+        cy.get("#editor" + " .cm-activeLine").type("{enter}");
+        cy.get("#editor" + " .cm-activeLine").invoke("text", "More here.");
 
-        cy.get(cesc("#p1")).should("have.text", "Hello!\nMore here.");
-        cy.get(cesc("#p2")).should("have.text", "Hello!");
+        cy.get("#p1").should("have.text", "Hello!\nMore here.");
+        cy.get("#p2").should("have.text", "Hello!");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -93,10 +90,10 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
         });
 
         cy.log("blur to update value");
-        cy.get(cesc("#editor") + " .cm-content").blur();
+        cy.get("#editor" + " .cm-content").blur();
 
-        cy.get(cesc("#p1")).should("have.text", "Hello!\nMore here.");
-        cy.get(cesc("#p2")).should("have.text", "Hello!\nMore here.");
+        cy.get("#p1").should("have.text", "Hello!\nMore here.");
+        cy.get("#p2").should("have.text", "Hello!\nMore here.");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -128,8 +125,8 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
 
         cy.get(cesc(`#editor::_id_0`)).should("exist");
 
-        cy.get(cesc("#p1")).should("have.text", "");
-        cy.get(cesc("#p2")).should("have.text", "");
+        cy.get("#p1").should("have.text", "");
+        cy.get("#p2").should("have.text", "");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -148,14 +145,14 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
         });
 
         cy.log("type text in editor");
-        cy.get(cesc("#editor") + " .cm-content").focus();
-        cy.get(cesc("#editor") + " .cm-activeLine").invoke(
+        cy.get("#editor" + " .cm-content").focus();
+        cy.get("#editor" + " .cm-activeLine").invoke(
             "text",
             '<p name="p1">Hello!</p>',
         );
 
-        cy.get(cesc("#p1")).should("have.text", '<p name="p1">Hello!</p>');
-        cy.get(cesc("#p2")).should("have.text", "");
+        cy.get("#p1").should("have.text", '<p name="p1">Hello!</p>');
+        cy.get("#p2").should("have.text", "");
         cy.get(cesc(`#editor::_id_0`)).should("exist");
         cy.get(cesc(`#editor::p1`)).should("not.exist");
 
@@ -176,10 +173,10 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
         });
 
         cy.log("blur updates value but not content");
-        cy.get(cesc("#editor") + " .cm-content").blur();
+        cy.get("#editor" + " .cm-content").blur();
 
-        cy.get(cesc("#p1")).should("have.text", '<p name="p1">Hello!</p>');
-        cy.get(cesc("#p2")).should("have.text", '<p name="p1">Hello!</p>');
+        cy.get("#p1").should("have.text", '<p name="p1">Hello!</p>');
+        cy.get("#p2").should("have.text", '<p name="p1">Hello!</p>');
         cy.get(cesc(`#editor::_id_0`)).should("exist");
         cy.get(cesc(`#editor::p1`)).should("not.exist");
 
@@ -203,8 +200,8 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
         cy.get(`[data-test="Viewer Update Button"]`).click();
 
         cy.get(cesc(`#editor::p1`)).should("have.text", "Hello!");
-        cy.get(cesc("#p1")).should("have.text", '<p name="p1">Hello!</p>');
-        cy.get(cesc("#p2")).should("have.text", '<p name="p1">Hello!</p>');
+        cy.get("#p1").should("have.text", '<p name="p1">Hello!</p>');
+        cy.get("#p2").should("have.text", '<p name="p1">Hello!</p>');
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -227,17 +224,17 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
 
         cy.log("type more content");
 
-        cy.get(cesc("#editor") + " .cm-activeLine").type("{ctrl+end}{enter}");
-        cy.get(cesc("#editor") + " .cm-activeLine").invoke(
+        cy.get("#editor" + " .cm-activeLine").type("{ctrl+end}{enter}");
+        cy.get("#editor" + " .cm-activeLine").invoke(
             "text",
             '<p name="p2"><math simplify>1+1</math></p>',
         );
 
-        cy.get(cesc("#p1")).should(
+        cy.get("#p1").should(
             "have.text",
             '<p name="p1">Hello!</p>\n<p name="p2"><math simplify>1+1</math></p>',
         );
-        cy.get(cesc("#p2")).should("have.text", '<p name="p1">Hello!</p>');
+        cy.get("#p2").should("have.text", '<p name="p1">Hello!</p>');
 
         cy.get(cesc(`#editor::p1`)).should("have.text", "Hello!");
         cy.get(cesc(`#editor::p2`)).should("not.exist");
@@ -266,11 +263,11 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
         });
 
         cy.log("Wait for value to be updated");
-        cy.get(cesc("#p2")).should(
+        cy.get("#p2").should(
             "have.text",
             '<p name="p1">Hello!</p>\n<p name="p2"><math simplify>1+1</math></p>',
         );
-        cy.get(cesc("#p1")).should(
+        cy.get("#p1").should(
             "have.text",
             '<p name="p1">Hello!</p>\n<p name="p2"><math simplify>1+1</math></p>',
         );
@@ -308,11 +305,11 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
 
         cy.get(cesc(`#editor::p2`)).should("contain.text", "2");
 
-        cy.get(cesc("#p1")).should(
+        cy.get("#p1").should(
             "have.text",
             '<p name="p1">Hello!</p>\n<p name="p2"><math simplify>1+1</math></p>',
         );
-        cy.get(cesc("#p2")).should(
+        cy.get("#p2").should(
             "have.text",
             '<p name="p1">Hello!</p>\n<p name="p2"><math simplify>1+1</math></p>',
         );
@@ -366,7 +363,7 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#text1")).should("contain.text", "a");
+        cy.get("#text1").should("contain.text", "a");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -376,14 +373,14 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
                     .activeChildren[0].componentIdx;
             let contentAnchor = "#_id_" + cesc(viewerIdx) + "_content";
 
-            cy.get(cesc("#p1")).should("have.text", "");
-            cy.get(cesc("#p2")).should("have.text", "");
-            cy.get(cesc("#p3")).should(
+            cy.get("#p1").should("have.text", "");
+            cy.get("#p2").should("have.text", "");
+            cy.get("#p3").should(
                 "have.text",
                 "The value of the entered math is ",
             );
             cy.get(contentAnchor).should("have.text", "");
-            cy.get(cesc("#m1")).should("not.exist");
+            cy.get("#m1").should("not.exist");
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
@@ -408,21 +405,18 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             });
 
             cy.log("type text in editor");
-            cy.get(cesc("#editor") + " .cm-content").type(
-                '<p name="p1">Hello!</p>',
-                {
-                    delay: 10,
-                },
-            );
+            cy.get("#editor" + " .cm-content").type('<p name="p1">Hello!</p>', {
+                delay: 10,
+            });
 
-            cy.get(cesc("#p1")).should("have.text", '<p name="p1">Hello!</p>');
-            cy.get(cesc("#p2")).should("have.text", "");
-            cy.get(cesc("#p3")).should(
+            cy.get("#p1").should("have.text", '<p name="p1">Hello!</p>');
+            cy.get("#p2").should("have.text", "");
+            cy.get("#p3").should(
                 "have.text",
                 "The value of the entered math is ",
             );
             cy.get(contentAnchor).should("have.text", "");
-            cy.get(cesc("#m1")).should("not.exist");
+            cy.get("#m1").should("not.exist");
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
@@ -447,16 +441,16 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             });
 
             cy.log("blur updates value but not content");
-            cy.get(cesc("#editor") + " .cm-content").blur();
+            cy.get("#editor" + " .cm-content").blur();
 
-            cy.get(cesc("#p1")).should("have.text", '<p name="p1">Hello!</p>');
-            cy.get(cesc("#p2")).should("have.text", '<p name="p1">Hello!</p>');
-            cy.get(cesc("#p3")).should(
+            cy.get("#p1").should("have.text", '<p name="p1">Hello!</p>');
+            cy.get("#p2").should("have.text", '<p name="p1">Hello!</p>');
+            cy.get("#p3").should(
                 "have.text",
                 "The value of the entered math is ",
             );
             cy.get(contentAnchor).should("have.text", "");
-            cy.get(cesc("#m1")).should("not.exist");
+            cy.get("#m1").should("not.exist");
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
@@ -483,14 +477,14 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             cy.log("click to update content");
             cy.get(`[data-test="Viewer Update Button"]`).click();
 
-            cy.get(cesc("#p1")).should("have.text", '<p name="p1">Hello!</p>');
-            cy.get(cesc("#p2")).should("have.text", '<p name="p1">Hello!</p>');
-            cy.get(cesc("#p3")).should(
+            cy.get("#p1").should("have.text", '<p name="p1">Hello!</p>');
+            cy.get("#p2").should("have.text", '<p name="p1">Hello!</p>');
+            cy.get("#p3").should(
                 "have.text",
                 "The value of the entered math is ",
             );
             cy.get(contentAnchor).should("have.text", "Hello!");
-            cy.get(cesc("#m1")).should("not.exist");
+            cy.get("#m1").should("not.exist");
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
@@ -519,22 +513,22 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             });
 
             cy.log("type more content");
-            cy.get(cesc("#editor") + " .cm-content").type(
+            cy.get("#editor" + " .cm-content").type(
                 '{ctrl+end}{enter}<p name="p2"><math simplify>1+1</math></p>',
                 { delay: 10 },
             );
 
-            cy.get(cesc("#p1")).should(
+            cy.get("#p1").should(
                 "have.text",
                 '<p name="p1">Hello!</p>\n<p name="p2"><math simplify>1+1</math></p>',
             );
-            cy.get(cesc("#p2")).should("have.text", '<p name="p1">Hello!</p>');
-            cy.get(cesc("#p3")).should(
+            cy.get("#p2").should("have.text", '<p name="p1">Hello!</p>');
+            cy.get("#p3").should(
                 "have.text",
                 "The value of the entered math is ",
             );
             cy.get(contentAnchor).should("have.text", "Hello!");
-            cy.get(cesc("#m1")).should("not.exist");
+            cy.get("#m1").should("not.exist");
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
@@ -565,20 +559,20 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             });
 
             cy.log("Wait for value to be updated");
-            cy.get(cesc("#p2")).should(
+            cy.get("#p2").should(
                 "have.text",
                 '<p name="p1">Hello!</p>\n<p name="p2"><math simplify>1+1</math></p>',
             );
-            cy.get(cesc("#p1")).should(
+            cy.get("#p1").should(
                 "have.text",
                 '<p name="p1">Hello!</p>\n<p name="p2"><math simplify>1+1</math></p>',
             );
-            cy.get(cesc("#p3")).should(
+            cy.get("#p3").should(
                 "have.text",
                 "The value of the entered math is ",
             );
             cy.get(contentAnchor).should("have.text", "Hello!");
-            cy.get(cesc("#m1")).should("not.exist");
+            cy.get("#m1").should("not.exist");
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
@@ -613,15 +607,15 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             cy.log("click to update content");
             cy.get(`[data-test="Viewer Update Button"]`).click();
 
-            cy.get(cesc("#p1")).should(
+            cy.get("#p1").should(
                 "have.text",
                 '<p name="p1">Hello!</p>\n<p name="p2"><math simplify>1+1</math></p>',
             );
-            cy.get(cesc("#p2")).should(
+            cy.get("#p2").should(
                 "have.text",
                 '<p name="p1">Hello!</p>\n<p name="p2"><math simplify>1+1</math></p>',
             );
-            cy.get(cesc("#p3")).should(
+            cy.get("#p3").should(
                 "contain.text",
                 "The value of the entered math is 2",
             );
@@ -632,7 +626,7 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
                 .then((text) => {
                     expect(text).eq("2");
                 });
-            cy.get(cesc("#m1") + " .mjx-mrow")
+            cy.get("#m1" + " .mjx-mrow")
                 .eq(0)
                 .invoke("text")
                 .then((text) => {
@@ -703,7 +697,7 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#text1")).should("contain.text", "a");
+        cy.get("#text1").should("contain.text", "a");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -712,19 +706,19 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
                 stateVariables[await win.resolvePath1("editor")]
                     .activeChildren[0].componentIdx;
 
-            cy.get(cesc("#px")).should(
+            cy.get("#px").should(
                 "have.text",
                 "The value of the dynamic math is ",
             );
-            cy.get(cesc("#psx")).should(
+            cy.get("#psx").should(
                 "have.text",
                 "The value of the static math is ",
             );
-            cy.get(cesc("#pP")).should(
+            cy.get("#pP").should(
                 "have.text",
                 "The coords of the dynamic point are ",
             );
-            cy.get(cesc("#psP")).should(
+            cy.get("#psP").should(
                 "have.text",
                 "The coords of the static point are ",
             );
@@ -775,26 +769,26 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             });
 
             cy.log("type text in editor");
-            cy.get(cesc("#editor") + " .cm-content").type(
+            cy.get("#editor" + " .cm-content").type(
                 "<p>Enter value <mathInput name='mi' prefill='y' /></p>{enter}",
             );
-            cy.get(cesc("#editor") + " .cm-content").type(
+            cy.get("#editor" + " .cm-content").type(
                 "<p>The value is <copy prop='value' target='$mi' assignNames='x' /></p>{enter}",
             );
 
-            cy.get(cesc("#px")).should(
+            cy.get("#px").should(
                 "have.text",
                 "The value of the dynamic math is ",
             );
-            cy.get(cesc("#psx")).should(
+            cy.get("#psx").should(
                 "have.text",
                 "The value of the static math is ",
             );
-            cy.get(cesc("#pP")).should(
+            cy.get("#pP").should(
                 "have.text",
                 "The coords of the dynamic point are ",
             );
-            cy.get(cesc("#psP")).should(
+            cy.get("#psP").should(
                 "have.text",
                 "The coords of the static point are ",
             );
@@ -847,26 +841,26 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             });
 
             cy.log("blur updates static but not dynamic");
-            cy.get(cesc("#editor") + " .cm-content").blur();
+            cy.get("#editor" + " .cm-content").blur();
 
-            cy.get(cesc("#psx")).should(
+            cy.get("#psx").should(
                 "contain.text",
                 "The value of the static math is y",
             );
-            cy.get(cesc("#px")).should(
+            cy.get("#px").should(
                 "have.text",
                 "The value of the dynamic math is ",
             );
-            cy.get(cesc("#pP")).should(
+            cy.get("#pP").should(
                 "have.text",
                 "The coords of the dynamic point are ",
             );
-            cy.get(cesc("#psP")).should(
+            cy.get("#psP").should(
                 "have.text",
                 "The coords of the static point are ",
             );
 
-            cy.get(cesc("#sx") + " .mjx-mrow")
+            cy.get("#sx" + " .mjx-mrow")
                 .eq(0)
                 .invoke("text")
                 .then((text) => {
@@ -956,30 +950,30 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             cy.log("click to update dynamic content");
             cy.get(`[data-test="Viewer Update Button"]`).click();
 
-            cy.get(cesc("#px")).should(
+            cy.get("#px").should(
                 "contain.text",
                 "The value of the dynamic math is y",
             );
-            cy.get(cesc("#psx")).should(
+            cy.get("#psx").should(
                 "contain.text",
                 "The value of the static math is y",
             );
-            cy.get(cesc("#pP")).should(
+            cy.get("#pP").should(
                 "have.text",
                 "The coords of the dynamic point are ",
             );
-            cy.get(cesc("#psP")).should(
+            cy.get("#psP").should(
                 "have.text",
                 "The coords of the static point are ",
             );
 
-            cy.get(cesc("#x") + " .mjx-mrow")
+            cy.get("#x" + " .mjx-mrow")
                 .eq(0)
                 .invoke("text")
                 .then((text) => {
                     expect(text).eq("y");
                 });
-            cy.get(cesc("#sx") + " .mjx-mrow")
+            cy.get("#sx" + " .mjx-mrow")
                 .eq(0)
                 .invoke("text")
                 .then((text) => {
@@ -1091,30 +1085,30 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
                 { force: true },
             );
 
-            cy.get(cesc("#px")).should(
+            cy.get("#px").should(
                 "contain.text",
                 "The value of the dynamic math is x",
             );
-            cy.get(cesc("#psx")).should(
+            cy.get("#psx").should(
                 "contain.text",
                 "The value of the static math is y",
             );
-            cy.get(cesc("#pP")).should(
+            cy.get("#pP").should(
                 "have.text",
                 "The coords of the dynamic point are ",
             );
-            cy.get(cesc("#psP")).should(
+            cy.get("#psP").should(
                 "have.text",
                 "The coords of the static point are ",
             );
 
-            cy.get(cesc("#x") + " .mjx-mrow")
+            cy.get("#x" + " .mjx-mrow")
                 .eq(0)
                 .invoke("text")
                 .then((text) => {
                     expect(text).eq("x");
                 });
-            cy.get(cesc("#sx") + " .mjx-mrow")
+            cy.get("#sx" + " .mjx-mrow")
                 .eq(0)
                 .invoke("text")
                 .then((text) => {
@@ -1221,42 +1215,42 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             });
 
             cy.log("type text in editor");
-            cy.get(cesc("#editor") + " .cm-content")
+            cy.get("#editor" + " .cm-content")
                 .type(
                     "{ctrl+end}<graph><point name='P'>(3,4)</point></graph>{enter}",
                 )
                 .blur();
 
-            cy.get(cesc("#psP")).should(
+            cy.get("#psP").should(
                 "contain.text",
                 "The coords of the static point are (3,4)",
             );
-            cy.get(cesc("#px")).should(
+            cy.get("#px").should(
                 "contain.text",
                 "The value of the dynamic math is x",
             );
-            cy.get(cesc("#psx")).should(
+            cy.get("#psx").should(
                 "contain.text",
                 "The value of the static math is y",
             );
-            cy.get(cesc("#pP")).should(
+            cy.get("#pP").should(
                 "have.text",
                 "The coords of the dynamic point are ",
             );
 
-            cy.get(cesc("#x") + " .mjx-mrow")
+            cy.get("#x" + " .mjx-mrow")
                 .eq(0)
                 .invoke("text")
                 .then((text) => {
                     expect(text).eq("x");
                 });
-            cy.get(cesc("#sx") + " .mjx-mrow")
+            cy.get("#sx" + " .mjx-mrow")
                 .eq(0)
                 .invoke("text")
                 .then((text) => {
                     expect(text).eq("y");
                 });
-            cy.get(cesc("#sP") + " .mjx-mrow")
+            cy.get("#sP" + " .mjx-mrow")
                 .eq(0)
                 .invoke("text")
                 .then((text) => {
@@ -1371,42 +1365,42 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             cy.log("click to update dynamic content");
             cy.get(`[data-test="Viewer Update Button"]`).click();
 
-            cy.get(cesc("#pP")).should(
+            cy.get("#pP").should(
                 "contain.text",
                 "The coords of the dynamic point are (3,4)",
             );
-            cy.get(cesc("#px")).should(
+            cy.get("#px").should(
                 "contain.text",
                 "The value of the dynamic math is y",
             );
-            cy.get(cesc("#psx")).should(
+            cy.get("#psx").should(
                 "contain.text",
                 "The value of the static math is y",
             );
-            cy.get(cesc("#psP")).should(
+            cy.get("#psP").should(
                 "contain.text",
                 "The coords of the static point are (3,4)",
             );
 
-            cy.get(cesc("#x") + " .mjx-mrow")
+            cy.get("#x" + " .mjx-mrow")
                 .eq(0)
                 .invoke("text")
                 .then((text) => {
                     expect(text).eq("y");
                 });
-            cy.get(cesc("#sx") + " .mjx-mrow")
+            cy.get("#sx" + " .mjx-mrow")
                 .eq(0)
                 .invoke("text")
                 .then((text) => {
                     expect(text).eq("y");
                 });
-            cy.get(cesc("#P") + " .mjx-mrow")
+            cy.get("#P" + " .mjx-mrow")
                 .eq(0)
                 .invoke("text")
                 .then((text) => {
                     expect(text).eq("(3,4)");
                 });
-            cy.get(cesc("#sP") + " .mjx-mrow")
+            cy.get("#sP" + " .mjx-mrow")
                 .eq(0)
                 .invoke("text")
                 .then((text) => {
@@ -1536,42 +1530,42 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
                 });
             });
 
-            cy.get(cesc("#pP")).should(
+            cy.get("#pP").should(
                 "contain.text",
                 "The coords of the dynamic point are (5,7)",
             );
-            cy.get(cesc("#px")).should(
+            cy.get("#px").should(
                 "contain.text",
                 "The value of the dynamic math is y",
             );
-            cy.get(cesc("#psx")).should(
+            cy.get("#psx").should(
                 "contain.text",
                 "The value of the static math is y",
             );
-            cy.get(cesc("#psP")).should(
+            cy.get("#psP").should(
                 "contain.text",
                 "The coords of the static point are (3,4)",
             );
 
-            cy.get(cesc("#x") + " .mjx-mrow")
+            cy.get("#x" + " .mjx-mrow")
                 .eq(0)
                 .invoke("text")
                 .then((text) => {
                     expect(text).eq("y");
                 });
-            cy.get(cesc("#sx") + " .mjx-mrow")
+            cy.get("#sx" + " .mjx-mrow")
                 .eq(0)
                 .invoke("text")
                 .then((text) => {
                     expect(text).eq("y");
                 });
-            cy.get(cesc("#P") + " .mjx-mrow")
+            cy.get("#P" + " .mjx-mrow")
                 .eq(0)
                 .invoke("text")
                 .then((text) => {
                     expect(text).eq("(5,7)");
                 });
-            cy.get(cesc("#sP") + " .mjx-mrow")
+            cy.get("#sP" + " .mjx-mrow")
                 .eq(0)
                 .invoke("text")
                 .then((text) => {
@@ -1731,10 +1725,10 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#ce") + " .cm-activeLine").invoke("text", "hello");
+        cy.get("#ce" + " .cm-activeLine").invoke("text", "hello");
 
-        cy.get(cesc("#piv")).should("have.text", "immediate value: hello");
-        cy.get(cesc("#pv")).should("have.text", "value: ");
+        cy.get("#piv").should("have.text", "immediate value: hello");
+        cy.get("#pv").should("have.text", "value: ");
 
         cy.wait(1500); // wait for debounce
 
@@ -1749,8 +1743,8 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#pv")).should("have.text", "value: hello");
-        cy.get(cesc("#piv")).should("have.text", "immediate value: hello");
+        cy.get("#pv").should("have.text", "value: hello");
+        cy.get("#piv").should("have.text", "immediate value: hello");
     });
 
     it("undo prompts save", () => {
@@ -1774,10 +1768,10 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#p1")).should("have.text", "");
+        cy.get("#p1").should("have.text", "");
 
         cy.log("type text in editor");
-        cy.get(cesc("#editor") + " .cm-activeLine").invoke(
+        cy.get("#editor" + " .cm-activeLine").invoke(
             "text",
             '<p name="p1">Hello!</p>',
         );
@@ -1786,7 +1780,7 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
 
         cy.get(`[data-test="Viewer Update Button"]`).click();
 
-        cy.get(cesc("#p1")).should("have.text", '<p name="p1">Hello!</p>');
+        cy.get("#p1").should("have.text", '<p name="p1">Hello!</p>');
         cy.get(cesc("#editor::p1")).should("have.text", "Hello!");
 
         cy.wait(1500); // wait for 1 second debounce
@@ -1802,19 +1796,19 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#p1")).should("have.text", '<p name="p1">Hello!</p>');
+        cy.get("#p1").should("have.text", '<p name="p1">Hello!</p>');
         cy.get(cesc("#editor::p1")).should("have.text", "Hello!");
 
         cy.log("Overwrite text");
 
-        cy.get(cesc("#editor") + " .cm-activeLine").invoke(
+        cy.get("#editor" + " .cm-activeLine").invoke(
             "text",
             '<alert name="alert">Overwritten!</alert>',
         );
 
         cy.get(`[data-test="Viewer Update Button"]`).click();
 
-        cy.get(cesc("#p1")).should(
+        cy.get("#p1").should(
             "have.text",
             '<alert name="alert">Overwritten!</alert>',
         );
@@ -1830,7 +1824,7 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
         }
         cy.get(`[data-test="Viewer Update Button"]`).click();
 
-        cy.get(cesc("#p1")).should("have.text", '<p name="p1">Hello!</p>');
+        cy.get("#p1").should("have.text", '<p name="p1">Hello!</p>');
         cy.get(cesc("#editor::p1")).should("have.text", "Hello!");
         cy.get(cesc("#editor::alert")).should("not.exist");
 
@@ -1847,7 +1841,7 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#p1")).should("have.text", '<p name="p1">Hello!</p>');
+        cy.get("#p1").should("have.text", '<p name="p1">Hello!</p>');
         cy.get(cesc("#editor::p1")).should("have.text", "Hello!");
         cy.get(cesc("#editor::alert")).should("not.exist");
     });
@@ -1866,50 +1860,47 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#p1")).should("have.text", "");
+        cy.get("#p1").should("have.text", "");
 
         cy.log("type text in editor");
-        cy.get(cesc("#editor") + " .cm-activeLine").invoke(
+        cy.get("#editor" + " .cm-activeLine").invoke(
             "text",
             '<p name="p1">Hello!</p>',
         );
 
-        cy.get(cesc("#editor") + " .cm-content").type("{end}{enter}");
+        cy.get("#editor" + " .cm-content").type("{end}{enter}");
 
         cy.wait(500);
 
         cy.get(`[data-test="Viewer Update Button"]`).click();
 
-        cy.get(cesc("#p1")).should("have.text", '<p name="p1">Hello!</p>\n');
+        cy.get("#p1").should("have.text", '<p name="p1">Hello!</p>\n');
         cy.get(cesc("#editor::p1")).should("have.text", "Hello!");
 
-        cy.get(cesc("#editor") + " .cm-activeLine").type("{ctrl+end}");
+        cy.get("#editor" + " .cm-activeLine").type("{ctrl+end}");
 
-        cy.get(cesc("#editor") + " .cm-activeLine").invoke(
+        cy.get("#editor" + " .cm-activeLine").invoke(
             "text",
             "<text name='ti'>$ti</text>",
         );
 
         cy.get(`[data-test="Viewer Update Button"]`).click();
 
-        cy.get(cesc("#p1")).should(
+        cy.get("#p1").should(
             "have.text",
             "<p name=\"p1\">Hello!</p>\n<text name='ti'>$ti</text>",
         );
 
-        cy.get(cesc("#editor-viewer")).should(
-            "contain.text",
-            "Circular dependency",
-        );
+        cy.get("#editor-viewer").should("contain.text", "Circular dependency");
 
-        cy.get(cesc("#editor") + " .cm-activeLine").invoke(
+        cy.get("#editor" + " .cm-activeLine").invoke(
             "text",
             "<text name='ti'>Bye</text>",
         );
 
         cy.get(`[data-test="Viewer Update Button"]`).click();
 
-        cy.get(cesc("#p1")).should(
+        cy.get("#p1").should(
             "have.text",
             "<p name=\"p1\">Hello!</p>\n<text name='ti'>Bye</text>",
         );
@@ -1940,51 +1931,48 @@ describe("Code Editor Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("contain.text", "a");
+        cy.get("#a").should("contain.text", "a");
 
         cy.log("type text in editor 1");
-        cy.get(cesc("#editor1") + " .cm-activeLine").invoke(
+        cy.get("#editor1" + " .cm-activeLine").invoke(
             "text",
             "<p name='p1'>Apple</p>",
         );
-        cy.get(cesc("#editor1") + " .cm-content").type("{end}{enter}");
+        cy.get("#editor1" + " .cm-content").type("{end}{enter}");
 
         cy.wait(500);
 
         cy.get(
-            cesc("#editor1-viewer-controls") +
-                ` [data-test="Viewer Update Button"]`,
+            "#editor1-viewer-controls" + ` [data-test="Viewer Update Button"]`,
         ).click();
 
-        cy.get(cesc("#p1")).should("have.text", "<p name='p1'>Apple</p>\n");
+        cy.get("#p1").should("have.text", "<p name='p1'>Apple</p>\n");
         cy.get(cesc("#editor1::p1")).should("contain.text", "Apple");
 
         cy.log("type text in editor 2");
-        cy.get(cesc("#editor2") + " .cm-activeLine").invoke(
+        cy.get("#editor2" + " .cm-activeLine").invoke(
             "text",
             "<p name='p1'>Banana</p>",
         );
-        cy.get(cesc("#editor2") + " .cm-content").type("{end}{enter}");
+        cy.get("#editor2" + " .cm-content").type("{end}{enter}");
         cy.get(
-            cesc("#editor2-viewer-controls") +
-                ` [data-test="Viewer Update Button"]`,
+            "#editor2-viewer-controls" + ` [data-test="Viewer Update Button"]`,
         ).click();
 
-        cy.get(cesc("#p2")).should("have.text", "<p name='p1'>Banana</p>\n");
+        cy.get("#p2").should("have.text", "<p name='p1'>Banana</p>\n");
         cy.get(cesc("#editor2::p1")).should("contain.text", "Banana");
 
         cy.log("type text in editor 3");
-        cy.get(cesc("#editor3") + " .cm-activeLine").invoke(
+        cy.get("#editor3" + " .cm-activeLine").invoke(
             "text",
             "<p name='p1'>Cherry</p>",
         );
-        cy.get(cesc("#editor3") + " .cm-content").type("{end}{enter}");
+        cy.get("#editor3" + " .cm-content").type("{end}{enter}");
         cy.get(
-            cesc("#editor3-viewer-controls") +
-                ` [data-test="Viewer Update Button"]`,
+            "#editor3-viewer-controls" + ` [data-test="Viewer Update Button"]`,
         ).click();
 
-        cy.get(cesc("#p3")).should("have.text", "<p name='p1'>Cherry</p>\n");
+        cy.get("#p3").should("have.text", "<p name='p1'>Cherry</p>\n");
         cy.get(cesc("#editor3::p1")).should("contain.text", "Cherry");
     });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/componentsize.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/componentsize.cy.js
@@ -77,9 +77,9 @@ describe("Component Size Tag Tests", { tags: ["@group1"] }, function () {
                 );
             });
 
-            cy.get(cesc("#text1")).should("have.text", `${ind}`);
+            cy.get("#text1").should("have.text", `${ind}`);
 
-            cy.get(cesc("#doc"))
+            cy.get("#doc")
                 .invoke("width")
                 .then((docWidth) => {
                     let expectedWidthPixels = sizes[ind];
@@ -87,7 +87,7 @@ describe("Component Size Tag Tests", { tags: ["@group1"] }, function () {
                         expectedWidthPixels *= docWidth / 100;
                     }
 
-                    cy.get(cesc("#ae"))
+                    cy.get("#ae")
                         .invoke("width")
                         .then((width) => {
                             expect(Number(width)).closeTo(
@@ -105,7 +105,7 @@ describe("Component Size Tag Tests", { tags: ["@group1"] }, function () {
                 thisUnit = "%";
             }
 
-            cy.get(cesc("#w"))
+            cy.get("#w")
                 .invoke("text")
                 .then((text) => {
                     expect(parseFloat(text)).closeTo(thisWidth, 1e-6);
@@ -113,25 +113,25 @@ describe("Component Size Tag Tests", { tags: ["@group1"] }, function () {
                         thisUnit,
                     );
                 });
-            cy.get(cesc("#wNum"))
+            cy.get("#wNum")
                 .invoke("text")
                 .then((text) => {
                     expect(Number(text)).closeTo(thisWidth, 1e-6);
                 });
-            cy.get(cesc("#wMath"))
+            cy.get("#wMath")
                 .find(".mjx-mrow")
                 .eq(0)
                 .invoke("text")
                 .then((text) => {
                     expect(Number(text)).closeTo(thisWidth, 1e-6);
                 });
-            cy.get(cesc("#wExtract"))
+            cy.get("#wExtract")
                 .invoke("text")
                 .then((text) => {
                     expect(Number(text)).closeTo(thisWidth, 1e-6);
                 });
 
-            cy.get(cesc("#absExtract")).should(
+            cy.get("#absExtract").should(
                 "have.text",
                 isAbsolutes[ind].toString(),
             );
@@ -171,23 +171,23 @@ describe("Component Size Tag Tests", { tags: ["@group1"] }, function () {
             );
         });
 
-        cy.get(cesc("#ae"))
+        cy.get("#ae")
             .invoke("css", "width")
             .then((text) => {
                 expect(parseFloat(text)).closeTo(500, 1);
             });
 
-        cy.get(cesc("#w")).should("have.text", "500px");
-        cy.get(cesc("#wNum")).should("have.text", "500");
-        cy.get(cesc("#wMath"))
+        cy.get("#w").should("have.text", "500px");
+        cy.get("#wNum").should("have.text", "500");
+        cy.get("#wMath")
             .find(".mjx-mrow")
             .eq(0)
             .invoke("text")
             .then((text) => {
                 expect(text).eq("500");
             });
-        cy.get(cesc("#wExtract")).should("have.text", "500");
-        cy.get(cesc("#absExtract")).should("have.text", "true");
+        cy.get("#wExtract").should("have.text", "500");
+        cy.get("#absExtract").should("have.text", "true");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -202,29 +202,29 @@ describe("Component Size Tag Tests", { tags: ["@group1"] }, function () {
         });
 
         cy.log(`changed prescribed width`);
-        cy.get(cesc("#wPrescribed") + " textarea").type(
+        cy.get("#wPrescribed" + " textarea").type(
             "{ctrl+home}{shift+end}{backspace}312{enter}",
             { force: true },
         );
 
-        cy.get(cesc("#w")).should("have.text", "312px");
-        cy.get(cesc("#wNum")).should("have.text", "312");
+        cy.get("#w").should("have.text", "312px");
+        cy.get("#wNum").should("have.text", "312");
 
-        cy.get(cesc("#ae"))
+        cy.get("#ae")
             .invoke("css", "width")
             .then((text) => {
                 expect(parseFloat(text)).closeTo(312, 1);
             });
 
-        cy.get(cesc("#wMath"))
+        cy.get("#wMath")
             .find(".mjx-mrow")
             .eq(0)
             .invoke("text")
             .then((text) => {
                 expect(text).eq("312");
             });
-        cy.get(cesc("#wExtract")).should("have.text", "312");
-        cy.get(cesc("#absExtract")).should("have.text", "true");
+        cy.get("#wExtract").should("have.text", "312");
+        cy.get("#absExtract").should("have.text", "true");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -239,29 +239,29 @@ describe("Component Size Tag Tests", { tags: ["@group1"] }, function () {
         });
 
         cy.log(`changed width from inverse direction`);
-        cy.get(cesc("#w2") + " textarea").type(
+        cy.get("#w2" + " textarea").type(
             "{ctrl+home}{shift+end}{backspace}476{enter}",
             { force: true },
         );
 
-        cy.get(cesc("#w")).should("have.text", "476px");
-        cy.get(cesc("#wNum")).should("have.text", "476");
+        cy.get("#w").should("have.text", "476px");
+        cy.get("#wNum").should("have.text", "476");
 
-        cy.get(cesc("#ae"))
+        cy.get("#ae")
             .invoke("css", "width")
             .then((text) => {
                 expect(parseFloat(text)).closeTo(476, 1);
             });
 
-        cy.get(cesc("#wMath"))
+        cy.get("#wMath")
             .find(".mjx-mrow")
             .eq(0)
             .invoke("text")
             .then((text) => {
                 expect(text).eq("476");
             });
-        cy.get(cesc("#wExtract")).should("have.text", "476");
-        cy.get(cesc("#absExtract")).should("have.text", "true");
+        cy.get("#wExtract").should("have.text", "476");
+        cy.get("#absExtract").should("have.text", "true");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -298,28 +298,28 @@ describe("Component Size Tag Tests", { tags: ["@group1"] }, function () {
             );
         });
 
-        cy.get(cesc("#doc"))
+        cy.get("#doc")
             .invoke("width")
             .then((docWidth) => {
                 let expectedWidthPixels = (50 * docWidth) / 100;
-                cy.get(cesc("#ae"))
+                cy.get("#ae")
                     .invoke("width")
                     .then((width) => {
                         expect(Number(width)).closeTo(expectedWidthPixels, 0.1);
                     });
             });
 
-        cy.get(cesc("#w")).should("have.text", "50%");
-        cy.get(cesc("#wNum")).should("have.text", "50");
-        cy.get(cesc("#wMath"))
+        cy.get("#w").should("have.text", "50%");
+        cy.get("#wNum").should("have.text", "50");
+        cy.get("#wMath")
             .find(".mjx-mrow")
             .eq(0)
             .invoke("text")
             .then((text) => {
                 expect(text).eq("50");
             });
-        cy.get(cesc("#wExtract")).should("have.text", "50");
-        cy.get(cesc("#absExtract")).should("have.text", "false");
+        cy.get("#wExtract").should("have.text", "50");
+        cy.get("#absExtract").should("have.text", "false");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -334,34 +334,34 @@ describe("Component Size Tag Tests", { tags: ["@group1"] }, function () {
         });
 
         cy.log(`changed prescribed width`);
-        cy.get(cesc("#wPrescribed") + " textarea").type(
+        cy.get("#wPrescribed" + " textarea").type(
             "{ctrl+home}{shift+end}{backspace}31{enter}",
             { force: true },
         );
 
-        cy.get(cesc("#w")).should("have.text", "31%");
-        cy.get(cesc("#wNum")).should("have.text", "31");
+        cy.get("#w").should("have.text", "31%");
+        cy.get("#wNum").should("have.text", "31");
 
-        cy.get(cesc("#doc"))
+        cy.get("#doc")
             .invoke("width")
             .then((docWidth) => {
                 let expectedWidthPixels = (31 * docWidth) / 100;
-                cy.get(cesc("#ae"))
+                cy.get("#ae")
                     .invoke("width")
                     .then((width) => {
                         expect(Number(width)).closeTo(expectedWidthPixels, 0.1);
                     });
             });
 
-        cy.get(cesc("#wMath"))
+        cy.get("#wMath")
             .find(".mjx-mrow")
             .eq(0)
             .invoke("text")
             .then((text) => {
                 expect(text).eq("31");
             });
-        cy.get(cesc("#wExtract")).should("have.text", "31");
-        cy.get(cesc("#absExtract")).should("have.text", "false");
+        cy.get("#wExtract").should("have.text", "31");
+        cy.get("#absExtract").should("have.text", "false");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -376,34 +376,34 @@ describe("Component Size Tag Tests", { tags: ["@group1"] }, function () {
         });
 
         cy.log(`changed width from inverse direction`);
-        cy.get(cesc("#w2") + " textarea").type(
+        cy.get("#w2" + " textarea").type(
             "{end}{backspace}{backspace}76{enter}",
             { force: true },
         );
 
-        cy.get(cesc("#w")).should("have.text", "76%");
-        cy.get(cesc("#wNum")).should("have.text", "76");
+        cy.get("#w").should("have.text", "76%");
+        cy.get("#wNum").should("have.text", "76");
 
-        cy.get(cesc("#doc"))
+        cy.get("#doc")
             .invoke("width")
             .then((docWidth) => {
                 let expectedWidthPixels = (76 * docWidth) / 100;
-                cy.get(cesc("#ae"))
+                cy.get("#ae")
                     .invoke("width")
                     .then((width) => {
                         expect(Number(width)).closeTo(expectedWidthPixels, 0.1);
                     });
             });
 
-        cy.get(cesc("#wMath"))
+        cy.get("#wMath")
             .find(".mjx-mrow")
             .eq(0)
             .invoke("text")
             .then((text) => {
                 expect(text).eq("76");
             });
-        cy.get(cesc("#wExtract")).should("have.text", "76");
-        cy.get(cesc("#absExtract")).should("have.text", "false");
+        cy.get("#wExtract").should("have.text", "76");
+        cy.get("#absExtract").should("have.text", "false");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -436,19 +436,19 @@ describe("Component Size Tag Tests", { tags: ["@group1"] }, function () {
             );
         });
 
-        cy.get(cesc("#ae"))
+        cy.get("#ae")
             .invoke("css", "width")
             .then((text) => {
                 expect(parseFloat(text)).closeTo(500, 1);
             });
-        cy.get(cesc("#ae"))
+        cy.get("#ae")
             .invoke("css", "height")
             .then((text) => {
                 expect(parseFloat(text)).closeTo(250, 1);
             });
 
-        cy.get(cesc("#w")).should("have.text", "500px");
-        cy.get(cesc("#h")).should("have.text", "250px");
+        cy.get("#w").should("have.text", "500px");
+        cy.get("#h").should("have.text", "250px");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -471,20 +471,20 @@ describe("Component Size Tag Tests", { tags: ["@group1"] }, function () {
         });
 
         cy.log(`changed prescribed width`);
-        cy.get(cesc("#wPrescribed") + " textarea").type(
+        cy.get("#wPrescribed" + " textarea").type(
             "{ctrl+home}{shift+end}{backspace}312{enter}",
             { force: true },
         );
 
-        cy.get(cesc("#w")).should("have.text", "312px");
-        cy.get(cesc("#h")).should("have.text", "156px");
+        cy.get("#w").should("have.text", "312px");
+        cy.get("#h").should("have.text", "156px");
 
-        cy.get(cesc("#ae"))
+        cy.get("#ae")
             .invoke("css", "width")
             .then((text) => {
                 expect(parseFloat(text)).closeTo(312, 1);
             });
-        cy.get(cesc("#ae"))
+        cy.get("#ae")
             .invoke("css", "height")
             .then((text) => {
                 expect(parseFloat(text)).closeTo(156, 1);
@@ -511,20 +511,20 @@ describe("Component Size Tag Tests", { tags: ["@group1"] }, function () {
         });
 
         cy.log(`changed width from inverse direction`);
-        cy.get(cesc("#w2") + " textarea").type(
+        cy.get("#w2" + " textarea").type(
             "{ctrl+home}{shift+end}{backspace}476{enter}",
             { force: true },
         );
 
-        cy.get(cesc("#w")).should("have.text", "476px");
-        cy.get(cesc("#h")).should("have.text", "238px");
+        cy.get("#w").should("have.text", "476px");
+        cy.get("#h").should("have.text", "238px");
 
-        cy.get(cesc("#ae"))
+        cy.get("#ae")
             .invoke("css", "width")
             .then((text) => {
                 expect(parseFloat(text)).closeTo(476, 1);
             });
-        cy.get(cesc("#ae"))
+        cy.get("#ae")
             .invoke("css", "height")
             .then((text) => {
                 expect(parseFloat(text)).closeTo(238, 1);
@@ -551,20 +551,20 @@ describe("Component Size Tag Tests", { tags: ["@group1"] }, function () {
         });
 
         cy.log(`changed height from inverse direction`);
-        cy.get(cesc("#h2") + " textarea").type(
+        cy.get("#h2" + " textarea").type(
             "{ctrl+home}{shift+end}{backspace}321{enter}",
             { force: true },
         );
 
-        cy.get(cesc("#w")).should("have.text", "642px");
-        cy.get(cesc("#h")).should("have.text", "321px");
+        cy.get("#w").should("have.text", "642px");
+        cy.get("#h").should("have.text", "321px");
 
-        cy.get(cesc("#ae"))
+        cy.get("#ae")
             .invoke("css", "width")
             .then((text) => {
                 expect(parseFloat(text)).closeTo(642, 1);
             });
-        cy.get(cesc("#ae"))
+        cy.get("#ae")
             .invoke("css", "height")
             .then((text) => {
                 expect(parseFloat(text)).closeTo(321, 1);

--- a/packages/test-cypress/cypress/e2e/tagSpecific/curve.bezier.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/curve.bezier.cy.js
@@ -1,5 +1,3 @@
-import { cesc } from "@doenet/utils";
-
 describe("Curve Tag Bezier Tests", { tags: ["@group2"] }, function () {
     beforeEach(() => {
         cy.clearIndexedDB();
@@ -32,7 +30,7 @@ describe("Curve Tag Bezier Tests", { tags: ["@group2"] }, function () {
             );
         });
 
-        cy.get(cesc("#text1")).should("have.text", "a"); //wait for window to load
+        cy.get("#text1").should("have.text", "a"); //wait for window to load
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -214,7 +212,7 @@ describe("Curve Tag Bezier Tests", { tags: ["@group2"] }, function () {
             );
         });
 
-        cy.get(cesc("#text1")).should("have.text", "a"); //wait for window to load
+        cy.get("#text1").should("have.text", "a"); //wait for window to load
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -360,7 +358,7 @@ describe("Curve Tag Bezier Tests", { tags: ["@group2"] }, function () {
             );
         });
 
-        cy.get(cesc("#text1")).should("have.text", "a"); //wait for window to load
+        cy.get("#text1").should("have.text", "a"); //wait for window to load
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();

--- a/packages/test-cypress/cypress/e2e/tagSpecific/graph.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/graph.cy.js
@@ -31,13 +31,13 @@ describe("Graph Tag Tests", { tags: ["@group1"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+        cy.get("#a").should("have.text", "a"); //wait for page to load
 
         function checkLimits(xmin, xmax, ymin, ymax) {
-            cy.get(cesc("#xmin")).should("have.text", String(xmin));
-            cy.get(cesc("#xmax")).should("have.text", String(xmax));
-            cy.get(cesc("#ymin")).should("have.text", String(ymin));
-            cy.get(cesc("#ymax")).should("have.text", String(ymax));
+            cy.get("#xmin").should("have.text", String(xmin));
+            cy.get("#xmax").should("have.text", String(xmax));
+            cy.get("#ymin").should("have.text", String(ymin));
+            cy.get("#ymax").should("have.text", String(ymax));
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
@@ -71,7 +71,7 @@ describe("Graph Tag Tests", { tags: ["@group1"] }, function () {
         // Can we pan with the mouse in cypress?
 
         // Zoom in
-        cy.get(cesc("#graph1_navigationbar") + " > :nth-child(3)")
+        cy.get("#graph1_navigationbar" + " > :nth-child(3)")
             .click()
             .then((_) => {
                 let meanx = (xmax + xmin) / 2;
@@ -84,7 +84,7 @@ describe("Graph Tag Tests", { tags: ["@group1"] }, function () {
             });
 
         // Zoom in
-        cy.get(cesc("#graph1_navigationbar") + " > :nth-child(3)")
+        cy.get("#graph1_navigationbar" + " > :nth-child(3)")
             .click()
             .then((_) => {
                 let meanx = (xmax + xmin) / 2;
@@ -97,7 +97,7 @@ describe("Graph Tag Tests", { tags: ["@group1"] }, function () {
             });
 
         // Zoom out
-        cy.get(cesc("#graph1_navigationbar") + " > :nth-child(1)")
+        cy.get("#graph1_navigationbar" + " > :nth-child(1)")
             .click()
             .then((_) => {
                 let meanx = (xmax + xmin) / 2;
@@ -109,28 +109,28 @@ describe("Graph Tag Tests", { tags: ["@group1"] }, function () {
                 checkLimits(xmin, xmax, ymin, ymax);
             });
 
-        cy.get(cesc("#xminInput") + " textarea")
+        cy.get("#xminInput" + " textarea")
             .type(`{end}{backspace}{backspace}-8{enter}`, { force: true })
             .then((_) => {
                 xmin = -8;
                 checkLimits(xmin, xmax, ymin, ymax);
             });
 
-        cy.get(cesc("#xmaxInput") + " textarea")
+        cy.get("#xmaxInput" + " textarea")
             .type(`{end}{backspace}{backspace}12{enter}`, { force: true })
             .then((_) => {
                 xmax = 12;
                 checkLimits(xmin, xmax, ymin, ymax);
             });
 
-        cy.get(cesc("#yminInput") + " textarea")
+        cy.get("#yminInput" + " textarea")
             .type(`{end}{backspace}{backspace}-4{enter}`, { force: true })
             .then((_) => {
                 ymin = -4;
                 checkLimits(xmin, xmax, ymin, ymax);
             });
 
-        cy.get(cesc("#ymaxInput") + " textarea")
+        cy.get("#ymaxInput" + " textarea")
             .type(`{end}{backspace}{backspace}16{enter}`, { force: true })
             .then((_) => {
                 ymax = 16;
@@ -138,7 +138,7 @@ describe("Graph Tag Tests", { tags: ["@group1"] }, function () {
             });
 
         // Zoom out
-        cy.get(cesc("#graph1_navigationbar") + " > :nth-child(1)")
+        cy.get("#graph1_navigationbar" + " > :nth-child(1)")
             .click()
             .then((_) => {
                 let meanx = (xmax + xmin) / 2;
@@ -151,7 +151,7 @@ describe("Graph Tag Tests", { tags: ["@group1"] }, function () {
             });
 
         // Zoom in
-        cy.get(cesc("#graph1_navigationbar") + " > :nth-child(3)")
+        cy.get("#graph1_navigationbar" + " > :nth-child(3)")
             .click()
             .then((_) => {
                 let meanx = (xmax + xmin) / 2;
@@ -196,170 +196,170 @@ describe("Graph Tag Tests", { tags: ["@group1"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+        cy.get("#a").should("have.text", "a"); //wait for page to load
 
         // Note: these are brittle tests and could start failing if internals of jsxgraph changes
 
-        cy.get(cesc("#none")).should("not.contain.text", "π");
-        cy.get(cesc("#none")).should("not.contain.text", "e");
-        cy.get(cesc("#none")).should("contain.text", "68");
-        cy.get(cesc("#none")).should("contain.text", "−2−4−6−8");
+        cy.get("#none").should("not.contain.text", "π");
+        cy.get("#none").should("not.contain.text", "e");
+        cy.get("#none").should("contain.text", "68");
+        cy.get("#none").should("contain.text", "−2−4−6−8");
 
-        cy.get(cesc("#xpi")).should("contain.text", "π2π3π");
-        cy.get(cesc("#xpi")).should("contain.text", "−π−2π−3π");
-        cy.get(cesc("#xpi")).should("contain.text", "24");
-        cy.get(cesc("#xpi")).should("contain.text", "68");
-        cy.get(cesc("#xpi")).should("contain.text", "−2−4−6−8");
+        cy.get("#xpi").should("contain.text", "π2π3π");
+        cy.get("#xpi").should("contain.text", "−π−2π−3π");
+        cy.get("#xpi").should("contain.text", "24");
+        cy.get("#xpi").should("contain.text", "68");
+        cy.get("#xpi").should("contain.text", "−2−4−6−8");
 
-        cy.get(cesc("#ypi")).should("contain.text", "π2π3π");
-        cy.get(cesc("#ypi")).should("contain.text", "−π−2π−3π");
-        cy.get(cesc("#ypi")).should("contain.text", "24");
-        cy.get(cesc("#ypi")).should("contain.text", "68");
-        cy.get(cesc("#ypi")).should("contain.text", "−2−4−6−8");
+        cy.get("#ypi").should("contain.text", "π2π3π");
+        cy.get("#ypi").should("contain.text", "−π−2π−3π");
+        cy.get("#ypi").should("contain.text", "24");
+        cy.get("#ypi").should("contain.text", "68");
+        cy.get("#ypi").should("contain.text", "−2−4−6−8");
 
-        cy.get(cesc("#bothPi")).should("contain.text", "π2π3π");
-        cy.get(cesc("#bothPi")).should("contain.text", "−π−2π−3π");
-        cy.get(cesc("#bothPi")).should("not.contain.text", "24");
-        cy.get(cesc("#bothPi")).should("not.contain.text", "68");
-        cy.get(cesc("#bothPi")).should("not.contain.text", "−2−4−6−8");
+        cy.get("#bothPi").should("contain.text", "π2π3π");
+        cy.get("#bothPi").should("contain.text", "−π−2π−3π");
+        cy.get("#bothPi").should("not.contain.text", "24");
+        cy.get("#bothPi").should("not.contain.text", "68");
+        cy.get("#bothPi").should("not.contain.text", "−2−4−6−8");
 
-        cy.get(cesc("#xe")).should("contain.text", "e2e3e");
-        cy.get(cesc("#xe")).should("contain.text", "−e−2e−3e");
-        cy.get(cesc("#xe")).should("contain.text", "24");
-        cy.get(cesc("#xe")).should("contain.text", "68");
-        cy.get(cesc("#xe")).should("contain.text", "−2−4−6−8");
+        cy.get("#xe").should("contain.text", "e2e3e");
+        cy.get("#xe").should("contain.text", "−e−2e−3e");
+        cy.get("#xe").should("contain.text", "24");
+        cy.get("#xe").should("contain.text", "68");
+        cy.get("#xe").should("contain.text", "−2−4−6−8");
 
-        cy.get(cesc("#ye")).should("contain.text", "e2e3e");
-        cy.get(cesc("#ye")).should("contain.text", "−e−2e−3e");
-        cy.get(cesc("#ye")).should("contain.text", "24");
-        cy.get(cesc("#ye")).should("contain.text", "68");
-        cy.get(cesc("#ye")).should("contain.text", "−2−4−6−8");
+        cy.get("#ye").should("contain.text", "e2e3e");
+        cy.get("#ye").should("contain.text", "−e−2e−3e");
+        cy.get("#ye").should("contain.text", "24");
+        cy.get("#ye").should("contain.text", "68");
+        cy.get("#ye").should("contain.text", "−2−4−6−8");
 
-        cy.get(cesc("#bothE")).should("contain.text", "e2e3e");
-        cy.get(cesc("#bothE")).should("contain.text", "−e−2e−3e");
-        cy.get(cesc("#bothE")).should("not.contain.text", "24");
-        cy.get(cesc("#bothE")).should("not.contain.text", "68");
-        cy.get(cesc("#bothE")).should("not.contain.text", "−2−4−6−8");
+        cy.get("#bothE").should("contain.text", "e2e3e");
+        cy.get("#bothE").should("contain.text", "−e−2e−3e");
+        cy.get("#bothE").should("not.contain.text", "24");
+        cy.get("#bothE").should("not.contain.text", "68");
+        cy.get("#bothE").should("not.contain.text", "−2−4−6−8");
 
-        cy.get(cesc("#ignoreBad")).should("not.contain.text", "π");
-        cy.get(cesc("#ignoreBad")).should("not.contain.text", "e");
-        cy.get(cesc("#ignoreBad")).should("contain.text", "68");
-        cy.get(cesc("#ignoreBad")).should("contain.text", "−2−4−6−8");
-
-        // Zoom out
-        cy.get(cesc("#none_navigationbar") + " > :nth-child(1)").click();
-        cy.get(cesc("#xpi_navigationbar") + " > :nth-child(1)").click();
-        cy.get(cesc("#ypi_navigationbar") + " > :nth-child(1)").click();
-        cy.get(cesc("#bothPi_navigationbar") + " > :nth-child(1)").click();
-        cy.get(cesc("#xe_navigationbar") + " > :nth-child(1)").click();
-        cy.get(cesc("#ye_navigationbar") + " > :nth-child(1)").click();
-        cy.get(cesc("#bothE_navigationbar") + " > :nth-child(1)").click();
-        cy.get(cesc("#ignoreBad_navigationbar") + " > :nth-child(1)").click();
-
-        cy.get(cesc("#xmax")).should("have.text", "12.5");
-
-        cy.get(cesc("#none")).should("not.contain.text", "π");
-        cy.get(cesc("#none")).should("not.contain.text", "e");
-        cy.get(cesc("#none")).should("contain.text", "10");
-        cy.get(cesc("#none")).should("contain.text", "−10");
-
-        cy.get(cesc("#xpi")).should("contain.text", "π2π3π");
-        cy.get(cesc("#xpi")).should("contain.text", "−π−2π−3π");
-        cy.get(cesc("#xpi")).should("contain.text", "10");
-        cy.get(cesc("#xpi")).should("contain.text", "−10");
-
-        cy.get(cesc("#ypi")).should("contain.text", "π2π3π");
-        cy.get(cesc("#ypi")).should("contain.text", "−π−2π−3π");
-        cy.get(cesc("#ypi")).should("contain.text", "10");
-        cy.get(cesc("#ypi")).should("contain.text", "−10");
-
-        cy.get(cesc("#bothPi")).should("contain.text", "π2π3π");
-        cy.get(cesc("#bothPi")).should("contain.text", "−π−2π−3π");
-        cy.get(cesc("#bothPi")).should("not.contain.text", "10");
-        cy.get(cesc("#bothPi")).should("not.contain.text", "−10");
-
-        cy.get(cesc("#xe")).should("contain.text", "e2e3e4e");
-        cy.get(cesc("#xe")).should("contain.text", "−e−2e");
-        cy.get(cesc("#xe")).should("contain.text", "−3e−4e");
-        cy.get(cesc("#xe")).should("contain.text", "10");
-        cy.get(cesc("#xe")).should("contain.text", "−10");
-
-        cy.get(cesc("#ye")).should("contain.text", "e2e3e4e");
-        cy.get(cesc("#ye")).should("contain.text", "−e−2e");
-        cy.get(cesc("#ye")).should("contain.text", "−3e−4e");
-        cy.get(cesc("#ye")).should("contain.text", "10");
-        cy.get(cesc("#ye")).should("contain.text", "−10");
-
-        cy.get(cesc("#bothE")).should("contain.text", "e2e3e4e");
-        cy.get(cesc("#bothE")).should("contain.text", "−e−2e");
-        cy.get(cesc("#bothE")).should("contain.text", "−3e−4e");
-        cy.get(cesc("#bothE")).should("not.contain.text", "10");
-        cy.get(cesc("#bothE")).should("not.contain.text", "−10");
-
-        cy.get(cesc("#ignoreBad")).should("not.contain.text", "π");
-        cy.get(cesc("#ignoreBad")).should("not.contain.text", "e");
-        cy.get(cesc("#ignoreBad")).should("contain.text", "10");
-        cy.get(cesc("#ignoreBad")).should("contain.text", "−10");
+        cy.get("#ignoreBad").should("not.contain.text", "π");
+        cy.get("#ignoreBad").should("not.contain.text", "e");
+        cy.get("#ignoreBad").should("contain.text", "68");
+        cy.get("#ignoreBad").should("contain.text", "−2−4−6−8");
 
         // Zoom out
-        cy.get(cesc("#none_navigationbar") + " > :nth-child(1)").click();
-        cy.get(cesc("#xpi_navigationbar") + " > :nth-child(1)").click();
-        cy.get(cesc("#ypi_navigationbar") + " > :nth-child(1)").click();
-        cy.get(cesc("#bothPi_navigationbar") + " > :nth-child(1)").click();
-        cy.get(cesc("#xe_navigationbar") + " > :nth-child(1)").click();
-        cy.get(cesc("#ye_navigationbar") + " > :nth-child(1)").click();
-        cy.get(cesc("#bothE_navigationbar") + " > :nth-child(1)").click();
-        cy.get(cesc("#ignoreBad_navigationbar") + " > :nth-child(1)").click();
+        cy.get("#none_navigationbar" + " > :nth-child(1)").click();
+        cy.get("#xpi_navigationbar" + " > :nth-child(1)").click();
+        cy.get("#ypi_navigationbar" + " > :nth-child(1)").click();
+        cy.get("#bothPi_navigationbar" + " > :nth-child(1)").click();
+        cy.get("#xe_navigationbar" + " > :nth-child(1)").click();
+        cy.get("#ye_navigationbar" + " > :nth-child(1)").click();
+        cy.get("#bothE_navigationbar" + " > :nth-child(1)").click();
+        cy.get("#ignoreBad_navigationbar" + " > :nth-child(1)").click();
 
-        cy.get(cesc("#xmax")).should("have.text", "15.625");
+        cy.get("#xmax").should("have.text", "12.5");
 
-        cy.get(cesc("#none")).should("not.contain.text", "π");
-        cy.get(cesc("#none")).should("not.contain.text", "e");
-        cy.get(cesc("#none")).should("contain.text", "10");
-        cy.get(cesc("#none")).should("contain.text", "−10");
+        cy.get("#none").should("not.contain.text", "π");
+        cy.get("#none").should("not.contain.text", "e");
+        cy.get("#none").should("contain.text", "10");
+        cy.get("#none").should("contain.text", "−10");
 
-        cy.get(cesc("#xpi")).should("contain.text", "π2π3π4π");
-        cy.get(cesc("#xpi")).should("contain.text", "−π−2π");
-        cy.get(cesc("#xpi")).should("contain.text", "−3π−4π");
-        cy.get(cesc("#xpi")).should("contain.text", "10");
-        cy.get(cesc("#xpi")).should("contain.text", "−10");
+        cy.get("#xpi").should("contain.text", "π2π3π");
+        cy.get("#xpi").should("contain.text", "−π−2π−3π");
+        cy.get("#xpi").should("contain.text", "10");
+        cy.get("#xpi").should("contain.text", "−10");
 
-        cy.get(cesc("#ypi")).should("contain.text", "π2π3π4π");
-        cy.get(cesc("#ypi")).should("contain.text", "−π−2π");
-        cy.get(cesc("#ypi")).should("contain.text", "−3π−4π");
-        cy.get(cesc("#ypi")).should("contain.text", "10");
-        cy.get(cesc("#ypi")).should("contain.text", "−10");
+        cy.get("#ypi").should("contain.text", "π2π3π");
+        cy.get("#ypi").should("contain.text", "−π−2π−3π");
+        cy.get("#ypi").should("contain.text", "10");
+        cy.get("#ypi").should("contain.text", "−10");
 
-        cy.get(cesc("#bothPi")).should("contain.text", "π2π3π4π");
-        cy.get(cesc("#bothPi")).should("contain.text", "−π−2π");
-        cy.get(cesc("#bothPi")).should("contain.text", "−3π−4π");
-        cy.get(cesc("#bothPi")).should("not.contain.text", "10");
-        cy.get(cesc("#bothPi")).should("not.contain.text", "−10");
+        cy.get("#bothPi").should("contain.text", "π2π3π");
+        cy.get("#bothPi").should("contain.text", "−π−2π−3π");
+        cy.get("#bothPi").should("not.contain.text", "10");
+        cy.get("#bothPi").should("not.contain.text", "−10");
 
-        cy.get(cesc("#xe")).should("contain.text", "e2e3e4e5e");
-        cy.get(cesc("#xe")).should("contain.text", "−e");
-        cy.get(cesc("#xe")).should("contain.text", "−2e−3e");
-        cy.get(cesc("#xe")).should("contain.text", "−4e−5e");
-        cy.get(cesc("#xe")).should("contain.text", "10");
-        cy.get(cesc("#xe")).should("contain.text", "−10");
+        cy.get("#xe").should("contain.text", "e2e3e4e");
+        cy.get("#xe").should("contain.text", "−e−2e");
+        cy.get("#xe").should("contain.text", "−3e−4e");
+        cy.get("#xe").should("contain.text", "10");
+        cy.get("#xe").should("contain.text", "−10");
 
-        cy.get(cesc("#ye")).should("contain.text", "e2e3e4e5e");
-        cy.get(cesc("#ye")).should("contain.text", "−e");
-        cy.get(cesc("#ye")).should("contain.text", "−2e−3e");
-        cy.get(cesc("#ye")).should("contain.text", "−4e−5e");
-        cy.get(cesc("#ye")).should("contain.text", "10");
-        cy.get(cesc("#ye")).should("contain.text", "−10");
+        cy.get("#ye").should("contain.text", "e2e3e4e");
+        cy.get("#ye").should("contain.text", "−e−2e");
+        cy.get("#ye").should("contain.text", "−3e−4e");
+        cy.get("#ye").should("contain.text", "10");
+        cy.get("#ye").should("contain.text", "−10");
 
-        cy.get(cesc("#bothE")).should("contain.text", "e2e3e4e5e");
-        cy.get(cesc("#bothE")).should("contain.text", "−e−2e");
-        cy.get(cesc("#bothE")).should("contain.text", "−3e−4e−5e");
-        cy.get(cesc("#bothE")).should("not.contain.text", "10");
-        cy.get(cesc("#bothE")).should("not.contain.text", "−10");
+        cy.get("#bothE").should("contain.text", "e2e3e4e");
+        cy.get("#bothE").should("contain.text", "−e−2e");
+        cy.get("#bothE").should("contain.text", "−3e−4e");
+        cy.get("#bothE").should("not.contain.text", "10");
+        cy.get("#bothE").should("not.contain.text", "−10");
 
-        cy.get(cesc("#ignoreBad")).should("not.contain.text", "π");
-        cy.get(cesc("#ignoreBad")).should("not.contain.text", "e");
-        cy.get(cesc("#ignoreBad")).should("contain.text", "10");
-        cy.get(cesc("#ignoreBad")).should("contain.text", "−10");
+        cy.get("#ignoreBad").should("not.contain.text", "π");
+        cy.get("#ignoreBad").should("not.contain.text", "e");
+        cy.get("#ignoreBad").should("contain.text", "10");
+        cy.get("#ignoreBad").should("contain.text", "−10");
+
+        // Zoom out
+        cy.get("#none_navigationbar" + " > :nth-child(1)").click();
+        cy.get("#xpi_navigationbar" + " > :nth-child(1)").click();
+        cy.get("#ypi_navigationbar" + " > :nth-child(1)").click();
+        cy.get("#bothPi_navigationbar" + " > :nth-child(1)").click();
+        cy.get("#xe_navigationbar" + " > :nth-child(1)").click();
+        cy.get("#ye_navigationbar" + " > :nth-child(1)").click();
+        cy.get("#bothE_navigationbar" + " > :nth-child(1)").click();
+        cy.get("#ignoreBad_navigationbar" + " > :nth-child(1)").click();
+
+        cy.get("#xmax").should("have.text", "15.625");
+
+        cy.get("#none").should("not.contain.text", "π");
+        cy.get("#none").should("not.contain.text", "e");
+        cy.get("#none").should("contain.text", "10");
+        cy.get("#none").should("contain.text", "−10");
+
+        cy.get("#xpi").should("contain.text", "π2π3π4π");
+        cy.get("#xpi").should("contain.text", "−π−2π");
+        cy.get("#xpi").should("contain.text", "−3π−4π");
+        cy.get("#xpi").should("contain.text", "10");
+        cy.get("#xpi").should("contain.text", "−10");
+
+        cy.get("#ypi").should("contain.text", "π2π3π4π");
+        cy.get("#ypi").should("contain.text", "−π−2π");
+        cy.get("#ypi").should("contain.text", "−3π−4π");
+        cy.get("#ypi").should("contain.text", "10");
+        cy.get("#ypi").should("contain.text", "−10");
+
+        cy.get("#bothPi").should("contain.text", "π2π3π4π");
+        cy.get("#bothPi").should("contain.text", "−π−2π");
+        cy.get("#bothPi").should("contain.text", "−3π−4π");
+        cy.get("#bothPi").should("not.contain.text", "10");
+        cy.get("#bothPi").should("not.contain.text", "−10");
+
+        cy.get("#xe").should("contain.text", "e2e3e4e5e");
+        cy.get("#xe").should("contain.text", "−e");
+        cy.get("#xe").should("contain.text", "−2e−3e");
+        cy.get("#xe").should("contain.text", "−4e−5e");
+        cy.get("#xe").should("contain.text", "10");
+        cy.get("#xe").should("contain.text", "−10");
+
+        cy.get("#ye").should("contain.text", "e2e3e4e5e");
+        cy.get("#ye").should("contain.text", "−e");
+        cy.get("#ye").should("contain.text", "−2e−3e");
+        cy.get("#ye").should("contain.text", "−4e−5e");
+        cy.get("#ye").should("contain.text", "10");
+        cy.get("#ye").should("contain.text", "−10");
+
+        cy.get("#bothE").should("contain.text", "e2e3e4e5e");
+        cy.get("#bothE").should("contain.text", "−e−2e");
+        cy.get("#bothE").should("contain.text", "−3e−4e−5e");
+        cy.get("#bothE").should("not.contain.text", "10");
+        cy.get("#bothE").should("not.contain.text", "−10");
+
+        cy.get("#ignoreBad").should("not.contain.text", "π");
+        cy.get("#ignoreBad").should("not.contain.text", "e");
+        cy.get("#ignoreBad").should("contain.text", "10");
+        cy.get("#ignoreBad").should("contain.text", "−10");
     });
 
     it("display axis ticks and tick labels combinations", () => {
@@ -444,7 +444,7 @@ describe("Graph Tag Tests", { tags: ["@group1"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+        cy.get("#a").should("have.text", "a"); //wait for page to load
 
         // g1: ticks and labels both on - should have tick marks with labels
         assertVisibleTickLabelCount("g1", (count) =>
@@ -509,7 +509,7 @@ describe("Graph Tag Tests", { tags: ["@group1"] }, function () {
         );
 
         // Turn off labels
-        cy.get(cesc("#xLabels_input")).click({ force: true });
+        cy.get("#xLabels_input").click({ force: true });
         assertVisibleTickLabelCount("dynamic", (count) =>
             expect(count).to.equal(0),
         );
@@ -523,7 +523,7 @@ describe("Graph Tag Tests", { tags: ["@group1"] }, function () {
         );
 
         // Turn off ticks (labels are already off)
-        cy.get(cesc("#xTicks_input")).click({ force: true });
+        cy.get("#xTicks_input").click({ force: true });
         assertVisibleTickLabelCount("dynamic", (count) =>
             expect(count).to.equal(0),
         );
@@ -537,7 +537,7 @@ describe("Graph Tag Tests", { tags: ["@group1"] }, function () {
         );
 
         // Turn on labels (ticks still off)
-        cy.get(cesc("#xLabels_input")).click({ force: true });
+        cy.get("#xLabels_input").click({ force: true });
         assertVisibleTickLabelCount("dynamic", (count) =>
             expect(count).to.be.greaterThan(0),
         );
@@ -551,7 +551,7 @@ describe("Graph Tag Tests", { tags: ["@group1"] }, function () {
         );
 
         // Turn on ticks (labels already on)
-        cy.get(cesc("#xTicks_input")).click({ force: true });
+        cy.get("#xTicks_input").click({ force: true });
         assertVisibleTickLabelCount("dynamic", (count) =>
             expect(count).to.be.greaterThan(0),
         );
@@ -580,13 +580,13 @@ describe("Graph Tag Tests", { tags: ["@group1"] }, function () {
         });
 
         // Make sure render doesn't crash when remove or add navigation buttons
-        cy.get(cesc("#showControls2")).should("have.text", "true");
+        cy.get("#showControls2").should("have.text", "true");
 
-        cy.get(cesc("#showControls")).click();
-        cy.get(cesc("#showControls2")).should("have.text", "false");
+        cy.get("#showControls").click();
+        cy.get("#showControls2").should("have.text", "false");
 
-        cy.get(cesc("#showControls")).click();
-        cy.get(cesc("#showControls2")).should("have.text", "true");
+        cy.get("#showControls").click();
+        cy.get("#showControls2").should("have.text", "true");
     });
 
     it("graph short description is aria-label", () => {
@@ -632,64 +632,64 @@ describe("Graph Tag Tests", { tags: ["@group1"] }, function () {
 
         const fullWidth = 850;
 
-        cy.get(cesc("#graph1"))
+        cy.get("#graph1")
             .invoke("css", "width")
             .then((width) => parseInt(width))
             .should("be.equal", fullWidth);
 
-        cy.get(cesc("#graph1"))
+        cy.get("#graph1")
             .invoke("css", "height")
             .then((height) => parseInt(height))
             .should("be.equal", fullWidth);
 
-        cy.get(cesc("#graph2a"))
+        cy.get("#graph2a")
             .invoke("css", "width")
             .then((width) => parseInt(width))
             .should("be.equal", fullWidth / 2);
-        cy.get(cesc("#graph2b"))
+        cy.get("#graph2b")
             .invoke("css", "width")
             .then((width) => parseInt(width))
-            .should("be.equal", fullWidth / 2);
-
-        cy.get(cesc("#graph2a"))
-            .invoke("css", "height")
-            .then((height) => parseInt(height))
-            .should("be.equal", fullWidth / 2);
-        cy.get(cesc("#graph2b"))
-            .invoke("css", "height")
-            .then((height) => parseInt(height))
             .should("be.equal", fullWidth / 2);
 
-        cy.get(cesc("#graph3a"))
+        cy.get("#graph2a")
+            .invoke("css", "height")
+            .then((height) => parseInt(height))
+            .should("be.equal", fullWidth / 2);
+        cy.get("#graph2b")
+            .invoke("css", "height")
+            .then((height) => parseInt(height))
+            .should("be.equal", fullWidth / 2);
+
+        cy.get("#graph3a")
             .invoke("css", "width")
             .then((width) => parseInt(width))
             .should("be.equal", Math.floor(fullWidth / 4));
-        cy.get(cesc("#graph3b"))
+        cy.get("#graph3b")
             .invoke("css", "width")
             .then((width) => parseInt(width))
             .should("be.equal", Math.floor(fullWidth / 4));
-        cy.get(cesc("#graph3c"))
+        cy.get("#graph3c")
             .invoke("css", "width")
             .then((width) => parseInt(width))
             .should("be.equal", Math.floor(fullWidth / 4));
-        cy.get(cesc("#graph3d"))
+        cy.get("#graph3d")
             .invoke("css", "width")
             .then((width) => parseInt(width))
             .should("be.equal", Math.floor(fullWidth / 4));
 
-        cy.get(cesc("#graph3a"))
+        cy.get("#graph3a")
             .invoke("css", "height")
             .then((height) => parseInt(height))
             .should("be.equal", Math.floor(fullWidth / 4));
-        cy.get(cesc("#graph3b"))
+        cy.get("#graph3b")
             .invoke("css", "height")
             .then((height) => parseInt(height))
             .should("be.equal", Math.floor(fullWidth / 4));
-        cy.get(cesc("#graph3c"))
+        cy.get("#graph3c")
             .invoke("css", "height")
             .then((height) => parseInt(height))
             .should("be.equal", Math.floor(fullWidth / 4));
-        cy.get(cesc("#graph3d"))
+        cy.get("#graph3d")
             .invoke("css", "height")
             .then((height) => parseInt(height))
             .should("be.equal", Math.floor(fullWidth / 4));

--- a/packages/test-cypress/cypress/e2e/tagSpecific/hint.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/hint.cy.js
@@ -26,70 +26,70 @@ describe("Hints Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#hint1") + " [data-test=hint-heading]").should(
+        cy.get("#hint1" + " [data-test=hint-heading]").should(
             "contain.text",
             "Hint",
         );
-        cy.get(cesc("#hint2") + " [data-test=hint-heading]").should(
+        cy.get("#hint2" + " [data-test=hint-heading]").should(
             "contain.text",
             "Hint 2",
         );
 
-        cy.get(cesc("#p1")).should("not.exist");
-        cy.get(cesc("#title1")).should("have.text", "Hint 2");
-        cy.get(cesc("#p2")).should("not.exist");
+        cy.get("#p1").should("not.exist");
+        cy.get("#title1").should("have.text", "Hint 2");
+        cy.get("#p2").should("not.exist");
 
-        cy.get(cesc("#hint1") + " [data-test=hint-heading]").click();
-        cy.get(cesc("#p1")).should("have.text", "Hello");
-        cy.get(cesc("#p2")).should("not.exist");
-        cy.get(cesc("#hint1") + " [data-test=hint-heading]").should(
+        cy.get("#hint1" + " [data-test=hint-heading]").click();
+        cy.get("#p1").should("have.text", "Hello");
+        cy.get("#p2").should("not.exist");
+        cy.get("#hint1" + " [data-test=hint-heading]").should(
             "contain.text",
             "Hint",
         );
-        cy.get(cesc("#hint2") + " [data-test=hint-heading]").should(
+        cy.get("#hint2" + " [data-test=hint-heading]").should(
             "contain.text",
             "Hint 2",
         );
-        cy.get(cesc("#title1")).should("have.text", "Hint 2");
+        cy.get("#title1").should("have.text", "Hint 2");
 
-        cy.get(cesc("#hint2") + " [data-test=hint-heading]").click();
-        cy.get(cesc("#p2")).should("have.text", "Good day!");
-        cy.get(cesc("#p1")).should("have.text", "Hello");
-        cy.get(cesc("#hint1") + " [data-test=hint-heading]").should(
+        cy.get("#hint2" + " [data-test=hint-heading]").click();
+        cy.get("#p2").should("have.text", "Good day!");
+        cy.get("#p1").should("have.text", "Hello");
+        cy.get("#hint1" + " [data-test=hint-heading]").should(
             "contain.text",
             "Hint",
         );
-        cy.get(cesc("#hint2") + " [data-test=hint-heading]").should(
+        cy.get("#hint2" + " [data-test=hint-heading]").should(
             "contain.text",
             "Hint 2",
         );
-        cy.get(cesc("#title1")).should("have.text", "Hint 2");
+        cy.get("#title1").should("have.text", "Hint 2");
 
-        cy.get(cesc("#hint1") + " [data-test=hint-heading]").click();
-        cy.get(cesc("#p1")).should("not.exist");
-        cy.get(cesc("#p2")).should("have.text", "Good day!");
-        cy.get(cesc("#hint1") + " [data-test=hint-heading]").should(
+        cy.get("#hint1" + " [data-test=hint-heading]").click();
+        cy.get("#p1").should("not.exist");
+        cy.get("#p2").should("have.text", "Good day!");
+        cy.get("#hint1" + " [data-test=hint-heading]").should(
             "contain.text",
             "Hint",
         );
-        cy.get(cesc("#hint2") + " [data-test=hint-heading]").should(
+        cy.get("#hint2" + " [data-test=hint-heading]").should(
             "contain.text",
             "Hint 2",
         );
-        cy.get(cesc("#title1")).should("have.text", "Hint 2");
+        cy.get("#title1").should("have.text", "Hint 2");
 
-        cy.get(cesc("#hint2") + " [data-test=hint-heading]").click();
-        cy.get(cesc("#p1")).should("not.exist");
-        cy.get(cesc("#p2")).should("not.exist");
-        cy.get(cesc("#hint1") + " [data-test=hint-heading]").should(
+        cy.get("#hint2" + " [data-test=hint-heading]").click();
+        cy.get("#p1").should("not.exist");
+        cy.get("#p2").should("not.exist");
+        cy.get("#hint1" + " [data-test=hint-heading]").should(
             "contain.text",
             "Hint",
         );
-        cy.get(cesc("#hint2") + " [data-test=hint-heading]").should(
+        cy.get("#hint2" + " [data-test=hint-heading]").should(
             "contain.text",
             "Hint 2",
         );
-        cy.get(cesc("#title1")).should("have.text", "Hint 2");
+        cy.get("#title1").should("have.text", "Hint 2");
     });
 
     it("copy and overwrite title", () => {
@@ -116,50 +116,50 @@ describe("Hints Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#hint1") + " [data-test=hint-heading]").should(
+        cy.get("#hint1" + " [data-test=hint-heading]").should(
             "contain.text",
             "Hint 1",
         );
-        cy.get(cesc("#revised") + " [data-test=hint-heading]").should(
+        cy.get("#revised" + " [data-test=hint-heading]").should(
             "contain.text",
             "Hint 2",
         );
         cy.get(cesc("#p3.title1")).should("have.text", "Hint 1");
         cy.get(cesc("#p4.title2")).should("have.text", "Hint 2");
         cy.get(cesc("#hint1.title1")).should("have.text", "Hint 1");
-        cy.get(cesc("#p1")).should("not.exist");
+        cy.get("#p1").should("not.exist");
         cy.get(cesc("#revised.title1")).should("not.exist");
         cy.get(cesc("#revised.title2")).should("have.text", "Hint 2");
-        cy.get(cesc("#p2")).should("not.exist");
+        cy.get("#p2").should("not.exist");
 
-        cy.get(cesc("#hint1") + " [data-test=hint-heading]").click();
-        cy.get(cesc("#p1")).should("have.text", "Hello");
+        cy.get("#hint1" + " [data-test=hint-heading]").click();
+        cy.get("#p1").should("have.text", "Hello");
         cy.get(cesc("#revised.p1")).should("not.exist");
-        cy.get(cesc("#p2")).should("not.exist");
+        cy.get("#p2").should("not.exist");
         cy.get(cesc("#hint1.title1")).should("have.text", "Hint 1");
         cy.get(cesc("#revised.title1")).should("not.exist");
         cy.get(cesc("#revised.title2")).should("have.text", "Hint 2");
 
-        cy.get(cesc("#revised") + " [data-test=hint-heading]").click();
+        cy.get("#revised" + " [data-test=hint-heading]").click();
         cy.get(cesc("#revised.p1")).should("have.text", "Hello");
-        cy.get(cesc("#p2")).should("have.text", "Good day!");
-        cy.get(cesc("#p1")).should("have.text", "Hello");
+        cy.get("#p2").should("have.text", "Good day!");
+        cy.get("#p1").should("have.text", "Hello");
         cy.get(cesc("#hint1.title1")).should("have.text", "Hint 1");
         cy.get(cesc("#revised.title1")).should("not.exist");
         cy.get(cesc("#revised.title2")).should("have.text", "Hint 2");
 
-        cy.get(cesc("#hint1") + " [data-test=hint-heading]").click();
-        cy.get(cesc("#p1")).should("not.exist");
+        cy.get("#hint1" + " [data-test=hint-heading]").click();
+        cy.get("#p1").should("not.exist");
         cy.get(cesc("#revised.p1")).should("have.text", "Hello");
-        cy.get(cesc("#p2")).should("have.text", "Good day!");
+        cy.get("#p2").should("have.text", "Good day!");
         cy.get(cesc("#hint1.title1")).should("have.text", "Hint 1");
         cy.get(cesc("#revised.title1")).should("not.exist");
         cy.get(cesc("#revised.title2")).should("have.text", "Hint 2");
 
-        cy.get(cesc("#revised") + " [data-test=hint-heading]").click();
+        cy.get("#revised" + " [data-test=hint-heading]").click();
         cy.get(cesc("#revised.p1")).should("not.exist");
-        cy.get(cesc("#p2")).should("not.exist");
-        cy.get(cesc("#p1")).should("not.exist");
+        cy.get("#p2").should("not.exist");
+        cy.get("#p1").should("not.exist");
         cy.get(cesc("#hint1.title1")).should("have.text", "Hint 1");
         cy.get(cesc("#revised.title1")).should("not.exist");
         cy.get(cesc("#revised.title2")).should("have.text", "Hint 2");
@@ -187,18 +187,18 @@ describe("Hints Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#hint1") + " [data-test=hint-heading]").should(
+        cy.get("#hint1" + " [data-test=hint-heading]").should(
             "contain.text",
             "Hello",
         );
 
-        cy.get(cesc("#p1")).should("not.exist");
-        cy.get(cesc("#ti_input")).should("be.disabled");
+        cy.get("#p1").should("not.exist");
+        cy.get("#ti_input").should("be.disabled");
 
-        cy.get(cesc("#hint1") + " [data-test=hint-heading]").click();
-        cy.get(cesc("#p1")).should("have.text", "Content");
+        cy.get("#hint1" + " [data-test=hint-heading]").click();
+        cy.get("#p1").should("have.text", "Content");
 
-        cy.get(cesc("#hint1") + " [data-test=hint-heading]").click();
-        cy.get(cesc("#p1")).should("not.exist");
+        cy.get("#hint1" + " [data-test=hint-heading]").click();
+        cy.get("#p1").should("not.exist");
     });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/image.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/image.cy.js
@@ -1,4 +1,4 @@
-import { cesc, widthsBySize } from "@doenet/utils";
+import { widthsBySize } from "@doenet/utils";
 import { assertCenteredWhenDescriptionOpens } from "./utils/mediaAlignment";
 
 describe("Image Tag Tests", { tags: ["@group1"] }, function () {
@@ -20,13 +20,13 @@ describe("Image Tag Tests", { tags: ["@group1"] }, function () {
                 "*",
             );
         });
-        cy.get(cesc("#image1"))
+        cy.get("#image1")
             .invoke("css", "width")
             .then((width) => parseInt(width))
             .should("be.gte", widthsBySize["small"] - 4)
             .and("be.lte", widthsBySize["small"] + 1);
-        // cy.get(cesc('#image1')).invoke('css', 'height').then((height) => expect(height).eq(undefined))
-        cy.get(cesc("#image1"))
+        // cy.get('#image1').invoke('css', 'height').then((height) => expect(height).eq(undefined))
+        cy.get("#image1")
             .invoke("attr", "alt")
             .then((alt) => expect(alt).eq("The Doenet logo"));
     });
@@ -62,28 +62,23 @@ describe("Image Tag Tests", { tags: ["@group1"] }, function () {
             );
         });
 
-        cy.get(cesc("#pWidth1")).should("have.text", "Width 1: 40%");
-        cy.get(cesc("#pWidth2")).should("have.text", "Width 2: 50%");
-        cy.get(cesc("#pAspectRatio1")).should("have.text", "Aspect Ratio 1: 1");
-        cy.get(cesc("#pAspectRatio2")).should(
-            "have.text",
-            "Aspect Ratio 2: NaN",
-        );
-        cy.get(cesc("#image1a"))
+        cy.get("#pWidth1").should("have.text", "Width 1: 40%");
+        cy.get("#pWidth2").should("have.text", "Width 2: 50%");
+        cy.get("#pAspectRatio1").should("have.text", "Aspect Ratio 1: 1");
+        cy.get("#pAspectRatio2").should("have.text", "Aspect Ratio 2: NaN");
+        cy.get("#image1a")
             .invoke("css", "width")
             .then((str) => parseInt(str))
             .should("be.closeTo", 255, 2);
-        cy.get(cesc("#image2a"))
+        cy.get("#image2a")
             .invoke("css", "width")
             .then((str) => parseInt(str))
             .should("be.closeTo", 425, 2);
-        cy.get(cesc("#image1a"))
+        cy.get("#image1a")
             .invoke("css", "aspectRatio")
             .then((str) => parseInt(str))
             .should("equal", 1);
-        cy.get(cesc("#image2a"))
-            .invoke("css", "aspectRatio")
-            .should("equal", "auto");
+        cy.get("#image2a").invoke("css", "aspectRatio").should("equal", "auto");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -105,23 +100,23 @@ describe("Image Tag Tests", { tags: ["@group1"] }, function () {
 
         cy.log("change widths");
 
-        cy.get(cesc("#width1") + " textarea").type(
+        cy.get("#width1" + " textarea").type(
             "{end}{backspace}{backspace}100{enter}",
             { force: true },
         );
-        cy.get(cesc("#width2") + " textarea").type(
+        cy.get("#width2" + " textarea").type(
             "{end}{backspace}{backspace}80{enter}",
             { force: true },
         );
 
-        cy.get(cesc("#pWidth1")).should("have.text", "Width 1: 100%");
-        cy.get(cesc("#pWidth2")).should("have.text", "Width 2: 80%");
+        cy.get("#pWidth1").should("have.text", "Width 1: 100%");
+        cy.get("#pWidth2").should("have.text", "Width 2: 80%");
 
-        cy.get(cesc("#image1a"))
+        cy.get("#image1a")
             .invoke("css", "width")
             .then((str) => parseInt(str))
             .should("be.closeTo", 850, 2);
-        cy.get(cesc("#image2a"))
+        cy.get("#image2a")
             .invoke("css", "width")
             .then((str) => parseInt(str))
             .should("be.closeTo", 595, 2);
@@ -144,11 +139,11 @@ describe("Image Tag Tests", { tags: ["@group1"] }, function () {
             });
         });
 
-        cy.get(cesc("#width1a") + " textarea").type("{end}{backspace}{enter}", {
+        cy.get("#width1a" + " textarea").type("{end}{backspace}{enter}", {
             force: true,
         });
-        cy.get(cesc("#pWidth1")).should("have.text", "Width 1: 10%");
-        cy.get(cesc("#image1a"))
+        cy.get("#pWidth1").should("have.text", "Width 1: 10%");
+        cy.get("#image1a")
             .invoke("css", "width")
             .then((str) => parseInt(str))
             .should("be.closeTo", 70.8, 2);
@@ -166,51 +161,36 @@ describe("Image Tag Tests", { tags: ["@group1"] }, function () {
 
         cy.log("change aspect ratio");
 
-        cy.get(cesc("#aspectRatio1") + " textarea").type(
-            "{end}{backspace}2{enter}",
-            { force: true },
-        );
-        cy.get(cesc("#aspectRatio2") + " textarea").type("1/2{enter}", {
+        cy.get("#aspectRatio1" + " textarea").type("{end}{backspace}2{enter}", {
+            force: true,
+        });
+        cy.get("#aspectRatio2" + " textarea").type("1/2{enter}", {
             force: true,
         });
 
-        cy.get(cesc("#pAspectRatio1")).should("have.text", "Aspect Ratio 1: 2");
-        cy.get(cesc("#pAspectRatio2")).should(
-            "have.text",
-            "Aspect Ratio 2: 0.5",
-        );
-        cy.get(cesc("#image1a"))
+        cy.get("#pAspectRatio1").should("have.text", "Aspect Ratio 1: 2");
+        cy.get("#pAspectRatio2").should("have.text", "Aspect Ratio 2: 0.5");
+        cy.get("#image1a")
             .invoke("css", "aspectRatio")
             .then((str) => parseFloat(str))
             .should("equal", 2);
-        cy.get(cesc("#image2a"))
+        cy.get("#image2a")
             .invoke("css", "aspectRatio")
             .then((str) => parseFloat(str))
             .should("equal", 0.5);
 
-        cy.get(cesc("#aspectRatio1a") + " textarea").type(
-            "{end}{backspace}{enter}",
-            { force: true },
-        );
-        cy.get(cesc("#aspectRatio2") + " textarea").type(
+        cy.get("#aspectRatio1a" + " textarea").type("{end}{backspace}{enter}", {
+            force: true,
+        });
+        cy.get("#aspectRatio2" + " textarea").type(
             "{end}{backspace}{backspace}{backspace}{enter}",
             { force: true },
         );
 
-        cy.get(cesc("#pAspectRatio1")).should(
-            "have.text",
-            "Aspect Ratio 1: NaN",
-        );
-        cy.get(cesc("#pAspectRatio2")).should(
-            "have.text",
-            "Aspect Ratio 2: NaN",
-        );
-        cy.get(cesc("#image1a"))
-            .invoke("css", "aspectRatio")
-            .should("equal", "auto");
-        cy.get(cesc("#image2a"))
-            .invoke("css", "aspectRatio")
-            .should("equal", "auto");
+        cy.get("#pAspectRatio1").should("have.text", "Aspect Ratio 1: NaN");
+        cy.get("#pAspectRatio2").should("have.text", "Aspect Ratio 2: NaN");
+        cy.get("#image1a").invoke("css", "aspectRatio").should("equal", "auto");
+        cy.get("#image2a").invoke("css", "aspectRatio").should("equal", "auto");
     });
 
     it("image in graph, absolute size", () => {
@@ -237,14 +217,14 @@ describe("Image Tag Tests", { tags: ["@group1"] }, function () {
             );
         });
 
-        cy.get(cesc("#pWidth1")).should("have.text", "Width 1: 5px");
-        cy.get(cesc("#pAspectRatio1")).should("have.text", "Aspect Ratio 1: 1");
+        cy.get("#pWidth1").should("have.text", "Width 1: 5px");
+        cy.get("#pAspectRatio1").should("have.text", "Aspect Ratio 1: 1");
 
-        cy.get(cesc("#image1a"))
+        cy.get("#image1a")
             .invoke("css", "width")
             .then((str) => parseInt(str))
             .should("be.closeTo", 70.8, 2);
-        cy.get(cesc("#image1a"))
+        cy.get("#image1a")
             .invoke("css", "aspectRatio")
             .then((str) => parseInt(str))
             .should("equal", 1);
@@ -262,14 +242,14 @@ describe("Image Tag Tests", { tags: ["@group1"] }, function () {
 
         cy.log("change width");
 
-        cy.get(cesc("#width1") + " textarea").type(
+        cy.get("#width1" + " textarea").type(
             "{end}{backspace}{backspace}10{enter}",
             { force: true },
         );
 
-        cy.get(cesc("#pWidth1")).should("have.text", "Width 1: 10px");
+        cy.get("#pWidth1").should("have.text", "Width 1: 10px");
 
-        cy.get(cesc("#image1a"))
+        cy.get("#image1a")
             .invoke("css", "width")
             .then((str) => parseInt(str))
             .should("be.closeTo", 70.8, 2);
@@ -285,13 +265,13 @@ describe("Image Tag Tests", { tags: ["@group1"] }, function () {
             });
         });
 
-        cy.get(cesc("#width1a") + " textarea").type(
+        cy.get("#width1a" + " textarea").type(
             "{end}{backspace}{backspace}15{enter}",
             { force: true },
         );
 
-        cy.get(cesc("#pWidth1")).should("have.text", "Width 1: 15px");
-        cy.get(cesc("#image1a"))
+        cy.get("#pWidth1").should("have.text", "Width 1: 15px");
+        cy.get("#image1a")
             .invoke("css", "width")
             .then((str) => parseInt(str))
             .should("be.closeTo", 70.8, 2);
@@ -309,29 +289,22 @@ describe("Image Tag Tests", { tags: ["@group1"] }, function () {
 
         cy.log("change aspect ratio");
 
-        cy.get(cesc("#aspectRatio1") + " textarea").type(
-            "{end}{backspace}2{enter}",
-            { force: true },
-        );
+        cy.get("#aspectRatio1" + " textarea").type("{end}{backspace}2{enter}", {
+            force: true,
+        });
 
-        cy.get(cesc("#pAspectRatio1")).should("have.text", "Aspect Ratio 1: 2");
-        cy.get(cesc("#image1a"))
+        cy.get("#pAspectRatio1").should("have.text", "Aspect Ratio 1: 2");
+        cy.get("#image1a")
             .invoke("css", "aspectRatio")
             .then((str) => parseFloat(str))
             .should("equal", 2);
 
-        cy.get(cesc("#aspectRatio1a") + " textarea").type(
-            "{end}{backspace}{enter}",
-            { force: true },
-        );
+        cy.get("#aspectRatio1a" + " textarea").type("{end}{backspace}{enter}", {
+            force: true,
+        });
 
-        cy.get(cesc("#pAspectRatio1")).should(
-            "have.text",
-            "Aspect Ratio 1: NaN",
-        );
-        cy.get(cesc("#image1a"))
-            .invoke("css", "aspectRatio")
-            .should("equal", "auto");
+        cy.get("#pAspectRatio1").should("have.text", "Aspect Ratio 1: NaN");
+        cy.get("#image1a").invoke("css", "aspectRatio").should("equal", "auto");
     });
 
     it("with description", () => {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/line.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/line.cy.js
@@ -1,5 +1,3 @@
-import { cesc } from "@doenet/utils";
-
 describe("Line Tag Tests", { tags: ["@group3"] }, function () {
     beforeEach(() => {
         cy.clearIndexedDB();
@@ -32,8 +30,8 @@ describe("Line Tag Tests", { tags: ["@group3"] }, function () {
             );
         });
 
-        cy.get(cesc("#Ac")).should("contain.text", "(1,2)");
-        cy.get(cesc("#Bc")).should("contain.text", "(3,4)");
+        cy.get("#Ac").should("contain.text", "(1,2)");
+        cy.get("#Bc").should("contain.text", "(3,4)");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -58,8 +56,8 @@ describe("Line Tag Tests", { tags: ["@group3"] }, function () {
             });
         });
 
-        cy.get(cesc("#Ac")).should("contain.text", "(9,8)");
-        cy.get(cesc("#Bc")).should("contain.text", "(6,7)");
+        cy.get("#Ac").should("contain.text", "(9,8)");
+        cy.get("#Bc").should("contain.text", "(6,7)");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -85,7 +83,7 @@ describe("Line Tag Tests", { tags: ["@group3"] }, function () {
             );
         });
 
-        cy.get(cesc("#Ac")).should("contain.text", "(9,8)");
+        cy.get("#Ac").should("contain.text", "(9,8)");
 
         // wait until core is loaded
         cy.waitUntil(() =>
@@ -95,8 +93,8 @@ describe("Line Tag Tests", { tags: ["@group3"] }, function () {
             }),
         );
 
-        cy.get(cesc("#Ac")).should("contain.text", "(9,8)");
-        cy.get(cesc("#Bc")).should("contain.text", "(6,7)");
+        cy.get("#Ac").should("contain.text", "(9,8)");
+        cy.get("#Bc").should("contain.text", "(6,7)");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -116,8 +114,8 @@ describe("Line Tag Tests", { tags: ["@group3"] }, function () {
             });
         });
 
-        cy.get(cesc("#Ac")).should("contain.text", "(0.5,3.5)");
-        cy.get(cesc("#Bc")).should("contain.text", "(6,7)");
+        cy.get("#Ac").should("contain.text", "(0.5,3.5)");
+        cy.get("#Bc").should("contain.text", "(6,7)");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -143,7 +141,7 @@ describe("Line Tag Tests", { tags: ["@group3"] }, function () {
             );
         });
 
-        cy.get(cesc("#Ac")).should("contain.text", "(0.5,3.5)");
+        cy.get("#Ac").should("contain.text", "(0.5,3.5)");
 
         // wait until core is loaded
         cy.waitUntil(() =>
@@ -153,8 +151,8 @@ describe("Line Tag Tests", { tags: ["@group3"] }, function () {
             }),
         );
 
-        cy.get(cesc("#Ac")).should("contain.text", "(0.5,3.5)");
-        cy.get(cesc("#Bc")).should("contain.text", "(6,7)");
+        cy.get("#Ac").should("contain.text", "(0.5,3.5)");
+        cy.get("#Bc").should("contain.text", "(6,7)");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -174,8 +172,8 @@ describe("Line Tag Tests", { tags: ["@group3"] }, function () {
             });
         });
 
-        cy.get(cesc("#Ac")).should("contain.text", "(8.5,1.5)");
-        cy.get(cesc("#Bc")).should("contain.text", "(6,7)");
+        cy.get("#Ac").should("contain.text", "(8.5,1.5)");
+        cy.get("#Bc").should("contain.text", "(6,7)");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();

--- a/packages/test-cypress/cypress/e2e/tagSpecific/lineFamilyLabels.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/lineFamilyLabels.cy.js
@@ -88,7 +88,7 @@ describe("Line-family label placement", { tags: ["@group3"] }, function () {
   </graph>
         `);
 
-        cy.get(cesc("#loaded")).should("have.text", "loaded");
+        cy.get("#loaded").should("have.text", "loaded");
 
         assertLabelFitsHorizontally("graphLine", lineLabel);
         assertLabelFitsHorizontally("graphLineSegment", lineSegmentLabel);

--- a/packages/test-cypress/cypress/e2e/tagSpecific/linesegment.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/linesegment.cy.js
@@ -1,4 +1,3 @@
-import { cesc } from "@doenet/utils";
 import { toMathJaxString } from "../../../src/util/mathDisplay";
 
 describe("Line Tag Tests", { tags: ["@group4"] }, function () {
@@ -22,7 +21,7 @@ describe("Line Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#P1")).should("have.text", toMathJaxString("(1,0)"));
-        cy.get(cesc("#P2")).should("have.text", toMathJaxString("(1,2i)"));
+        cy.get("#P1").should("have.text", toMathJaxString("(1,0)"));
+        cy.get("#P2").should("have.text", toMathJaxString("(1,2i)"));
     });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/math.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/math.cy.js
@@ -1,4 +1,3 @@
-import { cesc } from "@doenet/utils";
 import { toMathJaxString } from "../../../src/util/mathDisplay";
 
 describe("Math Tag Tests", { tags: ["@group5"] }, function () {
@@ -36,10 +35,10 @@ describe("Math Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#m1")).should("have.text", toMathJaxString("w"));
-        cy.get(cesc("#m2")).should("have.text", toMathJaxString("x+y"));
-        cy.get(cesc("#m4")).should("have.text", toMathJaxString("z"));
-        cy.get(cesc("#m5")).should("have.text", toMathJaxString("a+z"));
+        cy.get("#m1").should("have.text", toMathJaxString("w"));
+        cy.get("#m2").should("have.text", toMathJaxString("x+y"));
+        cy.get("#m4").should("have.text", toMathJaxString("z"));
+        cy.get("#m5").should("have.text", toMathJaxString("a+z"));
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -60,22 +59,22 @@ describe("Math Tag Tests", { tags: ["@group5"] }, function () {
             ).eqls(["+", "a", "z"]);
         });
 
-        cy.get(cesc("#mi1") + " textarea").type("{end}{backspace}1{enter}", {
+        cy.get("#mi1" + " textarea").type("{end}{backspace}1{enter}", {
             force: true,
         });
-        cy.get(cesc("#mi2") + " textarea").type("{end}{backspace}2{enter}", {
+        cy.get("#mi2" + " textarea").type("{end}{backspace}2{enter}", {
             force: true,
         });
-        cy.get(cesc("#mi4") + " textarea").type("{end}{backspace}3{enter}", {
+        cy.get("#mi4" + " textarea").type("{end}{backspace}3{enter}", {
             force: true,
         });
 
-        cy.get(cesc("#m4")).should("contain.text", "3");
+        cy.get("#m4").should("contain.text", "3");
 
-        cy.get(cesc("#m1")).should("have.text", toMathJaxString("1"));
-        cy.get(cesc("#m2")).should("have.text", toMathJaxString("x+2"));
-        cy.get(cesc("#m4")).should("have.text", toMathJaxString("3"));
-        cy.get(cesc("#m5")).should("have.text", toMathJaxString("a+3"));
+        cy.get("#m1").should("have.text", toMathJaxString("1"));
+        cy.get("#m2").should("have.text", toMathJaxString("x+2"));
+        cy.get("#m4").should("have.text", toMathJaxString("3"));
+        cy.get("#m5").should("have.text", toMathJaxString("a+3"));
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -109,7 +108,7 @@ describe("Math Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#m1")).should("have.text", "1");
+        cy.get("#m1").should("have.text", "1");
 
         // wait until core is loaded
         cy.waitUntil(() =>
@@ -119,10 +118,10 @@ describe("Math Tag Tests", { tags: ["@group5"] }, function () {
             }),
         );
 
-        cy.get(cesc("#m1")).should("have.text", toMathJaxString("1"));
-        cy.get(cesc("#m2")).should("have.text", toMathJaxString("x+2"));
-        cy.get(cesc("#m4")).should("have.text", toMathJaxString("3"));
-        cy.get(cesc("#m5")).should("have.text", toMathJaxString("a+3"));
+        cy.get("#m1").should("have.text", toMathJaxString("1"));
+        cy.get("#m2").should("have.text", toMathJaxString("x+2"));
+        cy.get("#m4").should("have.text", toMathJaxString("3"));
+        cy.get("#m5").should("have.text", toMathJaxString("a+3"));
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -143,22 +142,22 @@ describe("Math Tag Tests", { tags: ["@group5"] }, function () {
             ).eqls(["+", "a", 3]);
         });
 
-        cy.get(cesc("#mi1") + " textarea").type("{end}{backspace}4+5{enter}", {
+        cy.get("#mi1" + " textarea").type("{end}{backspace}4+5{enter}", {
             force: true,
         });
-        cy.get(cesc("#mi3") + " textarea").type("{end}{backspace}6+7{enter}", {
+        cy.get("#mi3" + " textarea").type("{end}{backspace}6+7{enter}", {
             force: true,
         });
-        cy.get(cesc("#mi5") + " textarea").type("{end}{backspace}8+9{enter}", {
+        cy.get("#mi5" + " textarea").type("{end}{backspace}8+9{enter}", {
             force: true,
         });
 
-        cy.get(cesc("#m5")).should("contain.text", "17");
+        cy.get("#m5").should("contain.text", "17");
 
-        cy.get(cesc("#m1")).should("have.text", toMathJaxString("4+5"));
-        cy.get(cesc("#m2")).should("have.text", toMathJaxString("x+6+7"));
-        cy.get(cesc("#m4")).should("have.text", toMathJaxString("17"));
-        cy.get(cesc("#m5")).should("have.text", toMathJaxString("a+17"));
+        cy.get("#m1").should("have.text", toMathJaxString("4+5"));
+        cy.get("#m2").should("have.text", toMathJaxString("x+6+7"));
+        cy.get("#m4").should("have.text", toMathJaxString("17"));
+        cy.get("#m5").should("have.text", toMathJaxString("a+17"));
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -192,7 +191,7 @@ describe("Math Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#m1")).should("have.text", toMathJaxString("4+5"));
+        cy.get("#m1").should("have.text", toMathJaxString("4+5"));
 
         // wait until core is loaded
         cy.waitUntil(() =>
@@ -202,10 +201,10 @@ describe("Math Tag Tests", { tags: ["@group5"] }, function () {
             }),
         );
 
-        cy.get(cesc("#m1")).should("have.text", toMathJaxString("4+5"));
-        cy.get(cesc("#m2")).should("have.text", toMathJaxString("x+6+7"));
-        cy.get(cesc("#m4")).should("have.text", toMathJaxString("17"));
-        cy.get(cesc("#m5")).should("have.text", toMathJaxString("a+17"));
+        cy.get("#m1").should("have.text", toMathJaxString("4+5"));
+        cy.get("#m2").should("have.text", toMathJaxString("x+6+7"));
+        cy.get("#m4").should("have.text", toMathJaxString("17"));
+        cy.get("#m5").should("have.text", toMathJaxString("a+17"));
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -255,42 +254,34 @@ describe("Math Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#tsd_no_style")).should("have.text", "black");
-        cy.get(cesc("#tc_no_style")).should("have.text", "black");
-        cy.get(cesc("#bc_no_style")).should("have.text", "none");
+        cy.get("#tsd_no_style").should("have.text", "black");
+        cy.get("#tc_no_style").should("have.text", "black");
+        cy.get("#bc_no_style").should("have.text", "none");
 
-        cy.get(cesc("#tsd_fixed_style")).should("have.text", "green");
-        cy.get(cesc("#tc_fixed_style")).should("have.text", "green");
-        cy.get(cesc("#bc_fixed_style")).should("have.text", "none");
+        cy.get("#tsd_fixed_style").should("have.text", "green");
+        cy.get("#tc_fixed_style").should("have.text", "green");
+        cy.get("#bc_fixed_style").should("have.text", "none");
 
-        cy.get(cesc("#tsd_variable_style")).should("have.text", "black");
-        cy.get(cesc("#tc_variable_style")).should("have.text", "black");
-        cy.get(cesc("#bc_variable_style")).should("have.text", "none");
+        cy.get("#tsd_variable_style").should("have.text", "black");
+        cy.get("#tc_variable_style").should("have.text", "black");
+        cy.get("#bc_variable_style").should("have.text", "none");
 
-        cy.get(cesc("#no_style")).should("have.css", "color", "rgb(0, 0, 0)");
-        cy.get(cesc("#no_style")).should(
+        cy.get("#no_style").should("have.css", "color", "rgb(0, 0, 0)");
+        cy.get("#no_style").should(
             "have.css",
             "background-color",
             "rgba(0, 0, 0, 0)",
         );
 
-        cy.get(cesc("#fixed_style")).should(
-            "have.css",
-            "color",
-            "rgb(0, 128, 0)",
-        );
-        cy.get(cesc("#fixed_style")).should(
+        cy.get("#fixed_style").should("have.css", "color", "rgb(0, 128, 0)");
+        cy.get("#fixed_style").should(
             "have.css",
             "background-color",
             "rgba(0, 0, 0, 0)",
         );
 
-        cy.get(cesc("#variable_style")).should(
-            "have.css",
-            "color",
-            "rgb(0, 0, 0)",
-        );
-        cy.get(cesc("#variable_style")).should(
+        cy.get("#variable_style").should("have.css", "color", "rgb(0, 0, 0)");
+        cy.get("#variable_style").should(
             "have.css",
             "background-color",
             "rgba(0, 0, 0, 0)",
@@ -298,94 +289,78 @@ describe("Math Tag Tests", { tags: ["@group5"] }, function () {
 
         // TODO: how to test color in graph
 
-        cy.get(cesc("#sn") + " textarea").type("{end}{backspace}2{enter}", {
+        cy.get("#sn" + " textarea").type("{end}{backspace}2{enter}", {
             force: true,
         });
 
-        cy.get(cesc("#tsd_variable_style")).should("have.text", "green");
-        cy.get(cesc("#tc_variable_style")).should("have.text", "green");
-        cy.get(cesc("#bc_variable_style")).should("have.text", "none");
+        cy.get("#tsd_variable_style").should("have.text", "green");
+        cy.get("#tc_variable_style").should("have.text", "green");
+        cy.get("#bc_variable_style").should("have.text", "none");
 
-        cy.get(cesc("#tsd_no_style")).should("have.text", "black");
-        cy.get(cesc("#tc_no_style")).should("have.text", "black");
-        cy.get(cesc("#bc_no_style")).should("have.text", "none");
+        cy.get("#tsd_no_style").should("have.text", "black");
+        cy.get("#tc_no_style").should("have.text", "black");
+        cy.get("#bc_no_style").should("have.text", "none");
 
-        cy.get(cesc("#tsd_fixed_style")).should("have.text", "green");
-        cy.get(cesc("#tc_fixed_style")).should("have.text", "green");
-        cy.get(cesc("#bc_fixed_style")).should("have.text", "none");
+        cy.get("#tsd_fixed_style").should("have.text", "green");
+        cy.get("#tc_fixed_style").should("have.text", "green");
+        cy.get("#bc_fixed_style").should("have.text", "none");
 
-        cy.get(cesc("#no_style")).should("have.css", "color", "rgb(0, 0, 0)");
-        cy.get(cesc("#no_style")).should(
+        cy.get("#no_style").should("have.css", "color", "rgb(0, 0, 0)");
+        cy.get("#no_style").should(
             "have.css",
             "background-color",
             "rgba(0, 0, 0, 0)",
         );
 
-        cy.get(cesc("#fixed_style")).should(
-            "have.css",
-            "color",
-            "rgb(0, 128, 0)",
-        );
-        cy.get(cesc("#fixed_style")).should(
+        cy.get("#fixed_style").should("have.css", "color", "rgb(0, 128, 0)");
+        cy.get("#fixed_style").should(
             "have.css",
             "background-color",
             "rgba(0, 0, 0, 0)",
         );
 
-        cy.get(cesc("#variable_style")).should(
-            "have.css",
-            "color",
-            "rgb(0, 128, 0)",
-        );
-        cy.get(cesc("#variable_style")).should(
+        cy.get("#variable_style").should("have.css", "color", "rgb(0, 128, 0)");
+        cy.get("#variable_style").should(
             "have.css",
             "background-color",
             "rgba(0, 0, 0, 0)",
         );
 
-        cy.get(cesc("#sn") + " textarea").type("{end}{backspace}3{enter}", {
+        cy.get("#sn" + " textarea").type("{end}{backspace}3{enter}", {
             force: true,
         });
 
-        cy.get(cesc("#tsd_variable_style")).should(
+        cy.get("#tsd_variable_style").should(
             "have.text",
             "red with a blue background",
         );
-        cy.get(cesc("#tc_variable_style")).should("have.text", "red");
-        cy.get(cesc("#bc_variable_style")).should("have.text", "blue");
+        cy.get("#tc_variable_style").should("have.text", "red");
+        cy.get("#bc_variable_style").should("have.text", "blue");
 
-        cy.get(cesc("#tsd_no_style")).should("have.text", "black");
-        cy.get(cesc("#tc_no_style")).should("have.text", "black");
-        cy.get(cesc("#bc_no_style")).should("have.text", "none");
+        cy.get("#tsd_no_style").should("have.text", "black");
+        cy.get("#tc_no_style").should("have.text", "black");
+        cy.get("#bc_no_style").should("have.text", "none");
 
-        cy.get(cesc("#tsd_fixed_style")).should("have.text", "green");
-        cy.get(cesc("#tc_fixed_style")).should("have.text", "green");
-        cy.get(cesc("#bc_fixed_style")).should("have.text", "none");
+        cy.get("#tsd_fixed_style").should("have.text", "green");
+        cy.get("#tc_fixed_style").should("have.text", "green");
+        cy.get("#bc_fixed_style").should("have.text", "none");
 
-        cy.get(cesc("#no_style")).should("have.css", "color", "rgb(0, 0, 0)");
-        cy.get(cesc("#no_style")).should(
+        cy.get("#no_style").should("have.css", "color", "rgb(0, 0, 0)");
+        cy.get("#no_style").should(
             "have.css",
             "background-color",
             "rgba(0, 0, 0, 0)",
         );
 
-        cy.get(cesc("#fixed_style")).should(
-            "have.css",
-            "color",
-            "rgb(0, 128, 0)",
-        );
-        cy.get(cesc("#fixed_style")).should(
+        cy.get("#fixed_style").should("have.css", "color", "rgb(0, 128, 0)");
+        cy.get("#fixed_style").should(
             "have.css",
             "background-color",
             "rgba(0, 0, 0, 0)",
         );
 
-        cy.get(cesc("#variable_style")).should(
-            "have.css",
-            "color",
-            "rgb(255, 0, 0)",
-        );
-        cy.get(cesc("#variable_style")).should(
+        cy.get("#variable_style").should("have.css", "color", "rgb(255, 0, 0)");
+        cy.get("#variable_style").should(
             "have.css",
             "background-color",
             "rgb(0, 0, 255)",
@@ -440,7 +415,7 @@ describe("Math Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); // to wait until loaded
+        cy.get("#a").should("have.text", "a"); // to wait until loaded
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -485,12 +460,12 @@ describe("Math Tag Tests", { tags: ["@group5"] }, function () {
             cy.get(m2cAnchor).should("have.css", "color", "rgb(255, 0, 0)");
             cy.get(m2dAnchor).should("have.css", "color", "rgb(0, 0, 0)");
 
-            cy.get(cesc("#m1coords")).eq(0).should("have.text", "(0,0)");
-            cy.get(cesc("#m2coords")).eq(0).should("have.text", "(3,4)");
-            cy.get(cesc("#m1acoords")).eq(0).should("have.text", "(0,0)");
-            cy.get(cesc("#m2acoords")).eq(0).should("have.text", "(3,4)");
-            cy.get(cesc("#m1bcoords")).eq(0).should("have.text", "(0,0)");
-            cy.get(cesc("#m2bcoords")).eq(0).should("have.text", "(0,0)");
+            cy.get("#m1coords").eq(0).should("have.text", "(0,0)");
+            cy.get("#m2coords").eq(0).should("have.text", "(3,4)");
+            cy.get("#m1acoords").eq(0).should("have.text", "(0,0)");
+            cy.get("#m2acoords").eq(0).should("have.text", "(3,4)");
+            cy.get("#m1bcoords").eq(0).should("have.text", "(0,0)");
+            cy.get("#m2bcoords").eq(0).should("have.text", "(0,0)");
 
             cy.log("move first maths");
             cy.window().then(async (win) => {
@@ -506,14 +481,14 @@ describe("Math Tag Tests", { tags: ["@group5"] }, function () {
                 });
             });
 
-            cy.get(cesc("#m2coords")).should("contain.text", "(4,−5)");
+            cy.get("#m2coords").should("contain.text", "(4,−5)");
 
-            cy.get(cesc("#m1coords")).eq(0).should("have.text", "(−2,3)");
-            cy.get(cesc("#m2coords")).eq(0).should("have.text", "(4,−5)");
-            cy.get(cesc("#m1acoords")).eq(0).should("have.text", "(−2,3)");
-            cy.get(cesc("#m2acoords")).eq(0).should("have.text", "(4,−5)");
-            cy.get(cesc("#m1bcoords")).eq(0).should("have.text", "(0,0)");
-            cy.get(cesc("#m2bcoords")).eq(0).should("have.text", "(0,0)");
+            cy.get("#m1coords").eq(0).should("have.text", "(−2,3)");
+            cy.get("#m2coords").eq(0).should("have.text", "(4,−5)");
+            cy.get("#m1acoords").eq(0).should("have.text", "(−2,3)");
+            cy.get("#m2acoords").eq(0).should("have.text", "(4,−5)");
+            cy.get("#m1bcoords").eq(0).should("have.text", "(0,0)");
+            cy.get("#m2bcoords").eq(0).should("have.text", "(0,0)");
 
             cy.log("move second maths");
             cy.window().then(async (win) => {
@@ -529,14 +504,14 @@ describe("Math Tag Tests", { tags: ["@group5"] }, function () {
                 });
             });
 
-            cy.get(cesc("#m2coords")).should("contain.text", "(−8,2)");
+            cy.get("#m2coords").should("contain.text", "(−8,2)");
 
-            cy.get(cesc("#m1coords")).eq(0).should("have.text", "(7,1)");
-            cy.get(cesc("#m2coords")).eq(0).should("have.text", "(−8,2)");
-            cy.get(cesc("#m1acoords")).eq(0).should("have.text", "(7,1)");
-            cy.get(cesc("#m2acoords")).eq(0).should("have.text", "(−8,2)");
-            cy.get(cesc("#m1bcoords")).eq(0).should("have.text", "(0,0)");
-            cy.get(cesc("#m2bcoords")).eq(0).should("have.text", "(0,0)");
+            cy.get("#m1coords").eq(0).should("have.text", "(7,1)");
+            cy.get("#m2coords").eq(0).should("have.text", "(−8,2)");
+            cy.get("#m1acoords").eq(0).should("have.text", "(7,1)");
+            cy.get("#m2acoords").eq(0).should("have.text", "(−8,2)");
+            cy.get("#m1bcoords").eq(0).should("have.text", "(0,0)");
+            cy.get("#m2bcoords").eq(0).should("have.text", "(0,0)");
 
             cy.log("move third maths");
             cy.window().then(async (win) => {
@@ -552,14 +527,14 @@ describe("Math Tag Tests", { tags: ["@group5"] }, function () {
                 });
             });
 
-            cy.get(cesc("#m2bcoords")).should("contain.text", "(−5,−4)");
+            cy.get("#m2bcoords").should("contain.text", "(−5,−4)");
 
-            cy.get(cesc("#m1coords")).eq(0).should("have.text", "(7,1)");
-            cy.get(cesc("#m2coords")).eq(0).should("have.text", "(−8,2)");
-            cy.get(cesc("#m1acoords")).eq(0).should("have.text", "(7,1)");
-            cy.get(cesc("#m2acoords")).eq(0).should("have.text", "(−8,2)");
-            cy.get(cesc("#m1bcoords")).eq(0).should("have.text", "(−6,3)");
-            cy.get(cesc("#m2bcoords")).eq(0).should("have.text", "(−5,−4)");
+            cy.get("#m1coords").eq(0).should("have.text", "(7,1)");
+            cy.get("#m2coords").eq(0).should("have.text", "(−8,2)");
+            cy.get("#m1acoords").eq(0).should("have.text", "(7,1)");
+            cy.get("#m2acoords").eq(0).should("have.text", "(−8,2)");
+            cy.get("#m1bcoords").eq(0).should("have.text", "(−6,3)");
+            cy.get("#m2bcoords").eq(0).should("have.text", "(−5,−4)");
         });
     });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/mathdisplay.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/mathdisplay.cy.js
@@ -32,42 +32,42 @@ describe("Math Display Tag Tests", { tags: ["@group2"] }, function () {
         });
 
         cy.log("Test value displayed in browser");
-        cy.get(cesc("#e1")).should("have.text", "sin⁡(𝑥)(1)");
-        cy.get(cesc("#e2")).should("have.text", "cos⁡(𝑥)(2)");
-        cy.get(cesc("#e3")).should("have.text", "tan⁡(𝑥)(3)");
-        cy.get(cesc("#p1")).should(
+        cy.get("#e1").should("have.text", "sin⁡(𝑥)(1)");
+        cy.get("#e2").should("have.text", "cos⁡(𝑥)(2)");
+        cy.get("#e3").should("have.text", "tan⁡(𝑥)(3)");
+        cy.get("#p1").should(
             "have.text",
             "We have equation (1), equation (2), and equation (3).",
         );
-        cy.get(cesc("#re1")).should("have.text", "(1)");
-        cy.get(cesc("#re2")).should("have.text", "(2)");
-        cy.get(cesc("#re3")).should("have.text", "(3)");
+        cy.get("#re1").should("have.text", "(1)");
+        cy.get("#re2").should("have.text", "(2)");
+        cy.get("#re3").should("have.text", "(3)");
 
-        cy.get(cesc("#p2")).should(
+        cy.get("#p2").should(
             "have.text",
             "From copying properties: 1, 2, and 3.",
         );
-        cy.get(cesc("#te1")).should("have.text", "1");
-        cy.get(cesc("#te2")).should("have.text", "2");
-        cy.get(cesc("#te3")).should("have.text", "3");
+        cy.get("#te1").should("have.text", "1");
+        cy.get("#te2").should("have.text", "2");
+        cy.get("#te3").should("have.text", "3");
 
-        cy.get(cesc("#re1")).click();
+        cy.get("#re1").click();
 
-        cy.get(cesc("#e1")).then((el) => {
+        cy.get("#e1").then((el) => {
             let rect = el[0].getBoundingClientRect();
             expect(rect.top).gt(-1).lt(5);
         });
 
-        cy.get(cesc("#re2")).click();
+        cy.get("#re2").click();
 
-        cy.get(cesc("#e2")).then((el) => {
+        cy.get("#e2").then((el) => {
             let rect = el[0].getBoundingClientRect();
             expect(rect.top).gt(-1).lt(5);
         });
 
-        cy.get(cesc("#re3")).click();
+        cy.get("#re3").click();
 
-        cy.get(cesc("#e3")).then((el) => {
+        cy.get("#e3").then((el) => {
             let rect = el[0].getBoundingClientRect();
             expect(rect.top).gt(-1).lt(5);
         });
@@ -122,18 +122,15 @@ describe("Math Display Tag Tests", { tags: ["@group2"] }, function () {
         function checkEquationNumbering(m, n) {
             let counter = 1;
 
-            cy.get(cesc("#x")).should(
-                "have.text",
-                toMathJaxString(`x(${counter})`),
-            );
-            cy.get(cesc("#px")).should(
+            cy.get("#x").should("have.text", toMathJaxString(`x(${counter})`));
+            cy.get("#px").should(
                 "have.text",
                 `x: ${counter}, equation (${counter})`,
             );
-            cy.get(cesc("#etx")).should("have.text", `${counter}`);
-            cy.get(cesc("#rx")).should("have.text", `(${counter})`);
-            cy.get(cesc("#rx")).click();
-            cy.get(cesc("#x")).then((el) => {
+            cy.get("#etx").should("have.text", `${counter}`);
+            cy.get("#rx").should("have.text", `(${counter})`);
+            cy.get("#rx").click();
+            cy.get("#x").then((el) => {
                 let rect = el[0].getBoundingClientRect();
                 expect(rect.top).gt(-1).lt(5);
             });
@@ -183,18 +180,18 @@ describe("Math Display Tag Tests", { tags: ["@group2"] }, function () {
 
             cy.window().then(async (win) => {
                 counter++;
-                cy.get(cesc("#y")).should(
+                cy.get("#y").should(
                     "have.text",
                     toMathJaxString(`y(${counter})`),
                 );
-                cy.get(cesc("#py")).should(
+                cy.get("#py").should(
                     "have.text",
                     `y: ${counter}, equation (${counter})`,
                 );
-                cy.get(cesc("#ety")).should("have.text", `${counter}`);
-                cy.get(cesc("#ry")).should("have.text", `(${counter})`);
-                cy.get(cesc("#ry")).click();
-                cy.get(cesc("#y")).then((el) => {
+                cy.get("#ety").should("have.text", `${counter}`);
+                cy.get("#ry").should("have.text", `(${counter})`);
+                cy.get("#ry").click();
+                cy.get("#y").then((el) => {
                     let rect = el[0].getBoundingClientRect();
                     expect(rect.top).gt(-1).lt(5);
                 });
@@ -246,18 +243,18 @@ describe("Math Display Tag Tests", { tags: ["@group2"] }, function () {
 
             cy.window().then(async (win) => {
                 counter++;
-                cy.get(cesc("#z")).should(
+                cy.get("#z").should(
                     "have.text",
                     toMathJaxString(`z(${counter})`),
                 );
-                cy.get(cesc("#pz")).should(
+                cy.get("#pz").should(
                     "have.text",
                     `z: ${counter}, equation (${counter})`,
                 );
-                cy.get(cesc("#etz")).should("have.text", `${counter}`);
-                cy.get(cesc("#rz")).should("have.text", `(${counter})`);
-                cy.get(cesc("#rz")).click();
-                cy.get(cesc("#z")).then((el) => {
+                cy.get("#etz").should("have.text", `${counter}`);
+                cy.get("#rz").should("have.text", `(${counter})`);
+                cy.get("#rz").click();
+                cy.get("#z").then((el) => {
                     let rect = el[0].getBoundingClientRect();
                     expect(rect.top).gt(-1).lt(5);
                 });
@@ -266,40 +263,40 @@ describe("Math Display Tag Tests", { tags: ["@group2"] }, function () {
 
         checkEquationNumbering(2, 1);
 
-        cy.get(cesc("#m") + " textarea").type(`{end}{backspace}4{enter}`, {
+        cy.get("#m" + " textarea").type(`{end}{backspace}4{enter}`, {
             force: true,
         });
-        cy.get(cesc("#ma")).should("contain.text", "4");
+        cy.get("#ma").should("contain.text", "4");
         checkEquationNumbering(4, 1);
 
-        cy.get(cesc("#n") + " textarea").type(`{end}{backspace}2{enter}`, {
+        cy.get("#n" + " textarea").type(`{end}{backspace}2{enter}`, {
             force: true,
         });
-        cy.get(cesc("#na")).should("contain.text", "2");
+        cy.get("#na").should("contain.text", "2");
         checkEquationNumbering(4, 2);
 
-        cy.get(cesc("#m") + " textarea").type(`{end}{backspace}0{enter}`, {
+        cy.get("#m" + " textarea").type(`{end}{backspace}0{enter}`, {
             force: true,
         });
-        cy.get(cesc("#ma")).should("contain.text", "0");
+        cy.get("#ma").should("contain.text", "0");
         checkEquationNumbering(0, 2);
 
-        cy.get(cesc("#n") + " textarea").type(`{end}{backspace}6{enter}`, {
+        cy.get("#n" + " textarea").type(`{end}{backspace}6{enter}`, {
             force: true,
         });
-        cy.get(cesc("#na")).should("contain.text", "6");
+        cy.get("#na").should("contain.text", "6");
         checkEquationNumbering(0, 6);
 
-        cy.get(cesc("#m") + " textarea").type(`{end}{backspace}3{enter}`, {
+        cy.get("#m" + " textarea").type(`{end}{backspace}3{enter}`, {
             force: true,
         });
-        cy.get(cesc("#ma")).should("contain.text", "3");
+        cy.get("#ma").should("contain.text", "3");
         checkEquationNumbering(3, 6);
 
-        cy.get(cesc("#n") + " textarea").type(`{end}{backspace}1{enter}`, {
+        cy.get("#n" + " textarea").type(`{end}{backspace}1{enter}`, {
             force: true,
         });
-        cy.get(cesc("#na")).should("contain.text", "1");
+        cy.get("#na").should("contain.text", "1");
         checkEquationNumbering(3, 1);
     });
 
@@ -356,24 +353,21 @@ describe("Math Display Tag Tests", { tags: ["@group2"] }, function () {
         function checkEquationNumbering(m, n) {
             let counter = 1;
 
-            cy.get(cesc("#x")).should(
-                "have.text",
-                toMathJaxString(`x(${counter})`),
-            );
-            cy.get(cesc("#px")).should(
+            cy.get("#x").should("have.text", toMathJaxString(`x(${counter})`));
+            cy.get("#px").should(
                 "have.text",
                 `x: ${counter}, equation (${counter})`,
             );
-            cy.get(cesc("#etx")).should("have.text", `${counter}`);
-            cy.get(cesc("#rx")).should("have.text", `(${counter})`);
-            cy.get(cesc("#rx")).click();
-            cy.get(cesc("#x")).then((el) => {
+            cy.get("#etx").should("have.text", `${counter}`);
+            cy.get("#rx").should("have.text", `(${counter})`);
+            cy.get("#rx").click();
+            cy.get("#x").then((el) => {
                 let rect = el[0].getBoundingClientRect();
                 expect(rect.top).gt(-1).lt(5);
             });
 
             cy.window().then(async (win) => {
-                cy.get(cesc("#ms")).should(
+                cy.get("#ms").should(
                     "have.text",
                     [
                         ...[...Array(m).keys()]
@@ -426,25 +420,25 @@ describe("Math Display Tag Tests", { tags: ["@group2"] }, function () {
 
             cy.window().then(async (win) => {
                 counter++;
-                cy.get(cesc("#y")).should(
+                cy.get("#y").should(
                     "have.text",
                     toMathJaxString(`y(${counter})`),
                 );
-                cy.get(cesc("#py")).should(
+                cy.get("#py").should(
                     "have.text",
                     `y: ${counter}, equation (${counter})`,
                 );
-                cy.get(cesc("#ety")).should("have.text", `${counter}`);
-                cy.get(cesc("#ry")).should("have.text", `(${counter})`);
-                cy.get(cesc("#ry")).click();
-                cy.get(cesc("#y")).then((el) => {
+                cy.get("#ety").should("have.text", `${counter}`);
+                cy.get("#ry").should("have.text", `(${counter})`);
+                cy.get("#ry").click();
+                cy.get("#y").then((el) => {
                     let rect = el[0].getBoundingClientRect();
                     expect(rect.top).gt(-1).lt(5);
                 });
             });
 
             cy.window().then(async (win) => {
-                cy.get(cesc("#ns")).should(
+                cy.get("#ns").should(
                     "have.text",
                     [
                         ...[...Array(n).keys()]
@@ -499,18 +493,18 @@ describe("Math Display Tag Tests", { tags: ["@group2"] }, function () {
 
             cy.window().then(async (win) => {
                 counter++;
-                cy.get(cesc("#z")).should(
+                cy.get("#z").should(
                     "have.text",
                     toMathJaxString(`z(${counter})`),
                 );
-                cy.get(cesc("#pz")).should(
+                cy.get("#pz").should(
                     "have.text",
                     `z: ${counter}, equation (${counter})`,
                 );
-                cy.get(cesc("#etz")).should("have.text", `${counter}`);
-                cy.get(cesc("#rz")).should("have.text", `(${counter})`);
-                cy.get(cesc("#rz")).click();
-                cy.get(cesc("#z")).then((el) => {
+                cy.get("#etz").should("have.text", `${counter}`);
+                cy.get("#rz").should("have.text", `(${counter})`);
+                cy.get("#rz").click();
+                cy.get("#z").then((el) => {
                     let rect = el[0].getBoundingClientRect();
                     expect(rect.top).gt(-1).lt(5);
                 });
@@ -519,40 +513,40 @@ describe("Math Display Tag Tests", { tags: ["@group2"] }, function () {
 
         checkEquationNumbering(2, 1);
 
-        cy.get(cesc("#m") + " textarea").type(`{end}{backspace}4{enter}`, {
+        cy.get("#m" + " textarea").type(`{end}{backspace}4{enter}`, {
             force: true,
         });
-        cy.get(cesc("#ma")).should("contain.text", "4");
+        cy.get("#ma").should("contain.text", "4");
         checkEquationNumbering(4, 1);
 
-        cy.get(cesc("#n") + " textarea").type(`{end}{backspace}2{enter}`, {
+        cy.get("#n" + " textarea").type(`{end}{backspace}2{enter}`, {
             force: true,
         });
-        cy.get(cesc("#na")).should("contain.text", "2");
+        cy.get("#na").should("contain.text", "2");
         checkEquationNumbering(4, 2);
 
-        cy.get(cesc("#m") + " textarea").type(`{end}{backspace}0{enter}`, {
+        cy.get("#m" + " textarea").type(`{end}{backspace}0{enter}`, {
             force: true,
         });
-        cy.get(cesc("#ma")).should("contain.text", "0");
+        cy.get("#ma").should("contain.text", "0");
         checkEquationNumbering(0, 2);
 
-        cy.get(cesc("#n") + " textarea").type(`{end}{backspace}6{enter}`, {
+        cy.get("#n" + " textarea").type(`{end}{backspace}6{enter}`, {
             force: true,
         });
-        cy.get(cesc("#na")).should("contain.text", "6");
+        cy.get("#na").should("contain.text", "6");
         checkEquationNumbering(0, 6);
 
-        cy.get(cesc("#m") + " textarea").type(`{end}{backspace}3{enter}`, {
+        cy.get("#m" + " textarea").type(`{end}{backspace}3{enter}`, {
             force: true,
         });
-        cy.get(cesc("#ma")).should("contain.text", "3");
+        cy.get("#ma").should("contain.text", "3");
         checkEquationNumbering(3, 6);
 
-        cy.get(cesc("#n") + " textarea").type(`{end}{backspace}1{enter}`, {
+        cy.get("#n" + " textarea").type(`{end}{backspace}1{enter}`, {
             force: true,
         });
-        cy.get(cesc("#na")).should("contain.text", "1");
+        cy.get("#na").should("contain.text", "1");
         checkEquationNumbering(3, 1);
     });
 
@@ -609,19 +603,16 @@ describe("Math Display Tag Tests", { tags: ["@group2"] }, function () {
         function checkEquationNumbering(m, n) {
             let counter = 1;
 
-            cy.get(cesc("#x")).should(
-                "have.text",
-                toMathJaxString(`x(${counter})`),
-            );
-            cy.get(cesc("#px")).should(
+            cy.get("#x").should("have.text", toMathJaxString(`x(${counter})`));
+            cy.get("#px").should(
                 "have.text",
                 `x: ${counter}, equation (${counter})`,
             );
-            cy.get(cesc("#etx")).should("have.text", `${counter}`);
-            cy.get(cesc("#rx")).should("have.text", `(${counter})`);
-            cy.get(cesc("#rx")).click();
+            cy.get("#etx").should("have.text", `${counter}`);
+            cy.get("#rx").should("have.text", `(${counter})`);
+            cy.get("#rx").click();
             cy.url().should("match", RegExp(cesc(`#x`) + "$"));
-            cy.get(cesc("#x")).then((el) => {
+            cy.get("#x").then((el) => {
                 let rect = el[0].getBoundingClientRect();
                 expect(rect.top).gt(-1).lt(5);
             });
@@ -682,7 +673,7 @@ describe("Math Display Tag Tests", { tags: ["@group2"] }, function () {
                 });
             }
             cy.window().then(async (win) => {
-                cy.get(cesc("#ms")).should(
+                cy.get("#ms").should(
                     "have.text",
                     [...mPieces, ...mCounterPieces].join(""),
                 );
@@ -706,19 +697,19 @@ describe("Math Display Tag Tests", { tags: ["@group2"] }, function () {
 
             cy.window().then(async (win) => {
                 counter++;
-                cy.get(cesc("#y")).should(
+                cy.get("#y").should(
                     "have.text",
                     toMathJaxString(`y(${counter})`),
                 );
-                cy.get(cesc("#py")).should(
+                cy.get("#py").should(
                     "have.text",
                     `y: ${counter}, equation (${counter})`,
                 );
-                cy.get(cesc("#ety")).should("have.text", `${counter}`);
-                cy.get(cesc("#ry")).should("have.text", `(${counter})`);
-                cy.get(cesc("#ry")).click();
+                cy.get("#ety").should("have.text", `${counter}`);
+                cy.get("#ry").should("have.text", `(${counter})`);
+                cy.get("#ry").click();
                 cy.url().should("match", RegExp(cesc(`#y`) + "$"));
-                cy.get(cesc("#y")).then((el) => {
+                cy.get("#y").then((el) => {
                     let rect = el[0].getBoundingClientRect();
                     expect(rect.top).gt(-1).lt(5);
                 });
@@ -779,7 +770,7 @@ describe("Math Display Tag Tests", { tags: ["@group2"] }, function () {
             }
 
             cy.window().then(async (win) => {
-                cy.get(cesc("#ns")).should(
+                cy.get("#ns").should(
                     "have.text",
                     [...nPieces, ...nCounterPieces].join(""),
                 );
@@ -803,19 +794,19 @@ describe("Math Display Tag Tests", { tags: ["@group2"] }, function () {
 
             cy.window().then(async (win) => {
                 counter++;
-                cy.get(cesc("#z")).should(
+                cy.get("#z").should(
                     "have.text",
                     toMathJaxString(`z(${counter})`),
                 );
-                cy.get(cesc("#pz")).should(
+                cy.get("#pz").should(
                     "have.text",
                     `z: ${counter}, equation (${counter})`,
                 );
-                cy.get(cesc("#etz")).should("have.text", `${counter}`);
-                cy.get(cesc("#rz")).should("have.text", `(${counter})`);
-                cy.get(cesc("#rz")).click();
+                cy.get("#etz").should("have.text", `${counter}`);
+                cy.get("#rz").should("have.text", `(${counter})`);
+                cy.get("#rz").click();
                 cy.url().should("match", RegExp(cesc(`#z`) + "$"));
-                cy.get(cesc("#z")).then((el) => {
+                cy.get("#z").then((el) => {
                     let rect = el[0].getBoundingClientRect();
                     expect(rect.top).gt(-1).lt(5);
                 });
@@ -824,40 +815,40 @@ describe("Math Display Tag Tests", { tags: ["@group2"] }, function () {
 
         checkEquationNumbering(2, 1);
 
-        cy.get(cesc("#m") + " textarea").type(`{end}{backspace}4{enter}`, {
+        cy.get("#m" + " textarea").type(`{end}{backspace}4{enter}`, {
             force: true,
         });
-        cy.get(cesc("#ma")).should("contain.text", "4");
+        cy.get("#ma").should("contain.text", "4");
         checkEquationNumbering(4, 1);
 
-        cy.get(cesc("#n") + " textarea").type(`{end}{backspace}2{enter}`, {
+        cy.get("#n" + " textarea").type(`{end}{backspace}2{enter}`, {
             force: true,
         });
-        cy.get(cesc("#na")).should("contain.text", "2");
+        cy.get("#na").should("contain.text", "2");
         checkEquationNumbering(4, 2);
 
-        cy.get(cesc("#m") + " textarea").type(`{end}{backspace}0{enter}`, {
+        cy.get("#m" + " textarea").type(`{end}{backspace}0{enter}`, {
             force: true,
         });
-        cy.get(cesc("#ma")).should("contain.text", "0");
+        cy.get("#ma").should("contain.text", "0");
         checkEquationNumbering(0, 2);
 
-        cy.get(cesc("#n") + " textarea").type(`{end}{backspace}6{enter}`, {
+        cy.get("#n" + " textarea").type(`{end}{backspace}6{enter}`, {
             force: true,
         });
-        cy.get(cesc("#na")).should("contain.text", "6");
+        cy.get("#na").should("contain.text", "6");
         checkEquationNumbering(0, 6);
 
-        cy.get(cesc("#m") + " textarea").type(`{end}{backspace}3{enter}`, {
+        cy.get("#m" + " textarea").type(`{end}{backspace}3{enter}`, {
             force: true,
         });
-        cy.get(cesc("#ma")).should("contain.text", "3");
+        cy.get("#ma").should("contain.text", "3");
         checkEquationNumbering(3, 6);
 
-        cy.get(cesc("#n") + " textarea").type(`{end}{backspace}1{enter}`, {
+        cy.get("#n" + " textarea").type(`{end}{backspace}1{enter}`, {
             force: true,
         });
-        cy.get(cesc("#na")).should("contain.text", "1");
+        cy.get("#na").should("contain.text", "1");
         checkEquationNumbering(3, 1);
     });
 
@@ -877,9 +868,9 @@ describe("Math Display Tag Tests", { tags: ["@group2"] }, function () {
             );
         });
 
-        cy.get(cesc("#cancel")).should("have.text", toMathJaxString("x"));
-        cy.get(cesc("#bcancel")).should("have.text", toMathJaxString("y"));
-        cy.get(cesc("#bbox")).should("have.text", toMathJaxString("R"));
-        cy.get(cesc("#circle")).should("have.text", toMathJaxString("1"));
+        cy.get("#cancel").should("have.text", toMathJaxString("x"));
+        cy.get("#bcancel").should("have.text", toMathJaxString("y"));
+        cy.get("#bbox").should("have.text", toMathJaxString("R"));
+        cy.get("#circle").should("have.text", toMathJaxString("1"));
     });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/matrixinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/matrixinput.cy.js
@@ -1,4 +1,3 @@
-import { cesc } from "@doenet/utils";
 import { toMathJaxString } from "../../../src/util/mathDisplay";
 
 describe("MatrixInput Tag Tests", { tags: ["@group4"] }, function () {
@@ -29,10 +28,10 @@ describe("MatrixInput Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#n") + " textarea").type("1", { force: true });
+        cy.get("#n" + " textarea").type("1", { force: true });
 
-        cy.get(cesc("#piv")).should("have.text", "immediate value: [1]");
-        cy.get(cesc("#pv")).should("contain.text", "[\uff3f]");
+        cy.get("#piv").should("have.text", "immediate value: [1]");
+        cy.get("#pv").should("contain.text", "[\uff3f]");
 
         cy.wait(1500); // wait for debounce
 
@@ -47,8 +46,8 @@ describe("MatrixInput Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#pv")).should("have.text", "value: [1]");
-        cy.get(cesc("#piv")).should("have.text", "immediate value: [1]");
+        cy.get("#pv").should("have.text", "value: [1]");
+        cy.get("#piv").should("have.text", "immediate value: [1]");
     });
 
     it("with description", () => {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/paginator.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/paginator.cy.js
@@ -61,7 +61,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+        cy.get("#a").should("have.text", "a"); //wait for page to load
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -82,39 +82,39 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                 cesc("#_id_" + mathInput4Idx) + " .mq-editable-field";
             let answer4Button = cesc("#_id_" + mathInput4Idx + "_button");
 
-            cy.get(cesc("#ca")).should("have.text", "0");
-            cy.get(cesc("#title1")).should("have.text", "Page 1");
-            cy.get(cesc("#section2_title")).should("not.exist");
-            cy.get(cesc("#title2")).should("not.exist");
+            cy.get("#ca").should("have.text", "0");
+            cy.get("#title1").should("have.text", "Page 1");
+            cy.get("#section2_title").should("not.exist");
+            cy.get("#title2").should("not.exist");
 
             cy.get(mathInput4Anchor).type("4{enter}", { force: true });
 
             cy.get(answer4Button).should("contain.text", "Correct");
-            cy.get(cesc("#ca")).should("have.text", "0.25");
+            cy.get("#ca").should("have.text", "0.25");
 
             cy.get(mathInput4DisplayAnchor).should("contain.text", "4");
 
             cy.get(mathInput1Anchor).type("2{enter}", { force: true });
 
             cy.get(answer1Button).should("contain.text", "Correct");
-            cy.get(cesc("#ca")).should("have.text", "0.5");
+            cy.get("#ca").should("have.text", "0.5");
             cy.get(mathInput1DisplayAnchor).should("contain.text", "2");
 
             cy.log("move to page 2");
-            cy.get(cesc("#pcontrols_next")).click();
-            cy.get(cesc("#title1")).should("not.exist");
-            cy.get(cesc("#section2_title")).should("have.text", "Section 2");
-            cy.get(cesc("#title2")).should("not.exist");
+            cy.get("#pcontrols_next").click();
+            cy.get("#title1").should("not.exist");
+            cy.get("#section2_title").should("have.text", "Section 2");
+            cy.get("#title2").should("not.exist");
 
             cy.get(answer4Button).should("contain.text", "Correct");
             cy.get(mathInput4DisplayAnchor).should("contain.text", "4");
 
-            cy.get(cesc("#ca")).should("have.text", "0.5");
+            cy.get("#ca").should("have.text", "0.5");
 
-            cy.get(cesc("#name_input")).type("Me{enter}");
-            cy.get(cesc("#p3")).should("have.text", "Hello, Me!");
-            cy.get(cesc("#ca")).should("have.text", "0.5");
-            cy.get(cesc("#name_input")).should("have.value", "Me");
+            cy.get("#name_input").type("Me{enter}");
+            cy.get("#p3").should("have.text", "Hello, Me!");
+            cy.get("#ca").should("have.text", "0.5");
+            cy.get("#name_input").should("have.value", "Me");
 
             cy.get(mathInput1Anchor).should("not.exist");
 
@@ -122,32 +122,32 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             cy.get(answer4Button).should("contain.text", "Check Work");
             cy.get(mathInput4Anchor).type("{enter}", { force: true });
             cy.get(answer4Button).should("contain.text", "Incorrect");
-            cy.get(cesc("#ca")).should("have.text", "0.25");
+            cy.get("#ca").should("have.text", "0.25");
             cy.get(mathInput4DisplayAnchor).should("contain.text", "3");
 
             cy.log("back to page 1");
-            cy.get(cesc("#pcontrols_previous")).click();
-            cy.get(cesc("#title1")).should("have.text", "Page 1");
-            cy.get(cesc("#section2_title")).should("not.exist");
-            cy.get(cesc("#title2")).should("not.exist");
+            cy.get("#pcontrols_previous").click();
+            cy.get("#title1").should("have.text", "Page 1");
+            cy.get("#section2_title").should("not.exist");
+            cy.get("#title2").should("not.exist");
 
             cy.get(answer1Button).should("contain.text", "Correct");
-            cy.get(cesc("#ca")).should("have.text", "0.25");
+            cy.get("#ca").should("have.text", "0.25");
             cy.get(mathInput1DisplayAnchor).should("contain.text", "2");
 
-            cy.get(cesc("#name")).should("not.exist");
+            cy.get("#name").should("not.exist");
 
             cy.log("back to second page");
-            cy.get(cesc("#nextPage_button")).click();
-            cy.get(cesc("#title1")).should("not.exist");
-            cy.get(cesc("#section2_title")).should("have.text", "Section 2");
-            cy.get(cesc("#title2")).should("not.exist");
+            cy.get("#nextPage_button").click();
+            cy.get("#title1").should("not.exist");
+            cy.get("#section2_title").should("have.text", "Section 2");
+            cy.get("#title2").should("not.exist");
 
-            cy.get(cesc("#name_input")).should("have.value", "Me");
-            cy.get(cesc("#p3")).should("have.text", "Hello, Me!");
+            cy.get("#name_input").should("have.value", "Me");
+            cy.get("#p3").should("have.text", "Hello, Me!");
 
             cy.get(answer4Button).should("contain.text", "Incorrect");
-            cy.get(cesc("#ca")).should("have.text", "0.25");
+            cy.get("#ca").should("have.text", "0.25");
             cy.get(mathInput4DisplayAnchor).should("contain.text", "3");
 
             cy.get(mathInput4Anchor).type("{end}{backspace}4", { force: true });
@@ -155,21 +155,21 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             cy.get(mathInput4Anchor).type("{enter}", { force: true });
 
             cy.get(answer4Button).should("contain.text", "Correct");
-            cy.get(cesc("#ca")).should("have.text", "0.5");
+            cy.get("#ca").should("have.text", "0.5");
             cy.get(mathInput4DisplayAnchor).should("contain.text", "4");
 
             cy.log("on to third page");
-            cy.get(cesc("#pcontrols_next")).click();
-            cy.get(cesc("#title1")).should("not.exist");
-            cy.get(cesc("#section2_title")).should("not.exist");
-            cy.get(cesc("#title2")).should("have.text", "Page 3");
+            cy.get("#pcontrols_next").click();
+            cy.get("#title1").should("not.exist");
+            cy.get("#section2_title").should("not.exist");
+            cy.get("#title2").should("have.text", "Page 3");
 
             cy.get(answer4Button).should("contain.text", "Correct");
-            cy.get(cesc("#ca")).should("have.text", "0.5");
+            cy.get("#ca").should("have.text", "0.5");
             cy.get(mathInput4DisplayAnchor).should("contain.text", "4");
 
-            // cy.get(cesc('#mxx') + ' .mjx-mrow').should('contain.text', 'x+x')
-            // cy.get(cesc('#myy') + ' .mjx-mrow').should('contain.text', 'y+y')
+            // cy.get('#mxx' + ' .mjx-mrow').should('contain.text', 'x+x')
+            // cy.get('#myy' + ' .mjx-mrow').should('contain.text', 'y+y')
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
@@ -194,12 +194,12 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
 
                 cy.get(mathInput2Anchor).type("2x{enter}", { force: true });
                 cy.get(answer2Button).should("contain.text", "Correct");
-                cy.get(cesc("#ca")).should("have.text", "0.75");
+                cy.get("#ca").should("have.text", "0.75");
                 cy.get(mathInput2DisplayAnchor).should("contain.text", "2x");
 
                 cy.get(mathInput3Anchor).type("2y{enter}", { force: true });
                 cy.get(answer3Button).should("contain.text", "Correct");
-                cy.get(cesc("#ca")).should("have.text", "1");
+                cy.get("#ca").should("have.text", "1");
                 cy.get(mathInput3DisplayAnchor).should("contain.text", "2y");
 
                 cy.get(mathInput2Anchor).type("{end}{backspace}z", {
@@ -208,33 +208,30 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                 cy.get(answer2Button).should("contain.text", "Check Work");
                 cy.get(mathInput2Anchor).type("{enter}", { force: true });
                 cy.get(answer2Button).should("contain.text", "Incorrect");
-                cy.get(cesc("#ca")).should("have.text", "0.75");
+                cy.get("#ca").should("have.text", "0.75");
                 cy.get(mathInput2DisplayAnchor).should("contain.text", "2z");
 
                 cy.log("back to second page");
-                cy.get(cesc("#prevPage_button")).click();
-                cy.get(cesc("#title1")).should("not.exist");
-                cy.get(cesc("#section2_title")).should(
-                    "have.text",
-                    "Section 2",
-                );
-                cy.get(cesc("#title2")).should("not.exist");
+                cy.get("#prevPage_button").click();
+                cy.get("#title1").should("not.exist");
+                cy.get("#section2_title").should("have.text", "Section 2");
+                cy.get("#title2").should("not.exist");
 
-                cy.get(cesc("#name_input")).should("have.value", "Me");
-                cy.get(cesc("#p3")).should("have.text", "Hello, Me!");
+                cy.get("#name_input").should("have.value", "Me");
+                cy.get("#p3").should("have.text", "Hello, Me!");
 
                 cy.get(answer4Button).should("contain.text", "Correct");
-                cy.get(cesc("#ca")).should("have.text", "0.75");
+                cy.get("#ca").should("have.text", "0.75");
                 cy.get(mathInput4DisplayAnchor).should("contain.text", "4");
 
                 cy.log("back to third page");
-                cy.get(cesc("#pcontrols_next")).click();
-                cy.get(cesc("#title1")).should("not.exist");
-                cy.get(cesc("#section2_title")).should("not.exist");
-                cy.get(cesc("#title2")).should("have.text", "Page 3");
+                cy.get("#pcontrols_next").click();
+                cy.get("#title1").should("not.exist");
+                cy.get("#section2_title").should("not.exist");
+                cy.get("#title2").should("have.text", "Page 3");
 
                 cy.get(answer4Button).should("contain.text", "Correct");
-                cy.get(cesc("#ca")).should("have.text", "0.75");
+                cy.get("#ca").should("have.text", "0.75");
                 cy.get(mathInput4DisplayAnchor).should("contain.text", "4");
 
                 cy.get(answer2Button).should("contain.text", "Incorrect");
@@ -243,22 +240,19 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                 cy.get(answer3Button).should("contain.text", "Correct");
                 cy.get(mathInput3DisplayAnchor).should("contain.text", "2y");
 
-                cy.get(cesc("#ca")).should("have.text", "0.75");
+                cy.get("#ca").should("have.text", "0.75");
 
                 cy.log("back to second page");
-                cy.get(cesc("#prevPage_button")).click();
-                cy.get(cesc("#title1")).should("not.exist");
-                cy.get(cesc("#section2_title")).should(
-                    "have.text",
-                    "Section 2",
-                );
-                cy.get(cesc("#title2")).should("not.exist");
+                cy.get("#prevPage_button").click();
+                cy.get("#title1").should("not.exist");
+                cy.get("#section2_title").should("have.text", "Section 2");
+                cy.get("#title2").should("not.exist");
 
-                cy.get(cesc("#name_input")).should("have.value", "Me");
-                cy.get(cesc("#p3")).should("have.text", "Hello, Me!");
+                cy.get("#name_input").should("have.value", "Me");
+                cy.get("#p3").should("have.text", "Hello, Me!");
 
                 cy.get(answer4Button).should("contain.text", "Correct");
-                cy.get(cesc("#ca")).should("have.text", "0.75");
+                cy.get("#ca").should("have.text", "0.75");
                 cy.get(mathInput4DisplayAnchor).should("contain.text", "4");
             });
         });
@@ -275,7 +269,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+        cy.get("#a").should("have.text", "a"); //wait for page to load
 
         cy.log("on page two");
 
@@ -287,9 +281,9 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             }),
         );
 
-        cy.get(cesc("#title1")).should("not.exist");
-        cy.get(cesc("#section2_title")).should("have.text", "Section 2");
-        cy.get(cesc("#title2")).should("not.exist");
+        cy.get("#title1").should("not.exist");
+        cy.get("#section2_title").should("have.text", "Section 2");
+        cy.get("#title2").should("not.exist");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -302,29 +296,29 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                 cesc("#_id_" + mathInput4Idx) + " .mq-editable-field";
             let answer4Button = cesc("#_id_" + mathInput4Idx + "_button");
 
-            cy.get(cesc("#name_input")).should("have.value", "Me");
-            cy.get(cesc("#p3")).should("have.text", "Hello, Me!");
+            cy.get("#name_input").should("have.value", "Me");
+            cy.get("#p3").should("have.text", "Hello, Me!");
 
             cy.get(answer4Button).should("contain.text", "Correct");
-            cy.get(cesc("#ca")).should("have.text", "0.75");
+            cy.get("#ca").should("have.text", "0.75");
             cy.get(mathInput4DisplayAnchor).should("contain.text", "4");
 
-            cy.get(cesc("#name_input")).clear().type("You{enter}");
-            cy.get(cesc("#name_input")).should("have.value", "You");
-            cy.get(cesc("#p3")).should("have.text", "Hello, You!");
+            cy.get("#name_input").clear().type("You{enter}");
+            cy.get("#name_input").should("have.value", "You");
+            cy.get("#p3").should("have.text", "Hello, You!");
 
             cy.get(answer4Button).should("contain.text", "Correct");
-            cy.get(cesc("#ca")).should("have.text", "0.75");
+            cy.get("#ca").should("have.text", "0.75");
             cy.get(mathInput4DisplayAnchor).should("contain.text", "4");
 
             cy.log("to third page");
-            cy.get(cesc("#pcontrols_next")).click();
-            cy.get(cesc("#title1")).should("not.exist");
-            cy.get(cesc("#section2_title")).should("not.exist");
-            cy.get(cesc("#title2")).should("have.text", "Page 3");
+            cy.get("#pcontrols_next").click();
+            cy.get("#title1").should("not.exist");
+            cy.get("#section2_title").should("not.exist");
+            cy.get("#title2").should("have.text", "Page 3");
 
             cy.get(answer4Button).should("contain.text", "Correct");
-            cy.get(cesc("#ca")).should("have.text", "0.75");
+            cy.get("#ca").should("have.text", "0.75");
             cy.get(mathInput4DisplayAnchor).should("contain.text", "4");
 
             cy.window().then(async (win) => {
@@ -359,7 +353,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                 cy.get(answer3Button).should("contain.text", "Check Work");
                 cy.get(mathInput3Anchor).type("{enter}", { force: true });
                 cy.get(answer3Button).should("contain.text", "Incorrect");
-                cy.get(cesc("#ca")).should("have.text", "0.5");
+                cy.get("#ca").should("have.text", "0.5");
                 cy.get(mathInput3DisplayAnchor).should("contain.text", "2q");
 
                 cy.get(mathInput4Anchor).type("{end}{backspace}3", {
@@ -368,7 +362,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                 cy.get(answer4Button).should("contain.text", "Check Work");
                 cy.get(mathInput4Anchor).type("{enter}", { force: true });
                 cy.get(answer4Button).should("contain.text", "Incorrect");
-                cy.get(cesc("#ca")).should("have.text", "0.25");
+                cy.get("#ca").should("have.text", "0.25");
                 cy.get(mathInput4DisplayAnchor).should("contain.text", "3");
 
                 cy.get(mathInput2Anchor).type("{end}{backspace}x", {
@@ -377,33 +371,30 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                 cy.get(answer2Button).should("contain.text", "Check Work");
                 cy.get(mathInput2Anchor).type("{enter}", { force: true });
                 cy.get(answer2Button).should("contain.text", "Correct");
-                cy.get(cesc("#ca")).should("have.text", "0.5");
+                cy.get("#ca").should("have.text", "0.5");
                 cy.get(mathInput2DisplayAnchor).should("contain.text", "2x");
 
                 cy.log("back to second page");
-                cy.get(cesc("#pcontrols_previous")).click();
-                cy.get(cesc("#title1")).should("not.exist");
-                cy.get(cesc("#section2_title")).should(
-                    "have.text",
-                    "Section 2",
-                );
-                cy.get(cesc("#title2")).should("not.exist");
+                cy.get("#pcontrols_previous").click();
+                cy.get("#title1").should("not.exist");
+                cy.get("#section2_title").should("have.text", "Section 2");
+                cy.get("#title2").should("not.exist");
 
-                cy.get(cesc("#name_input")).should("have.value", "You");
-                cy.get(cesc("#p3")).should("have.text", "Hello, You!");
+                cy.get("#name_input").should("have.value", "You");
+                cy.get("#p3").should("have.text", "Hello, You!");
 
                 cy.get(answer4Button).should("contain.text", "Incorrect");
-                cy.get(cesc("#ca")).should("have.text", "0.5");
+                cy.get("#ca").should("have.text", "0.5");
                 cy.get(mathInput4DisplayAnchor).should("contain.text", "3");
 
                 cy.log("to first page");
-                cy.get(cesc("#pcontrols_previous")).click();
-                cy.get(cesc("#title1")).should("have.text", "Page 1");
-                cy.get(cesc("#section2_title")).should("not.exist");
-                cy.get(cesc("#title2")).should("not.exist");
+                cy.get("#pcontrols_previous").click();
+                cy.get("#title1").should("have.text", "Page 1");
+                cy.get("#section2_title").should("not.exist");
+                cy.get("#title2").should("not.exist");
 
                 cy.get(answer4Button).should("contain.text", "Incorrect");
-                cy.get(cesc("#ca")).should("have.text", "0.5");
+                cy.get("#ca").should("have.text", "0.5");
                 cy.get(mathInput4DisplayAnchor).should("contain.text", "3");
 
                 cy.window().then(async (win) => {
@@ -431,22 +422,19 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                         "contain.text",
                         "2−",
                     );
-                    cy.get(cesc("#ca")).should("have.text", "0.25");
+                    cy.get("#ca").should("have.text", "0.25");
 
                     cy.log("back to second page");
-                    cy.get(cesc("#pcontrols_next")).click();
-                    cy.get(cesc("#title1")).should("not.exist");
-                    cy.get(cesc("#section2_title")).should(
-                        "have.text",
-                        "Section 2",
-                    );
-                    cy.get(cesc("#title2")).should("not.exist");
+                    cy.get("#pcontrols_next").click();
+                    cy.get("#title1").should("not.exist");
+                    cy.get("#section2_title").should("have.text", "Section 2");
+                    cy.get("#title2").should("not.exist");
 
                     cy.log("back to first page");
-                    cy.get(cesc("#pcontrols_previous")).click();
-                    cy.get(cesc("#title1")).should("have.text", "Page 1");
-                    cy.get(cesc("#section2_title")).should("not.exist");
-                    cy.get(cesc("#title2")).should("not.exist");
+                    cy.get("#pcontrols_previous").click();
+                    cy.get("#title1").should("have.text", "Page 1");
+                    cy.get("#section2_title").should("not.exist");
+                    cy.get("#title2").should("not.exist");
 
                     cy.get(answer1Button).should("contain.text", "Incorrect");
                     cy.get(mathInput1DisplayAnchor).should(
@@ -456,18 +444,15 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
 
                     cy.log("to third page");
 
-                    cy.get(cesc("#pcontrols_next")).click();
-                    cy.get(cesc("#title1")).should("not.exist");
-                    cy.get(cesc("#section2_title")).should(
-                        "have.text",
-                        "Section 2",
-                    );
-                    cy.get(cesc("#title2")).should("not.exist");
+                    cy.get("#pcontrols_next").click();
+                    cy.get("#title1").should("not.exist");
+                    cy.get("#section2_title").should("have.text", "Section 2");
+                    cy.get("#title2").should("not.exist");
 
-                    cy.get(cesc("#pcontrols_next")).click();
-                    cy.get(cesc("#title1")).should("not.exist");
-                    cy.get(cesc("#section2_title")).should("not.exist");
-                    cy.get(cesc("#title2")).should("have.text", "Page 3");
+                    cy.get("#pcontrols_next").click();
+                    cy.get("#title1").should("not.exist");
+                    cy.get("#section2_title").should("not.exist");
+                    cy.get("#title2").should("have.text", "Page 3");
 
                     cy.get(answer3Button).should("contain.text", "Incorrect");
                     cy.get(mathInput3DisplayAnchor).should(
@@ -483,7 +468,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                         "contain.text",
                         "2x",
                     );
-                    cy.get(cesc("#ca")).should("have.text", "0.25");
+                    cy.get("#ca").should("have.text", "0.25");
 
                     cy.get(mathInput2Anchor)
                         .type("{end}:", { force: true })
@@ -493,22 +478,19 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                         "contain.text",
                         "2x:",
                     );
-                    cy.get(cesc("#ca")).should("have.text", "0.25");
+                    cy.get("#ca").should("have.text", "0.25");
 
                     cy.log("to second page");
-                    cy.get(cesc("#pcontrols_previous")).click();
-                    cy.get(cesc("#title1")).should("not.exist");
-                    cy.get(cesc("#section2_title")).should(
-                        "have.text",
-                        "Section 2",
-                    );
-                    cy.get(cesc("#title2")).should("not.exist");
+                    cy.get("#pcontrols_previous").click();
+                    cy.get("#title1").should("not.exist");
+                    cy.get("#section2_title").should("have.text", "Section 2");
+                    cy.get("#title2").should("not.exist");
 
                     cy.log("back to third page");
-                    cy.get(cesc("#pcontrols_next")).click();
-                    cy.get(cesc("#title1")).should("not.exist");
-                    cy.get(cesc("#section2_title")).should("not.exist");
-                    cy.get(cesc("#title2")).should("have.text", "Page 3");
+                    cy.get("#pcontrols_next").click();
+                    cy.get("#title1").should("not.exist");
+                    cy.get("#section2_title").should("not.exist");
+                    cy.get("#title2").should("have.text", "Page 3");
 
                     cy.get(answer2Button).should("contain.text", "Check Work");
                     cy.get(mathInput2DisplayAnchor).should(
@@ -522,7 +504,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                     );
                     cy.get(answer4Button).should("contain.text", "Incorrect");
                     cy.get(mathInput4DisplayAnchor).should("contain.text", "3");
-                    cy.get(cesc("#ca")).should("have.text", "0.25");
+                    cy.get("#ca").should("have.text", "0.25");
                 });
             });
         });
@@ -539,7 +521,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+        cy.get("#a").should("have.text", "a"); //wait for page to load
 
         // wait until core is loaded
         cy.waitUntil(() =>
@@ -550,9 +532,9 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
         );
 
         cy.log("on third page without first and second defined");
-        cy.get(cesc("#title1")).should("not.exist");
-        cy.get(cesc("#section2_title")).should("not.exist");
-        cy.get(cesc("#title2")).should("have.text", "Page 3");
+        cy.get("#title1").should("not.exist");
+        cy.get("#section2_title").should("not.exist");
+        cy.get("#title2").should("have.text", "Page 3");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -587,41 +569,41 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             cy.get(mathInput3DisplayAnchor).should("contain.text", "2q");
             cy.get(answer4Button).should("contain.text", "Incorrect");
             cy.get(mathInput4DisplayAnchor).should("contain.text", "3");
-            cy.get(cesc("#ca")).should("have.text", "0.25");
+            cy.get("#ca").should("have.text", "0.25");
 
             cy.log("to second page");
-            cy.get(cesc("#pcontrols_previous")).click();
-            cy.get(cesc("#title1")).should("not.exist");
-            cy.get(cesc("#section2_title")).should("have.text", "Section 2");
-            cy.get(cesc("#title2")).should("not.exist");
+            cy.get("#pcontrols_previous").click();
+            cy.get("#title1").should("not.exist");
+            cy.get("#section2_title").should("have.text", "Section 2");
+            cy.get("#title2").should("not.exist");
 
-            cy.get(cesc("#name_input")).should("have.value", "You");
-            cy.get(cesc("#p3")).should("have.text", "Hello, You!");
+            cy.get("#name_input").should("have.value", "You");
+            cy.get("#p3").should("have.text", "Hello, You!");
 
             cy.get(answer4Button).should("contain.text", "Incorrect");
-            cy.get(cesc("#ca")).should("have.text", "0.25");
+            cy.get("#ca").should("have.text", "0.25");
             cy.get(mathInput4DisplayAnchor).should("contain.text", "3");
 
             cy.log("back to third page");
-            cy.get(cesc("#pcontrols_next")).click();
+            cy.get("#pcontrols_next").click();
             cy.get(answer2Button).should("contain.text", "Check Work");
             cy.get(mathInput2DisplayAnchor).should("contain.text", "2x:");
             cy.get(answer3Button).should("contain.text", "Incorrect");
             cy.get(mathInput3DisplayAnchor).should("contain.text", "2q");
             cy.get(answer4Button).should("contain.text", "Incorrect");
             cy.get(mathInput4DisplayAnchor).should("contain.text", "3");
-            cy.get(cesc("#ca")).should("have.text", "0.25");
+            cy.get("#ca").should("have.text", "0.25");
 
             cy.log("to first page");
-            cy.get(cesc("#pcontrols_previous")).click();
-            cy.get(cesc("#title1")).should("not.exist");
-            cy.get(cesc("#section2_title")).should("have.text", "Section 2");
-            cy.get(cesc("#title2")).should("not.exist");
+            cy.get("#pcontrols_previous").click();
+            cy.get("#title1").should("not.exist");
+            cy.get("#section2_title").should("have.text", "Section 2");
+            cy.get("#title2").should("not.exist");
 
-            cy.get(cesc("#pcontrols_previous")).click();
-            cy.get(cesc("#title1")).should("have.text", "Page 1");
-            cy.get(cesc("#section2_title")).should("not.exist");
-            cy.get(cesc("#title2")).should("not.exist");
+            cy.get("#pcontrols_previous").click();
+            cy.get("#title1").should("have.text", "Page 1");
+            cy.get("#section2_title").should("not.exist");
+            cy.get("#title2").should("not.exist");
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
@@ -637,7 +619,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
 
                 cy.get(answer1Button).should("contain.text", "Incorrect");
                 cy.get(mathInput1DisplayAnchor).should("contain.text", "2−");
-                cy.get(cesc("#ca")).should("have.text", "0.25");
+                cy.get("#ca").should("have.text", "0.25");
 
                 cy.get(answer4Button).should("contain.text", "Incorrect");
                 cy.get(mathInput4DisplayAnchor).should("contain.text", "3");
@@ -681,7 +663,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+        cy.get("#a").should("have.text", "a"); //wait for page to load
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -694,18 +676,18 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                 cesc("#_id_" + textInput1Idx) + " .mq-editable-field";
             let answer1Button = cesc("#_id_" + textInput1Idx + "_button");
 
-            cy.get(cesc("#problem1_title")).should("have.text", "Problem 1");
+            cy.get("#problem1_title").should("have.text", "Problem 1");
 
-            cy.get(cesc("#ca")).should("have.text", "0");
+            cy.get("#ca").should("have.text", "0");
 
             cy.get(textInput1Anchor).type("a{enter}");
 
             cy.get(answer1Button).should("contain.text", "Correct");
-            cy.get(cesc("#ca")).should("have.text", "0.167");
+            cy.get("#ca").should("have.text", "0.167");
 
-            cy.get(cesc("#pcontrols_next")).click();
-            cy.get(cesc("#problem2_title")).should("have.text", "Problem 2");
-            cy.get(cesc("#ca")).should("have.text", "0.167");
+            cy.get("#pcontrols_next").click();
+            cy.get("#problem2_title").should("have.text", "Problem 2");
+            cy.get("#ca").should("have.text", "0.167");
 
             cy.wait(200);
 
@@ -722,12 +704,9 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
 
                 cy.get(answer2Button).should("contain.text", "Check Work");
 
-                cy.get(cesc("#pcontrols_next")).click();
-                cy.get(cesc("#problem3_title")).should(
-                    "have.text",
-                    "Problem 3",
-                );
-                cy.get(cesc("#ca")).should("have.text", "0.167");
+                cy.get("#pcontrols_next").click();
+                cy.get("#problem3_title").should("have.text", "Problem 3");
+                cy.get("#ca").should("have.text", "0.167");
 
                 cy.window().then(async (win) => {
                     let stateVariables = await win.returnAllStateVariables1();
@@ -745,24 +724,18 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
 
                     cy.get(answer3Button).should("contain.text", "Check Work");
 
-                    cy.get(cesc("#pcontrols_previous")).click();
-                    cy.get(cesc("#problem2_title")).should(
-                        "have.text",
-                        "Problem 2",
-                    );
-                    cy.get(cesc("#ca")).should("have.text", "0.167");
+                    cy.get("#pcontrols_previous").click();
+                    cy.get("#problem2_title").should("have.text", "Problem 2");
+                    cy.get("#ca").should("have.text", "0.167");
 
                     cy.get(textInput2Anchor).type("b{enter}");
 
                     cy.get(answer2Button).should("contain.text", "Correct");
-                    cy.get(cesc("#ca")).should("have.text", "0.5");
+                    cy.get("#ca").should("have.text", "0.5");
 
-                    cy.get(cesc("#pcontrols_previous")).click();
-                    cy.get(cesc("#problem1_title")).should(
-                        "have.text",
-                        "Problem 1",
-                    );
-                    cy.get(cesc("#ca")).should("have.text", "0.5");
+                    cy.get("#pcontrols_previous").click();
+                    cy.get("#problem1_title").should("have.text", "Problem 1");
+                    cy.get("#ca").should("have.text", "0.5");
 
                     cy.get(answer1Button).should("contain.text", "Correct");
 
@@ -770,34 +743,25 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                     cy.get(answer1Button).should("contain.text", "Check Work");
                     cy.get(textInput1Anchor).type("{enter}");
                     cy.get(answer1Button).should("contain.text", "Incorrect");
-                    cy.get(cesc("#ca")).should("have.text", "0.333");
+                    cy.get("#ca").should("have.text", "0.333");
 
-                    cy.get(cesc("#pcontrols_next")).click();
-                    cy.get(cesc("#problem2_title")).should(
-                        "have.text",
-                        "Problem 2",
-                    );
-                    cy.get(cesc("#ca")).should("have.text", "0.333");
+                    cy.get("#pcontrols_next").click();
+                    cy.get("#problem2_title").should("have.text", "Problem 2");
+                    cy.get("#ca").should("have.text", "0.333");
 
                     cy.get(answer2Button).should("contain.text", "Correct");
 
-                    cy.get(cesc("#pcontrols_next")).click();
-                    cy.get(cesc("#problem3_title")).should(
-                        "have.text",
-                        "Problem 3",
-                    );
-                    cy.get(cesc("#ca")).should("have.text", "0.333");
+                    cy.get("#pcontrols_next").click();
+                    cy.get("#problem3_title").should("have.text", "Problem 3");
+                    cy.get("#ca").should("have.text", "0.333");
 
                     cy.get(textInput3Anchor).clear().type("c{enter}");
                     cy.get(answer3Button).should("contain.text", "Correct");
-                    cy.get(cesc("#ca")).should("have.text", "0.833");
+                    cy.get("#ca").should("have.text", "0.833");
 
-                    cy.get(cesc("#pcontrols_previous")).click();
-                    cy.get(cesc("#problem2_title")).should(
-                        "have.text",
-                        "Problem 2",
-                    );
-                    cy.get(cesc("#ca")).should("have.text", "0.833");
+                    cy.get("#pcontrols_previous").click();
+                    cy.get("#problem2_title").should("have.text", "Problem 2");
+                    cy.get("#ca").should("have.text", "0.833");
 
                     cy.get(answer2Button).should("contain.text", "Correct");
                 });
@@ -816,22 +780,22 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+        cy.get("#a").should("have.text", "a"); //wait for page to load
 
-        cy.get(cesc("#problem2_title")).should("have.text", "Problem 2");
-        cy.get(cesc("#ca")).should("have.text", "0.833");
+        cy.get("#problem2_title").should("have.text", "Problem 2");
+        cy.get("#ca").should("have.text", "0.833");
 
-        cy.get(cesc("#pcontrols_previous")).click();
-        cy.get(cesc("#problem1_title")).should("have.text", "Problem 1");
-        cy.get(cesc("#ca")).should("have.text", "0.833");
+        cy.get("#pcontrols_previous").click();
+        cy.get("#problem1_title").should("have.text", "Problem 1");
+        cy.get("#ca").should("have.text", "0.833");
 
-        cy.get(cesc("#pcontrols_next")).click();
-        cy.get(cesc("#problem2_title")).should("have.text", "Problem 2");
-        cy.get(cesc("#ca")).should("have.text", "0.833");
+        cy.get("#pcontrols_next").click();
+        cy.get("#problem2_title").should("have.text", "Problem 2");
+        cy.get("#ca").should("have.text", "0.833");
 
-        cy.get(cesc("#pcontrols_next")).click();
-        cy.get(cesc("#problem3_title")).should("have.text", "Problem 3");
-        cy.get(cesc("#ca")).should("have.text", "0.833");
+        cy.get("#pcontrols_next").click();
+        cy.get("#problem3_title").should("have.text", "Problem 3");
+        cy.get("#ca").should("have.text", "0.833");
     });
 
     // TODO: enable external copies in our cypress setup?
@@ -877,10 +841,10 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
 
         let choices;
 
-        cy.get(cesc("#text1")).should("have.text", "a"); //wait for page to load
+        cy.get("#text1").should("have.text", "a"); //wait for page to load
 
         cy.get(cesc("#problem1/_title1")).should("have.text", "Animal sounds");
-        cy.get(cesc("#ca")).should("have.text", "0");
+        cy.get("#ca").should("have.text", "0");
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
 
@@ -898,7 +862,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
 
         cy.get(cesc(`#problem1/_choiceInput1_button`)).click();
         cy.get(cesc(`#problem1/_choiceInput1_correct`)).should("be.visible");
-        cy.get(cesc("#ca")).should("have.text", "0.333");
+        cy.get("#ca").should("have.text", "0.333");
 
         cy.wait(2000); // wait for 1 second debounce
         cy.reload();
@@ -911,7 +875,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                 "*",
             );
         });
-        cy.get(cesc("#text1")).should("have.text", "a"); //wait for page to load
+        cy.get("#text1").should("have.text", "a"); //wait for page to load
 
         // wait until core is loaded
         cy.waitUntil(() =>
@@ -927,14 +891,14 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
 
         cy.get(cesc("#problem1/_title1")).should("have.text", "Animal sounds");
         cy.get(cesc(`#problem1/_choiceInput1_correct`)).should("be.visible");
-        cy.get(cesc("#ca")).should("have.text", "0.333");
+        cy.get("#ca").should("have.text", "0.333");
 
-        cy.get(cesc("#pcontrols_next")).click();
+        cy.get("#pcontrols_next").click();
         cy.get(cesc("#problem2/_title1")).should(
             "have.text",
             "Derivative problem",
         );
-        cy.get(cesc("#ca")).should("have.text", "0.333");
+        cy.get("#ca").should("have.text", "0.333");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -947,9 +911,9 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
 
             cy.get(mathInput2Anchor).type("2x{enter}", { force: true });
             cy.get(mathInput2Correct).should("be.visible");
-            cy.get(cesc("#ca")).should("have.text", "0.667");
+            cy.get("#ca").should("have.text", "0.667");
 
-            cy.get(cesc("#pcontrols_previous")).click();
+            cy.get("#pcontrols_previous").click();
             cy.get(cesc("#problem1/_title1")).should(
                 "have.text",
                 "Animal sounds",
@@ -957,7 +921,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             cy.get(cesc(`#problem1/_choiceInput1_correct`)).should(
                 "be.visible",
             );
-            cy.get(cesc("#ca")).should("have.text", "0.667");
+            cy.get("#ca").should("have.text", "0.667");
 
             cy.wait(2000); // wait for 1 second debounce
             cy.reload();
@@ -970,7 +934,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                     "*",
                 );
             });
-            cy.get(cesc("#text1")).should("have.text", "a"); //wait for page to load
+            cy.get("#text1").should("have.text", "a"); //wait for page to load
 
             cy.get(cesc("#problem1/_title1")).should(
                 "have.text",
@@ -979,22 +943,22 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             cy.get(cesc(`#problem1/_choiceInput1_correct`)).should(
                 "be.visible",
             );
-            cy.get(cesc("#ca")).should("have.text", "0.667");
+            cy.get("#ca").should("have.text", "0.667");
 
-            cy.get(cesc("#pcontrols_next")).click();
+            cy.get("#pcontrols_next").click();
             cy.get(cesc("#problem2/_title1")).should(
                 "have.text",
                 "Derivative problem",
             );
             cy.get(mathInput2Correct).should("be.visible");
-            cy.get(cesc("#ca")).should("have.text", "0.667");
+            cy.get("#ca").should("have.text", "0.667");
 
-            cy.get(cesc("#pcontrols_next")).click();
+            cy.get("#pcontrols_next").click();
             cy.get(cesc("#problem3/_title1")).should(
                 "have.text",
                 "A hard problem",
             );
-            cy.get(cesc("#ca")).should("have.text", "0.667");
+            cy.get("#ca").should("have.text", "0.667");
 
             cy.get(cesc("#problem3/_mathInput1") + " textarea").type(
                 "2{enter}",
@@ -1003,7 +967,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                 },
             );
             cy.get(cesc("#problem3/_mathInput1_correct")).should("be.visible");
-            cy.get(cesc("#ca")).should("have.text", "1");
+            cy.get("#ca").should("have.text", "1");
 
             cy.wait(2000); // wait for 1 second debounce
             cy.reload();
@@ -1016,24 +980,24 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                     "*",
                 );
             });
-            cy.get(cesc("#text1")).should("have.text", "a"); //wait for page to load
+            cy.get("#text1").should("have.text", "a"); //wait for page to load
 
             cy.get(cesc("#problem3/_title1")).should(
                 "have.text",
                 "A hard problem",
             );
             cy.get(cesc("#problem3/_mathInput1_correct")).should("be.visible");
-            cy.get(cesc("#ca")).should("have.text", "1");
+            cy.get("#ca").should("have.text", "1");
 
-            cy.get(cesc("#pcontrols_previous")).click();
+            cy.get("#pcontrols_previous").click();
             cy.get(cesc("#problem2/_title1")).should(
                 "have.text",
                 "Derivative problem",
             );
             cy.get(mathInput2Correct).should("be.visible");
-            cy.get(cesc("#ca")).should("have.text", "1");
+            cy.get("#ca").should("have.text", "1");
 
-            cy.get(cesc("#pcontrols_previous")).click();
+            cy.get("#pcontrols_previous").click();
             cy.get(cesc("#problem1/_title1")).should(
                 "have.text",
                 "Animal sounds",
@@ -1041,7 +1005,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             cy.get(cesc(`#problem1/_choiceInput1_correct`)).should(
                 "be.visible",
             );
-            cy.get(cesc("#ca")).should("have.text", "1");
+            cy.get("#ca").should("have.text", "1");
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
@@ -1066,7 +1030,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             cy.get(cesc(`#problem1/_choiceInput1_incorrect`)).should(
                 "be.visible",
             );
-            cy.get(cesc("#ca")).should("have.text", "0.667");
+            cy.get("#ca").should("have.text", "0.667");
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
@@ -1088,7 +1052,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             cy.get(cesc(`#problem1/_choiceInput1_correct`)).should(
                 "be.visible",
             );
-            cy.get(cesc("#ca")).should("have.text", "1");
+            cy.get("#ca").should("have.text", "1");
         });
     });
 
@@ -1131,10 +1095,10 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             );
         });
 
-        cy.get(cesc("#text1")).should("have.text", "a"); //wait for page to load
+        cy.get("#text1").should("have.text", "a"); //wait for page to load
 
         cy.get(cesc("#problem1/_title1")).should("have.text", "Animal sounds");
-        cy.get(cesc("#ca")).should("have.text", "0");
+        cy.get("#ca").should("have.text", "0");
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
 
@@ -1153,7 +1117,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
 
         cy.get(cesc(`#problem1/_choiceInput1_button`)).click();
         cy.get(cesc(`#problem1/_choiceInput1_correct`)).should("be.visible");
-        cy.get(cesc("#ca")).should("have.text", "0.333");
+        cy.get("#ca").should("have.text", "0.333");
 
         cy.wait(2000); // wait for 1 second debounce
         cy.reload();
@@ -1166,18 +1130,18 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                 "*",
             );
         });
-        cy.get(cesc("#text1")).should("have.text", "a"); //wait for page to load
+        cy.get("#text1").should("have.text", "a"); //wait for page to load
 
         cy.get(cesc("#problem1/_title1")).should("have.text", "Animal sounds");
         cy.get(cesc(`#problem1/_choiceInput1_correct`)).should("be.visible");
-        cy.get(cesc("#ca")).should("have.text", "0.333");
+        cy.get("#ca").should("have.text", "0.333");
 
-        cy.get(cesc("#pcontrols_next")).click();
+        cy.get("#pcontrols_next").click();
         cy.get(cesc("#problem2/_title1")).should(
             "have.text",
             "Derivative problem",
         );
-        cy.get(cesc("#ca")).should("have.text", "0.333");
+        cy.get("#ca").should("have.text", "0.333");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -1190,9 +1154,9 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
 
             cy.get(mathInput2Anchor).type("2x{enter}", { force: true });
             cy.get(mathInput2Correct).should("be.visible");
-            cy.get(cesc("#ca")).should("have.text", "0.667");
+            cy.get("#ca").should("have.text", "0.667");
 
-            cy.get(cesc("#pcontrols_previous")).click();
+            cy.get("#pcontrols_previous").click();
             cy.get(cesc("#problem1/_title1")).should(
                 "have.text",
                 "Animal sounds",
@@ -1200,7 +1164,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             cy.get(cesc(`#problem1/_choiceInput1_correct`)).should(
                 "be.visible",
             );
-            cy.get(cesc("#ca")).should("have.text", "0.667");
+            cy.get("#ca").should("have.text", "0.667");
 
             cy.wait(2000); // wait for 1 second debounce
             cy.reload();
@@ -1213,7 +1177,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                     "*",
                 );
             });
-            cy.get(cesc("#text1")).should("have.text", "a"); //wait for page to load
+            cy.get("#text1").should("have.text", "a"); //wait for page to load
 
             cy.get(cesc("#problem1/_title1")).should(
                 "have.text",
@@ -1222,22 +1186,22 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             cy.get(cesc(`#problem1/_choiceInput1_correct`)).should(
                 "be.visible",
             );
-            cy.get(cesc("#ca")).should("have.text", "0.667");
+            cy.get("#ca").should("have.text", "0.667");
 
-            cy.get(cesc("#pcontrols_next")).click();
+            cy.get("#pcontrols_next").click();
             cy.get(cesc("#problem2/_title1")).should(
                 "have.text",
                 "Derivative problem",
             );
             cy.get(mathInput2Correct).should("be.visible");
-            cy.get(cesc("#ca")).should("have.text", "0.667");
+            cy.get("#ca").should("have.text", "0.667");
 
-            cy.get(cesc("#pcontrols_next")).click();
+            cy.get("#pcontrols_next").click();
             cy.get(cesc("#problem3/_title1")).should(
                 "have.text",
                 "A hard problem",
             );
-            cy.get(cesc("#ca")).should("have.text", "0.667");
+            cy.get("#ca").should("have.text", "0.667");
 
             cy.get(cesc("#problem3/_mathInput1") + " textarea").type(
                 "2{enter}",
@@ -1246,7 +1210,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                 },
             );
             cy.get(cesc("#problem3/_mathInput1_correct")).should("be.visible");
-            cy.get(cesc("#ca")).should("have.text", "1");
+            cy.get("#ca").should("have.text", "1");
 
             cy.wait(2000); // wait for 1 second debounce
             cy.reload();
@@ -1259,24 +1223,24 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                     "*",
                 );
             });
-            cy.get(cesc("#text1")).should("have.text", "a"); //wait for page to load
+            cy.get("#text1").should("have.text", "a"); //wait for page to load
 
             cy.get(cesc("#problem3/_title1")).should(
                 "have.text",
                 "A hard problem",
             );
             cy.get(cesc("#problem3/_mathInput1_correct")).should("be.visible");
-            cy.get(cesc("#ca")).should("have.text", "1");
+            cy.get("#ca").should("have.text", "1");
 
-            cy.get(cesc("#pcontrols_previous")).click();
+            cy.get("#pcontrols_previous").click();
             cy.get(cesc("#problem2/_title1")).should(
                 "have.text",
                 "Derivative problem",
             );
             cy.get(mathInput2Correct).should("be.visible");
-            cy.get(cesc("#ca")).should("have.text", "1");
+            cy.get("#ca").should("have.text", "1");
 
-            cy.get(cesc("#pcontrols_previous")).click();
+            cy.get("#pcontrols_previous").click();
             cy.get(cesc("#problem1/_title1")).should(
                 "have.text",
                 "Animal sounds",
@@ -1284,7 +1248,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             cy.get(cesc(`#problem1/_choiceInput1_correct`)).should(
                 "be.visible",
             );
-            cy.get(cesc("#ca")).should("have.text", "1");
+            cy.get("#ca").should("have.text", "1");
         });
     });
 
@@ -1314,42 +1278,42 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             );
         });
 
-        cy.get(cesc("#title1")).should("have.text", "Problem 1");
+        cy.get("#title1").should("have.text", "Problem 1");
 
-        cy.get(cesc("#ti1_input")).type("1{enter}");
-        cy.get(cesc("#ti1_input")).should("have.value", "1");
+        cy.get("#ti1_input").type("1{enter}");
+        cy.get("#ti1_input").should("have.value", "1");
 
-        cy.get(cesc("#ti1_button")).should("contain.text", "Correct");
-        cy.get(cesc("#ca")).should("have.text", "0.5");
+        cy.get("#ti1_button").should("contain.text", "Correct");
+        cy.get("#ca").should("have.text", "0.5");
 
-        cy.get(cesc("#pcontrols_next")).click();
-        cy.get(cesc("#title2")).should("have.text", "Problem 2");
+        cy.get("#pcontrols_next").click();
+        cy.get("#title2").should("have.text", "Problem 2");
 
-        cy.get(cesc("#ti2_input")).type("2");
-        cy.get(cesc("#ti2_input")).should("have.value", "2");
-        cy.get(cesc("#ti2_button")).should("contain.text", "Check Work");
-        cy.get(cesc("#ca")).should("have.text", "0.5");
+        cy.get("#ti2_input").type("2");
+        cy.get("#ti2_input").should("have.value", "2");
+        cy.get("#ti2_button").should("contain.text", "Check Work");
+        cy.get("#ca").should("have.text", "0.5");
 
         cy.get("#testRunner_toggleControls").click();
         cy.get("#testRunner_readOnly").click();
         cy.wait(100);
         cy.get("#testRunner_toggleControls").click();
 
-        cy.get(cesc("#title1")).should("have.text", "Problem 1");
+        cy.get("#title1").should("have.text", "Problem 1");
 
-        cy.get(cesc("#ti1_input")).should("be.disabled");
-        cy.get(cesc("#ti1_button")).should("be.disabled");
+        cy.get("#ti1_input").should("be.disabled");
+        cy.get("#ti1_button").should("be.disabled");
 
-        cy.get(cesc("#pcontrols_next")).click();
-        cy.get(cesc("#title2")).should("have.text", "Problem 2");
+        cy.get("#pcontrols_next").click();
+        cy.get("#title2").should("have.text", "Problem 2");
 
-        cy.get(cesc("#ti2_input")).should("be.disabled");
-        cy.get(cesc("#ti2_button")).should("be.disabled");
+        cy.get("#ti2_input").should("be.disabled");
+        cy.get("#ti2_button").should("be.disabled");
 
-        cy.get(cesc("#pcontrols_previous")).click();
-        cy.get(cesc("#title1")).should("have.text", "Problem 1");
-        cy.get(cesc("#ti1_input")).should("be.disabled");
-        cy.get(cesc("#ti1_button")).should("be.disabled");
+        cy.get("#pcontrols_previous").click();
+        cy.get("#title1").should("have.text", "Problem 1");
+        cy.get("#ti1_input").should("be.disabled");
+        cy.get("#ti1_button").should("be.disabled");
     });
 
     // TODO: if keep this, move to variant tests?
@@ -1446,13 +1410,13 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                         "*",
                     );
                 });
-                cy.get(cesc("#text1")).should("have.text", "a"); //wait for page to load
+                cy.get("#text1").should("have.text", "a"); //wait for page to load
             }
 
             let problemInfo = [{}, {}];
             let problemOrder;
 
-            cy.get(cesc("#text1")).should("have.text", "a"); //wait for page to load
+            cy.get("#text1").should("have.text", "a"); //wait for page to load
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
@@ -1472,14 +1436,11 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
 
                 for (let ind = 0; ind < 2; ind++) {
                     if (ind === 1) {
-                        cy.get(cesc("#pcontrols_next")).click();
+                        cy.get("#pcontrols_next").click();
                     }
 
                     cy.wait(0).then((_) => {
-                        cy.get(cesc("#ca")).should(
-                            "have.text",
-                            `${creditAchieved}`,
-                        );
+                        cy.get("#ca").should("have.text", `${creditAchieved}`);
 
                         let thisProbInfo = problemInfo[ind];
                         let thisProbName = `/problem${ind + 1}`;
@@ -1665,7 +1626,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                     "*",
                 );
             });
-            cy.get(cesc("#text1")).should("have.text", "b"); //wait for page to load
+            cy.get("#text1").should("have.text", "b"); //wait for page to load
 
             cy.window().then(async (win) => {
                 win.postMessage(
@@ -1675,7 +1636,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                     "*",
                 );
             });
-            cy.get(cesc("#text1")).should("have.text", "a"); //wait for page to load
+            cy.get("#text1").should("have.text", "a"); //wait for page to load
 
             // wait until core is loaded
             cy.waitUntil(() =>
@@ -1690,11 +1651,11 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
 
             for (let ind = 1; ind >= 0; ind--) {
                 if (ind === 0) {
-                    cy.get(cesc("#pcontrols_previous")).click();
+                    cy.get("#pcontrols_previous").click();
                 }
 
                 cy.wait(0).then((_) => {
-                    cy.get(cesc("#ca")).should("have.text", `1`);
+                    cy.get("#ca").should("have.text", `1`);
 
                     let thisProbInfo = problemInfo[ind];
                     let thisProbName = `/problem${ind + 1}`;
@@ -1844,7 +1805,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                     "*",
                 );
             });
-            cy.get(cesc("#text1")).should("have.text", "b"); //wait for page to load
+            cy.get("#text1").should("have.text", "b"); //wait for page to load
 
             cy.window().then(async (win) => {
                 win.postMessage(
@@ -1854,7 +1815,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                     "*",
                 );
             });
-            cy.get(cesc("#text1")).should("have.text", "a"); //wait for page to load
+            cy.get("#text1").should("have.text", "a"); //wait for page to load
 
             // wait until core is loaded
             cy.waitUntil(() =>
@@ -1869,11 +1830,11 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
 
             for (let ind = 0; ind < 2; ind++) {
                 if (ind === 1) {
-                    cy.get(cesc("#pcontrols_next")).click();
+                    cy.get("#pcontrols_next").click();
                 }
 
                 cy.wait(0).then((_) => {
-                    cy.get(cesc("#ca")).should("have.text", `1`);
+                    cy.get("#ca").should("have.text", `1`);
 
                     let thisProbInfo = problemInfo[ind];
                     let thisProbName = `/problem${ind + 1}`;
@@ -2082,8 +2043,8 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             );
         });
 
-        cy.get(cesc("#problem1_title")).should("have.text", "Problem 1");
-        cy.get(cesc("#ca")).should("have.text", "0");
+        cy.get("#problem1_title").should("have.text", "Problem 1");
+        cy.get("#ca").should("have.text", "0");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -2117,7 +2078,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             );
             cy.get(answer1Button).click();
 
-            cy.get(cesc("#ca")).should("have.text", "0.25");
+            cy.get("#ca").should("have.text", "0.25");
 
             cy.get(mathInput2Anchor).type(`2${correctAnswer}`, { force: true });
             cy.get(mathInput2DisplayAnchor).should(
@@ -2126,15 +2087,15 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             );
             cy.get(answer2Button).click();
 
-            cy.get(cesc("#ca")).should("have.text", "0.5");
+            cy.get("#ca").should("have.text", "0.5");
 
-            cy.get(cesc("#pcontrols_next")).click();
-            cy.get(cesc("#problem2_title")).should("have.text", "Problem 2");
-            cy.get(cesc("#ca")).should("have.text", "0.5");
+            cy.get("#pcontrols_next").click();
+            cy.get("#problem2_title").should("have.text", "Problem 2");
+            cy.get("#ca").should("have.text", "0.5");
 
-            cy.get(cesc("#pcontrols_previous")).click();
-            cy.get(cesc("#problem1_title")).should("have.text", "Problem 1");
-            cy.get(cesc("#ca")).should("have.text", "0.5");
+            cy.get("#pcontrols_previous").click();
+            cy.get("#problem1_title").should("have.text", "Problem 1");
+            cy.get("#ca").should("have.text", "0.5");
 
             cy.get(mathInput1DisplayAnchor).should(
                 "contain.text",
@@ -2148,9 +2109,9 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
             );
             cy.get(answer2Button).should("contain.text", "Correct");
 
-            cy.get(cesc("#pcontrols_next")).click();
-            cy.get(cesc("#problem2_title")).should("have.text", "Problem 2");
-            cy.get(cesc("#ca")).should("have.text", "0.5");
+            cy.get("#pcontrols_next").click();
+            cy.get("#problem2_title").should("have.text", "Problem 2");
+            cy.get("#ca").should("have.text", "0.5");
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
@@ -2179,20 +2140,17 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                 cy.get(mathInput3DisplayAnchor).should("contain.text", "1");
                 cy.get(answer3Button).should("contain.text", "Correct");
 
-                cy.get(cesc("#ca")).should("have.text", "0.75");
+                cy.get("#ca").should("have.text", "0.75");
 
                 cy.get(mathInput4Anchor).type(`2{enter}`, { force: true });
                 cy.get(mathInput4DisplayAnchor).should("contain.text", "2");
                 cy.get(answer4Button).should("contain.text", "Correct");
 
-                cy.get(cesc("#ca")).should("have.text", "1");
+                cy.get("#ca").should("have.text", "1");
 
-                cy.get(cesc("#pcontrols_previous")).click();
-                cy.get(cesc("#problem1_title")).should(
-                    "have.text",
-                    "Problem 1",
-                );
-                cy.get(cesc("#ca")).should("have.text", "1");
+                cy.get("#pcontrols_previous").click();
+                cy.get("#problem1_title").should("have.text", "Problem 1");
+                cy.get("#ca").should("have.text", "1");
 
                 cy.get(mathInput1DisplayAnchor).should(
                     "contain.text",
@@ -2206,12 +2164,9 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                 );
                 cy.get(answer2Button).should("contain.text", "Correct");
 
-                cy.get(cesc("#pcontrols_next")).click();
-                cy.get(cesc("#problem2_title")).should(
-                    "have.text",
-                    "Problem 2",
-                );
-                cy.get(cesc("#ca")).should("have.text", "1");
+                cy.get("#pcontrols_next").click();
+                cy.get("#problem2_title").should("have.text", "Problem 2");
+                cy.get("#ca").should("have.text", "1");
 
                 cy.get(mathInput3DisplayAnchor).should("contain.text", "1");
                 cy.get(answer3Button).should("contain.text", "Correct");
@@ -2219,7 +2174,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                 cy.get(mathInput4DisplayAnchor).should("contain.text", "2");
                 cy.get(answer4Button).should("contain.text", "Correct");
 
-                cy.get(cesc("#ca")).should("have.text", "1");
+                cy.get("#ca").should("have.text", "1");
 
                 cy.wait(2000); // wait for 1 second debounce
 
@@ -2232,7 +2187,7 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                     );
                 });
 
-                cy.get(cesc("#b")).should("have.text", "b"); //wait for page to load
+                cy.get("#b").should("have.text", "b"); //wait for page to load
 
                 cy.window().then(async (win) => {
                     win.postMessage(
@@ -2243,11 +2198,8 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                     );
                 });
 
-                cy.get(cesc("#problem2_title")).should(
-                    "have.text",
-                    "Problem 2",
-                );
-                cy.get(cesc("#ca")).should("have.text", "1");
+                cy.get("#problem2_title").should("have.text", "Problem 2");
+                cy.get("#ca").should("have.text", "1");
 
                 cy.get(mathInput3DisplayAnchor).should("contain.text", "1");
                 cy.get(answer3Button).should("contain.text", "Correct");
@@ -2255,14 +2207,11 @@ describe("Paginator Tag Tests", { tags: ["@group3"] }, function () {
                 cy.get(mathInput4DisplayAnchor).should("contain.text", "2");
                 cy.get(answer4Button).should("contain.text", "Correct");
 
-                cy.get(cesc("#ca")).should("have.text", "1");
+                cy.get("#ca").should("have.text", "1");
 
-                cy.get(cesc("#pcontrols_previous")).click();
-                cy.get(cesc("#problem1_title")).should(
-                    "have.text",
-                    "Problem 1",
-                );
-                cy.get(cesc("#ca")).should("have.text", "1");
+                cy.get("#pcontrols_previous").click();
+                cy.get("#problem1_title").should("have.text", "Problem 1");
+                cy.get("#ca").should("have.text", "1");
 
                 cy.get(mathInput1DisplayAnchor).should(
                     "contain.text",

--- a/packages/test-cypress/cypress/e2e/tagSpecific/paragraphmarkup.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/paragraphmarkup.cy.js
@@ -1,5 +1,3 @@
-import { cesc } from "@doenet/utils";
-
 describe("Paragraph Markup Tag Tests", { tags: ["@group4"] }, function () {
     beforeEach(() => {
         cy.clearIndexedDB();
@@ -19,7 +17,7 @@ describe("Paragraph Markup Tag Tests", { tags: ["@group4"] }, function () {
         });
 
         cy.log("find em");
-        cy.get("em" + cesc("#em1")).should("have.text", "This is italics");
+        cy.get("em" + "#em1").should("have.text", "This is italics");
     });
 
     it("alert", () => {
@@ -35,7 +33,7 @@ describe("Paragraph Markup Tag Tests", { tags: ["@group4"] }, function () {
         });
 
         cy.log("find alert");
-        cy.get("strong" + cesc("#alert1")).should("have.text", "This is bold");
+        cy.get("strong" + "#alert1").should("have.text", "This is bold");
     });
 
     it("q", () => {
@@ -51,7 +49,7 @@ describe("Paragraph Markup Tag Tests", { tags: ["@group4"] }, function () {
         });
 
         cy.log("find quotes");
-        cy.get(cesc("#p1")).should("have.text", "“Double quoted”");
+        cy.get("#p1").should("have.text", "“Double quoted”");
     });
 
     it("sq", () => {
@@ -67,7 +65,7 @@ describe("Paragraph Markup Tag Tests", { tags: ["@group4"] }, function () {
         });
 
         cy.log("find quotes");
-        cy.get(cesc("#p1")).should("have.text", "‘Single quoted’");
+        cy.get("#p1").should("have.text", "‘Single quoted’");
     });
 
     it("c", () => {
@@ -83,7 +81,7 @@ describe("Paragraph Markup Tag Tests", { tags: ["@group4"] }, function () {
         });
 
         cy.log("find quotes");
-        cy.get("code" + cesc("#c1")).should("have.text", "Code!");
+        cy.get("code" + "#c1").should("have.text", "Code!");
     });
 
     it("term", () => {
@@ -99,6 +97,6 @@ describe("Paragraph Markup Tag Tests", { tags: ["@group4"] }, function () {
         });
 
         cy.log("find term");
-        cy.get("strong" + cesc("#term1")).should("have.text", "Homogeneous");
+        cy.get("strong" + "#term1").should("have.text", "Homogeneous");
     });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/point.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/point.cy.js
@@ -1,5 +1,4 @@
 import me from "math-expressions";
-import { cesc } from "@doenet/utils";
 
 describe("Point Tag Tests", { tags: ["@group4"] }, function () {
     beforeEach(() => {
@@ -36,7 +35,7 @@ describe("Point Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#P0a")).should("have.text", "(3,4)");
+        cy.get("#P0a").should("have.text", "(3,4)");
 
         cy.log("move point using skippable actions to upper right");
         let promises = [];
@@ -74,7 +73,7 @@ describe("Point Tag Tests", { tags: ["@group4"] }, function () {
             });
         });
 
-        cy.get(cesc("#P0a")).should("have.text", "(9.9,9.9)");
+        cy.get("#P0a").should("have.text", "(9.9,9.9)");
 
         cy.log(
             "move point using skippable and non-skippable actions to upper left",
@@ -116,7 +115,7 @@ describe("Point Tag Tests", { tags: ["@group4"] }, function () {
             });
         });
 
-        cy.get(cesc("#P0a")).should("have.text", "(−9.9,9.9)");
+        cy.get("#P0a").should("have.text", "(−9.9,9.9)");
     });
 
     it("restore state with point coords depending on function", () => {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/pretzel.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/pretzel.cy.js
@@ -1,9 +1,7 @@
-import { cesc } from "@doenet/utils";
-
 describe("Pretzel Tag Tests", { tags: ["@group5"] }, function () {
-    const pretzelSelector = cesc("#pretzel1");
-    const pretzelButtonSelector = cesc("#pretzel1_button");
-    const creditSelector = cesc("#ca");
+    const pretzelSelector = "#pretzel1";
+    const pretzelButtonSelector = "#pretzel1_button";
+    const creditSelector = "#ca";
     const pretzelRowsSelector = `${pretzelSelector} [data-test="pretzel-problem-row"]`;
     const pretzelRowInputSelector = '[data-test="pretzel-row-input"] input';
 

--- a/packages/test-cypress/cypress/e2e/tagSpecific/problem.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/problem.cy.js
@@ -43,9 +43,9 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#swcw_input")).should("not.be.checked");
+        cy.get("#swcw_input").should("not.be.checked");
 
-        cy.get(cesc("#theProblem_button")).should("not.exist");
+        cy.get("#theProblem_button").should("not.exist");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -76,97 +76,74 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
             cy.get(helloInputAnchor).type("hello{enter}");
             cy.get(helloInputButtonAnchor).should("contain.text", "Correct");
 
-            cy.get(cesc("#fruitInput_button")).should(
-                "contain.text",
-                "Check Work",
-            );
+            cy.get("#fruitInput_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#fruitInput"))
-                .contains(`banana`)
-                .click({ force: true });
-            cy.get(cesc("#fruitInput_button")).click();
+            cy.get("#fruitInput").contains(`banana`).click({ force: true });
+            cy.get("#fruitInput_button").click();
 
-            cy.get(cesc("#fruitInput_button")).should(
-                "contain.text",
-                "Correct",
-            );
+            cy.get("#fruitInput_button").should("contain.text", "Correct");
 
-            cy.get(cesc("#sum3_button")).should("contain.text", "Check Work");
+            cy.get("#sum3_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#n1") + " textarea").type("2{enter}", {
+            cy.get("#n1" + " textarea").type("2{enter}", {
                 force: true,
             });
-            cy.get(cesc("#n2") + " textarea").type("1{enter}", {
+            cy.get("#n2" + " textarea").type("1{enter}", {
                 force: true,
             });
 
-            cy.get(cesc("#sum3_button")).should("contain.text", "Check Work");
+            cy.get("#sum3_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#sum3_button")).click();
-            cy.get(cesc("#sum3_button")).should("contain.text", "Correct");
+            cy.get("#sum3_button").click();
+            cy.get("#sum3_button").should("contain.text", "Correct");
 
             cy.log("switch to section wide check work");
 
-            cy.get(cesc("#swcw")).click();
-            cy.get(cesc("#swcw_input")).should("be.checked");
+            cy.get("#swcw").click();
+            cy.get("#swcw_input").should("be.checked");
 
             cy.get(twoxInputButtonAnchor).should("not.exist");
 
             cy.get(helloInputButtonAnchor).should("not.exist");
 
-            cy.get(cesc("#fruitInput_button")).should("not.exist");
+            cy.get("#fruitInput_button").should("not.exist");
 
-            cy.get(cesc("#sum3_button")).should("not.exist");
+            cy.get("#sum3_button").should("not.exist");
 
-            cy.get(cesc("#theProblem_button")).should(
-                "contain.text",
-                "Correct",
-            );
+            cy.get("#theProblem_button").should("contain.text", "Correct");
 
             cy.get(twoxInputAnchor).type("{end}{backspace}y{enter}", {
                 force: true,
             });
             cy.get(twoxInputButtonAnchor).should("not.exist");
 
-            cy.get(cesc("#theProblem_button")).should(
-                "contain.text",
-                "Check Work",
-            );
+            cy.get("#theProblem_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#theProblem_button")).click();
-            cy.get(cesc("#theProblem_button")).should(
-                "contain.text",
-                "75% Correct",
-            );
+            cy.get("#theProblem_button").click();
+            cy.get("#theProblem_button").should("contain.text", "75% Correct");
 
             cy.get(helloInputAnchor).type("2{enter}");
             cy.get(helloInputButtonAnchor).should("not.exist");
 
-            cy.get(cesc("#theProblem_button")).should("be.visible");
+            cy.get("#theProblem_button").should("be.visible");
 
-            cy.get(cesc("#theProblem_button")).click();
-            cy.get(cesc("#theProblem_button")).should(
-                "contain.text",
-                "50% Correct",
-            );
+            cy.get("#theProblem_button").click();
+            cy.get("#theProblem_button").should("contain.text", "50% Correct");
 
             cy.log("turn off section wide check work");
 
-            cy.get(cesc("#swcw")).click();
-            cy.get(cesc("#swcw_input")).should("not.be.checked");
+            cy.get("#swcw").click();
+            cy.get("#swcw_input").should("not.be.checked");
 
             cy.get(twoxInputButtonAnchor).should("contain.text", "Incorrect");
 
             cy.get(helloInputButtonAnchor).should("contain.text", "Incorrect");
 
-            cy.get(cesc("#fruitInput_button")).should(
-                "contain.text",
-                "Correct",
-            );
+            cy.get("#fruitInput_button").should("contain.text", "Correct");
 
-            cy.get(cesc("#sum3_button")).should("contain.text", "Correct");
+            cy.get("#sum3_button").should("contain.text", "Correct");
 
-            cy.get(cesc("#theProblem_button")).should("not.exist");
+            cy.get("#theProblem_button").should("not.exist");
         });
     });
 
@@ -207,9 +184,9 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#swcw_input")).should("not.be.checked");
+        cy.get("#swcw_input").should("not.be.checked");
 
-        cy.get(cesc("#theProblem_button")).should("not.exist");
+        cy.get("#theProblem_button").should("not.exist");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -240,100 +217,74 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
             cy.get(helloInputAnchor).type("hello{enter}");
             cy.get(helloInputButtonAnchor).should("contain.text", "Correct");
 
-            cy.get(cesc("#fruitInput_button")).should(
-                "contain.text",
-                "Check Work",
-            );
+            cy.get("#fruitInput_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#fruitInput"))
-                .contains(`banana`)
-                .click({ force: true });
-            cy.get(cesc("#fruitInput_button")).click();
+            cy.get("#fruitInput").contains(`banana`).click({ force: true });
+            cy.get("#fruitInput_button").click();
 
-            cy.get(cesc("#fruitInput_button")).should(
-                "contain.text",
-                "Correct",
-            );
+            cy.get("#fruitInput_button").should("contain.text", "Correct");
 
-            cy.get(cesc("#sum3_button")).should("contain.text", "Check Work");
+            cy.get("#sum3_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#n1") + " textarea").type("2{enter}", {
+            cy.get("#n1" + " textarea").type("2{enter}", {
                 force: true,
             });
-            cy.get(cesc("#n2") + " textarea").type("1{enter}", {
+            cy.get("#n2" + " textarea").type("1{enter}", {
                 force: true,
             });
 
-            cy.get(cesc("#sum3_button")).should("contain.text", "Check Work");
+            cy.get("#sum3_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#sum3_button")).click();
-            cy.get(cesc("#sum3_button")).should("contain.text", "Correct");
+            cy.get("#sum3_button").click();
+            cy.get("#sum3_button").should("contain.text", "Correct");
 
             cy.log("switch to section wide check work");
 
-            cy.get(cesc("#swcw")).click();
-            cy.get(cesc("#swcw_input")).should("be.checked");
+            cy.get("#swcw").click();
+            cy.get("#swcw_input").should("be.checked");
 
             cy.get(twoxInputButtonAnchor).should("not.exist");
 
             cy.get(helloInputButtonAnchor).should("not.exist");
 
-            cy.get(cesc("#fruitInput_button")).should("not.exist");
+            cy.get("#fruitInput_button").should("not.exist");
 
-            cy.get(cesc("#sum3_button")).should("not.exist");
+            cy.get("#sum3_button").should("not.exist");
 
-            cy.get(cesc("#theProblem_button")).should(
-                "contain.text",
-                "Correct",
-            );
+            cy.get("#theProblem_button").should("contain.text", "Correct");
 
             cy.get(twoxInputAnchor).type("{end}{backspace}y{enter}", {
                 force: true,
             });
             cy.get(twoxInputButtonAnchor).should("not.exist");
 
-            cy.get(cesc("#theProblem_button")).should(
-                "contain.text",
-                "Check Work",
-            );
+            cy.get("#theProblem_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#theProblem_button")).click();
-            cy.get(cesc("#theProblem_button")).should(
-                "contain.text",
-                "75% Correct",
-            );
+            cy.get("#theProblem_button").click();
+            cy.get("#theProblem_button").should("contain.text", "75% Correct");
 
             cy.get(helloInputAnchor).type("2{enter}");
             cy.get(helloInputButtonAnchor).should("not.exist");
 
-            cy.get(cesc("#theProblem_button")).should(
-                "contain.text",
-                "Check Work",
-            );
+            cy.get("#theProblem_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#theProblem_button")).click();
-            cy.get(cesc("#theProblem_button")).should(
-                "contain.text",
-                "50% Correct",
-            );
+            cy.get("#theProblem_button").click();
+            cy.get("#theProblem_button").should("contain.text", "50% Correct");
 
             cy.log("turn off section wide check work");
 
-            cy.get(cesc("#swcw")).click();
-            cy.get(cesc("#swcw_input")).should("not.be.checked");
+            cy.get("#swcw").click();
+            cy.get("#swcw_input").should("not.be.checked");
 
             cy.get(twoxInputButtonAnchor).should("contain.text", "Incorrect");
 
             cy.get(helloInputButtonAnchor).should("contain.text", "Incorrect");
 
-            cy.get(cesc("#fruitInput_button")).should(
-                "contain.text",
-                "Correct",
-            );
+            cy.get("#fruitInput_button").should("contain.text", "Correct");
 
-            cy.get(cesc("#sum3_button")).should("contain.text", "Correct");
+            cy.get("#sum3_button").should("contain.text", "Correct");
 
-            cy.get(cesc("#theProblem_button")).should("not.exist");
+            cy.get("#theProblem_button").should("not.exist");
         });
     });
 
@@ -374,9 +325,9 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#dwcw_input")).should("not.be.checked");
+        cy.get("#dwcw_input").should("not.be.checked");
 
-        cy.get(cesc("#theDocument_button")).should("not.exist");
+        cy.get("#theDocument_button").should("not.exist");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -407,100 +358,74 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
             cy.get(helloInputAnchor).type("hello{enter}");
             cy.get(helloInputButtonAnchor).should("contain.text", "Correct");
 
-            cy.get(cesc("#fruitInput_button")).should(
-                "contain.text",
-                "Check Work",
-            );
+            cy.get("#fruitInput_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#fruitInput"))
-                .contains(`banana`)
-                .click({ force: true });
-            cy.get(cesc("#fruitInput_button")).click();
+            cy.get("#fruitInput").contains(`banana`).click({ force: true });
+            cy.get("#fruitInput_button").click();
 
-            cy.get(cesc("#fruitInput_button")).should(
-                "contain.text",
-                "Correct",
-            );
+            cy.get("#fruitInput_button").should("contain.text", "Correct");
 
-            cy.get(cesc("#sum3_button")).should("contain.text", "Check Work");
+            cy.get("#sum3_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#n1") + " textarea").type("2{enter}", {
+            cy.get("#n1" + " textarea").type("2{enter}", {
                 force: true,
             });
-            cy.get(cesc("#n2") + " textarea").type("1{enter}", {
+            cy.get("#n2" + " textarea").type("1{enter}", {
                 force: true,
             });
 
-            cy.get(cesc("#sum3_button")).should("contain.text", "Check Work");
+            cy.get("#sum3_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#sum3_button")).click();
-            cy.get(cesc("#sum3_button")).should("contain.text", "Correct");
+            cy.get("#sum3_button").click();
+            cy.get("#sum3_button").should("contain.text", "Correct");
 
             cy.log("switch to document wide check work");
 
-            cy.get(cesc("#dwcw")).click();
-            cy.get(cesc("#dwcw_input")).should("be.checked");
+            cy.get("#dwcw").click();
+            cy.get("#dwcw_input").should("be.checked");
 
             cy.get(twoxInputButtonAnchor).should("not.exist");
 
             cy.get(helloInputButtonAnchor).should("not.exist");
 
-            cy.get(cesc("#fruitInput_button")).should("not.exist");
+            cy.get("#fruitInput_button").should("not.exist");
 
-            cy.get(cesc("#sum3_button")).should("not.exist");
+            cy.get("#sum3_button").should("not.exist");
 
-            cy.get(cesc("#theDocument_button")).should(
-                "contain.text",
-                "Correct",
-            );
+            cy.get("#theDocument_button").should("contain.text", "Correct");
 
             cy.get(twoxInputAnchor).type("{end}{backspace}y{enter}", {
                 force: true,
             });
             cy.get(twoxInputButtonAnchor).should("not.exist");
 
-            cy.get(cesc("#theDocument_button")).should(
-                "contain.text",
-                "Check Work",
-            );
+            cy.get("#theDocument_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#theDocument_button")).click();
-            cy.get(cesc("#theDocument_button")).should(
-                "contain.text",
-                "75% Correct",
-            );
+            cy.get("#theDocument_button").click();
+            cy.get("#theDocument_button").should("contain.text", "75% Correct");
 
             cy.get(helloInputAnchor).type("2{enter}");
             cy.get(helloInputButtonAnchor).should("not.exist");
 
-            cy.get(cesc("#theDocument_button")).should(
-                "contain.text",
-                "Check Work",
-            );
+            cy.get("#theDocument_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#theDocument_button")).click();
-            cy.get(cesc("#theDocument_button")).should(
-                "contain.text",
-                "50% Correct",
-            );
+            cy.get("#theDocument_button").click();
+            cy.get("#theDocument_button").should("contain.text", "50% Correct");
 
             cy.log("turn off document wide check work");
 
-            cy.get(cesc("#dwcw")).click();
-            cy.get(cesc("#dwcw_input")).should("not.be.checked");
+            cy.get("#dwcw").click();
+            cy.get("#dwcw_input").should("not.be.checked");
 
             cy.get(twoxInputButtonAnchor).should("contain.text", "Incorrect");
 
             cy.get(helloInputButtonAnchor).should("contain.text", "Incorrect");
 
-            cy.get(cesc("#fruitInput_button")).should(
-                "contain.text",
-                "Correct",
-            );
+            cy.get("#fruitInput_button").should("contain.text", "Correct");
 
-            cy.get(cesc("#sum3_button")).should("contain.text", "Correct");
+            cy.get("#sum3_button").should("contain.text", "Correct");
 
-            cy.get(cesc("#theDocument_button")).should("not.exist");
+            cy.get("#theDocument_button").should("not.exist");
         });
     });
 
@@ -544,9 +469,9 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#swcw_input")).should("not.be.checked");
+        cy.get("#swcw_input").should("not.be.checked");
 
-        cy.get(cesc("#theProblem_button")).should("not.exist");
+        cy.get("#theProblem_button").should("not.exist");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -577,112 +502,80 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
             cy.get(helloInputAnchor).type("hello{enter}");
             cy.get(helloInputButtonAnchor).should("contain.text", "Correct");
 
-            cy.get(cesc("#fruitInput_button")).should("not.exist");
-            cy.get(cesc("#sum3_button")).should("not.exist");
+            cy.get("#fruitInput_button").should("not.exist");
+            cy.get("#sum3_button").should("not.exist");
 
-            cy.get(cesc("#subProblem_button")).should(
-                "contain.text",
-                "Check Work",
-            );
+            cy.get("#subProblem_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#fruitInput"))
-                .contains(`banana`)
-                .click({ force: true });
-            cy.get(cesc("#subProblem_button")).click();
+            cy.get("#fruitInput").contains(`banana`).click({ force: true });
+            cy.get("#subProblem_button").click();
 
-            cy.get(cesc("#subProblem_button")).should(
-                "contain.text",
-                "50% Correct",
-            );
+            cy.get("#subProblem_button").should("contain.text", "50% Correct");
 
-            cy.get(cesc("#n1") + " textarea").type("2{enter}", {
+            cy.get("#n1" + " textarea").type("2{enter}", {
                 force: true,
             });
-            cy.get(cesc("#n2") + " textarea").type("1{enter}", {
+            cy.get("#n2" + " textarea").type("1{enter}", {
                 force: true,
             });
 
-            cy.get(cesc("#subProblem_button")).should(
-                "contain.text",
-                "Check Work",
-            );
+            cy.get("#subProblem_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#subProblem_button")).click();
+            cy.get("#subProblem_button").click();
 
-            cy.get(cesc("#subProblem_button")).should(
-                "contain.text",
-                "Correct",
-            );
+            cy.get("#subProblem_button").should("contain.text", "Correct");
 
             cy.log("switch to section wide check work");
 
-            cy.get(cesc("#swcw")).click();
-            cy.get(cesc("#swcw_input")).should("be.checked");
+            cy.get("#swcw").click();
+            cy.get("#swcw_input").should("be.checked");
 
             cy.get(twoxInputButtonAnchor).should("not.exist");
 
             cy.get(helloInputButtonAnchor).should("not.exist");
 
-            cy.get(cesc("#fruitInput_button")).should("not.exist");
+            cy.get("#fruitInput_button").should("not.exist");
 
-            cy.get(cesc("#sum3_button")).should("not.exist");
+            cy.get("#sum3_button").should("not.exist");
 
-            cy.get(cesc("#subProblem_button")).should("not.exist");
+            cy.get("#subProblem_button").should("not.exist");
 
-            cy.get(cesc("#theProblem_button")).should(
-                "contain.text",
-                "Correct",
-            );
+            cy.get("#theProblem_button").should("contain.text", "Correct");
 
             cy.get(twoxInputAnchor).type("{end}{backspace}y{enter}", {
                 force: true,
             });
             cy.get(twoxInputButtonAnchor).should("not.exist");
 
-            cy.get(cesc("#theProblem_button")).should(
-                "contain.text",
-                "Check Work",
-            );
+            cy.get("#theProblem_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#theProblem_button")).click();
-            cy.get(cesc("#theProblem_button")).should(
-                "contain.text",
-                "67% Correct",
-            );
+            cy.get("#theProblem_button").click();
+            cy.get("#theProblem_button").should("contain.text", "67% Correct");
 
             cy.get(helloInputAnchor).type("2{enter}");
             cy.get(helloInputButtonAnchor).should("not.exist");
 
-            cy.get(cesc("#theProblem_button")).should(
-                "contain.text",
-                "Check Work",
-            );
+            cy.get("#theProblem_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#theProblem_button")).click();
-            cy.get(cesc("#theProblem_button")).should(
-                "contain.text",
-                "33% Correct",
-            );
+            cy.get("#theProblem_button").click();
+            cy.get("#theProblem_button").should("contain.text", "33% Correct");
 
             cy.log("turn off section wide check work");
 
-            cy.get(cesc("#swcw")).click();
-            cy.get(cesc("#swcw_input")).should("not.be.checked");
+            cy.get("#swcw").click();
+            cy.get("#swcw_input").should("not.be.checked");
 
             cy.get(twoxInputButtonAnchor).should("contain.text", "Incorrect");
 
             cy.get(helloInputButtonAnchor).should("contain.text", "Incorrect");
 
-            cy.get(cesc("#fruitInput_button")).should("not.exist");
+            cy.get("#fruitInput_button").should("not.exist");
 
-            cy.get(cesc("#sum3_button")).should("not.exist");
+            cy.get("#sum3_button").should("not.exist");
 
-            cy.get(cesc("#subProblem_button")).should(
-                "contain.text",
-                "Correct",
-            );
+            cy.get("#subProblem_button").should("contain.text", "Correct");
 
-            cy.get(cesc("#theProblem_button")).should("not.exist");
+            cy.get("#theProblem_button").should("not.exist");
         });
     });
 
@@ -726,9 +619,9 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#dwcw_input")).should("not.be.checked");
+        cy.get("#dwcw_input").should("not.be.checked");
 
-        cy.get(cesc("#theDocument_button")).should("not.exist");
+        cy.get("#theDocument_button").should("not.exist");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -759,112 +652,80 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
             cy.get(helloInputAnchor).type("hello{enter}");
             cy.get(helloInputButtonAnchor).should("contain.text", "Correct");
 
-            cy.get(cesc("#fruitInput_button")).should("not.exist");
-            cy.get(cesc("#sum3_button")).should("not.exist");
+            cy.get("#fruitInput_button").should("not.exist");
+            cy.get("#sum3_button").should("not.exist");
 
-            cy.get(cesc("#subProblem_button")).should(
-                "contain.text",
-                "Check Work",
-            );
+            cy.get("#subProblem_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#fruitInput"))
-                .contains(`banana`)
-                .click({ force: true });
-            cy.get(cesc("#subProblem_button")).click();
+            cy.get("#fruitInput").contains(`banana`).click({ force: true });
+            cy.get("#subProblem_button").click();
 
-            cy.get(cesc("#subProblem_button")).should(
-                "contain.text",
-                "50% Correct",
-            );
+            cy.get("#subProblem_button").should("contain.text", "50% Correct");
 
-            cy.get(cesc("#n1") + " textarea").type("2{enter}", {
+            cy.get("#n1" + " textarea").type("2{enter}", {
                 force: true,
             });
-            cy.get(cesc("#n2") + " textarea").type("1{enter}", {
+            cy.get("#n2" + " textarea").type("1{enter}", {
                 force: true,
             });
 
-            cy.get(cesc("#subProblem_button")).should(
-                "contain.text",
-                "Check Work",
-            );
+            cy.get("#subProblem_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#subProblem_button")).click();
+            cy.get("#subProblem_button").click();
 
-            cy.get(cesc("#subProblem_button")).should(
-                "contain.text",
-                "Correct",
-            );
+            cy.get("#subProblem_button").should("contain.text", "Correct");
 
             cy.log("switch to document wide check work");
 
-            cy.get(cesc("#dwcw")).click();
-            cy.get(cesc("#dwcw_input")).should("be.checked");
+            cy.get("#dwcw").click();
+            cy.get("#dwcw_input").should("be.checked");
 
             cy.get(twoxInputButtonAnchor).should("not.exist");
 
             cy.get(helloInputButtonAnchor).should("not.exist");
 
-            cy.get(cesc("#fruitInput_button")).should("not.exist");
+            cy.get("#fruitInput_button").should("not.exist");
 
-            cy.get(cesc("#sum3_button")).should("not.exist");
+            cy.get("#sum3_button").should("not.exist");
 
-            cy.get(cesc("#subProblem_button")).should("not.exist");
+            cy.get("#subProblem_button").should("not.exist");
 
-            cy.get(cesc("#theDocument_button")).should(
-                "contain.text",
-                "Correct",
-            );
+            cy.get("#theDocument_button").should("contain.text", "Correct");
 
             cy.get(twoxInputAnchor).type("{end}{backspace}y{enter}", {
                 force: true,
             });
             cy.get(twoxInputButtonAnchor).should("not.exist");
 
-            cy.get(cesc("#theDocument_button")).should(
-                "contain.text",
-                "Check Work",
-            );
+            cy.get("#theDocument_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#theDocument_button")).click();
-            cy.get(cesc("#theDocument_button")).should(
-                "contain.text",
-                "67% Correct",
-            );
+            cy.get("#theDocument_button").click();
+            cy.get("#theDocument_button").should("contain.text", "67% Correct");
 
             cy.get(helloInputAnchor).type("2{enter}");
             cy.get(helloInputButtonAnchor).should("not.exist");
 
-            cy.get(cesc("#theDocument_button")).should(
-                "contain.text",
-                "Check Work",
-            );
+            cy.get("#theDocument_button").should("contain.text", "Check Work");
 
-            cy.get(cesc("#theDocument_button")).click();
-            cy.get(cesc("#theDocument_button")).should(
-                "contain.text",
-                "33% Correct",
-            );
+            cy.get("#theDocument_button").click();
+            cy.get("#theDocument_button").should("contain.text", "33% Correct");
 
             cy.log("turn off document wide check work");
 
-            cy.get(cesc("#dwcw")).click();
-            cy.get(cesc("#dwcw_input")).should("not.be.checked");
+            cy.get("#dwcw").click();
+            cy.get("#dwcw_input").should("not.be.checked");
 
             cy.get(twoxInputButtonAnchor).should("contain.text", "Incorrect");
 
             cy.get(helloInputButtonAnchor).should("contain.text", "Incorrect");
 
-            cy.get(cesc("#fruitInput_button")).should("not.exist");
+            cy.get("#fruitInput_button").should("not.exist");
 
-            cy.get(cesc("#sum3_button")).should("not.exist");
+            cy.get("#sum3_button").should("not.exist");
 
-            cy.get(cesc("#subProblem_button")).should(
-                "contain.text",
-                "Correct",
-            );
+            cy.get("#subProblem_button").should("contain.text", "Correct");
 
-            cy.get(cesc("#theDocument_button")).should("not.exist");
+            cy.get("#theDocument_button").should("not.exist");
         });
     });
 
@@ -893,7 +754,7 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
         });
 
         // to wait for page to load
-        cy.get(cesc("#a")).should("have.text", "a");
+        cy.get("#a").should("have.text", "a");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -918,79 +779,55 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
                     .inputChildren[0].componentIdx;
             let mathInput4Anchor = cesc("#_id_" + mathInput4Idx) + " textarea";
 
-            cy.get(cesc("#prob1_button")).should("contain.text", "Check Work");
-            cy.get(cesc("#prob2_button")).should("contain.text", "Hit it!");
-            cy.get(cesc("#prob3_button")).should("contain.text", "Check Work");
-            cy.get(cesc("#prob4_button")).should("contain.text", "Hit it!");
+            cy.get("#prob1_button").should("contain.text", "Check Work");
+            cy.get("#prob2_button").should("contain.text", "Hit it!");
+            cy.get("#prob3_button").should("contain.text", "Check Work");
+            cy.get("#prob4_button").should("contain.text", "Hit it!");
 
             cy.get(mathInput1Anchor).type("x{enter}", { force: true });
             cy.get(mathInput2Anchor).type("x{enter}", { force: true });
             cy.get(mathInput3Anchor).type("x{enter}", { force: true });
             cy.get(mathInput4Anchor).type("x{enter}", { force: true });
 
-            cy.get(cesc("#prob1_button")).click();
-            cy.get(cesc("#prob2_button")).click();
-            cy.get(cesc("#prob3_button")).click();
-            cy.get(cesc("#prob4_button")).click();
+            cy.get("#prob1_button").click();
+            cy.get("#prob2_button").click();
+            cy.get("#prob3_button").click();
+            cy.get("#prob4_button").click();
 
-            cy.get(cesc("#prob1_button")).should("contain.text", "Correct");
-            cy.get(cesc("#prob2_button")).should("contain.text", "Correct");
-            cy.get(cesc("#prob3_button")).should("contain.text", "Correct");
-            cy.get(cesc("#prob4_button")).should("contain.text", "Correct");
+            cy.get("#prob1_button").should("contain.text", "Correct");
+            cy.get("#prob2_button").should("contain.text", "Correct");
+            cy.get("#prob3_button").should("contain.text", "Correct");
+            cy.get("#prob4_button").should("contain.text", "Correct");
 
             cy.get("#testRunner_toggleControls").click();
             cy.get("#testRunner_showCorrectness").click();
             cy.wait(100);
             cy.get("#testRunner_toggleControls").click();
 
-            cy.get(cesc("#prob1_button")).should(
-                "contain.text",
-                "Submit Response",
-            );
-            cy.get(cesc("#prob2_button")).should(
-                "contain.text",
-                "Submit Response",
-            );
-            cy.get(cesc("#prob3_button")).should("contain.text", "Guess");
-            cy.get(cesc("#prob4_button")).should("contain.text", "Guess");
+            cy.get("#prob1_button").should("contain.text", "Submit Response");
+            cy.get("#prob2_button").should("contain.text", "Submit Response");
+            cy.get("#prob3_button").should("contain.text", "Guess");
+            cy.get("#prob4_button").should("contain.text", "Guess");
 
-            cy.get(cesc("#prob1_button")).should(
-                "contain.text",
-                "Submit Response",
-            );
-            cy.get(cesc("#prob2_button")).should(
-                "contain.text",
-                "Submit Response",
-            );
-            cy.get(cesc("#prob3_button")).should("contain.text", "Guess");
-            cy.get(cesc("#prob4_button")).should("contain.text", "Guess");
+            cy.get("#prob1_button").should("contain.text", "Submit Response");
+            cy.get("#prob2_button").should("contain.text", "Submit Response");
+            cy.get("#prob3_button").should("contain.text", "Guess");
+            cy.get("#prob4_button").should("contain.text", "Guess");
 
             cy.get(mathInput1Anchor).type("x{enter}", { force: true });
             cy.get(mathInput2Anchor).type("x{enter}", { force: true });
             cy.get(mathInput3Anchor).type("x{enter}", { force: true });
             cy.get(mathInput4Anchor).type("x{enter}", { force: true });
 
-            cy.get(cesc("#prob1_button")).click();
-            cy.get(cesc("#prob2_button")).click();
-            cy.get(cesc("#prob3_button")).click();
-            cy.get(cesc("#prob4_button")).click();
+            cy.get("#prob1_button").click();
+            cy.get("#prob2_button").click();
+            cy.get("#prob3_button").click();
+            cy.get("#prob4_button").click();
 
-            cy.get(cesc("#prob1_button")).should(
-                "contain.text",
-                "Response Saved",
-            );
-            cy.get(cesc("#prob2_button")).should(
-                "contain.text",
-                "Response Saved",
-            );
-            cy.get(cesc("#prob3_button")).should(
-                "contain.text",
-                "Response Saved",
-            );
-            cy.get(cesc("#prob4_button")).should(
-                "contain.text",
-                "Response Saved",
-            );
+            cy.get("#prob1_button").should("contain.text", "Response Saved");
+            cy.get("#prob2_button").should("contain.text", "Response Saved");
+            cy.get("#prob3_button").should("contain.text", "Response Saved");
+            cy.get("#prob4_button").should("contain.text", "Response Saved");
         });
     });
 
@@ -1010,7 +847,7 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
         });
 
         // to wait for page to load
-        cy.get(cesc("#a")).should("have.text", "a");
+        cy.get("#a").should("have.text", "a");
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -1020,31 +857,28 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
                     .inputChildren[0].componentIdx;
             let mathInput1Anchor = cesc("#_id_" + mathInput1Idx) + " textarea";
 
-            cy.get(cesc("#doc_button")).should("contain.text", "Hit it!");
+            cy.get("#doc_button").should("contain.text", "Hit it!");
 
             cy.get(mathInput1Anchor).type("x{enter}", { force: true });
 
-            cy.get(cesc("#doc_button")).click();
+            cy.get("#doc_button").click();
 
-            cy.get(cesc("#doc_button")).should("contain.text", "Correct");
+            cy.get("#doc_button").should("contain.text", "Correct");
 
             cy.get("#testRunner_toggleControls").click();
             cy.get("#testRunner_showCorrectness").click();
             cy.wait(100);
             cy.get("#testRunner_toggleControls").click();
 
-            cy.get(cesc("#doc_button")).should("contain.text", "Guess");
+            cy.get("#doc_button").should("contain.text", "Guess");
 
-            cy.get(cesc("#doc_button")).should("contain.text", "Guess");
+            cy.get("#doc_button").should("contain.text", "Guess");
 
             cy.get(mathInput1Anchor).type("x{enter}", { force: true });
 
-            cy.get(cesc("#doc_button")).click();
+            cy.get("#doc_button").click();
 
-            cy.get(cesc("#doc_button")).should(
-                "contain.text",
-                "Response Saved",
-            );
+            cy.get("#doc_button").should("contain.text", "Response Saved");
         });
     });
 
@@ -1095,7 +929,7 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+        cy.get("#a").should("have.text", "a"); //wait for page to load
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -1111,42 +945,13 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
             let otherFruitColor =
                 selectedFruitColor === "red" ? "yellow" : "red";
 
-            cy.get(cesc("#ca")).should("have.text", "0");
+            cy.get("#ca").should("have.text", "0");
 
-            cy.get(cesc("#input1_input")).type(`${otherFruitName}{enter}`);
-            cy.get(cesc("#input1_button")).should("contain.text", "Incorrect");
-            cy.get(cesc("#ca")).should("have.text", "0");
+            cy.get("#input1_input").type(`${otherFruitName}{enter}`);
+            cy.get("#input1_button").should("contain.text", "Incorrect");
+            cy.get("#ca").should("have.text", "0");
 
-            cy.get(cesc("#input2_button")).should("contain.text", "Check Work");
-
-            cy.wait(2000); // wait to make sure debounce save happened
-
-            cy.reload();
-
-            cy.window().then(async (win) => {
-                win.postMessage(
-                    {
-                        doenetML,
-                    },
-                    "*",
-                );
-            });
-            cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
-
-            cy.get(cesc("#input1_button")).should("contain.text", "Incorrect");
-            cy.get(cesc("#input2_button")).should("contain.text", "Check Work");
-            cy.get(cesc("#ca")).should("have.text", "0");
-
-            cy.get(cesc("#input1_input")).clear().type(selectedFruitName);
-            cy.get(cesc("#input1_button")).click();
-            cy.get(cesc("#input1_button")).should("contain.text", "Correct");
-            cy.get(cesc("#ca")).should("have.text", "0.5");
-
-            cy.get(cesc("#input2_input"))
-                .clear()
-                .type(`${otherFruitColor}{enter}`);
-            cy.get(cesc("#input2_button")).should("contain.text", "Incorrect");
-            cy.get(cesc("#ca")).should("have.text", "0.5");
+            cy.get("#input2_button").should("contain.text", "Check Work");
 
             cy.wait(2000); // wait to make sure debounce save happened
 
@@ -1160,16 +965,20 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
                     "*",
                 );
             });
-            cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+            cy.get("#a").should("have.text", "a"); //wait for page to load
 
-            cy.get(cesc("#input1_button")).should("contain.text", "Correct");
-            cy.get(cesc("#input2_button")).should("contain.text", "Incorrect");
-            cy.get(cesc("#ca")).should("have.text", "0.5");
+            cy.get("#input1_button").should("contain.text", "Incorrect");
+            cy.get("#input2_button").should("contain.text", "Check Work");
+            cy.get("#ca").should("have.text", "0");
 
-            cy.get(cesc("#input2_input")).clear().type(selectedFruitColor);
-            cy.get(cesc("#input2_button")).click();
-            cy.get(cesc("#input2_button")).should("contain.text", "Correct");
-            cy.get(cesc("#ca")).should("have.text", "1");
+            cy.get("#input1_input").clear().type(selectedFruitName);
+            cy.get("#input1_button").click();
+            cy.get("#input1_button").should("contain.text", "Correct");
+            cy.get("#ca").should("have.text", "0.5");
+
+            cy.get("#input2_input").clear().type(`${otherFruitColor}{enter}`);
+            cy.get("#input2_button").should("contain.text", "Incorrect");
+            cy.get("#ca").should("have.text", "0.5");
 
             cy.wait(2000); // wait to make sure debounce save happened
 
@@ -1183,11 +992,34 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
                     "*",
                 );
             });
-            cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+            cy.get("#a").should("have.text", "a"); //wait for page to load
 
-            cy.get(cesc("#input1_button")).should("contain.text", "Correct");
-            cy.get(cesc("#input2_button")).should("contain.text", "Correct");
-            cy.get(cesc("#ca")).should("have.text", "1");
+            cy.get("#input1_button").should("contain.text", "Correct");
+            cy.get("#input2_button").should("contain.text", "Incorrect");
+            cy.get("#ca").should("have.text", "0.5");
+
+            cy.get("#input2_input").clear().type(selectedFruitColor);
+            cy.get("#input2_button").click();
+            cy.get("#input2_button").should("contain.text", "Correct");
+            cy.get("#ca").should("have.text", "1");
+
+            cy.wait(2000); // wait to make sure debounce save happened
+
+            cy.reload();
+
+            cy.window().then(async (win) => {
+                win.postMessage(
+                    {
+                        doenetML,
+                    },
+                    "*",
+                );
+            });
+            cy.get("#a").should("have.text", "a"); //wait for page to load
+
+            cy.get("#input1_button").should("contain.text", "Correct");
+            cy.get("#input2_button").should("contain.text", "Correct");
+            cy.get("#ca").should("have.text", "1");
         });
     });
 

--- a/packages/test-cypress/cypress/e2e/tagSpecific/ref.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/ref.cy.js
@@ -108,7 +108,7 @@ describe("ref Tag Tests", { tags: ["@group1"] }, function () {
         });
 
         // to wait for page to load
-        cy.get(cesc("#section1_title")).should("include.text", "Section 1");
+        cy.get("#section1_title").should("include.text", "Section 1");
 
         cy.get(cesc("#section1.toFour")).click();
         cy.url().should("include", "#section4");
@@ -116,7 +116,7 @@ describe("ref Tag Tests", { tags: ["@group1"] }, function () {
         cy.get(cesc("#section4.toOne")).click();
         cy.url().should("include", "#section1");
 
-        cy.get(cesc("#toThreeii")).click();
+        cy.get("#toThreeii").click();
         cy.url().should("include", "#section3.p2");
 
         cy.get(cesc("#section4.toTwoe")).click();
@@ -135,9 +135,9 @@ describe("ref Tag Tests", { tags: ["@group1"] }, function () {
             );
         });
 
-        cy.get(cesc("#p1")).should("have.text", "A ref to Doenet.");
+        cy.get("#p1").should("have.text", "A ref to Doenet.");
 
-        cy.get(cesc("#ref1"))
+        cy.get("#ref1")
             .should("have.text", "Doenet")
             .invoke("attr", "href")
             .then((href) => expect(href).eq("http://doenet.org"));
@@ -155,9 +155,9 @@ describe("ref Tag Tests", { tags: ["@group1"] }, function () {
             );
         });
 
-        cy.get(cesc("#p1")).should("have.text", "A ref to Doenet.");
+        cy.get("#p1").should("have.text", "A ref to Doenet.");
 
-        cy.get(cesc("#ref1"))
+        cy.get("#ref1")
             .should("have.text", "Doenet")
             .invoke("attr", "href")
             .then((href) => expect(href).eq("http://doenet.org/#a&b"));
@@ -175,9 +175,9 @@ describe("ref Tag Tests", { tags: ["@group1"] }, function () {
             );
         });
 
-        cy.get(cesc("#p1")).should("have.text", "A ref to a Doenet doc.");
+        cy.get("#p1").should("have.text", "A ref to a Doenet doc.");
 
-        cy.get(cesc("#ref1"))
+        cy.get("#ref1")
             .should("have.text", "a Doenet doc")
             .invoke("attr", "href")
             .then((href) =>
@@ -197,7 +197,7 @@ describe("ref Tag Tests", { tags: ["@group1"] }, function () {
             );
         });
 
-        cy.get(cesc("#toDoenet") + " button").should("contain", "Go to Doenet");
+        cy.get("#toDoenet" + " button").should("contain", "Go to Doenet");
     });
 
     // Note: the next 5 test currently do not work as we have not fixed the navigate to target action
@@ -239,10 +239,10 @@ describe("ref Tag Tests", { tags: ["@group1"] }, function () {
         });
 
         // to wait for page to load
-        cy.get(cesc("#asideTitle")).should("have.text", "The aside");
+        cy.get("#asideTitle").should("have.text", "The aside");
 
         cy.log("Aside closed at the beginning");
-        cy.get(cesc("#inside")).should("not.exist");
+        cy.get("#inside").should("not.exist");
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
             expect(
@@ -251,9 +251,9 @@ describe("ref Tag Tests", { tags: ["@group1"] }, function () {
         });
 
         cy.log("clicking ref opens aside");
-        cy.get(cesc("#toAside")).click();
+        cy.get("#toAside").click();
 
-        cy.get(cesc("#inside")).should("have.text", "Inside the aside");
+        cy.get("#inside").should("have.text", "Inside the aside");
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
             expect(
@@ -290,10 +290,10 @@ describe("ref Tag Tests", { tags: ["@group1"] }, function () {
         });
 
         // to wait for page to load
-        cy.get(cesc("#asideTitle")).should("have.text", "The aside");
+        cy.get("#asideTitle").should("have.text", "The aside");
 
         cy.log("Aside closed at the beginning");
-        cy.get(cesc("#inside")).should("not.exist");
+        cy.get("#inside").should("not.exist");
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
             expect(
@@ -302,14 +302,14 @@ describe("ref Tag Tests", { tags: ["@group1"] }, function () {
         });
 
         cy.log("clicking ref opens aside");
-        cy.get(cesc("#toAside")).click();
+        cy.get("#toAside").click();
 
-        cy.get(cesc("#inside")).should(
+        cy.get("#inside").should(
             "have.text",
             "Paragraph inside the section inside the aside.",
         );
 
-        cy.get(cesc("#inside")).then((el) => {
+        cy.get("#inside").then((el) => {
             let rect = el[0].getBoundingClientRect();
             expect(rect.top).gt(-1).lt(1);
         });
@@ -347,10 +347,10 @@ describe("ref Tag Tests", { tags: ["@group1"] }, function () {
         });
 
         // to wait for page to load
-        cy.get(cesc("#asideTitle")).should("have.text", "The aside");
+        cy.get("#asideTitle").should("have.text", "The aside");
 
         cy.log("Aside closed at the beginning");
-        cy.get(cesc("#inside")).should("not.exist");
+        cy.get("#inside").should("not.exist");
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
             expect(
@@ -359,9 +359,9 @@ describe("ref Tag Tests", { tags: ["@group1"] }, function () {
         });
 
         cy.log("clicking action opens aside");
-        cy.get(cesc("#go")).click();
+        cy.get("#go").click();
 
-        cy.get(cesc("#inside")).should("have.text", "Inside the aside");
+        cy.get("#inside").should("have.text", "Inside the aside");
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
             expect(
@@ -399,10 +399,10 @@ describe("ref Tag Tests", { tags: ["@group1"] }, function () {
         });
 
         // to wait for page to load
-        cy.get(cesc("#asideTitle")).should("have.text", "The aside");
+        cy.get("#asideTitle").should("have.text", "The aside");
 
         cy.log("Aside closed at the beginning");
-        cy.get(cesc("#inside")).should("not.exist");
+        cy.get("#inside").should("not.exist");
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
             expect(
@@ -411,14 +411,14 @@ describe("ref Tag Tests", { tags: ["@group1"] }, function () {
         });
 
         cy.log("clicking action opens aside");
-        cy.get(cesc("#go")).click();
+        cy.get("#go").click();
 
-        cy.get(cesc("#inside")).should(
+        cy.get("#inside").should(
             "have.text",
             "Paragraph inside the section inside the aside.",
         );
 
-        cy.get(cesc("#inside")).then((el) => {
+        cy.get("#inside").then((el) => {
             cy.waitUntil(() => {
                 let rect = el[0].getBoundingClientRect();
                 return rect.top > -1 && rect.top < 1;
@@ -467,18 +467,18 @@ describe("ref Tag Tests", { tags: ["@group1"] }, function () {
         });
 
         // to wait for page to load
-        cy.get(cesc("#asideTitle")).should("have.text", "Counting");
+        cy.get("#asideTitle").should("have.text", "Counting");
 
         cy.log("Aside closed at the beginning");
-        cy.get(cesc("#n")).should("not.exist");
+        cy.get("#n").should("not.exist");
 
         cy.log("clicking action opens aside and starts counting");
-        cy.get(cesc("#startCount")).click();
+        cy.get("#startCount").click();
 
-        cy.get(cesc("#n")).should("have.text", "1");
-        cy.get(cesc("#n")).should("have.text", "2");
-        cy.get(cesc("#n")).should("have.text", "3");
-        cy.get(cesc("#n")).should("have.text", "4");
-        cy.get(cesc("#n")).should("have.text", "5");
+        cy.get("#n").should("have.text", "1");
+        cy.get("#n").should("have.text", "2");
+        cy.get("#n").should("have.text", "3");
+        cy.get("#n").should("have.text", "4");
+        cy.get("#n").should("have.text", "5");
     });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/repeat.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/repeat.cy.js
@@ -1,5 +1,3 @@
-import { cesc } from "@doenet/utils";
-
 describe("Map Tag Tests", { tags: ["@group1"] }, function () {
     beforeEach(() => {
         cy.clearIndexedDB();

--- a/packages/test-cypress/cypress/e2e/tagSpecific/sampleprimenumbers.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/sampleprimenumbers.cy.js
@@ -1,5 +1,3 @@
-import { cesc } from "@doenet/utils";
-
 describe("SamplePrimeNumbers Tag Tests", { tags: ["@group1"] }, function () {
     beforeEach(() => {
         cy.clearIndexedDB();
@@ -24,7 +22,7 @@ describe("SamplePrimeNumbers Tag Tests", { tags: ["@group1"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+        cy.get("#a").should("have.text", "a"); //wait for page to load
 
         let samples = [];
 
@@ -60,7 +58,7 @@ describe("SamplePrimeNumbers Tag Tests", { tags: ["@group1"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+        cy.get("#a").should("have.text", "a"); //wait for page to load
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -110,7 +108,7 @@ describe("SamplePrimeNumbers Tag Tests", { tags: ["@group1"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+        cy.get("#a").should("have.text", "a"); //wait for page to load
 
         let samples = [];
 
@@ -136,8 +134,8 @@ describe("SamplePrimeNumbers Tag Tests", { tags: ["@group1"] }, function () {
         });
 
         cy.log("interact so changes will be saved to database");
-        cy.get(cesc("#bi")).click();
-        cy.get(cesc("#b2")).should("have.text", "true");
+        cy.get("#bi").click();
+        cy.get("#b2").should("have.text", "true");
 
         cy.log("wait for debounce");
         cy.wait(1500);
@@ -154,8 +152,8 @@ describe("SamplePrimeNumbers Tag Tests", { tags: ["@group1"] }, function () {
         });
 
         cy.log("make sure core is up and running");
-        cy.get(cesc("#bi")).click();
-        cy.get(cesc("#b2")).should("have.text", "false");
+        cy.get("#bi").click();
+        cy.get("#b2").should("have.text", "false");
 
         cy.log("check that values are unchanged");
         cy.window().then(async (win) => {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/samplerandomnumbers.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/samplerandomnumbers.cy.js
@@ -1,5 +1,3 @@
-import { cesc } from "@doenet/utils";
-
 describe("SampleRandomNumbers Tag Tests", { tags: ["@group4"] }, function () {
     beforeEach(() => {
         cy.clearIndexedDB();
@@ -23,7 +21,7 @@ describe("SampleRandomNumbers Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+        cy.get("#a").should("have.text", "a"); //wait for page to load
 
         let samples = [];
 
@@ -55,7 +53,7 @@ describe("SampleRandomNumbers Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+        cy.get("#a").should("have.text", "a"); //wait for page to load
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -102,7 +100,7 @@ describe("SampleRandomNumbers Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
+        cy.get("#a").should("have.text", "a"); //wait for page to load
 
         let samples = [];
 
@@ -124,8 +122,8 @@ describe("SampleRandomNumbers Tag Tests", { tags: ["@group4"] }, function () {
         });
 
         cy.log("interact so changes will be saved to database");
-        cy.get(cesc("#bi")).click();
-        cy.get(cesc("#b2")).should("have.text", "true");
+        cy.get("#bi").click();
+        cy.get("#b2").should("have.text", "true");
 
         cy.log("wait for debounce");
         cy.wait(1500);
@@ -142,8 +140,8 @@ describe("SampleRandomNumbers Tag Tests", { tags: ["@group4"] }, function () {
         });
 
         cy.log("make sure core is up and running");
-        cy.get(cesc("#bi")).click();
-        cy.get(cesc("#b2")).should("have.text", "false");
+        cy.get("#bi").click();
+        cy.get("#b2").should("have.text", "false");
 
         cy.log("check that values are unchanged");
 

--- a/packages/test-cypress/cypress/e2e/tagSpecific/sectioning.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/sectioning.cy.js
@@ -32,65 +32,65 @@ describe("Sectioning Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#expr1b")).should(
+        cy.get("#expr1b").should(
             "have.text",
             removeSpaces(toMathJaxString("(x+1)(x2−1)")), // not sure why don't have space in from of +s here
         );
-        cy.get(cesc("#expr2b")).should(
+        cy.get("#expr2b").should(
             "have.text",
             removeSpaces(toMathJaxString("(x−1)(x2+1)")),
         );
-        cy.get(cesc("#expr1a")).should("not.exist");
-        cy.get(cesc("#expr2a")).should(
+        cy.get("#expr1a").should("not.exist");
+        cy.get("#expr2a").should(
             "have.text",
             removeSpaces(toMathJaxString("(x−1)(x2+1)")),
         );
 
-        cy.get(cesc("#expr1")).should("not.exist");
-        // cy.get(cesc("#expr2") + " .mq-editable-field")
+        cy.get("#expr1").should("not.exist");
+        // cy.get("#expr2" + " .mq-editable-field")
         //     .invoke("text")
         //     .then((text) => {
         //         expect(text.trim()).eq("(x−1)(x2+1)");
         //     });
 
-        cy.get(cesc("#aside1_title")).click();
+        cy.get("#aside1_title").click();
 
-        cy.get(cesc("#expr1a")).should(
+        cy.get("#expr1a").should(
             "have.text",
             removeSpaces(toMathJaxString("(x+1)(x2−1)")),
         );
-        // cy.get(cesc("#expr1") + " .mq-editable-field")
+        // cy.get("#expr1" + " .mq-editable-field")
         //     .invoke("text")
         //     .then((text) => {
         //         expect(text.trim()).eq("(x+1)(x2−1)");
         //     });
 
-        cy.get(cesc("#aside2_title")).click();
-        cy.get(cesc("#expr2a")).should("not.exist");
-        cy.get(cesc("#expr2")).should("not.exist");
+        cy.get("#aside2_title").click();
+        cy.get("#expr2a").should("not.exist");
+        cy.get("#expr2").should("not.exist");
 
-        cy.get(cesc("#expr1b")).should(
+        cy.get("#expr1b").should(
             "have.text",
             removeSpaces(toMathJaxString("(x+1)(x2−1)")),
         );
-        cy.get(cesc("#expr2b")).should(
+        cy.get("#expr2b").should(
             "have.text",
             removeSpaces(toMathJaxString("(x−1)(x2+1)")),
         );
 
-        cy.get(cesc("#expr1") + " textarea")
+        cy.get("#expr1" + " textarea")
             .type("{end}{leftArrow}{backspace}4{enter}", { force: true })
             .blur();
 
-        cy.get(cesc("#expr1a")).should(
+        cy.get("#expr1a").should(
             "contain.text",
             removeSpaces(toMathJaxString("(x+1)(x2−4)")),
         );
-        cy.get(cesc("#expr1a")).should(
+        cy.get("#expr1a").should(
             "have.text",
             removeSpaces(toMathJaxString("(x+1)(x2−4)")),
         );
-        // cy.get(cesc("#expr1") + " .mq-editable-field")
+        // cy.get("#expr1" + " .mq-editable-field")
         //     .invoke("text")
         //     .then((text) => {
         //         expect(text.replace(/[\s\u200B-\u200D\uFEFF]/g, "")).eq(
@@ -98,49 +98,49 @@ describe("Sectioning Tag Tests", { tags: ["@group4"] }, function () {
         //         );
         //     });
 
-        cy.get(cesc("#expr1b")).should(
+        cy.get("#expr1b").should(
             "have.text",
             removeSpaces(toMathJaxString("(x+1)(x2−4)")),
         );
-        cy.get(cesc("#expr2b")).should(
+        cy.get("#expr2b").should(
             "have.text",
             removeSpaces(toMathJaxString("(x−1)(x2+1)")),
         );
 
-        cy.get(cesc("#aside1_title")).click();
-        cy.get(cesc("#expr1a")).should("not.exist");
-        cy.get(cesc("#expr1")).should("not.exist");
+        cy.get("#aside1_title").click();
+        cy.get("#expr1a").should("not.exist");
+        cy.get("#expr1").should("not.exist");
 
-        cy.get(cesc("#expr1b")).should(
+        cy.get("#expr1b").should(
             "have.text",
             removeSpaces(toMathJaxString("(x+1)(x2−4)")),
         );
-        cy.get(cesc("#expr2b")).should(
+        cy.get("#expr2b").should(
             "have.text",
             removeSpaces(toMathJaxString("(x−1)(x2+1)")),
         );
 
-        cy.get(cesc("#aside2_title")).click();
+        cy.get("#aside2_title").click();
 
-        cy.get(cesc("#expr2a")).should(
+        cy.get("#expr2a").should(
             "have.text",
             removeSpaces(toMathJaxString("(x−1)(x2+1)")),
         );
-        // cy.get(cesc("#expr2") + " .mq-editable-field")
+        // cy.get("#expr2" + " .mq-editable-field")
         //     .invoke("text")
         //     .then((text) => {
         //         expect(text.trim()).eq("(x−1)(x2+1)");
         //     });
 
-        cy.get(cesc("#expr2") + " textarea")
+        cy.get("#expr2" + " textarea")
             .type("{end}{leftArrow}{backspace}4{enter}", { force: true })
             .blur();
 
-        cy.get(cesc("#expr2a")).should(
+        cy.get("#expr2a").should(
             "have.text",
             removeSpaces(toMathJaxString("(x−1)(x2+4)")),
         );
-        // cy.get(cesc("#expr2") + " .mq-editable-field")
+        // cy.get("#expr2" + " .mq-editable-field")
         //     .invoke("text")
         //     .then((text) => {
         //         expect(text.replace(/[\s\u200B-\u200D\uFEFF]/g, "")).eq(
@@ -148,11 +148,11 @@ describe("Sectioning Tag Tests", { tags: ["@group4"] }, function () {
         //         );
         //     });
 
-        cy.get(cesc("#expr1b")).should(
+        cy.get("#expr1b").should(
             "have.text",
             removeSpaces(toMathJaxString("(x+1)(x2−4)")),
         );
-        cy.get(cesc("#expr2b")).should(
+        cy.get("#expr2b").should(
             "have.text",
             removeSpaces(toMathJaxString("(x−1)(x2+4)")),
         );
@@ -184,19 +184,19 @@ describe("Sectioning Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#sec_title")).should("have.text", "Section 1: A title");
-        cy.get(cesc("#revised_title")).should(
+        cy.get("#sec_title").should("have.text", "Section 1: A title");
+        cy.get("#revised_title").should(
             "have.text",
             "Section 2: A better title",
         );
-        cy.get(cesc("#title1")).should("have.text", "A title");
-        cy.get(cesc("#title2")).should("have.text", "A better title");
-        cy.get(cesc("#sectionNumber1")).should("have.text", "1");
-        cy.get(cesc("#sectionNumber2")).should("have.text", "2");
+        cy.get("#title1").should("have.text", "A title");
+        cy.get("#title2").should("have.text", "A better title");
+        cy.get("#sectionNumber1").should("have.text", "1");
+        cy.get("#sectionNumber2").should("have.text", "2");
 
-        cy.get(cesc("#p1")).should("have.text", "Hello");
+        cy.get("#p1").should("have.text", "Hello");
         cy.get("#revised .para").eq(0).should("have.text", "Hello");
-        cy.get(cesc("#p2")).should("have.text", "Good day!");
+        cy.get("#p2").should("have.text", "Good day!");
     });
 
     it("copy and overwrite title,s", () => {
@@ -225,8 +225,8 @@ describe("Sectioning Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#sec_title")).should("have.text", "Section 1: A title");
-        cy.get(cesc("#revised_title")).should(
+        cy.get("#sec_title").should("have.text", "Section 1: A title");
+        cy.get("#revised_title").should(
             "have.text",
             "Section 2: A better title",
         );
@@ -235,12 +235,12 @@ describe("Sectioning Tag Tests", { tags: ["@group4"] }, function () {
         cy.get(cesc("#revised.title2")).should("have.text", "A better title");
         cy.get(cesc("#p3.title1")).should("have.text", "A title");
         cy.get(cesc("#p4.title2")).should("have.text", "A better title");
-        cy.get(cesc("#sectionNumber1")).should("have.text", "1");
-        cy.get(cesc("#sectionNumber2")).should("have.text", "2");
+        cy.get("#sectionNumber1").should("have.text", "1");
+        cy.get("#sectionNumber2").should("have.text", "2");
 
-        cy.get(cesc("#p1")).should("have.text", "Hello");
+        cy.get("#p1").should("have.text", "Hello");
         cy.get(cesc("#revised.p1")).should("have.text", "Hello");
-        cy.get(cesc("#p2")).should("have.text", "Good day!");
+        cy.get("#p2").should("have.text", "Good day!");
     });
 
     // TODO: reinstate this test
@@ -281,30 +281,27 @@ describe("Sectioning Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#aside1_title")).should("contain.text", "Aside 1");
-        cy.get(cesc("#aside1_title")).should("not.contain.text", ":");
-        cy.get(cesc("#aside2_title")).should(
-            "contain.text",
-            "Aside: Side point",
-        );
-        cy.get(cesc("#aside3_title")).should(
+        cy.get("#aside1_title").should("contain.text", "Aside 1");
+        cy.get("#aside1_title").should("not.contain.text", ":");
+        cy.get("#aside2_title").should("contain.text", "Aside: Side point");
+        cy.get("#aside3_title").should(
             "contain.text",
             "Aside 3: Another side point",
         );
-        cy.get(cesc("#title1")).should("have.text", "Aside 1");
-        cy.get(cesc("#title2")).should("have.text", "Side point");
-        cy.get(cesc("#title3")).should("have.text", "Another side point");
+        cy.get("#title1").should("have.text", "Aside 1");
+        cy.get("#title2").should("have.text", "Side point");
+        cy.get("#title3").should("have.text", "Another side point");
 
-        cy.get(cesc("#aside3_title")).click();
+        cy.get("#aside3_title").click();
 
-        cy.get(cesc("#aside31_title")).should("contain.text", "Subpoint");
-        cy.get(cesc("#aside31_title")).should("not.contain.text", "1");
-        cy.get(cesc("#aside31_title")).should("not.contain.text", ":");
-        cy.get(cesc("#aside32_title")).should("contain.text", "Aside 5 ");
-        cy.get(cesc("#aside32_title")).should("not.contain.text", ":");
+        cy.get("#aside31_title").should("contain.text", "Subpoint");
+        cy.get("#aside31_title").should("not.contain.text", "1");
+        cy.get("#aside31_title").should("not.contain.text", ":");
+        cy.get("#aside32_title").should("contain.text", "Aside 5 ");
+        cy.get("#aside32_title").should("not.contain.text", ":");
 
-        cy.get(cesc("#title31")).should("have.text", "Subpoint");
-        cy.get(cesc("#title32")).should("have.text", "Aside 5");
+        cy.get("#title31").should("have.text", "Subpoint");
+        cy.get("#title32").should("have.text", "Aside 5");
     });
 
     it("Aside with postpone rendering opens before initializing", () => {
@@ -325,16 +322,16 @@ describe("Sectioning Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#aside")).should("contain.text", "An aside");
-        cy.get(cesc("#aside")).should("not.contain.text", "The aside");
+        cy.get("#aside").should("contain.text", "An aside");
+        cy.get("#aside").should("not.contain.text", "The aside");
 
-        cy.get(cesc("#aside")).click();
-        cy.get(cesc("#aside")).should("contain.text", "Initializing");
-        cy.get(cesc("#aside")).should("not.contain.text", "The aside");
+        cy.get("#aside").click();
+        cy.get("#aside").should("contain.text", "Initializing");
+        cy.get("#aside").should("not.contain.text", "The aside");
 
         cy.log("Eventually aside finishes rendering");
-        cy.get(cesc("#aside")).should("contain.text", "The aside");
-        cy.get(cesc("#aside")).should("not.contain.text", "Initializing");
+        cy.get("#aside").should("contain.text", "The aside");
+        cy.get("#aside").should("not.contain.text", "Initializing");
     });
 
     it("Proof with postpone rendering opens before initializing", () => {
@@ -355,16 +352,16 @@ describe("Sectioning Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#proof")).should("contain.text", "An proof");
-        cy.get(cesc("#proof")).should("not.contain.text", "The proof");
+        cy.get("#proof").should("contain.text", "An proof");
+        cy.get("#proof").should("not.contain.text", "The proof");
 
-        cy.get(cesc("#proof")).click();
-        cy.get(cesc("#proof")).should("contain.text", "Initializing");
-        cy.get(cesc("#proof")).should("not.contain.text", "The proof");
+        cy.get("#proof").click();
+        cy.get("#proof").should("contain.text", "Initializing");
+        cy.get("#proof").should("not.contain.text", "The proof");
 
         cy.log("Eventually proof finishes rendering");
-        cy.get(cesc("#proof")).should("contain.text", "The proof");
-        cy.get(cesc("#proof")).should("not.contain.text", "Initializing");
+        cy.get("#proof").should("contain.text", "The proof");
+        cy.get("#proof").should("not.contain.text", "Initializing");
     });
 
     it("Exercise with statement, hint, givenanswer, and solution", () => {
@@ -393,58 +390,34 @@ describe("Sectioning Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#title")).should("have.text", "An exercise");
+        cy.get("#title").should("have.text", "An exercise");
 
-        cy.get(cesc("#statement")).should("have.text", "The exercise");
+        cy.get("#statement").should("have.text", "The exercise");
 
-        cy.get(cesc("#hint") + " [data-test=hint-heading]").should(
+        cy.get("#hint" + " [data-test=hint-heading]").should(
             "contain.text",
             "Hint",
         );
-        cy.get(cesc("#hint")).should("not.contain.text", "Try harder");
-        cy.get(cesc("#givenAnswer")).should("contain.text", "Answer");
-        cy.get(cesc("#givenAnswer")).should(
-            "not.contain.text",
-            "The correct answer",
-        );
-        cy.get(cesc("#solution")).should("contain.text", "Solution");
-        cy.get(cesc("#solution")).should(
-            "not.contain.text",
-            "Here's how you do it.",
-        );
+        cy.get("#hint").should("not.contain.text", "Try harder");
+        cy.get("#givenAnswer").should("contain.text", "Answer");
+        cy.get("#givenAnswer").should("not.contain.text", "The correct answer");
+        cy.get("#solution").should("contain.text", "Solution");
+        cy.get("#solution").should("not.contain.text", "Here's how you do it.");
 
-        cy.get(cesc("#hint") + " [data-test=hint-heading]").click();
-        cy.get(cesc("#hint")).should("contain.text", "Try harder");
-        cy.get(cesc("#givenAnswer")).should(
-            "not.contain.text",
-            "The correct answer",
-        );
-        cy.get(cesc("#solution")).should(
-            "not.contain.text",
-            "Here's how you do it.",
-        );
+        cy.get("#hint" + " [data-test=hint-heading]").click();
+        cy.get("#hint").should("contain.text", "Try harder");
+        cy.get("#givenAnswer").should("not.contain.text", "The correct answer");
+        cy.get("#solution").should("not.contain.text", "Here's how you do it.");
 
-        cy.get(cesc("#givenAnswer_button")).click();
-        cy.get(cesc("#givenAnswer")).should(
-            "contain.text",
-            "The correct answer",
-        );
-        cy.get(cesc("#hint")).should("contain.text", "Try harder");
-        cy.get(cesc("#solution")).should(
-            "not.contain.text",
-            "Here's how you do it.",
-        );
+        cy.get("#givenAnswer_button").click();
+        cy.get("#givenAnswer").should("contain.text", "The correct answer");
+        cy.get("#hint").should("contain.text", "Try harder");
+        cy.get("#solution").should("not.contain.text", "Here's how you do it.");
 
-        cy.get(cesc("#solution_button")).click();
-        cy.get(cesc("#solution")).should(
-            "contain.text",
-            "Here's how you do it.",
-        );
-        cy.get(cesc("#hint")).should("contain.text", "Try harder");
-        cy.get(cesc("#givenAnswer")).should(
-            "contain.text",
-            "The correct answer",
-        );
+        cy.get("#solution_button").click();
+        cy.get("#solution").should("contain.text", "Here's how you do it.");
+        cy.get("#hint").should("contain.text", "Try harder");
+        cy.get("#givenAnswer").should("contain.text", "The correct answer");
     });
 
     it("Section with introduction, subsections and conclusion", () => {
@@ -479,26 +452,23 @@ describe("Sectioning Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#title")).should("have.text", "A section");
+        cy.get("#title").should("have.text", "A section");
 
-        cy.get(cesc("#introduction")).should(
+        cy.get("#introduction").should(
             "have.text",
             "\n    First this\n    Then that\n    Hello World\n  ",
         );
 
-        cy.get(cesc("#subsection1")).should(
+        cy.get("#subsection1").should(
             "have.text",
             "Point 1\n    \n    Make the first point\n  ",
         );
-        cy.get(cesc("#subsection2")).should(
+        cy.get("#subsection2").should(
             "have.text",
             "Point 2\n    \n    Make the second point\n  ",
         );
 
-        cy.get(cesc("#conclusion")).should(
-            "have.text",
-            "\n    Wrap it up!\n  ",
-        );
+        cy.get("#conclusion").should("have.text", "\n    Wrap it up!\n  ");
     });
 
     it("Objectives", () => {
@@ -521,12 +491,12 @@ describe("Sectioning Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#title")).should("have.text", "A section");
+        cy.get("#title").should("have.text", "A section");
 
-        cy.get(cesc("#objectives_title")).should("have.text", "Objectives 1");
-        cy.get(cesc("#objectives")).should("contain.text", "Hello World");
+        cy.get("#objectives_title").should("have.text", "Objectives 1");
+        cy.get("#objectives").should("contain.text", "Hello World");
 
-        cy.get(cesc("#p")).should("have.text", "Is objectives boxed? true");
+        cy.get("#p").should("have.text", "Is objectives boxed? true");
     });
 
     it("Activity", () => {
@@ -549,12 +519,12 @@ describe("Sectioning Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#title")).should("have.text", "A section");
+        cy.get("#title").should("have.text", "A section");
 
-        cy.get(cesc("#activity_title")).should("have.text", "Activity 1");
-        cy.get(cesc("#activity")).should("contain.text", "Hello World");
+        cy.get("#activity_title").should("have.text", "Activity 1");
+        cy.get("#activity").should("contain.text", "Hello World");
 
-        cy.get(cesc("#p")).should("have.text", "Is activity boxed? false");
+        cy.get("#p").should("have.text", "Is activity boxed? false");
     });
 
     it("Definition", () => {
@@ -577,12 +547,12 @@ describe("Sectioning Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#title")).should("have.text", "A section");
+        cy.get("#title").should("have.text", "A section");
 
-        cy.get(cesc("#definition_title")).should("have.text", "Definition 1");
-        cy.get(cesc("#definition")).should("contain.text", "Hello World");
+        cy.get("#definition_title").should("have.text", "Definition 1");
+        cy.get("#definition").should("contain.text", "Hello World");
 
-        cy.get(cesc("#p")).should("have.text", "Is definition boxed? false");
+        cy.get("#p").should("have.text", "Is definition boxed? false");
     });
 
     it("Note", () => {
@@ -605,12 +575,12 @@ describe("Sectioning Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#title")).should("have.text", "A section");
+        cy.get("#title").should("have.text", "A section");
 
-        cy.get(cesc("#note_title")).should("have.text", "Note 1");
-        cy.get(cesc("#note")).should("contain.text", "Hello World");
+        cy.get("#note_title").should("have.text", "Note 1");
+        cy.get("#note").should("contain.text", "Hello World");
 
-        cy.get(cesc("#p")).should("have.text", "Is note boxed? false");
+        cy.get("#p").should("have.text", "Is note boxed? false");
     });
 
     // TODO: reinstate this test
@@ -639,22 +609,22 @@ describe("Sectioning Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#title1")).should("have.text", "A section");
+        cy.get("#title1").should("have.text", "A section");
 
-        cy.get(cesc("#theorem1_title")).should("have.text", "Theorem 1");
-        cy.get(cesc("#statement1")).should("have.text", "The statement");
-        cy.get(cesc("#proof1_title")).should("contain.text", "Proof");
-        cy.get(cesc("#proof1_title")).should("contain.text", "Proof");
-        cy.get(cesc("#proof1")).should("not.contain.text", "The proof");
-        cy.get(cesc("#proof1_title")).click();
-        cy.get(cesc("#proof1")).should("contain.text", "The proof");
+        cy.get("#theorem1_title").should("have.text", "Theorem 1");
+        cy.get("#statement1").should("have.text", "The statement");
+        cy.get("#proof1_title").should("contain.text", "Proof");
+        cy.get("#proof1_title").should("contain.text", "Proof");
+        cy.get("#proof1").should("not.contain.text", "The proof");
+        cy.get("#proof1_title").click();
+        cy.get("#proof1").should("contain.text", "The proof");
 
-        cy.get(cesc("#theorem2_title")).should("have.text", "Corollary 2");
-        cy.get(cesc("#statement2")).should("have.text", "The statement");
-        cy.get(cesc("#proof2_title")).should("contain.text", "Proof");
-        cy.get(cesc("#proof2")).should("not.contain.text", "The proof");
-        cy.get(cesc("#proof2_title")).click();
-        cy.get(cesc("#proof2")).should("contain.text", "The proof");
+        cy.get("#theorem2_title").should("have.text", "Corollary 2");
+        cy.get("#statement2").should("have.text", "The statement");
+        cy.get("#proof2_title").should("contain.text", "Proof");
+        cy.get("#proof2").should("not.contain.text", "The proof");
+        cy.get("#proof2_title").click();
+        cy.get("#proof2").should("contain.text", "The proof");
     });
 
     // TODO: reinstate this test
@@ -718,21 +688,21 @@ describe("Sectioning Tag Tests", { tags: ["@group4"] }, function () {
         // Note: not sure if this is how we want numbering to work long term,
         // but this test at least documents how it is working now.
 
-        cy.get(cesc("#sec1_title")).should("have.text", "Section 1");
+        cy.get("#sec1_title").should("have.text", "Section 1");
 
-        cy.get(cesc("#obj1_title")).should("have.text", "Objectives 1");
-        cy.get(cesc("#exp2_title")).should("have.text", "Definition 2");
-        cy.get(cesc("#sec1-1_title")).should("have.text", "Section 1.1");
-        cy.get(cesc("#act3_title")).should("have.text", "Activity 3");
-        cy.get(cesc("#sec1-2_title")).should("have.text", "Section 1.2");
-        cy.get(cesc("#aside4_title")).should("contain.text", "Aside 4");
-        cy.get(cesc("#act5_title")).should("have.text", "Activity 5");
-        cy.get(cesc("#out6_title")).should("have.text", "Outcomes 6");
+        cy.get("#obj1_title").should("have.text", "Objectives 1");
+        cy.get("#exp2_title").should("have.text", "Definition 2");
+        cy.get("#sec1-1_title").should("have.text", "Section 1.1");
+        cy.get("#act3_title").should("have.text", "Activity 3");
+        cy.get("#sec1-2_title").should("have.text", "Section 1.2");
+        cy.get("#aside4_title").should("contain.text", "Aside 4");
+        cy.get("#act5_title").should("have.text", "Activity 5");
+        cy.get("#out6_title").should("have.text", "Outcomes 6");
 
-        cy.get(cesc("#sec2_title")).should("have.text", "Section 2");
+        cy.get("#sec2_title").should("have.text", "Section 2");
 
-        cy.get(cesc("#obj7_title")).should("have.text", "Objectives 7");
-        cy.get(cesc("#sec2-1_title")).should("have.text", "Section 2.1");
+        cy.get("#obj7_title").should("have.text", "Objectives 7");
+        cy.get("#sec2-1_title").should("have.text", "Section 2.1");
     });
 
     it("Problems tag causes child sections to be rendered as a list", () => {
@@ -773,30 +743,30 @@ describe("Sectioning Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#aProb_title")).should("have.text", "This is a problem");
+        cy.get("#aProb_title").should("have.text", "This is a problem");
         cy.get(cesc("#aProb.ol")).should(
             "have.css",
             "list-style-type",
             "decimal",
         );
 
-        cy.get(cesc("#exercises") + " article")
+        cy.get("#exercises" + " article")
             .eq(0)
             .should(
                 "contain.text",
                 "We don't have a title, but we have a list.",
             );
 
-        cy.get(cesc("#prob1_title")).should("not.exist");
+        cy.get("#prob1_title").should("not.exist");
         cy.get(cesc("#prob1.ol")).should(
             "have.css",
             "list-style-type",
             "lower-alpha",
         );
 
-        cy.get(cesc("#prob2_title")).should("have.text", "A titled problem");
+        cy.get("#prob2_title").should("have.text", "A titled problem");
 
-        cy.get(cesc("#aProbb_title")).should("have.text", "This is a problem");
+        cy.get("#aProbb_title").should("have.text", "This is a problem");
         cy.get(cesc("#aProbb.ol")).should(
             "have.css",
             "list-style-type",
@@ -842,30 +812,30 @@ describe("Sectioning Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#aProb_title")).should("have.text", "This is a problem");
+        cy.get("#aProb_title").should("have.text", "This is a problem");
         cy.get(cesc("#aProb.ol")).should(
             "have.css",
             "list-style-type",
             "decimal",
         );
 
-        cy.get(cesc("#exercises") + " article")
+        cy.get("#exercises" + " article")
             .eq(0)
             .should(
                 "contain.text",
                 "We don't have a title, but we have a list.",
             );
 
-        cy.get(cesc("#prob1_title")).should("not.exist");
+        cy.get("#prob1_title").should("not.exist");
         cy.get(cesc("#prob1.ol")).should(
             "have.css",
             "list-style-type",
             "lower-alpha",
         );
 
-        cy.get(cesc("#prob2_title")).should("have.text", "A titled problem");
+        cy.get("#prob2_title").should("have.text", "A titled problem");
 
-        cy.get(cesc("#aProbb_title")).should("have.text", "This is a problem");
+        cy.get("#aProbb_title").should("have.text", "This is a problem");
         cy.get(cesc("#aProbb.ol")).should(
             "have.css",
             "list-style-type",

--- a/packages/test-cypress/cypress/e2e/tagSpecific/select.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/select.cy.js
@@ -1,5 +1,3 @@
-import { cesc } from "@doenet/utils";
-
 describe("Select Tag Tests", { tags: ["@group5"] }, function () {
     beforeEach(() => {
         cy.clearIndexedDB();
@@ -24,7 +22,7 @@ describe("Select Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); //wait for page to load
-        cy.get(cesc("#sec")).should("not.contain.text", ",");
+        cy.get("#a").should("have.text", "a"); //wait for page to load
+        cy.get("#sec").should("not.contain.text", ",");
     });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/selectfromsequence.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/selectfromsequence.cy.js
@@ -1,4 +1,3 @@
-import { cesc } from "@doenet/utils";
 import { toMathJaxString } from "../../../src/util/mathDisplay";
 
 describe("SelectFromSequence Tag Tests", { tags: ["@group2"] }, function () {
@@ -30,10 +29,10 @@ describe("SelectFromSequence Tag Tests", { tags: ["@group2"] }, function () {
             );
         });
 
-        cy.get(cesc("#b")).should("have.text", "false");
+        cy.get("#b").should("have.text", "false");
 
-        cy.get(cesc("#bi")).click();
-        cy.get(cesc("#b")).should("have.text", "true");
+        cy.get("#bi").click();
+        cy.get("#b").should("have.text", "true");
 
         cy.wait(2000); // wait for debounce
 
@@ -48,11 +47,11 @@ describe("SelectFromSequence Tag Tests", { tags: ["@group2"] }, function () {
             );
         });
 
-        cy.get(cesc("#b")).should("have.text", "true");
+        cy.get("#b").should("have.text", "true");
 
         cy.log("core has not crashed and processes change in bi");
-        cy.get(cesc("#bi")).click();
-        cy.get(cesc("#b")).should("have.text", "false");
+        cy.get("#bi").click();
+        cy.get("#b").should("have.text", "false");
     });
 
     it("selectfromsequence depending on selectfromsequence handles reload 2", () => {
@@ -94,11 +93,11 @@ describe("SelectFromSequence Tag Tests", { tags: ["@group2"] }, function () {
             );
         });
 
-        cy.get(cesc("#m")).should("contain.text", "\uff3f");
+        cy.get("#m").should("contain.text", "\uff3f");
 
-        cy.get(cesc("#mi") + " textarea").type("x{enter}", { force: true });
-        cy.get(cesc("#m")).should("contain.text", toMathJaxString("x"));
-        cy.get(cesc("#m2")).should("contain.text", toMathJaxString("x"));
+        cy.get("#mi" + " textarea").type("x{enter}", { force: true });
+        cy.get("#m").should("contain.text", toMathJaxString("x"));
+        cy.get("#m2").should("contain.text", toMathJaxString("x"));
 
         cy.wait(2000); // wait for debounce
 
@@ -113,17 +112,17 @@ describe("SelectFromSequence Tag Tests", { tags: ["@group2"] }, function () {
             );
         });
 
-        cy.get(cesc("#m")).should("contain.text", toMathJaxString("x"));
+        cy.get("#m").should("contain.text", toMathJaxString("x"));
 
         cy.log("core has not crashed and processes change in bi");
-        cy.get(cesc("#mi") + " textarea")
+        cy.get("#mi" + " textarea")
             .type("{end}{backspace}y", { force: true })
             .blur();
 
-        cy.get(cesc("#m")).should("contain.text", toMathJaxString("y"));
+        cy.get("#m").should("contain.text", toMathJaxString("y"));
 
-        cy.get(cesc("#mi") + " textarea").type("{enter}", { force: true });
-        cy.get(cesc("#m")).should("contain.text", toMathJaxString("y"));
-        cy.get(cesc("#m2")).should("contain.text", toMathJaxString("y"));
+        cy.get("#mi" + " textarea").type("{enter}", { force: true });
+        cy.get("#m").should("contain.text", toMathJaxString("y"));
+        cy.get("#m2").should("contain.text", toMathJaxString("y"));
     });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/slider.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/slider.cy.js
@@ -1,4 +1,3 @@
-import { cesc } from "@doenet/utils";
 import { toMathJaxString } from "../../../src/util/mathDisplay";
 
 describe("Slider Tag Tests", { tags: ["@group1"] }, function () {
@@ -259,7 +258,7 @@ describe("Slider Tag Tests", { tags: ["@group1"] }, function () {
         cy.get("#sv").should("have.text", "0");
         cy.get("#s").should("have.value", "0");
 
-        cy.get(cesc("#s-label")).should(
+        cy.get("#s-label").should(
             "contain.text",
             `Hello ${toMathJaxString(`x2 = 0`)}`,
         );
@@ -283,7 +282,7 @@ describe("Slider Tag Tests", { tags: ["@group1"] }, function () {
         cy.get("#sv").should("have.text", "1");
         cy.get("#s").should("have.value", "1");
 
-        cy.get(cesc("#s-label")).should(
+        cy.get("#s-label").should(
             "contain.text",
             `Hello ${toMathJaxString(`x2 = 1`)}`,
         );

--- a/packages/test-cypress/cypress/e2e/tagSpecific/spreadsheet.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/spreadsheet.cy.js
@@ -84,7 +84,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
         });
 
         // to wait for page to load
-        cy.get(cesc("#t1")).should("have.text", "(1,2)");
+        cy.get("#t1").should("have.text", "(1,2)");
 
         cy.log("check initial cell values");
         cy.window().then(async (win) => {
@@ -156,7 +156,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
             text: "(4,9)",
             clear: true,
         });
-        cy.get(cesc("#t1")).should("have.text", "(4,9)");
+        cy.get("#t1").should("have.text", "(4,9)");
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
             expect(
@@ -213,7 +213,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
             text: "(5,4)",
             clear: true,
         });
-        cy.get(cesc("#t2")).should("have.text", "(5,4)");
+        cy.get("#t2").should("have.text", "(5,4)");
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
             expect(
@@ -307,7 +307,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
             text: ")x,-",
             clear: true,
         });
-        cy.get(cesc("#t1")).should("have.text", ")x,-");
+        cy.get("#t1").should("have.text", ")x,-");
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
             expect(
@@ -374,7 +374,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
             text: "(3,2)",
             clear: true,
         });
-        cy.get(cesc("#t3")).should("have.text", "(3,2)");
+        cy.get("#t3").should("have.text", "(3,2)");
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
             expect(
@@ -463,7 +463,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
             text: "(7,3)",
             clear: true,
         });
-        cy.get(cesc("#t1")).should("have.text", "(7,3)");
+        cy.get("#t1").should("have.text", "(7,3)");
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
             expect(
@@ -564,7 +564,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
             text: "(x,q)",
             clear: true,
         });
-        cy.get(cesc("#t4")).should("have.text", "(x,q)");
+        cy.get("#t4").should("have.text", "(x,q)");
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
             expect(
@@ -684,7 +684,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
         //     text: "(1,2,3)",
         //     clear: true,
         // });
-        // cy.get(cesc("#t5")).should("have.text", "(1,2,3)");
+        // cy.get("#t5").should("have.text", "(1,2,3)");
         // cy.window().then(async (win) => {
         //     let stateVariables = await win.returnAllStateVariables1();
         //     expect(
@@ -893,55 +893,55 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); // to wait for page to load
+        cy.get("#a").should("have.text", "a"); // to wait for page to load
 
         let row = ["1", "2", "3"];
         let column = ["2", "5", "7"];
 
-        cy.get(cesc("#R1")).should("have.text", "");
-        cy.get(cesc("#R2")).should("have.text", "");
-        cy.get(cesc("#R3")).should("have.text", "");
-        cy.get(cesc("#C1")).should("have.text", "");
-        cy.get(cesc("#C2")).should("have.text", "");
-        cy.get(cesc("#C3")).should("have.text", "");
+        cy.get("#R1").should("have.text", "");
+        cy.get("#R2").should("have.text", "");
+        cy.get("#R3").should("have.text", "");
+        cy.get("#C1").should("have.text", "");
+        cy.get("#C2").should("have.text", "");
+        cy.get("#C3").should("have.text", "");
 
-        cy.get(cesc("#n") + " textarea").type("1{enter}", { force: true });
-        cy.get(cesc("#R1")).should("have.text", row[0]);
-        cy.get(cesc("#R2")).should("have.text", "");
-        cy.get(cesc("#R3")).should("have.text", "");
-        cy.get(cesc("#C1")).should("have.text", column[0]);
-        cy.get(cesc("#C2")).should("have.text", "");
-        cy.get(cesc("#C3")).should("have.text", "");
+        cy.get("#n" + " textarea").type("1{enter}", { force: true });
+        cy.get("#R1").should("have.text", row[0]);
+        cy.get("#R2").should("have.text", "");
+        cy.get("#R3").should("have.text", "");
+        cy.get("#C1").should("have.text", column[0]);
+        cy.get("#C2").should("have.text", "");
+        cy.get("#C3").should("have.text", "");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}2{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}2{enter}", {
             force: true,
         });
-        cy.get(cesc("#R1")).should("have.text", row[1]);
-        cy.get(cesc("#R2")).should("have.text", "");
-        cy.get(cesc("#R3")).should("have.text", "");
-        cy.get(cesc("#C1")).should("have.text", column[1]);
-        cy.get(cesc("#C2")).should("have.text", "");
-        cy.get(cesc("#C3")).should("have.text", "");
+        cy.get("#R1").should("have.text", row[1]);
+        cy.get("#R2").should("have.text", "");
+        cy.get("#R3").should("have.text", "");
+        cy.get("#C1").should("have.text", column[1]);
+        cy.get("#C2").should("have.text", "");
+        cy.get("#C3").should("have.text", "");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}3{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}3{enter}", {
             force: true,
         });
-        cy.get(cesc("#R1")).should("have.text", row[2]);
-        cy.get(cesc("#R2")).should("have.text", "");
-        cy.get(cesc("#R3")).should("have.text", "");
-        cy.get(cesc("#C1")).should("have.text", column[2]);
-        cy.get(cesc("#C2")).should("have.text", "");
-        cy.get(cesc("#C3")).should("have.text", "");
+        cy.get("#R1").should("have.text", row[2]);
+        cy.get("#R2").should("have.text", "");
+        cy.get("#R3").should("have.text", "");
+        cy.get("#C1").should("have.text", column[2]);
+        cy.get("#C2").should("have.text", "");
+        cy.get("#C3").should("have.text", "");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}4{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}4{enter}", {
             force: true,
         });
-        cy.get(cesc("#R1")).should("have.text", "");
-        cy.get(cesc("#R2")).should("have.text", "");
-        cy.get(cesc("#R3")).should("have.text", "");
-        cy.get(cesc("#C1")).should("have.text", "");
-        cy.get(cesc("#C2")).should("have.text", "");
-        cy.get(cesc("#C3")).should("have.text", "");
+        cy.get("#R1").should("have.text", "");
+        cy.get("#R2").should("have.text", "");
+        cy.get("#R3").should("have.text", "");
+        cy.get("#C1").should("have.text", "");
+        cy.get("#C2").should("have.text", "");
+        cy.get("#C3").should("have.text", "");
     });
 
     it("copy multidimensional propIndex of evaluated cells, dot and array notation", () => {
@@ -990,55 +990,55 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); // to wait for page to load
+        cy.get("#a").should("have.text", "a"); // to wait for page to load
 
         let row = ["1", "2", "3"];
         let column = ["2", "5", "7"];
 
-        cy.get(cesc("#R1")).should("have.text", "");
-        cy.get(cesc("#R2")).should("have.text", "");
-        cy.get(cesc("#R3")).should("have.text", "");
-        cy.get(cesc("#C1")).should("have.text", "");
-        cy.get(cesc("#C2")).should("have.text", "");
-        cy.get(cesc("#C3")).should("have.text", "");
+        cy.get("#R1").should("have.text", "");
+        cy.get("#R2").should("have.text", "");
+        cy.get("#R3").should("have.text", "");
+        cy.get("#C1").should("have.text", "");
+        cy.get("#C2").should("have.text", "");
+        cy.get("#C3").should("have.text", "");
 
-        cy.get(cesc("#n") + " textarea").type("1{enter}", { force: true });
-        cy.get(cesc("#R1")).should("have.text", row[0]);
-        cy.get(cesc("#R2")).should("have.text", "");
-        cy.get(cesc("#R3")).should("have.text", "");
-        cy.get(cesc("#C1")).should("have.text", column[0]);
-        cy.get(cesc("#C2")).should("have.text", "");
-        cy.get(cesc("#C3")).should("have.text", "");
+        cy.get("#n" + " textarea").type("1{enter}", { force: true });
+        cy.get("#R1").should("have.text", row[0]);
+        cy.get("#R2").should("have.text", "");
+        cy.get("#R3").should("have.text", "");
+        cy.get("#C1").should("have.text", column[0]);
+        cy.get("#C2").should("have.text", "");
+        cy.get("#C3").should("have.text", "");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}2{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}2{enter}", {
             force: true,
         });
-        cy.get(cesc("#R1")).should("have.text", row[1]);
-        cy.get(cesc("#R2")).should("have.text", "");
-        cy.get(cesc("#R3")).should("have.text", "");
-        cy.get(cesc("#C1")).should("have.text", column[1]);
-        cy.get(cesc("#C2")).should("have.text", "");
-        cy.get(cesc("#C3")).should("have.text", "");
+        cy.get("#R1").should("have.text", row[1]);
+        cy.get("#R2").should("have.text", "");
+        cy.get("#R3").should("have.text", "");
+        cy.get("#C1").should("have.text", column[1]);
+        cy.get("#C2").should("have.text", "");
+        cy.get("#C3").should("have.text", "");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}3{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}3{enter}", {
             force: true,
         });
-        cy.get(cesc("#R1")).should("have.text", row[2]);
-        cy.get(cesc("#R2")).should("have.text", "");
-        cy.get(cesc("#R3")).should("have.text", "");
-        cy.get(cesc("#C1")).should("have.text", column[2]);
-        cy.get(cesc("#C2")).should("have.text", "");
-        cy.get(cesc("#C3")).should("have.text", "");
+        cy.get("#R1").should("have.text", row[2]);
+        cy.get("#R2").should("have.text", "");
+        cy.get("#R3").should("have.text", "");
+        cy.get("#C1").should("have.text", column[2]);
+        cy.get("#C2").should("have.text", "");
+        cy.get("#C3").should("have.text", "");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}4{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}4{enter}", {
             force: true,
         });
-        cy.get(cesc("#R1")).should("have.text", "");
-        cy.get(cesc("#R2")).should("have.text", "");
-        cy.get(cesc("#R3")).should("have.text", "");
-        cy.get(cesc("#C1")).should("have.text", "");
-        cy.get(cesc("#C2")).should("have.text", "");
-        cy.get(cesc("#C3")).should("have.text", "");
+        cy.get("#R1").should("have.text", "");
+        cy.get("#R2").should("have.text", "");
+        cy.get("#R3").should("have.text", "");
+        cy.get("#C1").should("have.text", "");
+        cy.get("#C2").should("have.text", "");
+        cy.get("#C3").should("have.text", "");
     });
 
     it("copy multidimensional propIndex of evaluated rows and columns, dot and array notation", () => {
@@ -1087,55 +1087,55 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); // to wait for page to load
+        cy.get("#a").should("have.text", "a"); // to wait for page to load
 
         let row = ["1", "2", "3"];
         let column = ["2", "5", "7"];
 
-        cy.get(cesc("#R1")).should("have.text", "");
-        cy.get(cesc("#R2")).should("have.text", "");
-        cy.get(cesc("#R3")).should("have.text", "");
-        cy.get(cesc("#C1")).should("have.text", "");
-        cy.get(cesc("#C2")).should("have.text", "");
-        cy.get(cesc("#C3")).should("have.text", "");
+        cy.get("#R1").should("have.text", "");
+        cy.get("#R2").should("have.text", "");
+        cy.get("#R3").should("have.text", "");
+        cy.get("#C1").should("have.text", "");
+        cy.get("#C2").should("have.text", "");
+        cy.get("#C3").should("have.text", "");
 
-        cy.get(cesc("#n") + " textarea").type("1{enter}", { force: true });
-        cy.get(cesc("#R1")).should("have.text", row[0]);
-        cy.get(cesc("#R2")).should("have.text", "");
-        cy.get(cesc("#R3")).should("have.text", "");
-        cy.get(cesc("#C1")).should("have.text", column[0]);
-        cy.get(cesc("#C2")).should("have.text", "");
-        cy.get(cesc("#C3")).should("have.text", "");
+        cy.get("#n" + " textarea").type("1{enter}", { force: true });
+        cy.get("#R1").should("have.text", row[0]);
+        cy.get("#R2").should("have.text", "");
+        cy.get("#R3").should("have.text", "");
+        cy.get("#C1").should("have.text", column[0]);
+        cy.get("#C2").should("have.text", "");
+        cy.get("#C3").should("have.text", "");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}2{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}2{enter}", {
             force: true,
         });
-        cy.get(cesc("#R1")).should("have.text", row[1]);
-        cy.get(cesc("#R2")).should("have.text", "");
-        cy.get(cesc("#R3")).should("have.text", "");
-        cy.get(cesc("#C1")).should("have.text", column[1]);
-        cy.get(cesc("#C2")).should("have.text", "");
-        cy.get(cesc("#C3")).should("have.text", "");
+        cy.get("#R1").should("have.text", row[1]);
+        cy.get("#R2").should("have.text", "");
+        cy.get("#R3").should("have.text", "");
+        cy.get("#C1").should("have.text", column[1]);
+        cy.get("#C2").should("have.text", "");
+        cy.get("#C3").should("have.text", "");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}3{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}3{enter}", {
             force: true,
         });
-        cy.get(cesc("#R1")).should("have.text", row[2]);
-        cy.get(cesc("#R2")).should("have.text", "");
-        cy.get(cesc("#R3")).should("have.text", "");
-        cy.get(cesc("#C1")).should("have.text", column[2]);
-        cy.get(cesc("#C2")).should("have.text", "");
-        cy.get(cesc("#C3")).should("have.text", "");
+        cy.get("#R1").should("have.text", row[2]);
+        cy.get("#R2").should("have.text", "");
+        cy.get("#R3").should("have.text", "");
+        cy.get("#C1").should("have.text", column[2]);
+        cy.get("#C2").should("have.text", "");
+        cy.get("#C3").should("have.text", "");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}4{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}4{enter}", {
             force: true,
         });
-        cy.get(cesc("#R1")).should("have.text", "");
-        cy.get(cesc("#R2")).should("have.text", "");
-        cy.get(cesc("#R3")).should("have.text", "");
-        cy.get(cesc("#C1")).should("have.text", "");
-        cy.get(cesc("#C2")).should("have.text", "");
-        cy.get(cesc("#C3")).should("have.text", "");
+        cy.get("#R1").should("have.text", "");
+        cy.get("#R2").should("have.text", "");
+        cy.get("#R3").should("have.text", "");
+        cy.get("#C1").should("have.text", "");
+        cy.get("#C2").should("have.text", "");
+        cy.get("#C3").should("have.text", "");
     });
 
     it("copy single propIndex of evaluated rows and columns, dot and array notation", () => {
@@ -1184,7 +1184,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); // to wait for page to load
+        cy.get("#a").should("have.text", "a"); // to wait for page to load
 
         let rows = [
             ["1", "2", "3"],
@@ -1197,50 +1197,50 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
             ["3", "F", "I"],
         ];
 
-        cy.get(cesc("#R1")).should("have.text", "");
-        cy.get(cesc("#R2")).should("have.text", "");
-        cy.get(cesc("#R3")).should("have.text", "");
-        cy.get(cesc("#C1")).should("have.text", "");
-        cy.get(cesc("#C2")).should("have.text", "");
-        cy.get(cesc("#C3")).should("have.text", "");
+        cy.get("#R1").should("have.text", "");
+        cy.get("#R2").should("have.text", "");
+        cy.get("#R3").should("have.text", "");
+        cy.get("#C1").should("have.text", "");
+        cy.get("#C2").should("have.text", "");
+        cy.get("#C3").should("have.text", "");
 
-        cy.get(cesc("#n") + " textarea").type("1{enter}", { force: true });
-        cy.get(cesc("#R1")).should("have.text", rows[0][0]);
-        cy.get(cesc("#R2")).should("have.text", rows[0][1]);
-        cy.get(cesc("#R3")).should("have.text", rows[0][2]);
-        cy.get(cesc("#C1")).should("have.text", columns[0][0]);
-        cy.get(cesc("#C2")).should("have.text", columns[0][1]);
-        cy.get(cesc("#C3")).should("have.text", columns[0][2]);
+        cy.get("#n" + " textarea").type("1{enter}", { force: true });
+        cy.get("#R1").should("have.text", rows[0][0]);
+        cy.get("#R2").should("have.text", rows[0][1]);
+        cy.get("#R3").should("have.text", rows[0][2]);
+        cy.get("#C1").should("have.text", columns[0][0]);
+        cy.get("#C2").should("have.text", columns[0][1]);
+        cy.get("#C3").should("have.text", columns[0][2]);
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}2{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}2{enter}", {
             force: true,
         });
-        cy.get(cesc("#R1")).should("have.text", rows[1][0]);
-        cy.get(cesc("#R2")).should("have.text", rows[1][1]);
-        cy.get(cesc("#R3")).should("have.text", rows[1][2]);
-        cy.get(cesc("#C1")).should("have.text", columns[1][0]);
-        cy.get(cesc("#C2")).should("have.text", columns[1][1]);
-        cy.get(cesc("#C3")).should("have.text", columns[1][2]);
+        cy.get("#R1").should("have.text", rows[1][0]);
+        cy.get("#R2").should("have.text", rows[1][1]);
+        cy.get("#R3").should("have.text", rows[1][2]);
+        cy.get("#C1").should("have.text", columns[1][0]);
+        cy.get("#C2").should("have.text", columns[1][1]);
+        cy.get("#C3").should("have.text", columns[1][2]);
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}3{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}3{enter}", {
             force: true,
         });
-        cy.get(cesc("#R1")).should("have.text", rows[2][0]);
-        cy.get(cesc("#R2")).should("have.text", rows[2][1]);
-        cy.get(cesc("#R3")).should("have.text", rows[2][2]);
-        cy.get(cesc("#C1")).should("have.text", columns[2][0]);
-        cy.get(cesc("#C2")).should("have.text", columns[2][1]);
-        cy.get(cesc("#C3")).should("have.text", columns[2][2]);
+        cy.get("#R1").should("have.text", rows[2][0]);
+        cy.get("#R2").should("have.text", rows[2][1]);
+        cy.get("#R3").should("have.text", rows[2][2]);
+        cy.get("#C1").should("have.text", columns[2][0]);
+        cy.get("#C2").should("have.text", columns[2][1]);
+        cy.get("#C3").should("have.text", columns[2][2]);
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}4{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}4{enter}", {
             force: true,
         });
-        cy.get(cesc("#R1")).should("have.text", "");
-        cy.get(cesc("#R2")).should("have.text", "");
-        cy.get(cesc("#R3")).should("have.text", "");
-        cy.get(cesc("#C1")).should("have.text", "");
-        cy.get(cesc("#C2")).should("have.text", "");
-        cy.get(cesc("#C3")).should("have.text", "");
+        cy.get("#R1").should("have.text", "");
+        cy.get("#R2").should("have.text", "");
+        cy.get("#R3").should("have.text", "");
+        cy.get("#C1").should("have.text", "");
+        cy.get("#C2").should("have.text", "");
+        cy.get("#C3").should("have.text", "");
     });
 
     it("copy propIndex of points in cells, dot and array notation", () => {
@@ -1268,7 +1268,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); // to wait for page to load
+        cy.get("#a").should("have.text", "a"); // to wait for page to load
 
         let c1 = "(1,2)";
         let c2 = "(3,4)";
@@ -1282,7 +1282,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(cesc("#P46:2")).should("not.exist");
         cy.get(cesc("#P46:3")).should("not.exist");
 
-        cy.get(cesc("#n") + " textarea").type("1{enter}", { force: true });
+        cy.get("#n" + " textarea").type("1{enter}", { force: true });
         cy.get(cesc("#P13:1")).should("contain.text", c1);
         cy.get(cesc("#P13:2")).should("not.exist");
         cy.get(cesc("#P13:3")).should("not.exist");
@@ -1290,7 +1290,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(cesc("#P46:2")).should("not.exist");
         cy.get(cesc("#P46:3")).should("not.exist");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}2{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}2{enter}", {
             force: true,
         });
         cy.get(cesc("#P13:1")).should("not.exist");
@@ -1300,7 +1300,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(cesc("#P46:2")).should("not.exist");
         cy.get(cesc("#P46:3")).should("not.exist");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}3{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}3{enter}", {
             force: true,
         });
         cy.get(cesc("#P13:1")).should("contain.text", c2);
@@ -1310,7 +1310,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(cesc("#P46:2")).should("not.exist");
         cy.get(cesc("#P46:3")).should("not.exist");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}4{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}4{enter}", {
             force: true,
         });
         cy.get(cesc("#P13:1")).should("not.exist");
@@ -1345,7 +1345,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); // to wait for page to load
+        cy.get("#a").should("have.text", "a"); // to wait for page to load
 
         let c1 = "(1,2)";
         let c2 = "(3,4)";
@@ -1359,7 +1359,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(cesc("#P46:2")).should("not.exist");
         cy.get(cesc("#P46:3")).should("not.exist");
 
-        cy.get(cesc("#n") + " textarea").type("1{enter}", { force: true });
+        cy.get("#n" + " textarea").type("1{enter}", { force: true });
         cy.get(cesc("#P13:1")).should("contain.text", c1);
         cy.get(cesc("#P13:2")).should("not.exist");
         cy.get(cesc("#P13:3")).should("not.exist");
@@ -1367,7 +1367,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(cesc("#P46:2")).should("not.exist");
         cy.get(cesc("#P46:3")).should("not.exist");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}2{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}2{enter}", {
             force: true,
         });
         cy.get(cesc("#P13:1")).should("not.exist");
@@ -1377,7 +1377,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(cesc("#P46:2")).should("not.exist");
         cy.get(cesc("#P46:3")).should("not.exist");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}3{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}3{enter}", {
             force: true,
         });
         cy.get(cesc("#P13:1")).should("contain.text", c2);
@@ -1387,7 +1387,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(cesc("#P46:2")).should("not.exist");
         cy.get(cesc("#P46:3")).should("not.exist");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}4{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}4{enter}", {
             force: true,
         });
         cy.get(cesc("#P13:1")).should("not.exist");
@@ -1422,7 +1422,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); // to wait for page to load
+        cy.get("#a").should("have.text", "a"); // to wait for page to load
 
         let c1 = "(1,2)";
         let c2 = "(3,4)";
@@ -1436,7 +1436,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(cesc("#P46:2")).should("not.exist");
         cy.get(cesc("#P46:3")).should("not.exist");
 
-        cy.get(cesc("#n") + " textarea").type("1{enter}", { force: true });
+        cy.get("#n" + " textarea").type("1{enter}", { force: true });
         cy.get(cesc("#P13:1")).should("contain.text", c1);
         cy.get(cesc("#P13:2")).should("not.exist");
         cy.get(cesc("#P13:3")).should("not.exist");
@@ -1444,7 +1444,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(cesc("#P46:2")).should("not.exist");
         cy.get(cesc("#P46:3")).should("not.exist");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}2{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}2{enter}", {
             force: true,
         });
         cy.get(cesc("#P13:1")).should("not.exist");
@@ -1454,7 +1454,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(cesc("#P46:2")).should("not.exist");
         cy.get(cesc("#P46:3")).should("not.exist");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}3{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}3{enter}", {
             force: true,
         });
         cy.get(cesc("#P13:1")).should("contain.text", c2);
@@ -1464,7 +1464,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(cesc("#P46:2")).should("not.exist");
         cy.get(cesc("#P46:3")).should("not.exist");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}4{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}4{enter}", {
             force: true,
         });
         cy.get(cesc("#P13:1")).should("not.exist");
@@ -1499,7 +1499,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); // to wait for page to load
+        cy.get("#a").should("have.text", "a"); // to wait for page to load
 
         let c1 = "(1,2)";
         let c2 = "(3,4)";
@@ -1513,7 +1513,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(cesc("#P46:2")).should("not.exist");
         cy.get(cesc("#P46:3")).should("not.exist");
 
-        cy.get(cesc("#n") + " textarea").type("1{enter}", { force: true });
+        cy.get("#n" + " textarea").type("1{enter}", { force: true });
         cy.get(cesc("#P13:1")).should("contain.text", c1);
         cy.get(cesc("#P13:2")).should("contain.text", c2);
         cy.get(cesc("#P13:3")).should("not.exist");
@@ -1521,7 +1521,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(cesc("#P46:2")).should("not.exist");
         cy.get(cesc("#P46:3")).should("not.exist");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}2{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}2{enter}", {
             force: true,
         });
         cy.get(cesc("#P13:1")).should("contain.text", c3);
@@ -1531,7 +1531,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(cesc("#P46:2")).should("contain.text", c4);
         cy.get(cesc("#P46:3")).should("not.exist");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}3{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}3{enter}", {
             force: true,
         });
         cy.get(cesc("#P13:1")).should("contain.text", c4);
@@ -1541,7 +1541,7 @@ describe("Spreadsheet Tag Tests", { tags: ["@group5"] }, function () {
         cy.get(cesc("#P46:2")).should("not.exist");
         cy.get(cesc("#P46:3")).should("not.exist");
 
-        cy.get(cesc("#n") + " textarea").type("{end}{backspace}4{enter}", {
+        cy.get("#n" + " textarea").type("{end}{backspace}4{enter}", {
             force: true,
         });
         cy.get(cesc("#P13:1")).should("not.exist");

--- a/packages/test-cypress/cypress/e2e/tagSpecific/subsetofrealsinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/subsetofrealsinput.cy.js
@@ -1,5 +1,3 @@
-import { cesc } from "@doenet/utils";
-
 describe("SubsetOfRealsInput Tag Tests", { tags: ["@group3"] }, function () {
     beforeEach(() => {
         cy.clearIndexedDB();
@@ -26,16 +24,13 @@ describe("SubsetOfRealsInput Tag Tests", { tags: ["@group3"] }, function () {
             );
         });
 
-        cy.get(cesc("#sor")).should("contain.text", "∅");
+        cy.get("#sor").should("contain.text", "∅");
 
-        cy.get(cesc("#sormi") + " textarea").type(
-            "{end}{backspace}{{}3}{enter}",
-            {
-                force: true,
-            },
-        );
+        cy.get("#sormi" + " textarea").type("{end}{backspace}{{}3}{enter}", {
+            force: true,
+        });
 
-        cy.get(cesc("#sor")).should("contain.text", "{3}");
+        cy.get("#sor").should("contain.text", "{3}");
         cy.wait(2000); // wait for 1 second debounce
 
         cy.reload();
@@ -48,6 +43,6 @@ describe("SubsetOfRealsInput Tag Tests", { tags: ["@group3"] }, function () {
             );
         });
 
-        cy.get(cesc("#sor")).should("contain.text", "{3}");
+        cy.get("#sor").should("contain.text", "{3}");
     });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/text.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/text.cy.js
@@ -1,5 +1,3 @@
-import { cesc } from "@doenet/utils";
-
 describe("Text Tag Tests", { tags: ["@group4"] }, function () {
     beforeEach(() => {
         cy.clearIndexedDB();
@@ -34,42 +32,34 @@ describe("Text Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#tsd_no_style")).should("have.text", "black");
-        cy.get(cesc("#tc_no_style")).should("have.text", "black");
-        cy.get(cesc("#bc_no_style")).should("have.text", "none");
+        cy.get("#tsd_no_style").should("have.text", "black");
+        cy.get("#tc_no_style").should("have.text", "black");
+        cy.get("#bc_no_style").should("have.text", "none");
 
-        cy.get(cesc("#tsd_fixed_style")).should("have.text", "green");
-        cy.get(cesc("#tc_fixed_style")).should("have.text", "green");
-        cy.get(cesc("#bc_fixed_style")).should("have.text", "none");
+        cy.get("#tsd_fixed_style").should("have.text", "green");
+        cy.get("#tc_fixed_style").should("have.text", "green");
+        cy.get("#bc_fixed_style").should("have.text", "none");
 
-        cy.get(cesc("#tsd_variable_style")).should("have.text", "black");
-        cy.get(cesc("#tc_variable_style")).should("have.text", "black");
-        cy.get(cesc("#bc_variable_style")).should("have.text", "none");
+        cy.get("#tsd_variable_style").should("have.text", "black");
+        cy.get("#tc_variable_style").should("have.text", "black");
+        cy.get("#bc_variable_style").should("have.text", "none");
 
-        cy.get(cesc("#no_style")).should("have.css", "color", "rgb(0, 0, 0)");
-        cy.get(cesc("#no_style")).should(
+        cy.get("#no_style").should("have.css", "color", "rgb(0, 0, 0)");
+        cy.get("#no_style").should(
             "have.css",
             "background-color",
             "rgba(0, 0, 0, 0)",
         );
 
-        cy.get(cesc("#fixed_style")).should(
-            "have.css",
-            "color",
-            "rgb(0, 128, 0)",
-        );
-        cy.get(cesc("#fixed_style")).should(
+        cy.get("#fixed_style").should("have.css", "color", "rgb(0, 128, 0)");
+        cy.get("#fixed_style").should(
             "have.css",
             "background-color",
             "rgba(0, 0, 0, 0)",
         );
 
-        cy.get(cesc("#variable_style")).should(
-            "have.css",
-            "color",
-            "rgb(0, 0, 0)",
-        );
-        cy.get(cesc("#variable_style")).should(
+        cy.get("#variable_style").should("have.css", "color", "rgb(0, 0, 0)");
+        cy.get("#variable_style").should(
             "have.css",
             "background-color",
             "rgba(0, 0, 0, 0)",
@@ -77,94 +67,78 @@ describe("Text Tag Tests", { tags: ["@group4"] }, function () {
 
         // TODO: how to test color in graph
 
-        cy.get(cesc("#sn") + " textarea").type("{end}{backspace}2{enter}", {
+        cy.get("#sn" + " textarea").type("{end}{backspace}2{enter}", {
             force: true,
         });
 
-        cy.get(cesc("#tsd_variable_style")).should("have.text", "green");
-        cy.get(cesc("#tc_variable_style")).should("have.text", "green");
-        cy.get(cesc("#bc_variable_style")).should("have.text", "none");
+        cy.get("#tsd_variable_style").should("have.text", "green");
+        cy.get("#tc_variable_style").should("have.text", "green");
+        cy.get("#bc_variable_style").should("have.text", "none");
 
-        cy.get(cesc("#tsd_no_style")).should("have.text", "black");
-        cy.get(cesc("#tc_no_style")).should("have.text", "black");
-        cy.get(cesc("#bc_no_style")).should("have.text", "none");
+        cy.get("#tsd_no_style").should("have.text", "black");
+        cy.get("#tc_no_style").should("have.text", "black");
+        cy.get("#bc_no_style").should("have.text", "none");
 
-        cy.get(cesc("#tsd_fixed_style")).should("have.text", "green");
-        cy.get(cesc("#tc_fixed_style")).should("have.text", "green");
-        cy.get(cesc("#bc_fixed_style")).should("have.text", "none");
+        cy.get("#tsd_fixed_style").should("have.text", "green");
+        cy.get("#tc_fixed_style").should("have.text", "green");
+        cy.get("#bc_fixed_style").should("have.text", "none");
 
-        cy.get(cesc("#no_style")).should("have.css", "color", "rgb(0, 0, 0)");
-        cy.get(cesc("#no_style")).should(
+        cy.get("#no_style").should("have.css", "color", "rgb(0, 0, 0)");
+        cy.get("#no_style").should(
             "have.css",
             "background-color",
             "rgba(0, 0, 0, 0)",
         );
 
-        cy.get(cesc("#fixed_style")).should(
-            "have.css",
-            "color",
-            "rgb(0, 128, 0)",
-        );
-        cy.get(cesc("#fixed_style")).should(
+        cy.get("#fixed_style").should("have.css", "color", "rgb(0, 128, 0)");
+        cy.get("#fixed_style").should(
             "have.css",
             "background-color",
             "rgba(0, 0, 0, 0)",
         );
 
-        cy.get(cesc("#variable_style")).should(
-            "have.css",
-            "color",
-            "rgb(0, 128, 0)",
-        );
-        cy.get(cesc("#variable_style")).should(
+        cy.get("#variable_style").should("have.css", "color", "rgb(0, 128, 0)");
+        cy.get("#variable_style").should(
             "have.css",
             "background-color",
             "rgba(0, 0, 0, 0)",
         );
 
-        cy.get(cesc("#sn") + " textarea").type("{end}{backspace}3{enter}", {
+        cy.get("#sn" + " textarea").type("{end}{backspace}3{enter}", {
             force: true,
         });
 
-        cy.get(cesc("#tsd_variable_style")).should(
+        cy.get("#tsd_variable_style").should(
             "have.text",
             "red with a blue background",
         );
-        cy.get(cesc("#tc_variable_style")).should("have.text", "red");
-        cy.get(cesc("#bc_variable_style")).should("have.text", "blue");
+        cy.get("#tc_variable_style").should("have.text", "red");
+        cy.get("#bc_variable_style").should("have.text", "blue");
 
-        cy.get(cesc("#tsd_no_style")).should("have.text", "black");
-        cy.get(cesc("#tc_no_style")).should("have.text", "black");
-        cy.get(cesc("#bc_no_style")).should("have.text", "none");
+        cy.get("#tsd_no_style").should("have.text", "black");
+        cy.get("#tc_no_style").should("have.text", "black");
+        cy.get("#bc_no_style").should("have.text", "none");
 
-        cy.get(cesc("#tsd_fixed_style")).should("have.text", "green");
-        cy.get(cesc("#tc_fixed_style")).should("have.text", "green");
-        cy.get(cesc("#bc_fixed_style")).should("have.text", "none");
+        cy.get("#tsd_fixed_style").should("have.text", "green");
+        cy.get("#tc_fixed_style").should("have.text", "green");
+        cy.get("#bc_fixed_style").should("have.text", "none");
 
-        cy.get(cesc("#no_style")).should("have.css", "color", "rgb(0, 0, 0)");
-        cy.get(cesc("#no_style")).should(
+        cy.get("#no_style").should("have.css", "color", "rgb(0, 0, 0)");
+        cy.get("#no_style").should(
             "have.css",
             "background-color",
             "rgba(0, 0, 0, 0)",
         );
 
-        cy.get(cesc("#fixed_style")).should(
-            "have.css",
-            "color",
-            "rgb(0, 128, 0)",
-        );
-        cy.get(cesc("#fixed_style")).should(
+        cy.get("#fixed_style").should("have.css", "color", "rgb(0, 128, 0)");
+        cy.get("#fixed_style").should(
             "have.css",
             "background-color",
             "rgba(0, 0, 0, 0)",
         );
 
-        cy.get(cesc("#variable_style")).should(
-            "have.css",
-            "color",
-            "rgb(255, 0, 0)",
-        );
-        cy.get(cesc("#variable_style")).should(
+        cy.get("#variable_style").should("have.css", "color", "rgb(255, 0, 0)");
+        cy.get("#variable_style").should(
             "have.css",
             "background-color",
             "rgb(0, 0, 255)",
@@ -219,7 +193,7 @@ describe("Text Tag Tests", { tags: ["@group4"] }, function () {
             );
         });
 
-        cy.get(cesc("#a")).should("have.text", "a"); // to wait until loaded
+        cy.get("#a").should("have.text", "a"); // to wait until loaded
 
         cy.window().then(async (win) => {
             let stateVariables = await win.returnAllStateVariables1();
@@ -264,12 +238,12 @@ describe("Text Tag Tests", { tags: ["@group4"] }, function () {
             cy.get(t2cAnchor).should("have.css", "color", "rgb(255, 0, 0)");
             cy.get(t2dAnchor).should("have.css", "color", "rgb(0, 0, 0)");
 
-            cy.get(cesc("#t1coords")).should("have.text", "(0,0)");
-            cy.get(cesc("#t2coords")).should("have.text", "(3,4)");
-            cy.get(cesc("#t1acoords")).should("have.text", "(0,0)");
-            cy.get(cesc("#t2acoords")).should("have.text", "(3,4)");
-            cy.get(cesc("#t1bcoords")).should("have.text", "(0,0)");
-            cy.get(cesc("#t2bcoords")).should("have.text", "(0,0)");
+            cy.get("#t1coords").should("have.text", "(0,0)");
+            cy.get("#t2coords").should("have.text", "(3,4)");
+            cy.get("#t1acoords").should("have.text", "(0,0)");
+            cy.get("#t2acoords").should("have.text", "(3,4)");
+            cy.get("#t1bcoords").should("have.text", "(0,0)");
+            cy.get("#t2bcoords").should("have.text", "(0,0)");
 
             cy.log("move first texts");
             cy.window().then(async (win) => {
@@ -285,14 +259,14 @@ describe("Text Tag Tests", { tags: ["@group4"] }, function () {
                 });
             });
 
-            cy.get(cesc("#t2coords")).should("contain.text", "(4,−5)");
+            cy.get("#t2coords").should("contain.text", "(4,−5)");
 
-            cy.get(cesc("#t1coords")).should("have.text", "(−2,3)");
-            cy.get(cesc("#t2coords")).should("have.text", "(4,−5)");
-            cy.get(cesc("#t1acoords")).should("have.text", "(−2,3)");
-            cy.get(cesc("#t2acoords")).should("have.text", "(4,−5)");
-            cy.get(cesc("#t1bcoords")).should("have.text", "(0,0)");
-            cy.get(cesc("#t2bcoords")).should("have.text", "(0,0)");
+            cy.get("#t1coords").should("have.text", "(−2,3)");
+            cy.get("#t2coords").should("have.text", "(4,−5)");
+            cy.get("#t1acoords").should("have.text", "(−2,3)");
+            cy.get("#t2acoords").should("have.text", "(4,−5)");
+            cy.get("#t1bcoords").should("have.text", "(0,0)");
+            cy.get("#t2bcoords").should("have.text", "(0,0)");
 
             cy.log("move second texts");
             cy.window().then(async (win) => {
@@ -308,14 +282,14 @@ describe("Text Tag Tests", { tags: ["@group4"] }, function () {
                 });
             });
 
-            cy.get(cesc("#t2coords")).should("contain.text", "(−8,2)");
+            cy.get("#t2coords").should("contain.text", "(−8,2)");
 
-            cy.get(cesc("#t1coords")).should("have.text", "(7,1)");
-            cy.get(cesc("#t2coords")).should("have.text", "(−8,2)");
-            cy.get(cesc("#t1acoords")).should("have.text", "(7,1)");
-            cy.get(cesc("#t2acoords")).should("have.text", "(−8,2)");
-            cy.get(cesc("#t1bcoords")).should("have.text", "(0,0)");
-            cy.get(cesc("#t2bcoords")).should("have.text", "(0,0)");
+            cy.get("#t1coords").should("have.text", "(7,1)");
+            cy.get("#t2coords").should("have.text", "(−8,2)");
+            cy.get("#t1acoords").should("have.text", "(7,1)");
+            cy.get("#t2acoords").should("have.text", "(−8,2)");
+            cy.get("#t1bcoords").should("have.text", "(0,0)");
+            cy.get("#t2bcoords").should("have.text", "(0,0)");
 
             cy.log("move third texts");
             cy.window().then(async (win) => {
@@ -331,14 +305,14 @@ describe("Text Tag Tests", { tags: ["@group4"] }, function () {
                 });
             });
 
-            cy.get(cesc("#t2bcoords")).should("contain.text", "(−5,−4)");
+            cy.get("#t2bcoords").should("contain.text", "(−5,−4)");
 
-            cy.get(cesc("#t1coords")).should("have.text", "(7,1)");
-            cy.get(cesc("#t2coords")).should("have.text", "(−8,2)");
-            cy.get(cesc("#t1acoords")).should("have.text", "(7,1)");
-            cy.get(cesc("#t2acoords")).should("have.text", "(−8,2)");
-            cy.get(cesc("#t1bcoords")).should("have.text", "(−6,3)");
-            cy.get(cesc("#t2bcoords")).should("have.text", "(−5,−4)");
+            cy.get("#t1coords").should("have.text", "(7,1)");
+            cy.get("#t2coords").should("have.text", "(−8,2)");
+            cy.get("#t1acoords").should("have.text", "(7,1)");
+            cy.get("#t2acoords").should("have.text", "(−8,2)");
+            cy.get("#t1bcoords").should("have.text", "(−6,3)");
+            cy.get("#t2bcoords").should("have.text", "(−5,−4)");
         });
     });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/updatevalue.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/updatevalue.cy.js
@@ -1,5 +1,4 @@
 import me from "math-expressions";
-import { cesc } from "@doenet/utils";
 
 describe("UpdateValue Tag Tests", { tags: ["@group3"] }, function () {
     beforeEach(() => {
@@ -36,16 +35,16 @@ describe("UpdateValue Tag Tests", { tags: ["@group3"] }, function () {
             );
         });
 
-        cy.get(cesc("#text1")).should("have.text", "a"); //wait for page to load
+        cy.get("#text1").should("have.text", "a"); //wait for page to load
 
-        cy.get(cesc("#m")).should("have.text", "1");
-        cy.get(cesc("#n")).should("have.text", "10");
+        cy.get("#m").should("have.text", "1");
+        cy.get("#n").should("have.text", "10");
 
-        cy.get(cesc("#incm_button")).click();
-        cy.get(cesc("#incn_button")).click();
+        cy.get("#incm_button").click();
+        cy.get("#incn_button").click();
 
-        cy.get(cesc("#m")).should("have.text", "2");
-        cy.get(cesc("#n")).should("have.text", "20");
+        cy.get("#m").should("have.text", "2");
+        cy.get("#n").should("have.text", "20");
 
         cy.wait(2000); // wait to make sure 1 second debounce occurred
 
@@ -65,16 +64,16 @@ describe("UpdateValue Tag Tests", { tags: ["@group3"] }, function () {
             );
         });
 
-        cy.get(cesc("#incm_button")).should("be.disabled");
-        cy.get(cesc("#incn_button")).should("not.be.disabled");
+        cy.get("#incm_button").should("be.disabled");
+        cy.get("#incn_button").should("not.be.disabled");
 
-        cy.get(cesc("#m")).should("have.text", "2");
-        cy.get(cesc("#n")).should("have.text", "20");
+        cy.get("#m").should("have.text", "2");
+        cy.get("#n").should("have.text", "20");
 
-        cy.get(cesc("#incm_button")).click();
-        cy.get(cesc("#incn_button")).click();
+        cy.get("#incm_button").click();
+        cy.get("#incn_button").click();
 
-        cy.get(cesc("#m")).should("have.text", "2");
-        cy.get(cesc("#n")).should("have.text", "30");
+        cy.get("#m").should("have.text", "2");
+        cy.get("#n").should("have.text", "30");
     });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/video.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/video.cy.js
@@ -1,4 +1,4 @@
-import { cesc, widthsBySize } from "@doenet/utils";
+import { widthsBySize } from "@doenet/utils";
 import { assertCenteredWhenDescriptionOpens } from "./utils/mediaAlignment";
 
 describe("Video Tag Tests", { tags: ["@group2"] }, function () {
@@ -20,14 +20,14 @@ describe("Video Tag Tests", { tags: ["@group2"] }, function () {
                 "*",
             );
         });
-        cy.get(cesc("#video1"))
+        cy.get("#video1")
             .invoke("css", "width")
             .then((width) => parseInt(width))
             .should("be.gte", widthsBySize["large"] - 4)
             .and("be.lte", widthsBySize["large"] + 1);
 
-        // cy.get(cesc('#video1')).invoke('attr', 'height').then((height) => expect(height).eq('315px'))
-        cy.get(cesc("#video1"))
+        // cy.get('#video1').invoke('attr', 'height').then((height) => expect(height).eq('315px'))
+        cy.get("#video1")
             .invoke("attr", "src")
             .then((src) => expect(src.includes("tJ4ypc5L6uU")).eq(true));
     });
@@ -43,20 +43,20 @@ describe("Video Tag Tests", { tags: ["@group2"] }, function () {
                 "*",
             );
         });
-        cy.get(cesc("#video1"))
+        cy.get("#video1")
             .invoke("css", "width")
             .then((width) => parseInt(width))
             .should("be.gte", widthsBySize["large"] - 4)
             .and("be.lte", widthsBySize["large"] + 1);
-        // cy.get(cesc('#video1')).invoke('attr', 'height').then((height) => expect(height).eq('315px'))
-        cy.get(cesc("#video1") + " source")
+        // cy.get('#video1').invoke('attr', 'height').then((height) => expect(height).eq('315px'))
+        cy.get("#video1" + " source")
             .invoke("attr", "src")
             .then((src) =>
                 expect(src).eq(
                     "https://jsoncompare.org/LearningContainer/SampleFiles/Video/MP4/Sample-MP4-Video-File-for-Testing.mp4",
                 ),
             );
-        cy.get(cesc("#video1") + " source")
+        cy.get("#video1" + " source")
             .invoke("attr", "type")
             .then((type) => expect(type).eq("video/mp4"));
     });
@@ -101,78 +101,75 @@ describe("Video Tag Tests", { tags: ["@group2"] }, function () {
             // Wait for the YouTube iframe to exist and be visible
             cy.get('iframe[src*="youtube.com"]').should("be.visible");
 
-            cy.get(cesc("#v"))
+            cy.get("#v")
                 .invoke("css", "width")
                 .then((width) => parseInt(width))
                 .should("be.gte", widthsBySize["full"] - 4)
                 .and("be.lte", widthsBySize["full"] + 1);
 
-            cy.get(cesc("#v"))
+            cy.get("#v")
                 .invoke("attr", "src")
                 .then((src) => expect(src.includes("tJ4ypc5L6uU")).eq(true));
 
-            cy.get(cesc("#state")).contains("initializing");
+            cy.get("#state").contains("initializing");
 
             cy.log(
                 "clicking play action too early does not do anything (no error)",
             );
-            cy.get(cesc("#playAction")).click();
-            cy.get(cesc("#state")).contains("stopped");
-            cy.get(cesc("#time")).contains("0");
-            cy.get(cesc("#duration")).should("have.text", "300");
-            cy.get(cesc("#secondsWatched")).should("have.text", "0");
-            cy.get(cesc("#fractionWatched")).should("have.text", "0");
+            cy.get("#playAction").click();
+            cy.get("#state").contains("stopped");
+            cy.get("#time").contains("0");
+            cy.get("#duration").should("have.text", "300");
+            cy.get("#secondsWatched").should("have.text", "0");
+            cy.get("#fractionWatched").should("have.text", "0");
 
             cy.wait(2000);
-            cy.get(cesc("#state")).contains("stopped");
-            cy.get(cesc("#time")).contains("0");
-            cy.get(cesc("#secondsWatched")).should("have.text", "0");
-            cy.get(cesc("#fractionWatched")).should("have.text", "0");
+            cy.get("#state").contains("stopped");
+            cy.get("#time").contains("0");
+            cy.get("#secondsWatched").should("have.text", "0");
+            cy.get("#fractionWatched").should("have.text", "0");
 
             cy.log("play via action");
-            cy.get(cesc("#playAction")).click();
+            cy.get("#playAction").click();
 
-            cy.get(cesc("#state")).contains("playing");
-            cy.get(cesc("#time")).contains("1");
-            cy.get(cesc("#time")).contains("2");
-            cy.get(cesc("#time")).contains("3");
+            cy.get("#state").contains("playing");
+            cy.get("#time").contains("1");
+            cy.get("#time").contains("2");
+            cy.get("#time").contains("3");
 
             cy.log("pause via action");
-            cy.get(cesc("#pauseAction")).click();
+            cy.get("#pauseAction").click();
 
-            cy.get(cesc("#state")).contains("stopped");
-            cy.get(cesc("#time")).contains("3");
-            cy.get(cesc("#secondsWatched")).should("have.text", "3");
-            cy.get(cesc("#fractionWatched")).should("have.text", "0.01");
+            cy.get("#state").contains("stopped");
+            cy.get("#time").contains("3");
+            cy.get("#secondsWatched").should("have.text", "3");
+            cy.get("#fractionWatched").should("have.text", "0.01");
 
             cy.log("cue to first minute");
-            cy.get(cesc("#mi") + " textarea").type(
-                "{end}{backspace}60{enter}",
-                {
-                    force: true,
-                },
-            );
+            cy.get("#mi" + " textarea").type("{end}{backspace}60{enter}", {
+                force: true,
+            });
 
-            cy.get(cesc("#state")).contains("stopped");
-            cy.get(cesc("#time")).contains("60");
-            cy.get(cesc("#secondsWatched")).should("have.text", "3");
-            cy.get(cesc("#fractionWatched")).should("have.text", "0.01");
+            cy.get("#state").contains("stopped");
+            cy.get("#time").contains("60");
+            cy.get("#secondsWatched").should("have.text", "3");
+            cy.get("#fractionWatched").should("have.text", "0.01");
 
             cy.log("play via update");
-            cy.get(cesc("#playUpdate")).click();
+            cy.get("#playUpdate").click();
 
-            cy.get(cesc("#state")).contains("playing");
-            cy.get(cesc("#time")).contains("61");
-            cy.get(cesc("#time")).contains("62");
+            cy.get("#state").contains("playing");
+            cy.get("#time").contains("61");
+            cy.get("#time").contains("62");
 
             cy.log("pause via update");
-            cy.get(cesc("#pauseUpdate")).click();
+            cy.get("#pauseUpdate").click();
 
-            cy.get(cesc("#state")).contains("stopped");
-            cy.get(cesc("#time")).contains("62");
-            cy.get(cesc("#secondsWatched")).contains(/5|6/);
+            cy.get("#state").contains("stopped");
+            cy.get("#time").contains("62");
+            cy.get("#secondsWatched").contains(/5|6/);
 
-            cy.get(cesc("#fractionWatched")).should("have.text", "0.02");
+            cy.get("#fractionWatched").should("have.text", "0.02");
         });
 
         it("video segmentsWatched watched merged, youtube video", () => {
@@ -203,19 +200,19 @@ describe("Video Tag Tests", { tags: ["@group2"] }, function () {
             // Wait for the YouTube iframe to exist and be visible
             cy.get('iframe[src*="youtube.com"]').should("be.visible");
 
-            cy.get(cesc("#v"))
+            cy.get("#v")
                 .invoke("css", "width")
                 .then((width) => parseInt(width))
                 .should("be.gte", widthsBySize["full"] - 4)
                 .and("be.lte", widthsBySize["full"] + 1);
 
-            cy.get(cesc("#v"))
+            cy.get("#v")
                 .invoke("attr", "src")
                 .then((src) => expect(src.includes("tJ4ypc5L6uU")).eq(true));
 
-            cy.get(cesc("#state")).should("have.text", "stopped");
-            cy.get(cesc("#time")).should("have.text", "0");
-            cy.get(cesc("#secondsWatched")).should("have.text", "0");
+            cy.get("#state").should("have.text", "stopped");
+            cy.get("#time").should("have.text", "0");
+            cy.get("#secondsWatched").should("have.text", "0");
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
@@ -226,17 +223,17 @@ describe("Video Tag Tests", { tags: ["@group2"] }, function () {
             });
 
             cy.log("play");
-            cy.get(cesc("#playAction")).click();
+            cy.get("#playAction").click();
 
-            cy.get(cesc("#state")).should("have.text", "playing");
-            cy.get(cesc("#time")).should("have.text", "1");
+            cy.get("#state").should("have.text", "playing");
+            cy.get("#time").should("have.text", "1");
 
             cy.log("pause");
-            cy.get(cesc("#pauseAction")).click();
+            cy.get("#pauseAction").click();
 
-            cy.get(cesc("#state")).should("have.text", "stopped");
-            cy.get(cesc("#time")).should("have.text", "1");
-            cy.get(cesc("#secondsWatched")).should("have.text", "1");
+            cy.get("#state").should("have.text", "stopped");
+            cy.get("#time").should("have.text", "1");
+            cy.get("#secondsWatched").should("have.text", "1");
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
@@ -252,17 +249,17 @@ describe("Video Tag Tests", { tags: ["@group2"] }, function () {
             });
 
             cy.log("play");
-            cy.get(cesc("#playAction")).click();
+            cy.get("#playAction").click();
 
-            cy.get(cesc("#state")).should("have.text", "playing");
-            cy.get(cesc("#time")).should("have.text", "3");
+            cy.get("#state").should("have.text", "playing");
+            cy.get("#time").should("have.text", "3");
 
             cy.log("pause");
-            cy.get(cesc("#pauseAction")).click();
+            cy.get("#pauseAction").click();
 
-            cy.get(cesc("#state")).should("have.text", "stopped");
-            cy.get(cesc("#time")).should("have.text", "3");
-            cy.get(cesc("#secondsWatched")).should("have.text", "3");
+            cy.get("#state").should("have.text", "stopped");
+            cy.get("#time").should("have.text", "3");
+            cy.get("#secondsWatched").should("have.text", "3");
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
@@ -278,17 +275,17 @@ describe("Video Tag Tests", { tags: ["@group2"] }, function () {
             });
 
             cy.log("play");
-            cy.get(cesc("#playAction")).click();
+            cy.get("#playAction").click();
 
-            cy.get(cesc("#state")).should("have.text", "playing");
-            cy.get(cesc("#time")).should("have.text", "4");
+            cy.get("#state").should("have.text", "playing");
+            cy.get("#time").should("have.text", "4");
 
             cy.log("pause");
-            cy.get(cesc("#pauseAction")).click();
+            cy.get("#pauseAction").click();
 
-            cy.get(cesc("#state")).should("have.text", "stopped");
-            cy.get(cesc("#time")).should("have.text", "4");
-            cy.get(cesc("#secondsWatched")).should("have.text", "4");
+            cy.get("#state").should("have.text", "stopped");
+            cy.get("#time").should("have.text", "4");
+            cy.get("#secondsWatched").should("have.text", "4");
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
@@ -304,26 +301,23 @@ describe("Video Tag Tests", { tags: ["@group2"] }, function () {
             });
 
             cy.log("cue to first minute");
-            cy.get(cesc("#mi") + " textarea").type(
-                "{end}{backspace}60{enter}",
-                {
-                    force: true,
-                },
-            );
-            cy.get(cesc("#time")).should("have.text", "60");
+            cy.get("#mi" + " textarea").type("{end}{backspace}60{enter}", {
+                force: true,
+            });
+            cy.get("#time").should("have.text", "60");
 
             cy.log("play");
-            cy.get(cesc("#playAction")).click();
+            cy.get("#playAction").click();
 
-            cy.get(cesc("#state")).should("have.text", "playing");
-            cy.get(cesc("#time")).should("have.text", "62");
+            cy.get("#state").should("have.text", "playing");
+            cy.get("#time").should("have.text", "62");
 
             cy.log("pause");
-            cy.get(cesc("#pauseAction")).click();
+            cy.get("#pauseAction").click();
 
-            cy.get(cesc("#state")).should("have.text", "stopped");
-            cy.get(cesc("#time")).should("have.text", "62");
-            cy.get(cesc("#secondsWatched")).contains(/6|7/);
+            cy.get("#state").should("have.text", "stopped");
+            cy.get("#time").should("have.text", "62");
+            cy.get("#secondsWatched").contains(/6|7/);
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
@@ -344,17 +338,17 @@ describe("Video Tag Tests", { tags: ["@group2"] }, function () {
             });
 
             cy.log("play");
-            cy.get(cesc("#playAction")).click();
+            cy.get("#playAction").click();
 
-            cy.get(cesc("#state")).should("have.text", "playing");
-            cy.get(cesc("#time")).should("have.text", "63");
+            cy.get("#state").should("have.text", "playing");
+            cy.get("#time").should("have.text", "63");
 
             cy.log("pause");
-            cy.get(cesc("#pauseAction")).click();
+            cy.get("#pauseAction").click();
 
-            cy.get(cesc("#state")).should("have.text", "stopped");
-            cy.get(cesc("#time")).should("have.text", "63");
-            cy.get(cesc("#secondsWatched")).contains(/7|8/);
+            cy.get("#state").should("have.text", "stopped");
+            cy.get("#time").should("have.text", "63");
+            cy.get("#secondsWatched").contains(/7|8/);
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
@@ -376,24 +370,24 @@ describe("Video Tag Tests", { tags: ["@group2"] }, function () {
 
             cy.log("replay part of beginning");
 
-            cy.get(cesc("#mi") + " textarea").type(
+            cy.get("#mi" + " textarea").type(
                 "{end}{backspace}{backspace}1{enter}",
                 { force: true },
             );
-            cy.get(cesc("#time")).should("have.text", "1");
+            cy.get("#time").should("have.text", "1");
 
             cy.log("play");
-            cy.get(cesc("#playAction")).click();
+            cy.get("#playAction").click();
 
-            cy.get(cesc("#state")).should("have.text", "playing");
-            cy.get(cesc("#time")).should("have.text", "3");
+            cy.get("#state").should("have.text", "playing");
+            cy.get("#time").should("have.text", "3");
 
             cy.log("pause");
-            cy.get(cesc("#pauseAction")).click();
+            cy.get("#pauseAction").click();
 
-            cy.get(cesc("#state")).should("have.text", "stopped");
-            cy.get(cesc("#time")).should("have.text", "3");
-            cy.get(cesc("#secondsWatched")).contains(/7|8/);
+            cy.get("#state").should("have.text", "stopped");
+            cy.get("#time").should("have.text", "3");
+            cy.get("#secondsWatched").contains(/7|8/);
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();
@@ -415,17 +409,17 @@ describe("Video Tag Tests", { tags: ["@group2"] }, function () {
 
             cy.log("play");
             cy.wait(100); // for some reason, need this delay when headless for play button to be activated
-            cy.get(cesc("#playAction")).click();
+            cy.get("#playAction").click();
 
-            cy.get(cesc("#state")).should("have.text", "playing");
-            cy.get(cesc("#time")).should("have.text", "5");
+            cy.get("#state").should("have.text", "playing");
+            cy.get("#time").should("have.text", "5");
 
             cy.log("pause");
-            cy.get(cesc("#pauseAction")).click();
+            cy.get("#pauseAction").click();
 
-            cy.get(cesc("#state")).should("have.text", "stopped");
-            cy.get(cesc("#time")).should("have.text", "5");
-            cy.get(cesc("#secondsWatched")).contains(/8|9/);
+            cy.get("#state").should("have.text", "stopped");
+            cy.get("#time").should("have.text", "5");
+            cy.get("#secondsWatched").contains(/8|9/);
 
             cy.window().then(async (win) => {
                 let stateVariables = await win.returnAllStateVariables1();

--- a/packages/test-cypress/cypress/e2e/variants/specifysinglevariant.cy.js
+++ b/packages/test-cypress/cypress/e2e/variants/specifysinglevariant.cy.js
@@ -67,7 +67,7 @@ describe(
                     );
                 });
                 // to wait for page to load
-                cy.get(cesc("#a")).should("have.text", `${ind}`);
+                cy.get("#a").should("have.text", `${ind}`);
 
                 cy.window().then(async (win) => {
                     let stateVariables = await win.returnAllStateVariables1();
@@ -112,10 +112,8 @@ describe(
                         expect(i).not.eq(-1);
                     }
 
-                    cy.get(cesc("#textInput1_input")).type(
-                        `${secondValue}{enter}`,
-                    );
-                    cy.get(cesc("#textInput1_button")).should(
+                    cy.get("#textInput1_input").type(`${secondValue}{enter}`);
+                    cy.get("#textInput1_button").should(
                         "contain.text",
                         "Correct",
                     );
@@ -134,7 +132,7 @@ describe(
                         );
                     });
                     // to wait for page to load
-                    cy.get(cesc("#a")).should("have.text", `${ind}`);
+                    cy.get("#a").should("have.text", `${ind}`);
 
                     // wait until core is loaded
                     cy.waitUntil(() =>
@@ -147,7 +145,7 @@ describe(
                         }),
                     );
 
-                    cy.get(cesc("#textInput1_button")).should(
+                    cy.get("#textInput1_button").should(
                         "contain.text",
                         "Correct",
                     );
@@ -166,17 +164,15 @@ describe(
                                 .stateValues.value;
                         expect(secondValue2).eq(secondValue);
 
-                        cy.get(cesc("#textInput1_input")).type(`{end}X`);
-                        cy.get(cesc("#textInput1_button")).click();
-                        cy.get(cesc("#textInput1_button")).should(
+                        cy.get("#textInput1_input").type(`{end}X`);
+                        cy.get("#textInput1_button").click();
+                        cy.get("#textInput1_button").should(
                             "contain.text",
                             "Incorrect",
                         );
-                        cy.get(cesc("#textInput1_input")).type(
-                            `{end}{backspace}`,
-                        );
-                        cy.get(cesc("#textInput1_button")).click();
-                        cy.get(cesc("#textInput1_button")).should(
+                        cy.get("#textInput1_input").type(`{end}{backspace}`);
+                        cy.get("#textInput1_button").click();
+                        cy.get("#textInput1_button").should(
                             "contain.text",
                             "Correct",
                         );
@@ -248,7 +244,7 @@ describe(
                     );
                 });
                 // to wait for page to load
-                cy.get(cesc("#text1")).should("have.text", `${ind}`);
+                cy.get("#text1").should("have.text", `${ind}`);
 
                 cy.window().then(async (win) => {
                     let stateVariables = await win.returnAllStateVariables1();
@@ -312,7 +308,7 @@ describe(
                         );
                     });
                     // to wait for page to load
-                    cy.get(cesc("#text1")).should("have.text", `${ind}`);
+                    cy.get("#text1").should("have.text", `${ind}`);
 
                     // wait until core is loaded
                     cy.waitUntil(() =>
@@ -419,7 +415,7 @@ describe(
                 });
 
                 // to wait for page to load
-                cy.get(cesc("#text1")).should("have.text", `${ind}`);
+                cy.get("#text1").should("have.text", `${ind}`);
 
                 let indexChosen1, indexChosen2;
                 let m, n;
@@ -439,23 +435,17 @@ describe(
                         stateVariables[await win.resolvePath1("n[1]")]
                             .stateValues.value;
 
-                    cy.get(cesc("#mathInput1") + " textarea").type(
-                        `${m}{enter}`,
-                        {
-                            force: true,
-                        },
-                    );
-                    cy.get(cesc("#mathInput2") + " textarea").type(
-                        `${n}{enter}`,
-                        {
-                            force: true,
-                        },
-                    );
-                    cy.get(cesc("#mathInput1_button")).should(
+                    cy.get("#mathInput1" + " textarea").type(`${m}{enter}`, {
+                        force: true,
+                    });
+                    cy.get("#mathInput2" + " textarea").type(`${n}{enter}`, {
+                        force: true,
+                    });
+                    cy.get("#mathInput1_button").should(
                         "contain.text",
                         "Correct",
                     );
-                    cy.get(cesc("#mathInput2_button")).should(
+                    cy.get("#mathInput2_button").should(
                         "contain.text",
                         "Correct",
                     );
@@ -474,7 +464,7 @@ describe(
                         );
                     });
                     // to wait for page to load
-                    cy.get(cesc("#text1")).should("have.text", `${ind}`);
+                    cy.get("#text1").should("have.text", `${ind}`);
 
                     // wait until core is loaded
                     cy.waitUntil(() =>
@@ -506,51 +496,51 @@ describe(
                         ).eq(n);
                     });
 
-                    cy.get(cesc("#mathInput1_button")).should(
+                    cy.get("#mathInput1_button").should(
                         "contain.text",
                         "Correct",
                     );
-                    cy.get(cesc("#mathInput2_button")).should(
+                    cy.get("#mathInput2_button").should(
                         "contain.text",
                         "Correct",
                     );
 
-                    cy.get(cesc("#mathInput1") + " textarea").type(`{end}X`, {
+                    cy.get("#mathInput1" + " textarea").type(`{end}X`, {
                         force: true,
                     });
-                    cy.get(cesc("#mathInput2") + " textarea").type(`{end}X`, {
+                    cy.get("#mathInput2" + " textarea").type(`{end}X`, {
                         force: true,
                     });
-                    cy.get(cesc("#mathInput1_button")).click();
-                    cy.get(cesc("#mathInput2_button")).click();
-                    cy.get(cesc("#mathInput1_button")).should(
+                    cy.get("#mathInput1_button").click();
+                    cy.get("#mathInput2_button").click();
+                    cy.get("#mathInput1_button").should(
                         "contain.text",
                         "Incorrect",
                     );
-                    cy.get(cesc("#mathInput2_button")).should(
+                    cy.get("#mathInput2_button").should(
                         "contain.text",
                         "Incorrect",
                     );
 
-                    cy.get(cesc("#mathInput1") + " textarea").type(
+                    cy.get("#mathInput1" + " textarea").type(
                         `{end}{backspace}`,
                         {
                             force: true,
                         },
                     );
-                    cy.get(cesc("#mathInput2") + " textarea").type(
+                    cy.get("#mathInput2" + " textarea").type(
                         `{end}{backspace}`,
                         {
                             force: true,
                         },
                     );
-                    cy.get(cesc("#mathInput1_button")).click();
-                    cy.get(cesc("#mathInput2_button")).click();
-                    cy.get(cesc("#mathInput1_button")).should(
+                    cy.get("#mathInput1_button").click();
+                    cy.get("#mathInput2_button").click();
+                    cy.get("#mathInput1_button").should(
                         "contain.text",
                         "Correct",
                     );
-                    cy.get(cesc("#mathInput2_button")).should(
+                    cy.get("#mathInput2_button").should(
                         "contain.text",
                         "Correct",
                     );
@@ -594,7 +584,7 @@ describe(
             });
 
             // to wait for page to load
-            cy.get(cesc("#text1")).should("have.text", `1`);
+            cy.get("#text1").should("have.text", `1`);
 
             let choices = ["a", "b", "c"];
 
@@ -640,13 +630,13 @@ describe(
                     cesc("#_id_" + mathInput4Idx) + " textarea";
                 let answer4Button = cesc("#_id_" + mathInput4Idx + "_button");
 
-                cy.get(`#${cesc("ci_choice1_input")}`)
+                cy.get(`#${"ci_choice1_input"}`)
                     .parent()
                     .should("have.text", choices[choiceOrder[0] - 1]);
-                cy.get(`#${cesc("ci_choice2_input")}`)
+                cy.get(`#${"ci_choice2_input"}`)
                     .parent()
                     .should("have.text", choices[choiceOrder[1] - 1]);
-                cy.get(`#${cesc("ci_choice3_input")}`)
+                cy.get(`#${"ci_choice3_input"}`)
                     .parent()
                     .should("have.text", choices[choiceOrder[2] - 1]);
                 cy.get(`#${cesc("g2.ci_choice1_input")}`)
@@ -784,7 +774,7 @@ describe(
                 });
 
                 // to wait for page to load
-                cy.get(cesc("#text1")).should("have.text", `1`);
+                cy.get("#text1").should("have.text", `1`);
 
                 // wait until core is loaded
                 cy.waitUntil(() =>

--- a/packages/test-cypress/cypress/e2e/variants/specifysinglevariant.cy.js
+++ b/packages/test-cypress/cypress/e2e/variants/specifysinglevariant.cy.js
@@ -630,13 +630,13 @@ describe(
                     cesc("#_id_" + mathInput4Idx) + " textarea";
                 let answer4Button = cesc("#_id_" + mathInput4Idx + "_button");
 
-                cy.get(`#${"ci_choice1_input"}`)
+                cy.get("#ci_choice1_input")
                     .parent()
                     .should("have.text", choices[choiceOrder[0] - 1]);
-                cy.get(`#${"ci_choice2_input"}`)
+                cy.get("#ci_choice2_input")
                     .parent()
                     .should("have.text", choices[choiceOrder[1] - 1]);
-                cy.get(`#${"ci_choice3_input"}`)
+                cy.get("#ci_choice3_input")
                     .parent()
                     .should("have.text", choices[choiceOrder[2] - 1]);
                 cy.get(`#${cesc("g2.ci_choice1_input")}`)

--- a/packages/test-cypress/cypress/support/prefigure.js
+++ b/packages/test-cypress/cypress/support/prefigure.js
@@ -38,7 +38,7 @@ export function waitPastDebounceWindow() {
     cy.wait(PREFIGURE_BUILD_DEBOUNCE_MS + REQUEST_SETTLE_BUFFER_MS);
 }
 
-export function postDebounceTestDoenetML(cesc) {
+export function postDebounceTestDoenetML() {
     cy.window().then(async (win) => {
         win.postMessage(
             {

--- a/packages/test-cypress/cypress/support/prefigure.js
+++ b/packages/test-cypress/cypress/support/prefigure.js
@@ -54,7 +54,7 @@ export function postDebounceTestDoenetML(cesc) {
         );
     });
 
-    cy.get(cesc("#ready")).should("have.text", "ready");
+    cy.get("#ready").should("have.text", "ready");
 }
 
 export function installMockPrefigureModule({


### PR DESCRIPTION
## Summary
- remove unnecessary `cesc()` wrappers in Cypress selectors where escaping is not needed
- keep `cesc()` where selector escaping is still required
- remove unused `cesc` imports in files where all calls were removed

## Validation
- formatted changed files with Prettier
- checked editor diagnostics on changed files (no errors)

## Notes
- commit: 39554b6a8
