### PR TITLE
Fix PreFigure curve rendering for implicit-multiplication expressions

### DIFF
--- a/.changeset/prefigure-explicit-multiplication.md
+++ b/.changeset/prefigure-explicit-multiplication.md
@@ -1,0 +1,7 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Fix PreFigure curve rendering for implicit-multiplication expressions. Functions like `(x-2)(x-5)` or `3x` now render correctly in the PreFigure renderer; previously these produced invalid formula strings that the PreFigure parser dropped silently.

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
                 "jszip": "^3.10.1",
                 "katex": "^0.16.27",
                 "lorem-ipsum": "^2.0.8",
-                "math-expressions": "^2.0.0-alpha89",
+                "math-expressions": "^2.0.0-alpha90",
                 "micromark": "^4.0.2",
                 "nanoid": "^5.1.6",
                 "nextra": "^3.3.1",
@@ -15223,14 +15223,14 @@
             }
         },
         "node_modules/math-expressions": {
-            "version": "2.0.0-alpha89",
-            "resolved": "https://registry.npmjs.org/math-expressions/-/math-expressions-2.0.0-alpha89.tgz",
-            "integrity": "sha512-gH/G+i9ut1xx5szgvHzTt2y0POyI2GV45Zrbkl+Lf78+rPXJH8l6OdDBPTQCpMt4Hz98PABgY9u4M6YTOo6MCA==",
+            "version": "2.0.0-alpha90",
+            "resolved": "https://registry.npmjs.org/math-expressions/-/math-expressions-2.0.0-alpha90.tgz",
+            "integrity": "sha512-U4bWIvSzze7rmbzFLigNYzwf6rr7uaW91D+KhaoY9KNzAea96MPU6MuhuBtv4t8+QexnF2k9JHX6i+4x60rffg==",
             "license": "(GPL-3.0 OR Apache-2.0)",
             "dependencies": {
                 "@babel/cli": "^7.28.6",
                 "babel-upgrade": "^1.0.1",
-                "mathjs": "^15.1.1",
+                "mathjs": "^15.2.0",
                 "number-theory": "1.1.0",
                 "numeric": "1.2.6",
                 "seedrandom": "^3.0.5",
@@ -15294,9 +15294,9 @@
             }
         },
         "node_modules/mathjs": {
-            "version": "15.1.1",
-            "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-15.1.1.tgz",
-            "integrity": "sha512-rM668DTtpSzMVoh/cKAllyQVEbBApM5g//IMGD8vD7YlrIz9ITRr3SrdhjaDxcBNTdyETWwPebj2unZyHD7ZdA==",
+            "version": "15.2.0",
+            "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-15.2.0.tgz",
+            "integrity": "sha512-UAQzSVob9rNLdGpqcFMYmSu9dkuLYy7Lr2hBEQS5SHQdknA9VppJz3cy2KkpMzTODunad6V6cNv+5kOLsePLow==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@babel/runtime": "^7.26.10",
@@ -24542,7 +24542,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.13",
+            "version": "0.7.14",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "dompurify": "^3.3.0"
@@ -24554,7 +24554,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.13",
+            "version": "0.7.14",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -25110,7 +25110,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.13",
+            "version": "0.7.14",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },
@@ -25154,7 +25154,7 @@
             "dependencies": {
                 "color-name": "^1.1.4",
                 "get-contrast": "^3.0.0",
-                "math-expressions": "^2.0.0-alpha89",
+                "math-expressions": "^2.0.0-alpha90",
                 "micromark": "^4.0.2",
                 "nearest-color": "^0.4.4",
                 "rgb": "^0.1.0"
@@ -25166,7 +25166,7 @@
         },
         "packages/v06-to-v07": {
             "name": "@doenet/v06-to-v07",
-            "version": "0.7.13",
+            "version": "0.7.14",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
         "jszip": "^3.10.1",
         "katex": "^0.16.27",
         "lorem-ipsum": "^2.0.8",
-        "math-expressions": "^2.0.0-alpha89",
+        "math-expressions": "^2.0.0-alpha90",
         "micromark": "^4.0.2",
         "nanoid": "^5.1.6",
         "nextra": "^3.3.1",

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
@@ -1297,10 +1297,30 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         );
 
         expect(prefigureXML).toContain(`<parametric-curve at="curve_0"`);
