### PR TITLE
Add sliderPosition support for PreFigure sliders

### DIFF
--- a/.changeset/prefigure-slider-position.md
+++ b/.changeset/prefigure-slider-position.md
@@ -1,0 +1,7 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Add `sliderPosition` support for PreFigure point sliders. Authors can now place sliders on the `left`, `right`, `top`, or `bottom` of the graph, with `left` as the default. Side placements responsively fall back to `top` or `bottom` on narrow layouts, and keyboard focus now lands on the graph itself before the sliders so PreFigure annotations remain accessible.

--- a/packages/doenetml-worker-javascript/src/components/Graph.js
+++ b/packages/doenetml-worker-javascript/src/components/Graph.js
@@ -112,6 +112,15 @@ export default class Graph extends BlockComponent {
             public: true,
             forRenderer: true,
         };
+        attributes.sliderPosition = {
+            createComponentOfType: "text",
+            createStateVariable: "sliderPosition",
+            defaultValue: "left",
+            public: true,
+            forRenderer: true,
+            toLowerCase: true,
+            validValues: ["bottom", "left", "right", "top"],
+        };
         attributes.displayXAxisTicks = {
             createComponentOfType: "boolean",
             createStateVariable: "displayXAxisTicks",

--- a/packages/doenetml/src/Viewer/renderers/prefigure.tsx
+++ b/packages/doenetml/src/Viewer/renderers/prefigure.tsx
@@ -32,6 +32,29 @@ type PrefigureBuildWinner =
     | { backend: "service"; data: PrefigureBuildResult }
     | { backend: "local"; module: PrefigureModule };
 
+type SliderPosition = "bottom" | "left" | "right" | "top";
+
+const MIN_GRAPH_WIDTH_FOR_SIDE_LAYOUT_PX = 280;
+const SIDE_SLIDER_COLUMN_WIDTH_PX = 220;
+const SIDE_LAYOUT_GAP_PX = 12;
+const MIN_SIDE_LAYOUT_WIDTH_PX =
+    MIN_GRAPH_WIDTH_FOR_SIDE_LAYOUT_PX +
+    SIDE_SLIDER_COLUMN_WIDTH_PX +
+    SIDE_LAYOUT_GAP_PX;
+
+function normalizeSliderPosition(value: unknown): SliderPosition {
+    if (
+        value === "bottom" ||
+        value === "left" ||
+        value === "right" ||
+        value === "top"
+    ) {
+        return value;
+    }
+
+    return "bottom";
+}
+
 async function importPrefigureFromUrl(url: string): Promise<PrefigureModule> {
     return import(/* @vite-ignore */ url);
 }
@@ -290,10 +313,12 @@ type PrefigureRendererProps = {
     SVs: {
         prefigureXML: string | null;
         hasAuthorAnnotations: boolean;
+        decorative: boolean;
         showBorder: boolean;
         width: { size: string; isAbsolute: boolean };
         aspectRatio: number;
         addSliders: boolean;
+        sliderPosition: SliderPosition;
         xMin: number;
         xMax: number;
         yMin: number;
@@ -725,6 +750,7 @@ export default React.memo(function Prefigure({
     const [transientSliderSet, setTransientSliderSet] = useState<Set<string>>(
         new Set(),
     );
+    const [availableWidth, setAvailableWidth] = useState<number | null>(null);
     const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const fetchAbortControllerRef = useRef<AbortController | null>(null);
     const diagcessTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -1136,8 +1162,8 @@ export default React.memo(function Prefigure({
               return (
                   <div
                       key={componentIdx}
+                      data-point-slider-card="true"
                       style={{
-                          marginTop: "12px",
                           padding: "10px",
                           border: "1px solid var(--canvasText)",
                           borderRadius: "8px",
@@ -1164,6 +1190,54 @@ export default React.memo(function Prefigure({
               );
           })
         : null;
+
+    useEffect(() => {
+        const fallbackElement = prefigureContainerRef.current;
+        if (!fallbackElement) {
+            return;
+        }
+
+        const measuredElement =
+            document.getElementById(`${id}-container`) ?? fallbackElement;
+
+        function updateContainerWidth() {
+            setAvailableWidth(measuredElement.clientWidth);
+        }
+
+        updateContainerWidth();
+
+        if (typeof ResizeObserver === "undefined") {
+            window.addEventListener("resize", updateContainerWidth);
+            return () => {
+                window.removeEventListener("resize", updateContainerWidth);
+            };
+        }
+
+        const observer = new ResizeObserver(() => {
+            updateContainerWidth();
+        });
+        observer.observe(measuredElement);
+
+        return () => {
+            observer.disconnect();
+        };
+    }, []);
+
+    const requestedSliderPosition = normalizeSliderPosition(SVs.sliderPosition);
+    const requestedSideLayout =
+        requestedSliderPosition === "left" ||
+        requestedSliderPosition === "right";
+    const canUseSideLayout =
+        availableWidth === null || availableWidth >= MIN_SIDE_LAYOUT_WIDTH_PX;
+    const effectiveSliderPosition: SliderPosition =
+        requestedSliderPosition === "left" && !canUseSideLayout
+            ? "top"
+            : requestedSliderPosition === "right" && !canUseSideLayout
+              ? "bottom"
+              : requestedSliderPosition;
+    const useSideLayout =
+        effectiveSliderPosition === "left" ||
+        effectiveSliderPosition === "right";
 
     // Load diagcess script
     useEffect(() => {
@@ -1357,26 +1431,79 @@ export default React.memo(function Prefigure({
         justifyContent: "center",
     };
 
+    const layoutStyle: React.CSSProperties = {
+        display: "flex",
+        flexDirection: useSideLayout ? "row" : "column",
+        alignItems: useSideLayout ? "flex-start" : "stretch",
+        gap: `${SIDE_LAYOUT_GAP_PX}px`,
+    };
+
+    const graphSectionStyle: React.CSSProperties = {
+        order:
+            effectiveSliderPosition === "top" ||
+            effectiveSliderPosition === "left"
+                ? 2
+                : 1,
+        flex: useSideLayout ? "1 1 auto" : undefined,
+        minWidth: useSideLayout
+            ? `${MIN_GRAPH_WIDTH_FOR_SIDE_LAYOUT_PX}px`
+            : undefined,
+    };
+
+    const sliderSectionStyle: React.CSSProperties = {
+        order:
+            effectiveSliderPosition === "top" ||
+            effectiveSliderPosition === "left"
+                ? 1
+                : 2,
+        display: "flex",
+        flexDirection: "column",
+        gap: "12px",
+        marginTop: useSideLayout ? surfaceStyle.marginTop : undefined,
+        width: useSideLayout ? `${SIDE_SLIDER_COLUMN_WIDTH_PX}px` : "100%",
+        maxWidth: useSideLayout
+            ? `${SIDE_SLIDER_COLUMN_WIDTH_PX}px`
+            : undefined,
+    };
+
     return (
-        <div id={id} ref={prefigureContainerRef}>
-            <div className="ChemAccess-element" style={frameStyle}>
-                {svgMarkup ? (
+        <div
+            id={id}
+            ref={prefigureContainerRef}
+            data-slider-position-requested={requestedSliderPosition}
+            data-slider-position-effective={effectiveSliderPosition}
+            data-slider-position-side-fallback={
+                requestedSideLayout && !canUseSideLayout ? "true" : "false"
+            }
+        >
+            <div style={layoutStyle}>
+                <div style={graphSectionStyle}>
                     <div
-                        className="svg"
-                        style={svgContainerStyle}
-                        dangerouslySetInnerHTML={{ __html: svgMarkup }}
-                    />
-                ) : (
-                    <div className="svg" style={svgMessageStyle}>
-                        {svgMessage}
+                        className="ChemAccess-element"
+                        style={frameStyle}
+                        tabIndex={SVs.decorative ? undefined : 0}
+                    >
+                        {svgMarkup ? (
+                            <div
+                                className="svg"
+                                style={svgContainerStyle}
+                                dangerouslySetInnerHTML={{ __html: svgMarkup }}
+                            />
+                        ) : (
+                            <div className="svg" style={svgMessageStyle}>
+                                {svgMessage}
+                            </div>
+                        )}
+                        <div
+                            className="cml"
+                            dangerouslySetInnerHTML={{ __html: annotationsXml }}
+                        />
                     </div>
-                )}
-                <div
-                    className="cml"
-                    dangerouslySetInnerHTML={{ __html: annotationsXml }}
-                />
+                </div>
+                {sliderSection ? (
+                    <div style={sliderSectionStyle}>{sliderSection}</div>
+                ) : null}
             </div>
-            {sliderSection}
         </div>
     );
 });

--- a/packages/doenetml/src/Viewer/renderers/prefigure.tsx
+++ b/packages/doenetml/src/Viewer/renderers/prefigure.tsx
@@ -1419,8 +1419,15 @@ export default React.memo(function Prefigure({
         };
     }, [svgMarkup, annotationsXml, diagcessReady, hasAuthorAnnotations]);
 
+    const { marginTop, marginBottom, ...frameSurfaceStyle } = surfaceStyle;
+
+    const wrapperStyle: React.CSSProperties = {
+        marginTop,
+        marginBottom,
+    };
+
     const frameStyle: React.CSSProperties = {
-        ...surfaceStyle,
+        ...frameSurfaceStyle,
         overflow: "hidden",
         backgroundColor: "var(--canvas)",
         color: "var(--canvasText)",
@@ -1470,7 +1477,6 @@ export default React.memo(function Prefigure({
         display: "flex",
         flexDirection: "column",
         gap: "12px",
-        marginTop: useSideLayout ? surfaceStyle.marginTop : undefined,
         width: useSideLayout ? `${SIDE_SLIDER_COLUMN_WIDTH_PX}px` : "100%",
         maxWidth: useSideLayout
             ? `${SIDE_SLIDER_COLUMN_WIDTH_PX}px`
@@ -1481,6 +1487,7 @@ export default React.memo(function Prefigure({
         <div
             id={id}
             ref={prefigureContainerRef}
+            style={wrapperStyle}
             data-slider-position-requested={requestedSliderPosition}
             data-slider-position-effective={effectiveSliderPosition}
             data-slider-position-side-fallback={

--- a/packages/doenetml/src/Viewer/renderers/prefigure.tsx
+++ b/packages/doenetml/src/Viewer/renderers/prefigure.tsx
@@ -37,6 +37,8 @@ type SliderPosition = "bottom" | "left" | "right" | "top";
 const MIN_GRAPH_WIDTH_FOR_SIDE_LAYOUT_PX = 280;
 const SIDE_SLIDER_COLUMN_WIDTH_PX = 220;
 const SIDE_LAYOUT_GAP_PX = 12;
+// Side layout needs enough room for graph + slider column + gap.
+// Current breakpoint: 280 + 220 + 12 = 512px.
 const MIN_SIDE_LAYOUT_WIDTH_PX =
     MIN_GRAPH_WIDTH_FOR_SIDE_LAYOUT_PX +
     SIDE_SLIDER_COLUMN_WIDTH_PX +
@@ -255,23 +257,26 @@ async function buildPrefigureDiagram(
     });
 
     try {
-        const serviceBuildPromise: Promise<PrefigureBuildWinner> =
-            buildWithPrefigureService(
+        async function buildServicePromise(): Promise<PrefigureBuildWinner> {
+            const data = await buildWithPrefigureService(
                 diagramXML,
                 serviceAbortController.signal,
-            ).then((data) => {
-                return { backend: "service", data };
-            });
+            );
+            return { backend: "service", data };
+        }
 
-        const localReadyPromise: Promise<PrefigureBuildWinner> =
-            startPrefigureWarmup()
-                .then((module) => {
-                    return { backend: "local" as const, module };
-                })
-                .catch((error) => {
-                    logWarmupFailure(error);
-                    throw error;
-                });
+        async function buildLocalPromise(): Promise<PrefigureBuildWinner> {
+            try {
+                const module = await startPrefigureWarmup();
+                return { backend: "local" as const, module };
+            } catch (error) {
+                logWarmupFailure(error);
+                throw error;
+            }
+        }
+
+        const serviceBuildPromise = buildServicePromise();
+        const localReadyPromise = buildLocalPromise();
 
         const winner = await Promise.race([
             firstSuccessful([serviceBuildPromise, localReadyPromise]),
@@ -313,6 +318,7 @@ type PrefigureRendererProps = {
     SVs: {
         prefigureXML: string | null;
         hasAuthorAnnotations: boolean;
+        shortDescription?: string;
         decorative: boolean;
         showBorder: boolean;
         width: { size: string; isAbsolute: boolean };
@@ -1244,15 +1250,18 @@ export default React.memo(function Prefigure({
     useEffect(() => {
         let active = true;
 
-        ensureDiagcessScriptLoaded()
-            .then(() => {
+        async function loadDiagcessScript() {
+            try {
+                await ensureDiagcessScriptLoaded();
                 if (active) {
                     setDiagcessReady(true);
                 }
-            })
-            .catch((error) => {
+            } catch (error) {
                 console.error(error);
-            });
+            }
+        }
+
+        loadDiagcessScript();
 
         return () => {
             active = false;
@@ -1439,6 +1448,7 @@ export default React.memo(function Prefigure({
         gap: `${SIDE_LAYOUT_GAP_PX}px`,
     };
 
+    // Keep graph first in DOM for focus/screen-reader flow, and reorder only visually.
     const graphSectionStyle: React.CSSProperties = {
         order:
             effectiveSliderPosition === "top" ||
@@ -1483,6 +1493,12 @@ export default React.memo(function Prefigure({
                         className="ChemAccess-element"
                         style={frameStyle}
                         tabIndex={SVs.decorative ? undefined : 0}
+                        role={SVs.decorative ? undefined : "img"}
+                        aria-label={
+                            SVs.decorative
+                                ? undefined
+                                : SVs.shortDescription || undefined
+                        }
                     >
                         {svgMarkup ? (
                             <div

--- a/packages/doenetml/src/Viewer/renderers/prefigure.tsx
+++ b/packages/doenetml/src/Viewer/renderers/prefigure.tsx
@@ -52,7 +52,7 @@ function normalizeSliderPosition(value: unknown): SliderPosition {
         return value;
     }
 
-    return "bottom";
+    return "left";
 }
 
 async function importPrefigureFromUrl(url: string): Promise<PrefigureModule> {
@@ -1189,7 +1189,8 @@ export default React.memo(function Prefigure({
                   </div>
               );
           })
-        : null;
+        : [];
+    const hasSliderSection = sliderSection.length > 0;
 
     useEffect(() => {
         const fallbackElement = prefigureContainerRef.current;
@@ -1500,7 +1501,7 @@ export default React.memo(function Prefigure({
                         />
                     </div>
                 </div>
-                {sliderSection ? (
+                {hasSliderSection ? (
                     <div style={sliderSectionStyle}>{sliderSection}</div>
                 ) : null}
             </div>

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -870,7 +870,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -11805,7 +11807,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "unorderedCompare": {
@@ -12372,7 +12376,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "unorderedCompare": {
@@ -12685,7 +12691,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "unorderedCompare": {
@@ -12998,7 +13006,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "unorderedCompare": {
@@ -13311,7 +13321,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "unorderedCompare": {
@@ -13825,7 +13837,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "unorderedCompare": {
@@ -14339,7 +14353,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "unorderedCompare": {
@@ -14869,7 +14885,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -15659,7 +15677,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -16449,7 +16469,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -17237,7 +17259,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -18025,7 +18049,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -18813,7 +18839,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -19590,7 +19618,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -20344,7 +20374,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -21110,7 +21142,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -21876,7 +21910,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -22642,7 +22678,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -23408,7 +23446,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -24198,7 +24238,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -24988,7 +25030,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -25790,7 +25834,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -26592,7 +26638,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -27382,7 +27430,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -28172,7 +28222,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -28962,7 +29014,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -29752,7 +29806,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -30542,7 +30598,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -31332,7 +31390,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -32123,7 +32183,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -33023,7 +33085,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -33923,7 +33987,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -64196,7 +64262,9 @@
                         "none",
                         "both",
                         "xOnly",
-                        "yOnly"
+                        "yOnly",
+                        "true",
+                        "false"
                     ]
                 },
                 "hideOffGraphIndicator": {
@@ -66969,7 +67037,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -79772,7 +79842,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "unorderedCompare": {
@@ -80499,7 +80571,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -83580,7 +83654,9 @@
                         "none",
                         "both",
                         "xOnly",
-                        "yOnly"
+                        "yOnly",
+                        "true",
+                        "false"
                     ]
                 },
                 "hideOffGraphIndicator": {
@@ -84150,7 +84226,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -92747,7 +92825,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expandOnCompare": {
@@ -93659,7 +93739,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "unorderedCompare": {
@@ -94324,7 +94406,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "unorderedCompare": {
@@ -99233,6 +99317,15 @@
                         "false"
                     ]
                 },
+                "sliderPosition": {
+                    "optional": true,
+                    "type": [
+                        "bottom",
+                        "left",
+                        "right",
+                        "top"
+                    ]
+                },
                 "displayXAxisTicks": {
                     "optional": true,
                     "type": [
@@ -99833,6 +99926,11 @@
                     "isArray": false
                 },
                 {
+                    "name": "sliderPosition",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
                     "name": "displayXAxisTicks",
                     "type": "boolean",
                     "isArray": false
@@ -99955,6 +100053,11 @@
                 {
                     "name": "yLabel",
                     "type": "label",
+                    "isArray": false
+                },
+                {
+                    "name": "hasAuthorAnnotations",
+                    "type": "boolean",
                     "isArray": false
                 },
                 {
@@ -100402,7 +100505,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -101280,7 +101385,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -101894,7 +102001,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -113726,7 +113835,9 @@
                     "type": [
                         "unsorted",
                         "increasing",
-                        "decreasing"
+                        "decreasing",
+                        "true",
+                        "false"
                     ]
                 },
                 "excludeCombinations": {
@@ -115059,7 +115170,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -116111,7 +116224,9 @@
                     "type": [
                         "unsorted",
                         "increasing",
-                        "decreasing"
+                        "decreasing",
+                        "true",
+                        "false"
                     ]
                 },
                 "excludeCombinations": {
@@ -116444,7 +116559,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "displayDigits": {
@@ -117342,7 +117459,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -123132,7 +123251,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 }
             },
@@ -127781,7 +127902,9 @@
                         "none",
                         "both",
                         "xOnly",
-                        "yOnly"
+                        "yOnly",
+                        "true",
+                        "false"
                     ]
                 },
                 "hideOffGraphIndicator": {
@@ -130717,7 +130840,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {
@@ -134325,7 +134450,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "unorderedCompare": {
@@ -136157,7 +136284,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "unorderedCompare": {
@@ -136759,7 +136888,9 @@
                         "full",
                         "numbers",
                         "numbersPreserveOrder",
-                        "normalizeOrder"
+                        "normalizeOrder",
+                        "true",
+                        "false"
                     ]
                 },
                 "expand": {

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -61916,6 +61916,15 @@
                     ]
                 },
                 {
+                    "name": "sliderPosition",
+                    "values": [
+                        "bottom",
+                        "left",
+                        "right",
+                        "top"
+                    ]
+                },
+                {
                     "name": "displayXAxisTicks",
                     "values": [
                         "true",
@@ -62089,6 +62098,11 @@
                     "isArray": false
                 },
                 {
+                    "name": "sliderPosition",
+                    "type": "text",
+                    "isArray": false
+                },
+                {
                     "name": "displayXAxisTicks",
                     "type": "boolean",
                     "isArray": false
@@ -62211,6 +62225,11 @@
                 {
                     "name": "yLabel",
                     "type": "label",
+                    "isArray": false
+                },
+                {
+                    "name": "hasAuthorAnnotations",
+                    "type": "boolean",
                     "isArray": false
                 },
                 {

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureSliders.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureSliders.cy.js
@@ -804,6 +804,8 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         cy.get("#g .ChemAccess-element")
             .should("have.attr", "tabindex", "0")
+            .and("have.attr", "role", "img")
+            .and("have.attr", "aria-label", "Graph first semantic order test")
             .focus()
             .should("have.focus");
 

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureSliders.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureSliders.cy.js
@@ -668,6 +668,162 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         cy.get("#Py").should("have.text", "0.1");
     });
 
+    it("defaults sliderPosition to left and keeps side-by-side on wide layout", () => {
+        cy.clearIndexedDB();
+        cy.viewport(1400, 900);
+        cy.visit("/");
+
+        installPrefigureBuildIntercept();
+
+        postDoenetML(`
+<text name="ready">ready</text>
+<graph name="g" renderer="prefigure" addSliders width="640px">
+  <point name="P" labelIsName>(2,3)</point>
+</graph>
+`);
+
+        cy.get("#ready").should("have.text", "ready");
+        cy.get("#g")
+            .should("have.attr", "data-slider-position-requested", "left")
+            .and("have.attr", "data-slider-position-effective", "left")
+            .and("have.attr", "data-slider-position-side-fallback", "false");
+
+        cy.get("#g > div").should("have.css", "flex-direction", "row");
+        cy.get("#g .ChemAccess-element")
+            .parent()
+            .should("have.css", "order", "2");
+
+        cy.get("#g .ChemAccess-element").then(($graph) => {
+            const graphTop = $graph[0].getBoundingClientRect().top;
+
+            cy.get('#g [data-point-slider-card="true"]')
+                .first()
+                .then(($sliderCard) => {
+                    const sliderTop =
+                        $sliderCard[0].getBoundingClientRect().top;
+                    expect(Math.abs(sliderTop - graphTop)).to.be.lessThan(2);
+                });
+        });
+    });
+
+    it("falls back from left to top on narrow layout", () => {
+        cy.clearIndexedDB();
+        cy.viewport(420, 900);
+        cy.visit("/");
+
+        installPrefigureBuildIntercept();
+
+        postDoenetML(`
+<text name="ready">ready</text>
+<graph name="g" renderer="prefigure" addSliders sliderPosition="left">
+  <point name="P" labelIsName>(2,3)</point>
+</graph>
+`);
+
+        cy.get("#ready").should("have.text", "ready");
+        cy.get("#g")
+            .should("have.attr", "data-slider-position-requested", "left")
+            .and("have.attr", "data-slider-position-effective", "top")
+            .and("have.attr", "data-slider-position-side-fallback", "true");
+
+        cy.get("#g > div").should("have.css", "flex-direction", "column");
+    });
+
+    it("falls back from right to bottom on narrow layout", () => {
+        cy.clearIndexedDB();
+        cy.viewport(420, 900);
+        cy.visit("/");
+
+        installPrefigureBuildIntercept();
+
+        postDoenetML(`
+<text name="ready">ready</text>
+<graph name="g" renderer="prefigure" addSliders sliderPosition="right">
+  <point name="P" labelIsName>(2,3)</point>
+</graph>
+`);
+
+        cy.get("#ready").should("have.text", "ready");
+        cy.get("#g")
+            .should("have.attr", "data-slider-position-requested", "right")
+            .and("have.attr", "data-slider-position-effective", "bottom")
+            .and("have.attr", "data-slider-position-side-fallback", "true");
+
+        cy.get("#g > div").should("have.css", "flex-direction", "column");
+        cy.get("#g .ChemAccess-element")
+            .parent()
+            .should("have.css", "order", "1");
+    });
+
+    it("returns from top fallback back to left when width increases again", () => {
+        cy.clearIndexedDB();
+        cy.viewport(1400, 900);
+        cy.visit("/");
+
+        installPrefigureBuildIntercept();
+
+        postDoenetML(`
+<text name="ready">ready</text>
+<graph name="g" renderer="prefigure" addSliders sliderPosition="left">
+  <point name="P" labelIsName>(2,3)</point>
+</graph>
+`);
+
+        cy.get("#ready").should("have.text", "ready");
+        cy.get("#g")
+            .should("have.attr", "data-slider-position-effective", "left")
+            .and("have.attr", "data-slider-position-side-fallback", "false");
+
+        cy.viewport(420, 900);
+        cy.get("#g")
+            .should("have.attr", "data-slider-position-effective", "top")
+            .and("have.attr", "data-slider-position-side-fallback", "true");
+
+        cy.viewport(1400, 900);
+        cy.get("#g")
+            .should("have.attr", "data-slider-position-effective", "left")
+            .and("have.attr", "data-slider-position-side-fallback", "false");
+        cy.get("#g > div").should("have.css", "flex-direction", "row");
+    });
+
+    it("keeps graph first in semantic order even when sliders are visually on top", () => {
+        cy.clearIndexedDB();
+        cy.visit("/");
+
+        installPrefigureBuildIntercept();
+
+        postDoenetML(`
+<text name="ready">ready</text>
+<graph name="g" renderer="prefigure" addSliders sliderPosition="top">
+  <shortDescription>Graph first semantic order test</shortDescription>
+  <point name="P" labelIsName>(2,3)</point>
+</graph>
+`);
+
+        cy.get("#ready").should("have.text", "ready");
+
+        cy.get("#g .ChemAccess-element")
+            .should("have.attr", "tabindex", "0")
+            .focus()
+            .should("have.focus");
+
+        cy.get("#g > div").then(($layout) => {
+            const children = $layout.children();
+            expect(children.length).to.eq(2);
+            expect(children.eq(0).find(".ChemAccess-element").length).to.eq(1);
+            expect(
+                children.eq(1).find('input[type="range"]').length,
+            ).to.be.greaterThan(0);
+        });
+
+        cy.get("#g")
+            .should("have.attr", "data-slider-position-effective", "top")
+            .and("have.attr", "data-slider-position-side-fallback", "false");
+        cy.get("#g .ChemAccess-element")
+            .parent()
+            .should("have.css", "order", "2");
+    });
+
     it("addSliders false on point is equivalent to none", () => {
         cy.clearIndexedDB();
         cy.visit("/");

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureSliders.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureSliders.cy.js
@@ -824,6 +824,26 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
             .should("have.css", "order", "2");
     });
 
+    it("does not render slider wrapper when no slider-enabled points exist", () => {
+        cy.clearIndexedDB();
+        cy.viewport(1400, 900);
+        cy.visit("/");
+
+        installPrefigureBuildIntercept();
+
+        postDoenetML(`
+<text name="ready">ready</text>
+<graph name="g" renderer="prefigure" addSliders sliderPosition="left" width="640px">
+  <point name="P" labelIsName addSliders="false">(2,3)</point>
+</graph>
+`);
+
+        cy.get("#ready").should("have.text", "ready");
+        cy.get('#g [data-point-slider-card="true"]').should("not.exist");
+        cy.get("#g > div").children().should("have.length", 1);
+        cy.get("#g > div > div .ChemAccess-element").should("have.length", 1);
+    });
+
     it("addSliders false on point is equivalent to none", () => {
         cy.clearIndexedDB();
         cy.visit("/");


### PR DESCRIPTION
## Summary

- add graph-level `sliderPosition` support for PreFigure point sliders with `left`, `right`, `top`, and `bottom` placements
- make left/right layouts responsive, including fallback to top or bottom on narrow widths and recovery back to side layout when width increases again
- keep keyboard focus on the graph itself before sliders so PreFigure annotations remain accessible

## Testing

- npm run build:schema -w @doenet/static-assets
- build doenetml then test-cypress
- cypress run -w @doenet/test-cypress --spec cypress/e2e/prefigure/prefigureSliders.cy.js
