### PR TITLE
Suppress implicit PreFigure annotations when none authored

### DIFF
--- a/.changeset/prefigure-suppress-implicit-annotations.md
+++ b/.changeset/prefigure-suppress-implicit-annotations.md
@@ -1,0 +1,7 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Suppress implicit PreFigure accessibility annotations when authors do not provide an `<annotations>` block. We now emit an empty `<annotations>` container in generated PreFigure XML and only initialize `diagcess` when authored annotations are present, preventing unintended auto-generated annotation text from appearing.

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-core.test.ts
@@ -76,7 +76,7 @@ describe("Graph prefigure renderer core @group4", () => {
         const prefigureXML = await getPrefigureXML(prefigureGraph(""));
 
         expect(prefigureXML).eq(
-            `<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="all" /></coordinates></diagram>`,
+            `<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="all" /></coordinates><annotations></annotations></diagram>`,
         );
     });
 
@@ -86,7 +86,7 @@ describe("Graph prefigure renderer core @group4", () => {
         );
 
         expect(prefigureXML).eq(
-            `<diagram dimensions="(425,425)"><coordinates bbox="(0,-10,10,10)"><axes axes="all" /></coordinates></diagram>`,
+            `<diagram dimensions="(425,425)"><coordinates bbox="(0,-10,10,10)"><axes axes="all" /></coordinates><annotations></annotations></diagram>`,
         );
     });
 
@@ -96,7 +96,7 @@ describe("Graph prefigure renderer core @group4", () => {
         );
 
         expect(prefigureXML).eq(
-            `<diagram dimensions="(850,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="all" /></coordinates></diagram>`,
+            `<diagram dimensions="(850,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="all" /></coordinates><annotations></annotations></diagram>`,
         );
     });
 
@@ -117,10 +117,10 @@ describe("Graph prefigure renderer core @group4", () => {
         );
 
         expect(gxPrefigureXML).eq(
-            `<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="horizontal" /></coordinates></diagram>`,
+            `<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="horizontal" /></coordinates><annotations></annotations></diagram>`,
         );
         expect(gyPrefigureXML).eq(
-            `<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="vertical" /></coordinates></diagram>`,
+            `<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="vertical" /></coordinates><annotations></annotations></diagram>`,
         );
     });
 
@@ -132,7 +132,7 @@ describe("Graph prefigure renderer core @group4", () => {
         );
 
         expect(prefigureXML).eq(
-            `<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"></coordinates></diagram>`,
+            `<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"></coordinates><annotations></annotations></diagram>`,
         );
     });
 
@@ -238,7 +238,7 @@ describe("Graph prefigure renderer core @group4", () => {
         );
 
         expect(prefigureXML).toMatchInlineSnapshot(
-            `"<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="all"><xlabel alignment="nw"><m>x^2</m></xlabel><ylabel alignment="se"><m>y_1</m></ylabel></axes></coordinates></diagram>"`,
+            `"<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="all"><xlabel alignment="nw"><m>x^2</m></xlabel><ylabel alignment="se"><m>y_1</m></ylabel></axes></coordinates><annotations></annotations></diagram>"`,
         );
     });
 