-        expect(prefigureXML).toContain(`function="curve_0_r(x)=(3 x,x^2)"`);
+        expect(prefigureXML).toContain(`function="curve_0_r(x)=(3*x,x^2)"`);
         expect(prefigureXML).toContain(`domain="(-2,3)"`);
         expect(prefigureXML).not.toContain(`fill="`);
         expect(prefigureXML).not.toContain(`fill-opacity="`);
+    });
+
+    it("renderer=prefigure curve formula uses explicit multiplication for coefficient input", async () => {
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph("<curve><function>3x</function></curve>"),
+        );
+
+        expect(prefigureXML).toContain(`<graph at="curve_0"`);
+        expect(prefigureXML).toContain(`function="curve_0_f(x)=3*x"`);
+    });
+
+    it("renderer=prefigure curve formula uses explicit multiplication for factored input", async () => {
+        const prefigureXML = await getPrefigureXML(
+            prefigureGraph("<curve><function>(x-2)(x-5)</function></curve>"),
+        );
+
+        expect(prefigureXML).toContain(`<graph at="curve_0"`);
+        expect(prefigureXML).toContain(
+            `function="curve_0_f(x)=(x - 2)*(x - 5)"`,
+        );
     });
 
     it("renderer=prefigure normalizes parameter names across parametric coordinates", async () => {

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/components/curve.ts
@@ -154,7 +154,9 @@ function curveDefinitionAtIndex(
  */
 function astToExpressionString(ast: unknown): string | null {
     try {
-        return me.fromAst(ast as any).toString();
+        return me
+            .fromAst(ast as any)
+            .toString({ explicitMultiplicationSymbols: true });
     } catch (_e) {
         return null;
     }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -46,7 +46,7 @@
     "dependencies": {
         "color-name": "^1.1.4",
         "get-contrast": "^3.0.0",
-        "math-expressions": "^2.0.0-alpha89",
+        "math-expressions": "^2.0.0-alpha90",
         "micromark": "^4.0.2",
         "nearest-color": "^0.4.4",
         "rgb": "^0.1.0"


### PR DESCRIPTION
## Problem

Functions defined with implicit multiplication — such as `(x-2)(x-5)` or `3x` — were not rendering correctly in the PreFigure renderer. The math-expressions library serialized these to strings like `(x - 2)(x - 5)` or `3 x`, which the PreFigure formula parser does not recognize as valid multiplication, causing the curve to be silently dropped.

For example, with a graph like:

```xml
<graph renderer="prefigure">
  <function name="f">x^2-4</function>
  <function name="g">(x-2)(x-5)</function>
  <function name="h">x^2 +2x + 3</function>
</graph>
```

`f` rendered correctly, but `g` (factored form) and `h` (coefficient form `2x`) would produce invalid PreFigure XML and not appear.

## Fix

Upgrade `math-expressions` to `2.0.0-alpha90`, which adds an `explicitMultiplicationSymbols` option to `toString()`. Update the PreFigure curve formula serializer in `curve.ts` to use this option, so expressions are emitted with explicit `*` (e.g. `(x - 2)*(x - 5)`, `3*x`).

The change is scoped to the `astToExpressionString` helper used only in PreFigure curve serialization — no other renderers or expression formatting are affected.

## Tests

Two new regression tests verify that explicit `*` appears in emitted `function="..."` XML attributes for:
- Factored input: `(x-2)(x-5)` → `(x - 2)*(x - 5)`
- Coefficient input: `3x` → `3*x`

An existing test asserting `3 x` in a parametric curve is updated to the now-correct `3*x`.