### PR TITLE
LSP: support boolean-alias enum attributes

### DIFF
--- a/.changeset/few-snails-rule.md
+++ b/.changeset/few-snails-rule.md
@@ -1,0 +1,9 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Fix LSP schema validation and autocomplete for enum attributes that also support boolean aliases.
+
+Attributes like `simplify`, `simplifyOnCompare`, `addSliders`, and `sort` now accept presence form and explicit `"true"`/`"false"` without warnings, while autocomplete continues to prioritize the author-facing enum values.

--- a/packages/lsp-tools/src/auto-completer/index.ts
+++ b/packages/lsp-tools/src/auto-completer/index.ts
@@ -14,7 +14,11 @@ import type { RustResolverAdapter } from "./rust-resolver-adapter";
 type ElementSchema = {
     name: string;
     top: boolean;
-    attributes: { name: string; values?: string[] }[];
+    attributes: {
+        name: string;
+        values?: string[];
+        autocompleteValues?: string[];
+    }[];
     properties?: { name: string }[];
     children: string[];
     acceptsStringChildren: boolean;

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -781,6 +781,8 @@ export function getCompletionItems(
         const allowedAttribute = allowedAttributes.find(
             (a) => a.name === attribute?.name,
         );
+        // Prefer explicit autocomplete values when provided; fall back to
+        // full validation values otherwise.
         const allowedAttrValues =
             allowedAttribute?.autocompleteValues ?? allowedAttribute?.values;
         if (!allowedAttrValues) {

--- a/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-completion-items.ts
@@ -778,9 +778,11 @@ export function getCompletionItems(
         const allowedAttributes =
             this.schemaElementsByName[elmName]?.attributes || [];
         const attribute = this._getAttributeContainsOffset(element, offset);
-        const allowedAttrValues = allowedAttributes.find(
+        const allowedAttribute = allowedAttributes.find(
             (a) => a.name === attribute?.name,
-        )?.values;
+        );
+        const allowedAttrValues =
+            allowedAttribute?.autocompleteValues ?? allowedAttribute?.values;
         if (!allowedAttrValues) {
             return [{ label: '""', kind: CompletionItemKind.Value }];
         }

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -27,7 +27,11 @@ const schema = {
             children: ["www"],
             attributes: [
                 { name: "foo", values: ["true", "false"] },
-                { name: "bar", values: ["more", "less"] },
+                {
+                    name: "bar",
+                    values: ["more", "less", "true", "false"],
+                    autocompleteValues: ["more", "less"],
+                },
             ],
             top: false,
             acceptsStringChildren: false,
@@ -127,6 +131,21 @@ describe("AutoCompleter", () => {
               ]
             `);
         }
+    });
+
+    it("Prefers autocompleteValues for attribute value completions", () => {
+        const source = `<aa><b foo="true" bar="less"></b></aa>`;
+        const autoCompleter = new AutoCompleter(source, schema.elements);
+        const offset = source.indexOf("<b") + 19;
+
+        const values = autoCompleter
+            .getCompletionItems(offset)
+            .map((item) => String(item.label).replace(/^"|"$/g, ""));
+
+        expect(values).toContain("more");
+        expect(values).toContain("less");
+        expect(values).not.toContain("true");
+        expect(values).not.toContain("false");
     });
     it("Can suggest closing tag completion when there is no closing tag", () => {
         let source: string;

--- a/packages/lsp-tools/test/doenet-auto-complete.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-complete.test.ts
@@ -32,6 +32,11 @@ const schema = {
                     values: ["more", "less", "true", "false"],
                     autocompleteValues: ["more", "less"],
                 },
+                {
+                    name: "modeOneSided",
+                    values: ["none", "full", "true"],
+                    autocompleteValues: ["none", "full"],
+                },
             ],
             top: false,
             acceptsStringChildren: false,
@@ -70,18 +75,11 @@ describe("AutoCompleter", () => {
         {
             let offset = source.indexOf("<b") + 3;
             let elm = autoCompleter.getCompletionItems(offset);
-            expect(elm).toMatchInlineSnapshot(`
-              [
-                {
-                  "kind": 13,
-                  "label": "foo",
-                },
-                {
-                  "kind": 13,
-                  "label": "bar",
-                },
-              ]
-            `);
+            expect(elm.map((item) => item.label)).toEqual([
+                "foo",
+                "bar",
+                "modeOneSided",
+            ]);
         }
         {
             let offset = source.indexOf("<b") + 8;
@@ -147,6 +145,22 @@ describe("AutoCompleter", () => {
         expect(values).not.toContain("true");
         expect(values).not.toContain("false");
     });
+
+    it("Prefers autocompleteValues for one-sided boolean aliases", () => {
+        const source = `<aa><b modeOneSided="none"></b></aa>`;
+        const autoCompleter = new AutoCompleter(source, schema.elements);
+        const offset = source.indexOf("modeOneSided") + 15;
+
+        const values = autoCompleter
+            .getCompletionItems(offset)
+            .map((item) => String(item.label).replace(/^"|"$/g, ""));
+
+        expect(values).toContain("none");
+        expect(values).toContain("full");
+        expect(values).not.toContain("true");
+        expect(values).not.toContain("false");
+    });
+
     it("Can suggest closing tag completion when there is no closing tag", () => {
         let source: string;
         let autoCompleter: AutoCompleter;

--- a/packages/lsp-tools/test/doenet-auto-schema-check.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-schema-check.test.ts
@@ -32,6 +32,11 @@ const schema = {
                     values: ["none", "full", "true", "false"],
                     autocompleteValues: ["none", "full"],
                 },
+                {
+                    name: "modeOneSided",
+                    values: ["none", "full", "true"],
+                    autocompleteValues: ["none", "full"],
+                },
             ],
             top: true,
             acceptsStringChildren: false,
@@ -379,6 +384,35 @@ describe("AutoCompleter", () => {
         source = `<b mode="false" />`;
         autoCompleter = new AutoCompleter(source, schema.elements);
         expect(autoCompleter.getSchemaViolations()).toMatchInlineSnapshot("[]");
+
+        source = `<b modeOneSided />`;
+        autoCompleter = new AutoCompleter(source, schema.elements);
+        expect(autoCompleter.getSchemaViolations()).toMatchInlineSnapshot("[]");
+
+        source = `<b modeOneSided="true" />`;
+        autoCompleter = new AutoCompleter(source, schema.elements);
+        expect(autoCompleter.getSchemaViolations()).toMatchInlineSnapshot("[]");
+
+        source = `<b modeOneSided="false" />`;
+        autoCompleter = new AutoCompleter(source, schema.elements);
+        expect(autoCompleter.getSchemaViolations()).toMatchInlineSnapshot(`
+          [
+            {
+              "message": "Attribute \`modeOneSided\` of element \`<b>\` must be one of: \"none\", \"full\", \"true\"",
+              "range": {
+                "end": {
+                  "character": 23,
+                  "line": 0,
+                },
+                "start": {
+                  "character": 16,
+                  "line": 0,
+                },
+              },
+              "severity": 2,
+            },
+          ]
+        `);
     });
 
     it("allows styleDefinition and feedbackDefinition at the root with Doenet schema", () => {

--- a/packages/lsp-tools/test/doenet-auto-schema-check.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-schema-check.test.ts
@@ -25,7 +25,14 @@ const schema = {
         {
             name: "b",
             children: ["www"],
-            attributes: [{ name: "foo", values: ["true", "false"] }],
+            attributes: [
+                { name: "foo", values: ["true", "false"] },
+                {
+                    name: "mode",
+                    values: ["none", "full", "true", "false"],
+                    autocompleteValues: ["none", "full"],
+                },
+            ],
             top: true,
             acceptsStringChildren: false,
         },
@@ -358,6 +365,18 @@ describe("AutoCompleter", () => {
 
         // No error for correct values
         source = `<b  foo />`;
+        autoCompleter = new AutoCompleter(source, schema.elements);
+        expect(autoCompleter.getSchemaViolations()).toMatchInlineSnapshot("[]");
+
+        source = `<b mode />`;
+        autoCompleter = new AutoCompleter(source, schema.elements);
+        expect(autoCompleter.getSchemaViolations()).toMatchInlineSnapshot("[]");
+
+        source = `<b mode="true" />`;
+        autoCompleter = new AutoCompleter(source, schema.elements);
+        expect(autoCompleter.getSchemaViolations()).toMatchInlineSnapshot("[]");
+
+        source = `<b mode="false" />`;
         autoCompleter = new AutoCompleter(source, schema.elements);
         expect(autoCompleter.getSchemaViolations()).toMatchInlineSnapshot("[]");
     });

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -354,17 +354,20 @@ export function getSchema() {
                     name: attrName,
                 };
 
-                const hasBooleanAlias =
-                    attrDef.valueForTrue !== undefined ||
-                    attrDef.valueForFalse !== undefined;
+                const booleanAliasValues: string[] = [];
+                if (attrDef.valueForTrue !== undefined) {
+                    booleanAliasValues.push("true");
+                }
+                if (attrDef.valueForFalse !== undefined) {
+                    booleanAliasValues.push("false");
+                }
 
                 if (attrDef.validValues) {
-                    if (hasBooleanAlias) {
+                    if (booleanAliasValues.length > 0) {
                         attrSpec.values = [
                             ...new Set([
                                 ...attrDef.validValues,
-                                "true",
-                                "false",
+                                ...booleanAliasValues,
                             ]),
                         ];
                         attrSpec.autocompleteValues = attrDef.validValues;

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -131,7 +131,9 @@ type PublicStateVariableDescription = {
 
 type SchemaAttribute = {
     name: string;
+    /** Values accepted by validation/schema checks. */
     values?: unknown[];
+    /** Optional author-facing subset used for autocomplete suggestions. */
     autocompleteValues?: unknown[];
 };
 
@@ -346,11 +348,7 @@ export function getSchema() {
             // one can add a excludeFromSchema to an attribute definition
             // to keep it from showing up in the schema
             if (!attrDef.excludeFromSchema) {
-                const attrSpec: {
-                    name: string;
-                    values?: unknown[];
-                    autocompleteValues?: unknown[];
-                } = {
+                const attrSpec: SchemaAttribute = {
                     name: attrName,
                 };
 
@@ -364,6 +362,8 @@ export function getSchema() {
 
                 if (attrDef.validValues) {
                     if (booleanAliasValues.length > 0) {
+                        // Keep validation permissive for boolean aliases while
+                        // preserving author-facing enum suggestions in autocomplete.
                         attrSpec.values = [
                             ...new Set([
                                 ...attrDef.validValues,

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -15,6 +15,8 @@ type AttributeObject = {
     public: boolean;
     excludeFromSchema: boolean;
     validValues?: unknown[];
+    valueForTrue?: unknown;
+    valueForFalse?: unknown;
 };
 
 type ComponentClass = {
@@ -127,7 +129,11 @@ type PublicStateVariableDescription = {
     arrayVarNameFromPropIndex?: Function;
 };
 
-type SchemaAttribute = { name: string; values?: unknown[] };
+type SchemaAttribute = {
+    name: string;
+    values?: unknown[];
+    autocompleteValues?: unknown[];
+};
 
 type SchemaElement = {
     /** The component type of this component */
@@ -340,12 +346,31 @@ export function getSchema() {
             // one can add a excludeFromSchema to an attribute definition
             // to keep it from showing up in the schema
             if (!attrDef.excludeFromSchema) {
-                const attrSpec: { name: string; values?: unknown[] } = {
+                const attrSpec: {
+                    name: string;
+                    values?: unknown[];
+                    autocompleteValues?: unknown[];
+                } = {
                     name: attrName,
                 };
 
+                const hasBooleanAlias =
+                    attrDef.valueForTrue !== undefined ||
+                    attrDef.valueForFalse !== undefined;
+
                 if (attrDef.validValues) {
-                    attrSpec.values = attrDef.validValues;
+                    if (hasBooleanAlias) {
+                        attrSpec.values = [
+                            ...new Set([
+                                ...attrDef.validValues,
+                                "true",
+                                "false",
+                            ]),
+                        ];
+                        attrSpec.autocompleteValues = attrDef.validValues;
+                    } else {
+                        attrSpec.values = attrDef.validValues;
+                    }
                 } else if (
                     attrDef.createPrimitiveOfType === "boolean" ||
                     attrDef.createComponentOfType === "boolean"

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -408,6 +408,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -6346,6 +6355,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -6618,6 +6636,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -6885,6 +6912,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -7148,6 +7184,15 @@
                 {
                     "name": "simplifyOnCompare",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -7486,6 +7531,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -7820,6 +7874,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -8150,6 +8213,15 @@
                 {
                     "name": "simplifyOnCompare",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -8497,6 +8569,15 @@
                 {
                     "name": "simplify",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -9093,6 +9174,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -9685,6 +9775,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -10265,6 +10364,15 @@
                 {
                     "name": "simplify",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -10853,6 +10961,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -11437,6 +11554,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -12013,6 +12139,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -12565,6 +12700,15 @@
                 {
                     "name": "simplify",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -13137,6 +13281,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -13701,6 +13854,15 @@
                 {
                     "name": "simplify",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -14273,6 +14435,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -14837,6 +15008,15 @@
                 {
                     "name": "simplify",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -15433,6 +15613,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -16021,6 +16210,15 @@
                 {
                     "name": "simplify",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -16629,6 +16827,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -17233,6 +17440,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -17821,6 +18037,15 @@
                 {
                     "name": "simplify",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -18417,6 +18642,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -19005,6 +19239,15 @@
                 {
                     "name": "simplify",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -19601,6 +19844,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -20189,6 +20441,15 @@
                 {
                     "name": "simplify",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -20785,6 +21046,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -21371,6 +21641,15 @@
                 {
                     "name": "simplify",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -22044,6 +22323,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -22709,6 +22997,15 @@
                 {
                     "name": "simplify",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -39321,6 +39618,14 @@
                         "none",
                         "both",
                         "xOnly",
+                        "yOnly",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "both",
+                        "xOnly",
                         "yOnly"
                     ]
                 },
@@ -41394,6 +41699,15 @@
                 {
                     "name": "simplify",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -48214,6 +48528,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -48663,6 +48986,15 @@
                 {
                     "name": "simplify",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -50452,6 +50784,14 @@
                         "none",
                         "both",
                         "xOnly",
+                        "yOnly",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "both",
+                        "xOnly",
                         "yOnly"
                     ]
                 },
@@ -50814,6 +51154,15 @@
                 {
                     "name": "simplify",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -57274,6 +57623,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -57942,6 +58300,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -58379,6 +58746,15 @@
                 {
                     "name": "simplifyOnCompare",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -62318,6 +62694,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -62893,6 +63278,15 @@
                 {
                     "name": "simplify",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -63519,6 +63913,15 @@
                 {
                     "name": "simplify",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -70192,6 +70595,13 @@
                     "values": [
                         "unsorted",
                         "increasing",
+                        "decreasing",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "unsorted",
+                        "increasing",
                         "decreasing"
                     ]
                 },
@@ -70974,6 +71384,15 @@
                 {
                     "name": "simplify",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -71880,6 +72299,13 @@
                     "values": [
                         "unsorted",
                         "increasing",
+                        "decreasing",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "unsorted",
+                        "increasing",
                         "decreasing"
                     ]
                 },
@@ -72401,6 +72827,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -72584,6 +73019,15 @@
                 {
                     "name": "simplify",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -75904,6 +76348,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 }
@@ -78362,6 +78815,14 @@
                         "none",
                         "both",
                         "xOnly",
+                        "yOnly",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "both",
+                        "xOnly",
                         "yOnly"
                     ]
                 },
@@ -79915,6 +80376,15 @@
                 {
                     "name": "simplify",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",
@@ -82232,6 +82702,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -83501,6 +83980,15 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
                         "normalizeOrder"
                     ]
                 },
@@ -83836,6 +84324,15 @@
                 {
                     "name": "simplify",
                     "values": [
+                        "none",
+                        "full",
+                        "numbers",
+                        "numbersPreserveOrder",
+                        "normalizeOrder",
+                        "true",
+                        "false"
+                    ],
+                    "autocompleteValues": [
                         "none",
                         "full",
                         "numbers",

--- a/packages/static-assets/test/get-schema-top-level.test.ts
+++ b/packages/static-assets/test/get-schema-top-level.test.ts
@@ -48,4 +48,52 @@ describe("generated schema top-level elements", () => {
         expect(elementsByName.document.children).not.toContain("when");
         expect(elementsByName.when.top).toBe(false);
     });
+
+    it("includes boolean aliases for two-sided enum aliases", () => {
+        const schema = getSchema();
+        const elementsByName = Object.fromEntries(
+            schema.elements.map((element) => [element.name, element]),
+        );
+
+        const sortAttribute = elementsByName.selectFromSequence.attributes.find(
+            (attribute) => attribute.name === "sort",
+        );
+
+        expect(sortAttribute).toBeDefined();
+        if (!sortAttribute) {
+            throw new Error("Expected selectFromSequence.sort attribute");
+        }
+        expect(sortAttribute.values).toEqual(
+            expect.arrayContaining([
+                "unsorted",
+                "increasing",
+                "decreasing",
+                "true",
+                "false",
+            ]),
+        );
+        expect(sortAttribute.autocompleteValues).toEqual([
+            "unsorted",
+            "increasing",
+            "decreasing",
+        ]);
+    });
+
+    it("does not invent a missing false alias for one-sided attributes", () => {
+        const schema = getSchema();
+        const elementsByName = Object.fromEntries(
+            schema.elements.map((element) => [element.name, element]),
+        );
+
+        const gridAttribute = elementsByName.graph.attributes.find(
+            (attribute) => attribute.name === "grid",
+        );
+
+        expect(gridAttribute).toBeDefined();
+        if (!gridAttribute) {
+            throw new Error("Expected graph.grid attribute");
+        }
+        expect(gridAttribute.values).toBeUndefined();
+        expect(gridAttribute.autocompleteValues).toBeUndefined();
+    });
 });


### PR DESCRIPTION
## Summary
- allow LSP validation of enum attributes that define boolean aliases (`valueForTrue`/`valueForFalse`) to accept presence form and explicit `"true"`/`"false"`
- keep autocomplete focused on author-facing enum choices via `autocompleteValues`
- regenerate static schema metadata and add targeted LSP tests
- add a changeset for `@doenet/doenetml`, `@doenet/standalone`, and `@doenet/doenetml-iframe`

## Testing
- npm run test -w @doenet/lsp-tools -- --run test/doenet-auto-schema-check.test.ts test/doenet-auto-complete.test.ts