@@ -548,7 +548,8 @@ describe("Graph prefigure renderer core @group4", () => {
         );
 
         const prefigureXML = await getPrefigureXML(doenetML);
-        expect(prefigureXML).not.toContain(`<annotations>`);
+        expect(prefigureXML).toContain(`<annotations></annotations>`);
+        expect(prefigureXML).not.toContain(`<annotation `);
 
         const diagnosticsByType = await getWarnings(doenetML);
         expect(
@@ -569,7 +570,8 @@ describe("Graph prefigure renderer core @group4", () => {
 `;
 
         const prefigureXML = await getPrefigureXML(doenetML);
-        expect(prefigureXML).not.toContain(`<annotations>`);
+        expect(prefigureXML).toContain(`<annotations></annotations>`);
+        expect(prefigureXML).not.toContain(`<annotation `);
 
         const diagnosticsByType = await getWarnings(doenetML);
         expect(
@@ -624,7 +626,8 @@ describe("Graph prefigure renderer core @group4", () => {
 `;
 
         const prefigureXML = await getPrefigureXML(doenetML);
-        expect(prefigureXML).not.toContain(`<annotations>`);
+        expect(prefigureXML).toContain(`<annotations></annotations>`);
+        expect(prefigureXML).not.toContain(`<annotation `);
 
         const diagnosticsByType = await getWarnings(doenetML);
         expect(
@@ -640,7 +643,8 @@ describe("Graph prefigure renderer core @group4", () => {
         );
 
         const prefigureXML = await getPrefigureXML(doenetML);
-        expect(prefigureXML).not.toContain(`<annotations>`);
+        expect(prefigureXML).toContain(`<annotations></annotations>`);
+        expect(prefigureXML).not.toContain(`<annotation `);
 
         const diagnosticsByType = await getWarnings(doenetML);
         expect(

--- a/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/prefigure/graph-prefigure-geometry.test.ts
@@ -127,7 +127,7 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         );
 
         expect(prefigureXML).toMatchInlineSnapshot(
-            `"<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="all" /><line at="line_0" endpoints="((1,2),(3,4))" infinite="yes" stroke="#648FFF" thickness="4" fill="#648FFF" stroke-opacity="0.7" fill-opacity="0.3" label-location="0.95" alignment="s">A</line></coordinates></diagram>"`,
+            `"<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="all" /><line at="line_0" endpoints="((1,2),(3,4))" infinite="yes" stroke="#648FFF" thickness="4" fill="#648FFF" stroke-opacity="0.7" fill-opacity="0.3" label-location="0.95" alignment="s">A</line></coordinates><annotations></annotations></diagram>"`,
         );
     });
 
@@ -1060,7 +1060,7 @@ describe("Graph prefigure renderer geometry mappings @group4", () => {
         );
 
         expect(prefigureXML).toMatchInlineSnapshot(
-            `"<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="all" /><vector at="vector_0" tail="(0,0)" v="(3,3)" stroke="#648FFF" thickness="4" fill="#648FFF" stroke-opacity="0.7" fill-opacity="0.3" /><label p="(2.85,2.85)" alignment="north">V</label></coordinates></diagram>"`,
+            `"<diagram dimensions="(425,425)"><coordinates bbox="(-10,-10,10,10)"><axes axes="all" /><vector at="vector_0" tail="(0,0)" v="(3,3)" stroke="#648FFF" thickness="4" fill="#648FFF" stroke-opacity="0.7" fill-opacity="0.3" /><label p="(2.85,2.85)" alignment="north">V</label></coordinates><annotations></annotations></diagram>"`,
         );
     });
 

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/annotations.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/annotations.ts
@@ -90,7 +90,7 @@ export function convertDoenetMLAnnotationsToPreFigureXml({
     functionToCurveComponentIdx,
 }: BuildAnnotationsXmlParams): string {
     if (!Array.isArray(annotations) || annotations.length === 0) {
-        return "";
+        return "<annotations></annotations>";
     }
 
     const state: AnnotationXmlBuildState = {
@@ -110,7 +110,7 @@ export function convertDoenetMLAnnotationsToPreFigureXml({
         .filter((x): x is string => x !== null)
         .join("");
 
-    return annotationsXml ? `<annotations>${annotationsXml}</annotations>` : "";
+    return `<annotations>${annotationsXml}</annotations>`;
 }
 
 function pushAnnotationWarning({

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/annotations.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/annotations.ts
@@ -89,6 +89,9 @@ export function convertDoenetMLAnnotationsToPreFigureXml({
     graphDescendantComponentIndices,
     functionToCurveComponentIdx,
 }: BuildAnnotationsXmlParams): string {
+    // Always emit an empty <annotations> container when none are authored.
+    // This suppresses PreFigure WASM's implicit auto-generated annotations;
+    // we have not found a separate PreFigure option to disable that behavior.
     if (!Array.isArray(annotations) || annotations.length === 0) {
         return "<annotations></annotations>";
     }

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
@@ -607,6 +607,9 @@ function returnGraphHasAuthorAnnotationsStateVariableDefinition() {
         }: {
             dependencyValues: GraphDependencyValues;
         }) {
+            // True when the author included at least one <annotations> child,
+            // even if that child is explicitly empty. False only when no
+            // authored <annotations> child exists.
             return {
                 setValue: {
                     hasAuthorAnnotations:

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
@@ -600,7 +600,6 @@ function returnGraphHasAuthorAnnotationsStateVariableDefinition() {
             annotationsChildren: {
                 dependencyType: "child",
                 childGroups: ["annotations"],
-                variableNames: ["annotationSubtrees"],
             },
         }),
         definition({

--- a/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
+++ b/packages/doenetml-worker-javascript/src/utils/prefigure/stateVariable.ts
@@ -589,6 +589,35 @@ function returnGraphPrefigureXMLStateVariableDefinition() {
     };
 }
 
+function returnGraphHasAuthorAnnotationsStateVariableDefinition() {
+    return {
+        public: true,
+        forRenderer: true,
+        shadowingInstructions: {
+            createComponentOfType: "boolean",
+        },
+        returnDependencies: () => ({
+            annotationsChildren: {
+                dependencyType: "child",
+                childGroups: ["annotations"],
+                variableNames: ["annotationSubtrees"],
+            },
+        }),
+        definition({
+            dependencyValues,
+        }: {
+            dependencyValues: GraphDependencyValues;
+        }) {
+            return {
+                setValue: {
+                    hasAuthorAnnotations:
+                        (dependencyValues.annotationsChildren?.length ?? 0) > 0,
+                },
+            };
+        },
+    };
+}
+
 /**
  * Returns all Graph state-variable definitions needed for prefigure conversion.
  *
@@ -602,6 +631,8 @@ export function returnGraphPrefigureStateVariableDefinitions() {
             returnGraphCurveDescendantComponentIndicesStateVariableDefinition(),
         functionToCurveComponentIdx:
             returnGraphFunctionCurveAliasMapStateVariableDefinition(),
+        hasAuthorAnnotations:
+            returnGraphHasAuthorAnnotationsStateVariableDefinition(),
         prefigureXML: returnGraphPrefigureXMLStateVariableDefinition(),
     };
 }

--- a/packages/doenetml/src/Viewer/renderers/prefigure.tsx
+++ b/packages/doenetml/src/Viewer/renderers/prefigure.tsx
@@ -289,7 +289,7 @@ type PrefigureRendererProps = {
     id: string;
     SVs: {
         prefigureXML: string | null;
-        hasAuthorAnnotations?: boolean;
+        hasAuthorAnnotations: boolean;
         showBorder: boolean;
         width: { size: string; isAbsolute: boolean };
         aspectRatio: number;
@@ -444,6 +444,21 @@ function hasAnnotationsXml(value: string): boolean {
     return /<diagram\b/i.test(trimmed);
 }
 
+function removeDiagcessMessages(container: HTMLElement | null): void {
+    if (!container) {
+        return;
+    }
+
+    for (const child of Array.from(container.children)) {
+        if (
+            child instanceof HTMLParagraphElement &&
+            child.classList.contains("cacc-message")
+        ) {
+            child.remove();
+        }
+    }
+}
+
 const FORBIDDEN_MARKUP_TAGS = new Set([
     "script",
     "foreignobject",
@@ -550,12 +565,12 @@ function applyBuildResultToState({
     data,
     setSvgMarkup,
     setSvgMessage,
-    setCmlContent,
+    setAnnotationsXml,
 }: {
     data: PrefigureBuildResult;
     setSvgMarkup: React.Dispatch<React.SetStateAction<string>>;
     setSvgMessage: React.Dispatch<React.SetStateAction<string>>;
-    setCmlContent: React.Dispatch<React.SetStateAction<string>>;
+    setAnnotationsXml: React.Dispatch<React.SetStateAction<string>>;
 }) {
     const svg = normalizeSerializedMarkup(data.svg);
     if (svg) {
@@ -576,11 +591,11 @@ function applyBuildResultToState({
         setSvgMessage("Error: No SVG found in response.");
     }
 
-    const cml = normalizeSerializedMarkup(data.annotationsXml);
-    if (cml) {
-        setCmlContent(sanitizeAnnotationsMarkup(cml));
+    const annotationsMarkup = normalizeSerializedMarkup(data.annotationsXml);
+    if (annotationsMarkup) {
+        setAnnotationsXml(sanitizeAnnotationsMarkup(annotationsMarkup));
     } else {
-        setCmlContent("");
+        setAnnotationsXml("");
     }
 }
 
@@ -694,11 +709,11 @@ export default React.memo(function Prefigure({
     callAction,
 }: PrefigureRendererProps) {
     const diagramXML = SVs.prefigureXML;
-    const hasAuthorAnnotations = Boolean(SVs.hasAuthorAnnotations);
+    const hasAuthorAnnotations = SVs.hasAuthorAnnotations;
     const coreSliderPoints = SVs.draggablePointsForSliders;
     const [svgMarkup, setSvgMarkup] = useState("");
     const [svgMessage, setSvgMessage] = useState("Building...");
-    const [cmlContent, setCmlContent] = useState("");
+    const [annotationsXml, setAnnotationsXml] = useState("");
     const [diagcessReady, setDiagcessReady] = useState(Boolean(diagcessApi()));
     const [rendererSliderCoordinates, setRendererSliderCoordinates] = useState<
         Record<number, { x: number; y: number }>
@@ -1190,14 +1205,14 @@ export default React.memo(function Prefigure({
             hasStartedBuildRef.current = false;
             setSvgMarkup("");
             setSvgMessage("");
-            setCmlContent("");
+            setAnnotationsXml("");
             return;
         }
 
         const resetBuildState = () => {
             setSvgMarkup("");
             setSvgMessage("Building...");
-            setCmlContent("");
+            setAnnotationsXml("");
         };
 
         const runBuildWithLogging = (startBuild: () => Promise<void>) => {
@@ -1232,7 +1247,7 @@ export default React.memo(function Prefigure({
                     data,
                     setSvgMarkup,
                     setSvgMessage,
-                    setCmlContent,
+                    setAnnotationsXml,
                 });
             } catch (error) {
                 if (isAbortError(error)) {
@@ -1279,33 +1294,19 @@ export default React.memo(function Prefigure({
         const diagcess = diagcessApi();
         const prefigureContainer = prefigureContainerRef.current;
 
-        if (prefigureContainer && !hasAuthorAnnotations) {
-            for (const child of Array.from(prefigureContainer.children)) {
-                if (
-                    child instanceof HTMLParagraphElement &&
-                    child.classList.contains("cacc-message")
-                ) {
-                    child.remove();
-                }
-            }
+        if (!hasAuthorAnnotations) {
+            removeDiagcessMessages(prefigureContainer);
         }
 
         if (
             diagcessReady &&
             svgMarkup &&
             hasAuthorAnnotations &&
-            hasAnnotationsXml(cmlContent) &&
+            hasAnnotationsXml(annotationsXml) &&
             diagcess &&
             prefigureContainer
         ) {
-            for (const child of Array.from(prefigureContainer.children)) {
-                if (
-                    child instanceof HTMLParagraphElement &&
-                    child.classList.contains("cacc-message")
-                ) {
-                    child.remove();
-                }
-            }
+            removeDiagcessMessages(prefigureContainer);
 
             // diagcess mutates molMap during init, so clear any stale
             // entries before re-running it against newly inserted markup.
@@ -1313,7 +1314,7 @@ export default React.memo(function Prefigure({
             if (diagcessTimerRef.current) {
                 clearTimeout(diagcessTimerRef.current);
             }
-            // Wait briefly for the sanitized SVG/CML markup to be present
+            // Wait briefly for the sanitized SVG/annotations XML markup to be present
             // in the live DOM before diagcess scans and annotates it.
             diagcessTimerRef.current = setTimeout(() => {
                 diagcessTimerRef.current = null;
@@ -1327,7 +1328,7 @@ export default React.memo(function Prefigure({
                 diagcessTimerRef.current = null;
             }
         };
-    }, [svgMarkup, cmlContent, diagcessReady, hasAuthorAnnotations]);
+    }, [svgMarkup, annotationsXml, diagcessReady, hasAuthorAnnotations]);
 
     const frameStyle: React.CSSProperties = {
         ...surfaceStyle,
@@ -1367,7 +1368,7 @@ export default React.memo(function Prefigure({
                 )}
                 <div
                     className="cml"
-                    dangerouslySetInnerHTML={{ __html: cmlContent }}
+                    dangerouslySetInnerHTML={{ __html: annotationsXml }}
                 />
             </div>
             {sliderSection}

--- a/packages/doenetml/src/Viewer/renderers/prefigure.tsx
+++ b/packages/doenetml/src/Viewer/renderers/prefigure.tsx
@@ -441,6 +441,7 @@ function hasAnnotationsXml(value: string): boolean {
         return false;
     }
 
+    // The annotations payload uses <diagram> as its root element.
     return /<diagram\b/i.test(trimmed);
 }
 
@@ -1290,11 +1291,15 @@ export default React.memo(function Prefigure({
     }, [diagramXML]);
 
     useEffect(() => {
-        // Call diagcess.Base.init() after content is set
+        // Run diagcess only when annotations were explicitly authored.
+        // When no authored <annotations> exists, we still render a generated
+        // empty <annotations></annotations> container to suppress implicit
+        // PreFigure auto-annotations, but skip diagcess init.
         const diagcess = diagcessApi();
         const prefigureContainer = prefigureContainerRef.current;
 
         if (!hasAuthorAnnotations) {
+            // Remove stale accessibility messages from previous renders.
             removeDiagcessMessages(prefigureContainer);
         }
 

--- a/packages/doenetml/src/Viewer/renderers/prefigure.tsx
+++ b/packages/doenetml/src/Viewer/renderers/prefigure.tsx
@@ -289,6 +289,7 @@ type PrefigureRendererProps = {
     id: string;
     SVs: {
         prefigureXML: string | null;
+        hasAuthorAnnotations?: boolean;
         showBorder: boolean;
         width: { size: string; isAbsolute: boolean };
         aspectRatio: number;
@@ -693,6 +694,7 @@ export default React.memo(function Prefigure({
     callAction,
 }: PrefigureRendererProps) {
     const diagramXML = SVs.prefigureXML;
+    const hasAuthorAnnotations = Boolean(SVs.hasAuthorAnnotations);
     const coreSliderPoints = SVs.draggablePointsForSliders;
     const [svgMarkup, setSvgMarkup] = useState("");
     const [svgMessage, setSvgMessage] = useState("Building...");
@@ -1275,36 +1277,48 @@ export default React.memo(function Prefigure({
     useEffect(() => {
         // Call diagcess.Base.init() after content is set
         const diagcess = diagcessApi();
+        const prefigureContainer = prefigureContainerRef.current;
+
+        if (prefigureContainer && !hasAuthorAnnotations) {
+            for (const child of Array.from(prefigureContainer.children)) {
+                if (
+                    child instanceof HTMLParagraphElement &&
+                    child.classList.contains("cacc-message")
+                ) {
+                    child.remove();
+                }
+            }
+        }
+
         if (
             diagcessReady &&
             svgMarkup &&
+            hasAuthorAnnotations &&
             hasAnnotationsXml(cmlContent) &&
-            diagcess
+            diagcess &&
+            prefigureContainer
         ) {
-            const prefigureContainer = prefigureContainerRef.current;
-            if (prefigureContainer) {
-                for (const child of Array.from(prefigureContainer.children)) {
-                    if (
-                        child instanceof HTMLParagraphElement &&
-                        child.classList.contains("cacc-message")
-                    ) {
-                        child.remove();
-                    }
+            for (const child of Array.from(prefigureContainer.children)) {
+                if (
+                    child instanceof HTMLParagraphElement &&
+                    child.classList.contains("cacc-message")
+                ) {
+                    child.remove();
                 }
-
-                // diagcess mutates molMap during init, so clear any stale
-                // entries before re-running it against newly inserted markup.
-                diagcess.Base.molMap = {};
-                if (diagcessTimerRef.current) {
-                    clearTimeout(diagcessTimerRef.current);
-                }
-                // Wait briefly for the sanitized SVG/CML markup to be present
-                // in the live DOM before diagcess scans and annotates it.
-                diagcessTimerRef.current = setTimeout(() => {
-                    diagcessTimerRef.current = null;
-                    diagcess.Base.init();
-                }, DIAGCESS_REINIT_DELAY_MS);
             }
+
+            // diagcess mutates molMap during init, so clear any stale
+            // entries before re-running it against newly inserted markup.
+            diagcess.Base.molMap = {};
+            if (diagcessTimerRef.current) {
+                clearTimeout(diagcessTimerRef.current);
+            }
+            // Wait briefly for the sanitized SVG/CML markup to be present
+            // in the live DOM before diagcess scans and annotates it.
+            diagcessTimerRef.current = setTimeout(() => {
+                diagcessTimerRef.current = null;
+                diagcess.Base.init();
+            }, DIAGCESS_REINIT_DELAY_MS);
         }
 
         return () => {
@@ -1313,7 +1327,7 @@ export default React.memo(function Prefigure({
                 diagcessTimerRef.current = null;
             }
         };
-    }, [svgMarkup, cmlContent, diagcessReady]);
+    }, [svgMarkup, cmlContent, diagcessReady, hasAuthorAnnotations]);
 
     const frameStyle: React.CSSProperties = {
         ...surfaceStyle,

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureAnnotationsAccessibility.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureAnnotationsAccessibility.cy.js
@@ -114,6 +114,108 @@ describe(
                 .and("contain.text", "diagcess init 2");
         });
 
+        it("does not re-init diagcess when updated graph has no authored annotations", () => {
+            const requestBodies = [];
+
+            cy.clearIndexedDB();
+            cy.visit("/", {
+                onBeforeLoad(win) {
+                    win.__diagcessInitCount = 0;
+                    win.diagcess = {
+                        Base: {
+                            molMap: {},
+                            init() {
+                                win.__diagcessInitCount += 1;
+
+                                const container =
+                                    win.document.querySelector("#prefig");
+                                if (!container) {
+                                    return;
+                                }
+
+                                const message = win.document.createElement("p");
+                                message.className = "cacc-message";
+                                message.textContent = `diagcess init ${win.__diagcessInitCount}`;
+                                container.appendChild(message);
+                            },
+                        },
+                    };
+                },
+            });
+
+            cy.intercept("POST", "**/build", (req) => {
+                requestBodies.push(String(req.body));
+
+                const requestNumber = requestBodies.length;
+
+                req.reply({
+                    statusCode: 200,
+                    headers: { "content-type": "application/json" },
+                    body: {
+                        svg: `<svg xmlns="http://www.w3.org/2000/svg"><text>svg-${requestNumber}</text></svg>`,
+                        annotationsXml: `<?xml version="1.0"?><diagram><annotation>safe-cml-${requestNumber}</annotation></diagram>`,
+                    },
+                });
+            }).as("prefigureBuild");
+
+            cy.window().then((win) => {
+                win.postMessage(
+                    {
+                        doenetML: `
+<graph name="prefig" renderer="prefigure">
+  <point name="P">(0,0)</point>
+  <annotations>
+    <annotation ref="$P" text="point summary" />
+  </annotations>
+</graph>
+`,
+                    },
+                    "*",
+                );
+            });
+
+            cy.wait("@prefigureBuild");
+            cy.wait(450);
+
+            cy.then(() => {
+                expect(requestBodies[0]).to.include(`text="point summary"`);
+            });
+            cy.window().its("__diagcessInitCount").should("eq", 1);
+            cy.get("#prefig")
+                .children("p.cacc-message")
+                .should("have.length", 1);
+
+            cy.window().then((win) => {
+                win.postMessage(
+                    {
+                        doenetML: `
+<graph name="prefig" renderer="prefigure">
+  <point>(2,1)</point>
+</graph>
+`,
+                    },
+                    "*",
+                );
+            });
+
+            cy.wait("@prefigureBuild");
+            cy.wait(450);
+
+            cy.then(() => {
+                expect(requestBodies).to.have.length(2);
+                expect(requestBodies[1]).to.include(
+                    "<annotations></annotations>",
+                );
+                expect(requestBodies[1]).not.to.include("<annotation ");
+            });
+
+            cy.get("#prefig").find(".svg").should("contain.text", "svg-2");
+            cy.window().its("__diagcessInitCount").should("eq", 1);
+            cy.get("#prefig")
+                .children("p.cacc-message")
+                .should("have.length", 0);
+        });
+
         it("applies shortDescription and aria-details to a prefigure graph", () => {
             cy.clearIndexedDB();
             cy.visit("/");


### PR DESCRIPTION
## Summary
- emit an empty <annotations> container in generated PreFigure XML when no annotations are authored
- add and propagate hasAuthorAnnotations state to the renderer
- gate diagcess initialization on authored annotations
- add changeset for @doenet/doenetml, @doenet/standalone, and @doenet/doenetml-iframe

## Validation
- worker prefigure core tests pass
- @doenet/doenetml build succeeds
