### PR TITLE
Implement addControls feature with graph/point control modes and input validation

### DIFF
--- a/.changeset/add-controls-generalized.md
+++ b/.changeset/add-controls-generalized.md
@@ -1,0 +1,13 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Generalize point slider controls into an `addControls` feature with graph-level modes. Replace the boolean `addSliders` attribute with `addControls` text attribute supporting `all`, `slidersOnly`, `inputsOnly`, and `none`. Rename the per-point `addSliders` attribute to `addControls` while preserving point-level options (`both`, `xOnly`, `yOnly`, `none`).
+
+New capabilities in `all` mode: sliders are paired with editable inline axis inputs in their labels, allowing users to both drag and type to adjust coordinates.
+
+New `inputsOnly` mode: pure text input controls where users can enter single values or ordered pairs, validated as math expressions before committing.
+
+Authors can now choose the control interaction style that best fits their pedagogical goals: traditional sliders, text input boxes, or a hybrid combining both.

--- a/packages/doenetml-worker-javascript/src/components/Graph.js
+++ b/packages/doenetml-worker-javascript/src/components/Graph.js
@@ -105,16 +105,20 @@ export default class Graph extends BlockComponent {
             public: true,
             forRenderer: true,
         };
-        attributes.addSliders = {
-            createComponentOfType: "boolean",
-            createStateVariable: "addSliders",
-            defaultValue: false,
+        attributes.addControls = {
+            createComponentOfType: "text",
+            createStateVariable: "addControls",
+            defaultValue: "none",
             public: true,
+            toLowerCase: true,
+            validValues: ["all", "slidersOnly", "inputsOnly", "none"],
+            valueForTrue: "all",
+            valueForFalse: "none",
             forRenderer: true,
         };
-        attributes.sliderPosition = {
+        attributes.controlsPosition = {
             createComponentOfType: "text",
-            createStateVariable: "sliderPosition",
+            createStateVariable: "controlsPosition",
             defaultValue: "left",
             public: true,
             forRenderer: true,
@@ -567,12 +571,12 @@ export default class Graph extends BlockComponent {
             },
         };
 
-        stateVariableDefinitions.draggablePointsForSliders = {
+        stateVariableDefinitions.draggablePointsForControls = {
             forRenderer: true,
             returnDependencies: () => ({
-                addSliders: {
+                addControls: {
                     dependencyType: "stateVariable",
-                    variableName: "addSliders",
+                    variableName: "addControls",
                 },
                 effectiveRenderer: {
                     dependencyType: "stateVariable",
@@ -586,7 +590,7 @@ export default class Graph extends BlockComponent {
                         "draggable",
                         "fixed",
                         "fixLocation",
-                        "addSliders",
+                        "addControls",
                         "label",
                         "labelHasLatex",
                         "displayDigits",
@@ -597,19 +601,19 @@ export default class Graph extends BlockComponent {
                 },
             }),
             definition({ dependencyValues }) {
-                // Feature only applies to PreFigure renderer when addSliders is enabled at graph level
+                // Feature only applies to PreFigure renderer when controls are enabled at graph level
                 if (
-                    !dependencyValues.addSliders ||
+                    dependencyValues.addControls === "none" ||
                     dependencyValues.effectiveRenderer !== "prefigure"
                 ) {
                     return {
                         setValue: {
-                            draggablePointsForSliders: [],
+                            draggablePointsForControls: [],
                         },
                     };
                 }
 
-                const draggablePointsForSliders = [];
+                const draggablePointsForControls = [];
 
                 for (const [pointInd, pointDescendant] of (
                     dependencyValues.pointDescendants ?? []
@@ -634,18 +638,18 @@ export default class Graph extends BlockComponent {
                     const draggable = stateValues.draggable !== false;
                     const fixed = stateValues.fixed === true;
                     const fixLocation = stateValues.fixLocation === true;
-                    const addSliders = stateValues.addSliders;
+                    const addControls = stateValues.addControls;
 
-                    // Skip points that cannot be interacted with via sliders:
+                    // Skip points that cannot be interacted with via controls:
                     // - not draggable (fixed by default)
                     // - explicitly marked as fixed
                     // - constrained via fixLocation
-                    // - author explicitly set addSliders="none" on the point
+                    // - author explicitly set addControls="none" on the point
                     if (
                         !draggable ||
                         fixed ||
                         fixLocation ||
-                        addSliders === "none"
+                        addControls === "none"
                     ) {
                         continue;
                     }
@@ -655,12 +659,12 @@ export default class Graph extends BlockComponent {
                         continue;
                     }
 
-                    draggablePointsForSliders.push({
+                    draggablePointsForControls.push({
                         componentIdx,
                         pointNumber,
                         x,
                         y,
-                        addSliders,
+                        addControls,
                         label:
                             typeof stateValues.label === "string"
                                 ? stateValues.label
@@ -675,7 +679,7 @@ export default class Graph extends BlockComponent {
 
                 return {
                     setValue: {
-                        draggablePointsForSliders,
+                        draggablePointsForControls,
                     },
                 };
             },

--- a/packages/doenetml-worker-javascript/src/components/Point.js
+++ b/packages/doenetml-worker-javascript/src/components/Point.js
@@ -100,9 +100,9 @@ export default class Point extends GraphicalComponent {
             forRenderer: true,
         };
 
-        attributes.addSliders = {
+        attributes.addControls = {
             createComponentOfType: "text",
-            createStateVariable: "addSliders",
+            createStateVariable: "addControls",
             defaultValue: "both",
             public: true,
             toLowerCase: true,

--- a/packages/doenetml/src/Viewer/renderers/prefigure.tsx
+++ b/packages/doenetml/src/Viewer/renderers/prefigure.tsx
@@ -866,6 +866,7 @@ export default React.memo(function Prefigure({
     const latestSliderCoordinatesRef = useRef<
         Record<number, { x: number; y: number }>
     >({});
+    const committingInputKeysRef = useRef<Set<string>>(new Set());
     const [transientSliderSet, setTransientSliderSet] = useState<Set<string>>(
         new Set(),
     );
@@ -1361,54 +1362,110 @@ export default React.memo(function Prefigure({
         currentCoordinates: { x: number; y: number };
         inputKey: string;
     }) {
-        const parsedValue = parseSingleMathNumber(rawValue);
-        if (parsedValue === null) {
-            setInputError(
-                inputKey,
-                "Enter a valid number or numeric expression.",
-            );
+        const hasDraft = Object.prototype.hasOwnProperty.call(
+            inputDraftByKey,
+            inputKey,
+        );
+        if (!hasDraft) {
             return;
         }
 
-        const nextCoordinates = {
-            x: axis === "x" ? parsedValue : currentCoordinates.x,
-            y: axis === "y" ? parsedValue : currentCoordinates.y,
-        };
+        if (committingInputKeysRef.current.has(inputKey)) {
+            return;
+        }
+        committingInputKeysRef.current.add(inputKey);
 
-        setInputError(inputKey, null);
-        clearInputDraft(inputKey);
-        await updatePointCoordinatesFromControls({
-            componentIdx,
-            x: nextCoordinates.x,
-            y: nextCoordinates.y,
-        });
+        try {
+            const parsedValue = parseSingleMathNumber(rawValue);
+            if (parsedValue === null) {
+                setInputError(
+                    inputKey,
+                    "Enter a valid number or numeric expression.",
+                );
+                return;
+            }
+
+            const nextCoordinates = {
+                x: axis === "x" ? parsedValue : currentCoordinates.x,
+                y: axis === "y" ? parsedValue : currentCoordinates.y,
+            };
+
+            const axisValueUnchanged =
+                (axis === "x" && parsedValue === currentCoordinates.x) ||
+                (axis === "y" && parsedValue === currentCoordinates.y);
+
+            if (axisValueUnchanged) {
+                setInputError(inputKey, null);
+                clearInputDraft(inputKey);
+                return;
+            }
+
+            setInputError(inputKey, null);
+            clearInputDraft(inputKey);
+            await updatePointCoordinatesFromControls({
+                componentIdx,
+                x: nextCoordinates.x,
+                y: nextCoordinates.y,
+            });
+        } finally {
+            committingInputKeysRef.current.delete(inputKey);
+        }
     }
 
     async function submitPairInput({
         componentIdx,
         rawValue,
+        currentCoordinates,
         inputKey,
     }: {
         componentIdx: number;
         rawValue: string;
+        currentCoordinates: { x: number; y: number };
         inputKey: string;
     }) {
-        const parsedPair = parseOrderedPair(rawValue);
-        if (!parsedPair) {
-            setInputError(
-                inputKey,
-                "Enter an ordered pair like (x,y) with numeric values.",
-            );
+        const hasDraft = Object.prototype.hasOwnProperty.call(
+            inputDraftByKey,
+            inputKey,
+        );
+        if (!hasDraft) {
             return;
         }
 
-        setInputError(inputKey, null);
-        clearInputDraft(inputKey);
-        await updatePointCoordinatesFromControls({
-            componentIdx,
-            x: parsedPair.x,
-            y: parsedPair.y,
-        });
+        if (committingInputKeysRef.current.has(inputKey)) {
+            return;
+        }
+        committingInputKeysRef.current.add(inputKey);
+
+        try {
+            const parsedPair = parseOrderedPair(rawValue);
+            if (!parsedPair) {
+                setInputError(
+                    inputKey,
+                    "Enter an ordered pair like (x,y) with numeric values.",
+                );
+                return;
+            }
+
+            const pairUnchanged =
+                parsedPair.x === currentCoordinates.x &&
+                parsedPair.y === currentCoordinates.y;
+
+            if (pairUnchanged) {
+                setInputError(inputKey, null);
+                clearInputDraft(inputKey);
+                return;
+            }
+
+            setInputError(inputKey, null);
+            clearInputDraft(inputKey);
+            await updatePointCoordinatesFromControls({
+                componentIdx,
+                x: parsedPair.x,
+                y: parsedPair.y,
+            });
+        } finally {
+            committingInputKeysRef.current.delete(inputKey);
+        }
     }
 
     /**
@@ -1609,10 +1666,14 @@ export default React.memo(function Prefigure({
             const showInputsOnlyForPoint =
                 graphControlsMode === "inputsonly" && includeInputs;
 
+            const pointHeadingId = `${id}-point-${componentIdx}-heading`;
+
             return (
                 <div
                     key={componentIdx}
                     data-point-slider-card="true"
+                    role="group"
+                    aria-labelledby={pointHeadingId}
                     style={{
                         width: "100%",
                         boxSizing: "border-box",
@@ -1621,7 +1682,7 @@ export default React.memo(function Prefigure({
                         borderRadius: "8px",
                     }}
                 >
-                    <div style={{ fontWeight: 600 }}>
+                    <div id={pointHeadingId} style={{ fontWeight: 600 }}>
                         {pointLabelForDisplay}
                     </div>
                     {showInputsOnlyForPoint && pointControlsMode === "both" ? (
@@ -1657,6 +1718,7 @@ export default React.memo(function Prefigure({
                                     submitPairInput({
                                         componentIdx,
                                         rawValue: event.target.value,
+                                        currentCoordinates,
                                         inputKey: pairInputKey,
                                     }).catch((error) => {
                                         console.error(
@@ -1671,6 +1733,7 @@ export default React.memo(function Prefigure({
                                         submitPairInput({
                                             componentIdx,
                                             rawValue: event.currentTarget.value,
+                                            currentCoordinates,
                                             inputKey: pairInputKey,
                                         }).catch((error) => {
                                             console.error(
@@ -2156,7 +2219,13 @@ export default React.memo(function Prefigure({
     const wrapperStyle: React.CSSProperties = {
         marginTop,
         marginBottom,
+        position: "relative",
     };
+
+    // Accessible live region text: announce build progress and errors to screen
+    // readers. Empty string when the SVG is visible (success is self-evident by
+    // the diagram appearing in the accessibility tree).
+    const statusLiveText = svgMarkup ? "" : svgMessage;
 
     const frameStyle: React.CSSProperties = {
         ...frameSurfaceStyle,
@@ -2229,6 +2298,24 @@ export default React.memo(function Prefigure({
                 requestedSideLayout && !canUseSideLayout ? "true" : "false"
             }
         >
+            {/* Announce build / error status to screen readers without cluttering
+                the visual layout. Lives outside role="img" so the live region is
+                not suppressed by the img role's presentational children semantics. */}
+            <span
+                aria-live="polite"
+                aria-atomic="true"
+                style={{
+                    position: "absolute",
+                    width: "1px",
+                    height: "1px",
+                    overflow: "hidden",
+                    clip: "rect(0, 0, 0, 0)",
+                    whiteSpace: "nowrap",
+                    border: 0,
+                }}
+            >
+                {statusLiveText}
+            </span>
             <div style={layoutStyle}>
                 <div style={graphSectionStyle}>
                     <div
@@ -2239,7 +2326,7 @@ export default React.memo(function Prefigure({
                         aria-label={
                             SVs.decorative
                                 ? undefined
-                                : SVs.shortDescription || undefined
+                                : SVs.shortDescription?.trim() || "Diagram"
                         }
                     >
                         {svgMarkup ? (
@@ -2260,7 +2347,13 @@ export default React.memo(function Prefigure({
                     </div>
                 </div>
                 {hasControlsSection ? (
-                    <div style={sliderSectionStyle}>{controlsSection}</div>
+                    <div
+                        role="group"
+                        aria-label="Point controls"
+                        style={sliderSectionStyle}
+                    >
+                        {controlsSection}
+                    </div>
                 ) : null}
             </div>
         </div>

--- a/packages/doenetml/src/Viewer/renderers/prefigure.tsx
+++ b/packages/doenetml/src/Viewer/renderers/prefigure.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import DOMPurify from "dompurify";
+import me from "math-expressions";
 import { roundForDisplay } from "@doenet/utils";
 import {
     PREFIGURE_BUILD_ENDPOINT,
@@ -32,7 +33,9 @@ type PrefigureBuildWinner =
     | { backend: "service"; data: PrefigureBuildResult }
     | { backend: "local"; module: PrefigureModule };
 
-type SliderPosition = "bottom" | "left" | "right" | "top";
+type ControlsPosition = "bottom" | "left" | "right" | "top";
+type GraphControlsMode = "all" | "slidersonly" | "inputsonly" | "none";
+type PointControlsMode = "both" | "xonly" | "yonly" | "none";
 
 const MIN_GRAPH_WIDTH_FOR_SIDE_LAYOUT_PX = 280;
 const SIDE_SLIDER_COLUMN_WIDTH_PX = 220;
@@ -44,7 +47,7 @@ const MIN_SIDE_LAYOUT_WIDTH_PX =
     SIDE_SLIDER_COLUMN_WIDTH_PX +
     SIDE_LAYOUT_GAP_PX;
 
-function normalizeSliderPosition(value: unknown): SliderPosition {
+function normalizeControlsPosition(value: unknown): ControlsPosition {
     if (
         value === "bottom" ||
         value === "left" ||
@@ -55,6 +58,82 @@ function normalizeSliderPosition(value: unknown): SliderPosition {
     }
 
     return "left";
+}
+
+function normalizeGraphControlsMode(value: unknown): GraphControlsMode {
+    if (typeof value !== "string") {
+        return "none";
+    }
+
+    const normalized = value.toLowerCase();
+    if (
+        normalized === "all" ||
+        normalized === "slidersonly" ||
+        normalized === "inputsonly" ||
+        normalized === "none"
+    ) {
+        return normalized;
+    }
+
+    return "none";
+}
+
+function normalizePointControlsMode(value: unknown): PointControlsMode {
+    if (typeof value !== "string") {
+        return "both";
+    }
+
+    const normalized = value.toLowerCase();
+    if (
+        normalized === "both" ||
+        normalized === "xonly" ||
+        normalized === "yonly" ||
+        normalized === "none"
+    ) {
+        return normalized;
+    }
+
+    return "both";
+}
+
+function parseSingleMathNumber(input: string): number | null {
+    try {
+        const expression = me.fromText(input);
+        const value = expression?.evaluate_to_constant?.();
+        return Number.isFinite(value) ? value : null;
+    } catch (_error) {
+        return null;
+    }
+}
+
+function parseOrderedPair(input: string): { x: number; y: number } | null {
+    try {
+        const expression = me.fromText(input);
+        const tree = expression?.tree;
+        if (!Array.isArray(tree) || tree.length !== 3) {
+            return null;
+        }
+
+        const operator = tree[0];
+        if (operator !== "tuple" && operator !== "vector") {
+            return null;
+        }
+
+        const x = me.fromAst(tree[1])?.evaluate_to_constant?.();
+        const y = me.fromAst(tree[2])?.evaluate_to_constant?.();
+
+        if (x === null || y === null) {
+            return null;
+        }
+
+        if (!Number.isFinite(x) || !Number.isFinite(y)) {
+            return null;
+        }
+
+        return { x, y };
+    } catch (_error) {
+        return null;
+    }
 }
 
 async function importPrefigureFromUrl(url: string): Promise<PrefigureModule> {
@@ -323,18 +402,18 @@ type PrefigureRendererProps = {
         showBorder: boolean;
         width: { size: string; isAbsolute: boolean };
         aspectRatio: number;
-        addSliders: boolean;
-        sliderPosition: SliderPosition;
+        addControls: string;
+        controlsPosition: ControlsPosition;
         xMin: number;
         xMax: number;
         yMin: number;
         yMax: number;
-        draggablePointsForSliders: Array<{
+        draggablePointsForControls: Array<{
             componentIdx: number;
             pointNumber: number;
             x: number;
             y: number;
-            addSliders: string;
+            addControls: string;
             label: string;
             labelHasLatex: boolean;
             displayDigits: number;
@@ -734,6 +813,29 @@ function sanitizeAnnotationsMarkup(markup: string): string {
     });
 }
 
+function pruneRecordByActiveKeys(
+    previousRecord: Record<string, string>,
+    activeKeys: Set<string>,
+): Record<string, string> {
+    const nextRecord: Record<string, string> = {};
+    let changed = false;
+
+    for (const key in previousRecord) {
+        if (!Object.prototype.hasOwnProperty.call(previousRecord, key)) {
+            continue;
+        }
+
+        const value = previousRecord[key];
+        if (activeKeys.has(key)) {
+            nextRecord[key] = value;
+        } else {
+            changed = true;
+        }
+    }
+
+    return changed ? nextRecord : previousRecord;
+}
+
 export default React.memo(function Prefigure({
     id,
     SVs,
@@ -742,13 +844,24 @@ export default React.memo(function Prefigure({
 }: PrefigureRendererProps) {
     const diagramXML = SVs.prefigureXML;
     const hasAuthorAnnotations = SVs.hasAuthorAnnotations;
-    const coreSliderPoints = SVs.draggablePointsForSliders;
+    const coreControlPoints = SVs.draggablePointsForControls;
+    const graphControlsMode = normalizeGraphControlsMode(SVs.addControls);
+    const includeSliders =
+        graphControlsMode === "all" || graphControlsMode === "slidersonly";
+    const includeInputs =
+        graphControlsMode === "all" || graphControlsMode === "inputsonly";
     const [svgMarkup, setSvgMarkup] = useState("");
     const [svgMessage, setSvgMessage] = useState("Building...");
     const [annotationsXml, setAnnotationsXml] = useState("");
     const [diagcessReady, setDiagcessReady] = useState(Boolean(diagcessApi()));
     const [rendererSliderCoordinates, setRendererSliderCoordinates] = useState<
         Record<number, { x: number; y: number }>
+    >({});
+    const [inputDraftByKey, setInputDraftByKey] = useState<
+        Record<string, string>
+    >({});
+    const [inputErrorByKey, setInputErrorByKey] = useState<
+        Record<string, string>
     >({});
     const latestSliderCoordinatesRef = useRef<
         Record<number, { x: number; y: number }>
@@ -771,6 +884,22 @@ export default React.memo(function Prefigure({
         return `${componentIdx}|${axis}`;
     }
 
+    function pointAxisInputKey(componentIdx: number, axis: "x" | "y"): string {
+        return `${componentIdx}|${axis}`;
+    }
+
+    function pointPairInputKey(componentIdx: number): string {
+        return `${componentIdx}|pair`;
+    }
+
+    function setInputDraftValue(key: string, value: string) {
+        setInputDraftByKey((previousDraftByKey) => ({
+            ...previousDraftByKey,
+            [key]: value,
+        }));
+        setInputError(key, null);
+    }
+
     useEffect(() => {
         // Merge new state values into ref without overwriting values that
         // updatePointCoordinateFromSlider may have just set. This prevents
@@ -784,12 +913,12 @@ export default React.memo(function Prefigure({
 
     /**
      * Synchronize slider coordinates state with core state and transient drag state.
-     * This effect runs whenever coreSliderPoints or transientSliderSet changes.
+     * This effect runs whenever coreControlPoints, includeSliders, or transientSliderSet changes.
      *
      * Performs two key operations:
-     * 1. Sync rendererSliderCoordinates: Updates x/y values from coreSliderPoints for
+     * 1. Sync rendererSliderCoordinates: Updates x/y values from coreControlPoints for
      *    non-actively-dragging slider axes.
-     *    Removes entries for points no longer in coreSliderPoints (cleanup).
+     *    Removes entries for points no longer in coreControlPoints (cleanup).
      * 2. Filter transientSliderSet: Removes inactive slider-axis keys from the dragging set,
      *    maintaining consistency when points or rendered slider axes are removed.
      *
@@ -797,20 +926,25 @@ export default React.memo(function Prefigure({
      * snap-back behavior from constraints when the user releases the mouse.
      */
     useEffect(() => {
-        // Compute active point and slider-axis keys once from coreSliderPoints,
+        // Compute active point and slider-axis keys once from coreControlPoints,
         // outside any state updater.
         // Both setRendererSliderCoordinates and setTransientSliderSet will read this
         // immutable set without mutation.
         const activePointIndices = new Set<number>(
-            coreSliderPoints.map((p) => p.componentIdx),
+            coreControlPoints.map((p) => p.componentIdx),
         );
         const activeSliderAxisKeys = new Set<string>();
 
-        for (const { componentIdx, addSliders } of coreSliderPoints) {
-            const normalizedAddSliders = addSliders.toLowerCase();
+        for (const { componentIdx, addControls } of coreControlPoints) {
+            if (!includeSliders) {
+                continue;
+            }
+
+            const normalizedAddControls =
+                normalizePointControlsMode(addControls);
             if (
-                normalizedAddSliders !== "yonly" &&
-                normalizedAddSliders !== "none"
+                normalizedAddControls !== "yonly" &&
+                normalizedAddControls !== "none"
             ) {
                 activeSliderAxisKeys.add(
                     sliderAxisTransientKey(componentIdx, "x"),
@@ -818,8 +952,8 @@ export default React.memo(function Prefigure({
             }
 
             if (
-                normalizedAddSliders !== "xonly" &&
-                normalizedAddSliders !== "none"
+                normalizedAddControls !== "xonly" &&
+                normalizedAddControls !== "none"
             ) {
                 activeSliderAxisKeys.add(
                     sliderAxisTransientKey(componentIdx, "y"),
@@ -837,7 +971,7 @@ export default React.memo(function Prefigure({
                 componentIdx,
                 x: coreX,
                 y: coreY,
-            } of coreSliderPoints) {
+            } of coreControlPoints) {
                 const previousPointCoordinates =
                     previousCoordinates[componentIdx];
                 const latestPointCoordinates =
@@ -870,7 +1004,7 @@ export default React.memo(function Prefigure({
                 }
             }
 
-            // Clean up coordinates for points that no longer exist in coreSliderPoints.
+            // Clean up coordinates for points that no longer exist in coreControlPoints.
             for (const componentIdxString of Object.keys(nextCoordinates)) {
                 const componentIdx = Number(componentIdxString);
                 if (!activePointIndices.has(componentIdx)) {
@@ -914,7 +1048,71 @@ export default React.memo(function Prefigure({
 
             return nextTransientSliderSet;
         });
-    }, [coreSliderPoints, transientSliderSet]);
+    }, [coreControlPoints, includeSliders, transientSliderSet]);
+
+    /**
+     * Keeps input draft/error state aligned with the currently rendered controls.
+     *
+     * As graph mode, point mode, or eligible points change, some inputs may no
+     * longer exist (for example switching from `all` to `slidersOnly`, or a point
+     * changing from `both` to `xOnly`). This effect computes the active input-key
+     * set for the current render configuration, then prunes stale entries from:
+     * - inputDraftByKey: temporary user-edited values not yet committed
+     * - inputErrorByKey: validation errors associated with input controls
+     *
+     * It intentionally preserves keys that are still active so in-progress edits
+     * are not lost during unrelated updates.
+     */
+    useEffect(() => {
+        const activeInputKeys = new Set<string>();
+
+        if (includeInputs) {
+            for (const point of coreControlPoints) {
+                const pointControlsMode = normalizePointControlsMode(
+                    point.addControls,
+                );
+
+                if (pointControlsMode === "none") {
+                    continue;
+                }
+
+                if (graphControlsMode === "all") {
+                    if (pointControlsMode !== "yonly") {
+                        activeInputKeys.add(
+                            pointAxisInputKey(point.componentIdx, "x"),
+                        );
+                    }
+                    if (pointControlsMode !== "xonly") {
+                        activeInputKeys.add(
+                            pointAxisInputKey(point.componentIdx, "y"),
+                        );
+                    }
+                } else if (graphControlsMode === "inputsonly") {
+                    if (pointControlsMode === "both") {
+                        activeInputKeys.add(
+                            pointPairInputKey(point.componentIdx),
+                        );
+                    } else if (pointControlsMode === "xonly") {
+                        activeInputKeys.add(
+                            pointAxisInputKey(point.componentIdx, "x"),
+                        );
+                    } else if (pointControlsMode === "yonly") {
+                        activeInputKeys.add(
+                            pointAxisInputKey(point.componentIdx, "y"),
+                        );
+                    }
+                }
+            }
+        }
+
+        // Remove drafts and validation errors for inputs that are no longer rendered.
+        setInputDraftByKey((previousDraftByKey) =>
+            pruneRecordByActiveKeys(previousDraftByKey, activeInputKeys),
+        );
+        setInputErrorByKey((previousErrorByKey) =>
+            pruneRecordByActiveKeys(previousErrorByKey, activeInputKeys),
+        );
+    }, [coreControlPoints, graphControlsMode, includeInputs]);
 
     /**
      * Update coordinates for a point based on slider input.
@@ -1053,7 +1251,7 @@ export default React.memo(function Prefigure({
      */
     function formatCoordinateForSlider(
         value: number,
-        point: (typeof coreSliderPoints)[number],
+        point: (typeof coreControlPoints)[number],
     ): string {
         const rounded = roundForDisplay({
             value,
@@ -1080,15 +1278,155 @@ export default React.memo(function Prefigure({
 
     const { xMin, xMax, yMin, yMax } = SVs;
 
+    async function updatePointCoordinatesFromControls({
+        componentIdx,
+        x,
+        y,
+    }: {
+        componentIdx: number;
+        x: number;
+        y: number;
+    }) {
+        const nextCoordinates = { x, y };
+
+        latestSliderCoordinatesRef.current = {
+            ...latestSliderCoordinatesRef.current,
+            [componentIdx]: nextCoordinates,
+        };
+
+        setRendererSliderCoordinates((previousCoordinates) => ({
+            ...previousCoordinates,
+            [componentIdx]: nextCoordinates,
+        }));
+
+        try {
+            await callAction({
+                action: { actionName: "movePoint", componentIdx },
+                args: {
+                    x,
+                    y,
+                    transient: false,
+                    skippable: false,
+                },
+            });
+        } catch (error) {
+            console.error(
+                `[prefigure] movePoint failed for component ${componentIdx}`,
+                error,
+            );
+        }
+    }
+
+    function setInputError(key: string, error: string | null) {
+        setInputErrorByKey((previousErrorByKey) => {
+            if (error) {
+                if (previousErrorByKey[key] === error) {
+                    return previousErrorByKey;
+                }
+                return { ...previousErrorByKey, [key]: error };
+            }
+
+            if (!(key in previousErrorByKey)) {
+                return previousErrorByKey;
+            }
+
+            const nextErrorByKey = { ...previousErrorByKey };
+            delete nextErrorByKey[key];
+            return nextErrorByKey;
+        });
+    }
+
+    function clearInputDraft(key: string) {
+        setInputDraftByKey((previousDraftByKey) => {
+            if (!(key in previousDraftByKey)) {
+                return previousDraftByKey;
+            }
+
+            const nextDraftByKey = { ...previousDraftByKey };
+            delete nextDraftByKey[key];
+            return nextDraftByKey;
+        });
+    }
+
+    async function submitAxisInput({
+        componentIdx,
+        axis,
+        rawValue,
+        currentCoordinates,
+        inputKey,
+    }: {
+        componentIdx: number;
+        axis: "x" | "y";
+        rawValue: string;
+        currentCoordinates: { x: number; y: number };
+        inputKey: string;
+    }) {
+        const parsedValue = parseSingleMathNumber(rawValue);
+        if (parsedValue === null) {
+            setInputError(
+                inputKey,
+                "Enter a valid number or numeric expression.",
+            );
+            return;
+        }
+
+        const nextCoordinates = {
+            x: axis === "x" ? parsedValue : currentCoordinates.x,
+            y: axis === "y" ? parsedValue : currentCoordinates.y,
+        };
+
+        setInputError(inputKey, null);
+        clearInputDraft(inputKey);
+        await updatePointCoordinatesFromControls({
+            componentIdx,
+            x: nextCoordinates.x,
+            y: nextCoordinates.y,
+        });
+    }
+
+    async function submitPairInput({
+        componentIdx,
+        rawValue,
+        inputKey,
+    }: {
+        componentIdx: number;
+        rawValue: string;
+        inputKey: string;
+    }) {
+        const parsedPair = parseOrderedPair(rawValue);
+        if (!parsedPair) {
+            setInputError(
+                inputKey,
+                "Enter an ordered pair like (x,y) with numeric values.",
+            );
+            return;
+        }
+
+        setInputError(inputKey, null);
+        clearInputDraft(inputKey);
+        await updatePointCoordinatesFromControls({
+            componentIdx,
+            x: parsedPair.x,
+            y: parsedPair.y,
+        });
+    }
+
     /**
      * Helper to render a single axis slider (x or y).
      * Reduces duplication in the sliderSection mapping.
      */
     function renderAxisSlider(
         axis: "x" | "y",
-        point: (typeof coreSliderPoints)[number],
+        point: (typeof coreControlPoints)[number],
         currentCoordinates: { x: number; y: number },
         pointLabelForAria: string,
+        axisInputConfig?: {
+            value: string;
+            error: string | undefined;
+            describedBy: string;
+            onChange: (value: string) => void;
+            onCommit: (value: string) => Promise<void>;
+        },
     ) {
         const isX = axis === "x";
         const value = isX ? currentCoordinates.x : currentCoordinates.y;
@@ -1097,12 +1435,81 @@ export default React.memo(function Prefigure({
         const { min, max } = normalizedSliderBounds(rawMin, rawMax);
         const step = max !== min ? (max - min) / 100 : 1;
         const axisLabel = isX ? "x" : "y";
+        const label = axisInputConfig ? (
+            <span
+                style={{
+                    display: "flex",
+                    alignItems: "flex-start",
+                    gap: "6px",
+                    flexWrap: "wrap",
+                    width: "100%",
+                }}
+            >
+                <span>{`${axisLabel}:`}</span>
+                <input
+                    type="text"
+                    value={axisInputConfig.value}
+                    aria-label={`${axisLabel} value input for ${pointLabelForAria}`}
+                    aria-invalid={axisInputConfig.error ? true : undefined}
+                    aria-describedby={
+                        axisInputConfig.error
+                            ? axisInputConfig.describedBy
+                            : undefined
+                    }
+                    onChange={(event) => {
+                        axisInputConfig.onChange(event.target.value);
+                    }}
+                    onBlur={(event) => {
+                        axisInputConfig
+                            .onCommit(event.target.value)
+                            .catch((error) => {
+                                console.error(
+                                    `[prefigure] failed to commit ${axisLabel} input for component ${point.componentIdx}`,
+                                    error,
+                                );
+                            });
+                    }}
+                    onKeyDown={(event) => {
+                        if (event.key === "Enter") {
+                            event.preventDefault();
+                            axisInputConfig
+                                .onCommit(event.currentTarget.value)
+                                .catch((error) => {
+                                    console.error(
+                                        `[prefigure] failed to commit ${axisLabel} input for component ${point.componentIdx}`,
+                                        error,
+                                    );
+                                });
+                        }
+                    }}
+                    style={{ width: "84px" }}
+                />
+                {axisInputConfig.error ? (
+                    <span
+                        id={axisInputConfig.describedBy}
+                        style={{
+                            color: "#b00020",
+                            fontSize: "0.85em",
+                            flexBasis: "100%",
+                            width: "100%",
+                            whiteSpace: "normal",
+                            overflowWrap: "anywhere",
+                            wordBreak: "break-word",
+                        }}
+                    >
+                        {axisInputConfig.error}
+                    </span>
+                ) : null}
+            </span>
+        ) : (
+            `${axisLabel}: ${formatCoordinateForSlider(value, point)}`
+        );
 
         return (
             <SliderUI
                 key={axis}
                 id={`${id}-point-${point.componentIdx}-${axis}`}
-                label={`${axisLabel}: ${formatCoordinateForSlider(value, point)}`}
+                label={label}
                 ariaLabel={`${axis} coordinate for ${pointLabelForAria}`}
                 min={min}
                 max={max}
@@ -1139,64 +1546,374 @@ export default React.memo(function Prefigure({
         );
     }
 
-    const sliderSection = SVs.addSliders
-        ? coreSliderPoints.map((point) => {
-              const {
-                  componentIdx,
-                  x: defaultX,
-                  y: defaultY,
-                  pointNumber,
-                  label,
-                  labelHasLatex,
-              } = point;
-              const currentCoordinates = rendererSliderCoordinates[
-                  componentIdx
-              ] ?? {
-                  x: defaultX,
-                  y: defaultY,
-              };
-              const pointFallbackLabel = `Point ${pointNumber}`;
-              const pointLabelForAria = accessibleLabelText({
-                  label,
-                  labelHasLatex,
-                  fallback: pointFallbackLabel,
-              });
-              const pointLabelForDisplay = label.trim()
-                  ? renderLabelWithLatex({ label, labelHasLatex })
-                  : pointFallbackLabel;
+    const controlsSection = coreControlPoints
+        .map((point) => {
+            const {
+                componentIdx,
+                x: defaultX,
+                y: defaultY,
+                pointNumber,
+                label,
+                labelHasLatex,
+            } = point;
+            const pointControlsMode = normalizePointControlsMode(
+                point.addControls,
+            );
+            if (pointControlsMode === "none") {
+                return null;
+            }
 
-              return (
-                  <div
-                      key={componentIdx}
-                      data-point-slider-card="true"
-                      style={{
-                          padding: "10px",
-                          border: "1px solid var(--canvasText)",
-                          borderRadius: "8px",
-                      }}
-                  >
-                      <div style={{ fontWeight: 600 }}>
-                          {pointLabelForDisplay}
-                      </div>
-                      {point.addSliders !== "yonly" &&
-                          renderAxisSlider(
+            const currentCoordinates = rendererSliderCoordinates[
+                componentIdx
+            ] ?? {
+                x: defaultX,
+                y: defaultY,
+            };
+            const pointFallbackLabel = `Point ${pointNumber}`;
+            const pointLabelForAria = accessibleLabelText({
+                label,
+                labelHasLatex,
+                fallback: pointFallbackLabel,
+            });
+            const pointLabelForDisplay = label.trim()
+                ? renderLabelWithLatex({ label, labelHasLatex })
+                : pointFallbackLabel;
+
+            const xInputKey = pointAxisInputKey(componentIdx, "x");
+            const yInputKey = pointAxisInputKey(componentIdx, "y");
+            const pairInputKey = pointPairInputKey(componentIdx);
+
+            const formattedX = formatCoordinateForSlider(
+                currentCoordinates.x,
+                point,
+            );
+            const formattedY = formatCoordinateForSlider(
+                currentCoordinates.y,
+                point,
+            );
+
+            const xInputValue = inputDraftByKey[xInputKey] ?? formattedX;
+            const yInputValue = inputDraftByKey[yInputKey] ?? formattedY;
+            const pairInputValue =
+                inputDraftByKey[pairInputKey] ??
+                `(${formattedX},${formattedY})`;
+
+            const xInputError = inputErrorByKey[xInputKey];
+            const yInputError = inputErrorByKey[yInputKey];
+            const pairInputError = inputErrorByKey[pairInputKey];
+
+            const showXAxis = pointControlsMode !== "yonly";
+            const showYAxis = pointControlsMode !== "xonly";
+            const showAxisInputsInline = graphControlsMode === "all";
+            const showSlidersForPoint = includeSliders;
+            const showInputsOnlyForPoint =
+                graphControlsMode === "inputsonly" && includeInputs;
+
+            return (
+                <div
+                    key={componentIdx}
+                    data-point-slider-card="true"
+                    style={{
+                        width: "100%",
+                        boxSizing: "border-box",
+                        padding: "10px",
+                        border: "1px solid var(--canvasText)",
+                        borderRadius: "8px",
+                    }}
+                >
+                    <div style={{ fontWeight: 600 }}>
+                        {pointLabelForDisplay}
+                    </div>
+                    {showInputsOnlyForPoint && pointControlsMode === "both" ? (
+                        <div
+                            style={{
+                                display: "flex",
+                                flexDirection: "column",
+                                gap: "4px",
+                                marginTop: "8px",
+                            }}
+                        >
+                            <label htmlFor={`${id}-point-${componentIdx}-pair`}>
+                                Coordinates
+                            </label>
+                            <input
+                                id={`${id}-point-${componentIdx}-pair`}
+                                type="text"
+                                value={pairInputValue}
+                                aria-label={`coordinates for ${pointLabelForAria}`}
+                                aria-invalid={pairInputError ? true : undefined}
+                                aria-describedby={
+                                    pairInputError
+                                        ? `${id}-error-point-${componentIdx}-pair`
+                                        : undefined
+                                }
+                                onChange={(event) => {
+                                    setInputDraftValue(
+                                        pairInputKey,
+                                        event.target.value,
+                                    );
+                                }}
+                                onBlur={(event) => {
+                                    submitPairInput({
+                                        componentIdx,
+                                        rawValue: event.target.value,
+                                        inputKey: pairInputKey,
+                                    }).catch((error) => {
+                                        console.error(
+                                            `[prefigure] failed to commit pair input for component ${componentIdx}`,
+                                            error,
+                                        );
+                                    });
+                                }}
+                                onKeyDown={(event) => {
+                                    if (event.key === "Enter") {
+                                        event.preventDefault();
+                                        submitPairInput({
+                                            componentIdx,
+                                            rawValue: event.currentTarget.value,
+                                            inputKey: pairInputKey,
+                                        }).catch((error) => {
+                                            console.error(
+                                                `[prefigure] failed to commit pair input for component ${componentIdx}`,
+                                                error,
+                                            );
+                                        });
+                                    }
+                                }}
+                            />
+                            {pairInputError ? (
+                                <span
+                                    id={`${id}-error-point-${componentIdx}-pair`}
+                                    style={{
+                                        color: "#b00020",
+                                        fontSize: "0.85em",
+                                    }}
+                                >
+                                    {pairInputError}
+                                </span>
+                            ) : null}
+                        </div>
+                    ) : null}
+
+                    {showInputsOnlyForPoint && pointControlsMode === "xonly" ? (
+                        <div
+                            style={{
+                                display: "flex",
+                                flexDirection: "column",
+                                gap: "4px",
+                                marginTop: "8px",
+                            }}
+                        >
+                            <label
+                                htmlFor={`${id}-point-${componentIdx}-x-input`}
+                            >
+                                x
+                            </label>
+                            <input
+                                id={`${id}-point-${componentIdx}-x-input`}
+                                type="text"
+                                value={xInputValue}
+                                aria-label={`x input for ${pointLabelForAria}`}
+                                aria-invalid={xInputError ? true : undefined}
+                                aria-describedby={
+                                    xInputError
+                                        ? `${id}-error-point-${componentIdx}-x`
+                                        : undefined
+                                }
+                                onChange={(event) => {
+                                    setInputDraftValue(
+                                        xInputKey,
+                                        event.target.value,
+                                    );
+                                }}
+                                onBlur={(event) => {
+                                    submitAxisInput({
+                                        componentIdx,
+                                        axis: "x",
+                                        rawValue: event.target.value,
+                                        currentCoordinates,
+                                        inputKey: xInputKey,
+                                    }).catch((error) => {
+                                        console.error(
+                                            `[prefigure] failed to commit x input for component ${componentIdx}`,
+                                            error,
+                                        );
+                                    });
+                                }}
+                                onKeyDown={(event) => {
+                                    if (event.key === "Enter") {
+                                        event.preventDefault();
+                                        submitAxisInput({
+                                            componentIdx,
+                                            axis: "x",
+                                            rawValue: event.currentTarget.value,
+                                            currentCoordinates,
+                                            inputKey: xInputKey,
+                                        }).catch((error) => {
+                                            console.error(
+                                                `[prefigure] failed to commit x input for component ${componentIdx}`,
+                                                error,
+                                            );
+                                        });
+                                    }
+                                }}
+                            />
+                            {xInputError ? (
+                                <span
+                                    id={`${id}-error-point-${componentIdx}-x`}
+                                    style={{
+                                        color: "#b00020",
+                                        fontSize: "0.85em",
+                                    }}
+                                >
+                                    {xInputError}
+                                </span>
+                            ) : null}
+                        </div>
+                    ) : null}
+
+                    {showInputsOnlyForPoint && pointControlsMode === "yonly" ? (
+                        <div
+                            style={{
+                                display: "flex",
+                                flexDirection: "column",
+                                gap: "4px",
+                                marginTop: "8px",
+                            }}
+                        >
+                            <label
+                                htmlFor={`${id}-point-${componentIdx}-y-input`}
+                            >
+                                y
+                            </label>
+                            <input
+                                id={`${id}-point-${componentIdx}-y-input`}
+                                type="text"
+                                value={yInputValue}
+                                aria-label={`y input for ${pointLabelForAria}`}
+                                aria-invalid={yInputError ? true : undefined}
+                                aria-describedby={
+                                    yInputError
+                                        ? `${id}-error-point-${componentIdx}-y`
+                                        : undefined
+                                }
+                                onChange={(event) => {
+                                    setInputDraftValue(
+                                        yInputKey,
+                                        event.target.value,
+                                    );
+                                }}
+                                onBlur={(event) => {
+                                    submitAxisInput({
+                                        componentIdx,
+                                        axis: "y",
+                                        rawValue: event.target.value,
+                                        currentCoordinates,
+                                        inputKey: yInputKey,
+                                    }).catch((error) => {
+                                        console.error(
+                                            `[prefigure] failed to commit y input for component ${componentIdx}`,
+                                            error,
+                                        );
+                                    });
+                                }}
+                                onKeyDown={(event) => {
+                                    if (event.key === "Enter") {
+                                        event.preventDefault();
+                                        submitAxisInput({
+                                            componentIdx,
+                                            axis: "y",
+                                            rawValue: event.currentTarget.value,
+                                            currentCoordinates,
+                                            inputKey: yInputKey,
+                                        }).catch((error) => {
+                                            console.error(
+                                                `[prefigure] failed to commit y input for component ${componentIdx}`,
+                                                error,
+                                            );
+                                        });
+                                    }
+                                }}
+                            />
+                            {yInputError ? (
+                                <span
+                                    id={`${id}-error-point-${componentIdx}-y`}
+                                    style={{
+                                        color: "#b00020",
+                                        fontSize: "0.85em",
+                                    }}
+                                >
+                                    {yInputError}
+                                </span>
+                            ) : null}
+                        </div>
+                    ) : null}
+
+                    {showSlidersForPoint && showXAxis
+                        ? renderAxisSlider(
                               "x",
                               point,
                               currentCoordinates,
                               pointLabelForAria,
-                          )}
-                      {point.addSliders !== "xonly" &&
-                          renderAxisSlider(
+                              showAxisInputsInline
+                                  ? {
+                                        value: xInputValue,
+                                        error: xInputError,
+                                        describedBy: `${id}-error-point-${componentIdx}-x`,
+                                        onChange: (value) => {
+                                            setInputDraftValue(
+                                                xInputKey,
+                                                value,
+                                            );
+                                        },
+                                        onCommit: async (value) => {
+                                            await submitAxisInput({
+                                                componentIdx,
+                                                axis: "x",
+                                                rawValue: value,
+                                                currentCoordinates,
+                                                inputKey: xInputKey,
+                                            });
+                                        },
+                                    }
+                                  : undefined,
+                          )
+                        : null}
+                    {showSlidersForPoint && showYAxis
+                        ? renderAxisSlider(
                               "y",
                               point,
                               currentCoordinates,
                               pointLabelForAria,
-                          )}
-                  </div>
-              );
-          })
-        : [];
-    const hasSliderSection = sliderSection.length > 0;
+                              showAxisInputsInline
+                                  ? {
+                                        value: yInputValue,
+                                        error: yInputError,
+                                        describedBy: `${id}-error-point-${componentIdx}-y`,
+                                        onChange: (value) => {
+                                            setInputDraftValue(
+                                                yInputKey,
+                                                value,
+                                            );
+                                        },
+                                        onCommit: async (value) => {
+                                            await submitAxisInput({
+                                                componentIdx,
+                                                axis: "y",
+                                                rawValue: value,
+                                                currentCoordinates,
+                                                inputKey: yInputKey,
+                                            });
+                                        },
+                                    }
+                                  : undefined,
+                          )
+                        : null}
+                </div>
+            );
+        })
+        .filter((section): section is React.JSX.Element => Boolean(section));
+    const hasControlsSection = controlsSection.length > 0;
 
     useEffect(() => {
         const fallbackElement = prefigureContainerRef.current;
@@ -1230,21 +1947,23 @@ export default React.memo(function Prefigure({
         };
     }, []);
 
-    const requestedSliderPosition = normalizeSliderPosition(SVs.sliderPosition);
+    const requestedControlsPosition = normalizeControlsPosition(
+        SVs.controlsPosition,
+    );
     const requestedSideLayout =
-        requestedSliderPosition === "left" ||
-        requestedSliderPosition === "right";
+        requestedControlsPosition === "left" ||
+        requestedControlsPosition === "right";
     const canUseSideLayout =
         availableWidth === null || availableWidth >= MIN_SIDE_LAYOUT_WIDTH_PX;
-    const effectiveSliderPosition: SliderPosition =
-        requestedSliderPosition === "left" && !canUseSideLayout
+    const effectiveControlsPosition: ControlsPosition =
+        requestedControlsPosition === "left" && !canUseSideLayout
             ? "top"
-            : requestedSliderPosition === "right" && !canUseSideLayout
+            : requestedControlsPosition === "right" && !canUseSideLayout
               ? "bottom"
-              : requestedSliderPosition;
+              : requestedControlsPosition;
     const useSideLayout =
-        effectiveSliderPosition === "left" ||
-        effectiveSliderPosition === "right";
+        effectiveControlsPosition === "left" ||
+        effectiveControlsPosition === "right";
 
     // Load diagcess script
     useEffect(() => {
@@ -1294,18 +2013,31 @@ export default React.memo(function Prefigure({
             return;
         }
 
+        /**
+         * Resets renderer-visible build state before a cold-path compile request.
+         */
         const resetBuildState = () => {
             setSvgMarkup("");
             setSvgMessage("Building...");
             setAnnotationsXml("");
         };
 
+        /**
+         * Executes a build task and centralizes top-level error logging.
+         * The inner build function already handles user-facing error state.
+         */
         const runBuildWithLogging = (startBuild: () => Promise<void>) => {
             startBuild().catch((error) => {
                 console.error("[prefigure] build failed", error);
             });
         };
 
+        /**
+         * Performs one concrete build attempt for the current XML snapshot.
+         *
+         * It creates a new abort controller, races service/local backends, and only
+         * applies results if this request is still the newest sequence.
+         */
         const startBuild = async () => {
             const requestSequence = ++requestSequenceRef.current;
             const abortController = new AbortController();
@@ -1453,25 +2185,26 @@ export default React.memo(function Prefigure({
         flexDirection: useSideLayout ? "row" : "column",
         alignItems: useSideLayout ? "flex-start" : "stretch",
         gap: `${SIDE_LAYOUT_GAP_PX}px`,
+        width: "100%",
+        minWidth: 0,
     };
 
     // Keep graph first in DOM for focus/screen-reader flow, and reorder only visually.
     const graphSectionStyle: React.CSSProperties = {
         order:
-            effectiveSliderPosition === "top" ||
-            effectiveSliderPosition === "left"
+            effectiveControlsPosition === "top" ||
+            effectiveControlsPosition === "left"
                 ? 2
                 : 1,
         flex: useSideLayout ? "1 1 auto" : undefined,
-        minWidth: useSideLayout
-            ? `${MIN_GRAPH_WIDTH_FOR_SIDE_LAYOUT_PX}px`
-            : undefined,
+        width: useSideLayout ? undefined : "100%",
+        minWidth: useSideLayout ? `${MIN_GRAPH_WIDTH_FOR_SIDE_LAYOUT_PX}px` : 0,
     };
 
     const sliderSectionStyle: React.CSSProperties = {
         order:
-            effectiveSliderPosition === "top" ||
-            effectiveSliderPosition === "left"
+            effectiveControlsPosition === "top" ||
+            effectiveControlsPosition === "left"
                 ? 1
                 : 2,
         display: "flex",
@@ -1481,6 +2214,8 @@ export default React.memo(function Prefigure({
         maxWidth: useSideLayout
             ? `${SIDE_SLIDER_COLUMN_WIDTH_PX}px`
             : undefined,
+        minWidth: 0,
+        overflowX: "hidden",
     };
 
     return (
@@ -1488,9 +2223,9 @@ export default React.memo(function Prefigure({
             id={id}
             ref={prefigureContainerRef}
             style={wrapperStyle}
-            data-slider-position-requested={requestedSliderPosition}
-            data-slider-position-effective={effectiveSliderPosition}
-            data-slider-position-side-fallback={
+            data-controls-position-requested={requestedControlsPosition}
+            data-controls-position-effective={effectiveControlsPosition}
+            data-controls-position-side-fallback={
                 requestedSideLayout && !canUseSideLayout ? "true" : "false"
             }
         >
@@ -1524,8 +2259,8 @@ export default React.memo(function Prefigure({
                         />
                     </div>
                 </div>
-                {hasSliderSection ? (
-                    <div style={sliderSectionStyle}>{sliderSection}</div>
+                {hasControlsSection ? (
+                    <div style={sliderSectionStyle}>{controlsSection}</div>
                 ) : null}
             </div>
         </div>

--- a/packages/doenetml/src/Viewer/renderers/utils/SliderUI.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/SliderUI.tsx
@@ -22,7 +22,7 @@ const RANGE_INPUT_KEYS = new Set([
  * Props for the SliderUI component
  * @typedef {Object} SliderUIProps
  * @property {string} id - HTML id for the range input
- * @property {string} label - Display label for the slider
+ * @property {React.ReactNode} label - Display label content for the slider (text or JSX)
  * @property {string} ariaLabel - Accessible label for screen readers
  * @property {number} min - Minimum value
  * @property {number} max - Maximum value

--- a/packages/doenetml/src/Viewer/renderers/utils/SliderUI.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/SliderUI.tsx
@@ -36,7 +36,7 @@ const RANGE_INPUT_KEYS = new Set([
  */
 type SliderUIProps = {
     id: string;
-    label: string;
+    label: React.ReactNode;
     ariaLabel: string;
     min: number;
     max: number;
@@ -102,8 +102,18 @@ export default function SliderUI({
     }, [value, transient]);
 
     return (
-        <div>
-            <label htmlFor={id}>{label}</label>
+        <div style={{ width: "100%", minWidth: 0 }}>
+            <label
+                htmlFor={id}
+                style={{
+                    display: "block",
+                    width: "100%",
+                    minWidth: 0,
+                    overflowWrap: "anywhere",
+                }}
+            >
+                {label}
+            </label>
             <input
                 id={id}
                 type="range"

--- a/packages/doenetml/src/Viewer/renderers/utils/SliderUI.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/SliderUI.tsx
@@ -69,6 +69,8 @@ export default function SliderUI({
     const [transient, setTransient] = useState(false);
     const draggingRef = useRef(false);
     const keyboardActiveRef = useRef(false);
+    const hasPlainTextLabel =
+        typeof label === "string" || typeof label === "number";
 
     /**
      * Extract numeric value from input element with fallback to localValue
@@ -103,17 +105,30 @@ export default function SliderUI({
 
     return (
         <div style={{ width: "100%", minWidth: 0 }}>
-            <label
-                htmlFor={id}
-                style={{
-                    display: "block",
-                    width: "100%",
-                    minWidth: 0,
-                    overflowWrap: "anywhere",
-                }}
-            >
-                {label}
-            </label>
+            {hasPlainTextLabel ? (
+                <label
+                    htmlFor={id}
+                    style={{
+                        display: "block",
+                        width: "100%",
+                        minWidth: 0,
+                        overflowWrap: "anywhere",
+                    }}
+                >
+                    {label}
+                </label>
+            ) : (
+                <div
+                    style={{
+                        display: "block",
+                        width: "100%",
+                        minWidth: 0,
+                        overflowWrap: "anywhere",
+                    }}
+                >
+                    {label}
+                </div>
+            )}
             <input
                 id={id}
                 type="range"

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -64256,7 +64256,7 @@
                         "false"
                     ]
                 },
-                "addSliders": {
+                "addControls": {
                     "optional": true,
                     "type": [
                         "none",
@@ -64622,7 +64622,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "addSliders",
+                    "name": "addControls",
                     "type": "text",
                     "isArray": false
                 },
@@ -83648,7 +83648,7 @@
                         "false"
                     ]
                 },
-                "addSliders": {
+                "addControls": {
                     "optional": true,
                     "type": [
                         "none",
@@ -84000,7 +84000,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "addSliders",
+                    "name": "addControls",
                     "type": "text",
                     "isArray": false
                 },
@@ -99310,14 +99310,18 @@
                         "false"
                     ]
                 },
-                "addSliders": {
+                "addControls": {
                     "optional": true,
                     "type": [
+                        "all",
+                        "slidersOnly",
+                        "inputsOnly",
+                        "none",
                         "true",
                         "false"
                     ]
                 },
-                "sliderPosition": {
+                "controlsPosition": {
                     "optional": true,
                     "type": [
                         "bottom",
@@ -99921,12 +99925,12 @@
                     "isArray": false
                 },
                 {
-                    "name": "addSliders",
-                    "type": "boolean",
+                    "name": "addControls",
+                    "type": "text",
                     "isArray": false
                 },
                 {
-                    "name": "sliderPosition",
+                    "name": "controlsPosition",
                     "type": "text",
                     "isArray": false
                 },
@@ -127896,7 +127900,7 @@
                         "false"
                     ]
                 },
-                "addSliders": {
+                "addControls": {
                     "optional": true,
                     "type": [
                         "none",
@@ -128262,7 +128266,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "addSliders",
+                    "name": "addControls",
                     "type": "text",
                     "isArray": false
                 },

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -39613,7 +39613,7 @@
                     ]
                 },
                 {
-                    "name": "addSliders",
+                    "name": "addControls",
                     "values": [
                         "none",
                         "both",
@@ -39708,7 +39708,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "addSliders",
+                    "name": "addControls",
                     "type": "text",
                     "isArray": false
                 },
@@ -50779,7 +50779,7 @@
                     ]
                 },
                 {
-                    "name": "addSliders",
+                    "name": "addControls",
                     "values": [
                         "none",
                         "both",
@@ -50860,7 +50860,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "addSliders",
+                    "name": "addControls",
                     "type": "text",
                     "isArray": false
                 },
@@ -61909,14 +61909,24 @@
                     ]
                 },
                 {
-                    "name": "addSliders",
+                    "name": "addControls",
                     "values": [
+                        "all",
+                        "slidersOnly",
+                        "inputsOnly",
+                        "none",
                         "true",
                         "false"
+                    ],
+                    "autocompleteValues": [
+                        "all",
+                        "slidersOnly",
+                        "inputsOnly",
+                        "none"
                     ]
                 },
                 {
-                    "name": "sliderPosition",
+                    "name": "controlsPosition",
                     "values": [
                         "bottom",
                         "left",
@@ -62093,12 +62103,12 @@
                     "isArray": false
                 },
                 {
-                    "name": "addSliders",
-                    "type": "boolean",
+                    "name": "addControls",
+                    "type": "text",
                     "isArray": false
                 },
                 {
-                    "name": "sliderPosition",
+                    "name": "controlsPosition",
                     "type": "text",
                     "isArray": false
                 },
@@ -78829,7 +78839,7 @@
                     ]
                 },
                 {
-                    "name": "addSliders",
+                    "name": "addControls",
                     "values": [
                         "none",
                         "both",
@@ -78924,7 +78934,7 @@
                     "isArray": false
                 },
                 {
-                    "name": "addSliders",
+                    "name": "addControls",
                     "type": "text",
                     "isArray": false
                 },

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureSliders.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureSliders.cy.js
@@ -658,6 +658,9 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
             .invoke("val", "5")
             .trigger("input");
         cy.get('[aria-label="x coordinate for P"]').trigger("mouseup");
+        cy.get('input[aria-label="x value input for P"]')
+            .parents("label")
+            .should("have.length", 0);
         cy.get('input[aria-label="x value input for P"]').should(
             "have.value",
             "5",

--- a/packages/test-cypress/cypress/e2e/prefigure/prefigureSliders.cy.js
+++ b/packages/test-cypress/cypress/e2e/prefigure/prefigureSliders.cy.js
@@ -33,7 +33,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph name="g" renderer="prefigure" addSliders>
+<graph name="g" renderer="prefigure" addControls>
   <point name="Q">(3,4)</point>
   <point name="P" labelIsName>(-2,1)</point>
 </graph>
@@ -85,7 +85,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph renderer="prefigure" addSliders>
+<graph renderer="prefigure" addControls="slidersOnly">
   <point name="Q">(3,4)</point>
   <point name="P" labelIsName>
     <constrainToGrid />
@@ -124,7 +124,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph renderer="prefigure" addSliders>
+<graph renderer="prefigure" addControls="slidersOnly">
   <point name="P" labelIsName>
     <constrainToGrid />
     (3,4)
@@ -172,7 +172,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph renderer="prefigure" addSliders>
+<graph renderer="prefigure" addControls="slidersOnly">
   <point name="P" labelIsName>(1,2)</point>
 </graph>
 <p>Px: <number name="Px">$P.x</number></p>
@@ -224,7 +224,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph renderer="prefigure" addSliders size="small">
+<graph renderer="prefigure" addControls size="small">
   <line name="l">y=x</line>
     <point name="P" labelIsName><constrainTo>$l</constrainTo>(0,0)</point>
 </graph>
@@ -278,7 +278,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph renderer="prefigure" addSliders xMin="10" xMax="-10" yMin="5" yMax="-5">
+<graph renderer="prefigure" addControls xMin="10" xMax="-10" yMin="5" yMax="-5">
   <point name="P" labelIsName>(1,2)</point>
 </graph>
 <p>Px: <number name="Px">$P.x</number></p>
@@ -309,7 +309,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph renderer="prefigure" addSliders>
+<graph renderer="prefigure" addControls="slidersOnly">
     <point>(1,1)</point>
     <point draggable="false">(2,2)</point>
     <point fixed="true">(3,3)</point>
@@ -336,7 +336,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         postDoenetML(`
 <text name="ready">ready</text>
 <booleanInput name="middleDraggable" prefill="true" />
-<graph renderer="prefigure" addSliders>
+<graph renderer="prefigure" addControls>
     <point>(1,1)</point>
     <point draggable="$middleDraggable.value">(2,2)</point>
     <point>(3,3)</point>
@@ -368,7 +368,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph renderer="prefigure" addSliders>
+<graph renderer="prefigure" addControls="slidersOnly">
     <point name="P" labelIsName displayDecimals="1">(1.555, 2.777)</point>
     <point name="Q" labelIsName displayDigits="2">(3.456, 4.789)</point>
     <point name="R" labelIsName>(0.123, 0.456)</point>
@@ -421,7 +421,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph renderer="prefigure" addSliders>
+<graph renderer="prefigure" addControls="slidersOnly">
     <point name="P" labelIsName displayDecimals="2" padZeros="true">(1.5, 2)</point>
     <point name="Q" labelIsName displayDigits="3" padZeros="true">(3.45, 4.56)</point>
 </graph>
@@ -453,7 +453,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         });
     });
 
-    it("addSliders='none' on a point suppresses both sliders for that point", () => {
+    it("addControls='none' on a point suppresses both sliders for that point", () => {
         cy.clearIndexedDB();
         cy.visit("/");
 
@@ -461,9 +461,9 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph renderer="prefigure" addSliders>
+<graph renderer="prefigure" addControls>
     <point>(1,1)</point>
-    <point addSliders="none">(2,2)</point>
+    <point addControls="none">(2,2)</point>
     <point>(3,3)</point>
 </graph>
 `);
@@ -479,7 +479,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         cy.get('[aria-label="y coordinate for Point 3"]').should("exist");
     });
 
-    it("addSliders='xOnly' on a point renders only the x slider", () => {
+    it("addControls='xOnly' on a point renders only the x slider", () => {
         cy.clearIndexedDB();
         cy.visit("/");
 
@@ -487,8 +487,8 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph renderer="prefigure" addSliders>
-    <point name="P" labelIsName addSliders="xOnly">(3,4)</point>
+<graph renderer="prefigure" addControls>
+    <point name="P" labelIsName addControls="xOnly">(3,4)</point>
     <point name="Q" labelIsName>(1,2)</point>
 </graph>
 <p>Px: <number name="Px">$P.x</number></p>
@@ -514,7 +514,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         cy.get("#Px").should("have.text", "5");
     });
 
-    it("addSliders='yOnly' on a point renders only the y slider", () => {
+    it("addControls='yOnly' on a point renders only the y slider", () => {
         cy.clearIndexedDB();
         cy.visit("/");
 
@@ -522,8 +522,8 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph renderer="prefigure" addSliders>
-    <point name="P" labelIsName addSliders="yOnly">(3,4)</point>
+<graph renderer="prefigure" addControls>
+    <point name="P" labelIsName addControls="yOnly">(3,4)</point>
     <point name="Q" labelIsName>(1,2)</point>
 </graph>
 <p>Px: <number name="Px">$P.x</number></p>
@@ -549,7 +549,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         cy.get("#Py").should("have.text", "7");
     });
 
-    it("addSliders defaults to 'both' when graph-level addSliders is set", () => {
+    it("addControls defaults to 'both' when graph-level addControls is set", () => {
         cy.clearIndexedDB();
         cy.visit("/");
 
@@ -557,7 +557,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph renderer="prefigure" addSliders>
+<graph renderer="prefigure" addControls>
     <point name="P" labelIsName>(3,4)</point>
 </graph>
 `);
@@ -569,6 +569,128 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         cy.get('input[type="range"]').should("have.length", 2);
     });
 
+    it("addControls='slidersOnly' keeps slider-only rendering", () => {
+        cy.clearIndexedDB();
+        cy.visit("/");
+
+        installPrefigureBuildIntercept();
+
+        postDoenetML(`
+<text name="ready">ready</text>
+<graph renderer="prefigure" addControls="slidersOnly">
+    <point name="P" labelIsName>(3,4)</point>
+</graph>
+`);
+
+        cy.get("#ready").should("have.text", "ready");
+
+        cy.get('[aria-label="x coordinate for P"]').should("exist");
+        cy.get('[aria-label="y coordinate for P"]').should("exist");
+        cy.get('input[type="range"]').should("have.length", 2);
+        cy.get('input[type="text"]').should("have.length", 0);
+    });
+
+    it("addControls='inputsOnly' renders coordinate inputs and validates before moving", () => {
+        cy.clearIndexedDB();
+        cy.visit("/");
+
+        installPrefigureBuildIntercept();
+
+        postDoenetML(`
+<text name="ready">ready</text>
+<graph renderer="prefigure" addControls="inputsOnly">
+  <point name="P" labelIsName>(3,4)</point>
+  <point name="Q" labelIsName addControls="xOnly">(1,2)</point>
+</graph>
+<p>Px: <number name="Px">$P.x</number></p>
+<p>Py: <number name="Py">$P.y</number></p>
+<p>Qx: <number name="Qx">$Q.x</number></p>
+<p>Qy: <number name="Qy">$Q.y</number></p>
+`);
+
+        cy.get("#ready").should("have.text", "ready");
+
+        cy.get('input[type="range"]').should("have.length", 0);
+        cy.get('[aria-label="coordinates for P"]').should(
+            "have.value",
+            "(3,4)",
+        );
+        cy.get('[aria-label="x input for Q"]').should("have.value", "1");
+
+        cy.get('[aria-label="coordinates for P"]').clear().type("(6,7){enter}");
+        cy.get("#Px").should("have.text", "6");
+        cy.get("#Py").should("have.text", "7");
+
+        cy.get('[aria-label="coordinates for P"]')
+            .clear()
+            .type("not-a-pair{enter}");
+        cy.get('[aria-label="coordinates for P"]').should(
+            "have.attr",
+            "aria-invalid",
+            "true",
+        );
+        cy.get("#Px").should("have.text", "6");
+        cy.get("#Py").should("have.text", "7");
+
+        cy.get('[aria-label="x input for Q"]').clear().type("2+3{enter}");
+        cy.get("#Qx").should("have.text", "5");
+        cy.get("#Qy").should("have.text", "2");
+    });
+
+    it("addControls='all' keeps sliders and syncs inline inputs", () => {
+        cy.clearIndexedDB();
+        cy.visit("/");
+
+        installPrefigureBuildIntercept();
+
+        postDoenetML(`
+<text name="ready">ready</text>
+<graph renderer="prefigure" addControls="all">
+  <point name="P" labelIsName>(3,4)</point>
+</graph>
+<p>Px: <number name="Px">$P.x</number></p>
+`);
+
+        cy.get("#ready").should("have.text", "ready");
+
+        cy.get('[aria-label="x coordinate for P"]').trigger("mousedown");
+        cy.get('[aria-label="x coordinate for P"]')
+            .invoke("val", "5")
+            .trigger("input");
+        cy.get('[aria-label="x coordinate for P"]').trigger("mouseup");
+        cy.get('input[aria-label="x value input for P"]').should(
+            "have.value",
+            "5",
+        );
+        cy.get("#Px").should("have.text", "5");
+
+        cy.get('input[aria-label="x value input for P"]')
+            .clear()
+            .type("8{enter}");
+        cy.get('[aria-label="x coordinate for P"]').should("have.value", "8");
+        cy.get("#Px").should("have.text", "8");
+    });
+
+    it("addControls='none' renders no controls", () => {
+        cy.clearIndexedDB();
+        cy.visit("/");
+
+        installPrefigureBuildIntercept();
+
+        postDoenetML(`
+<text name="ready">ready</text>
+<graph name="g" renderer="prefigure" addControls="none">
+  <point name="P" labelIsName>(2,3)</point>
+</graph>
+`);
+
+        cy.get("#ready").should("have.text", "ready");
+        cy.get('#g [data-point-slider-card="true"]').should("not.exist");
+        cy.get('#g input[type="range"]').should("have.length", 0);
+        cy.get('#g input[type="text"]').should("have.length", 0);
+        cy.get("#g > div").children().should("have.length", 1);
+    });
+
     it("keyboard arrow keys accumulate as transient and commit final value on blur", () => {
         cy.clearIndexedDB();
         cy.visit("/");
@@ -577,7 +699,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph renderer="prefigure" addSliders size="small">
+<graph renderer="prefigure" addControls size="small">
   <point name="P" labelIsName><constrainToGrid/>(0,0)</point>
 </graph>
 <p>Px: <number name="Px">$P.x</number></p>
@@ -622,7 +744,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph renderer="prefigure" addSliders size="small">
+<graph renderer="prefigure" addControls size="small">
   <line name="l">y=x</line>
   <point name="P" labelIsName><constrainTo>$l</constrainTo>(0,0)</point>
 </graph>
@@ -668,7 +790,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         cy.get("#Py").should("have.text", "0.1");
     });
 
-    it("defaults sliderPosition to left and keeps side-by-side on wide layout", () => {
+    it("defaults controlsPosition to left and keeps side-by-side on wide layout", () => {
         cy.clearIndexedDB();
         cy.viewport(1400, 900);
         cy.visit("/");
@@ -677,16 +799,16 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph name="g" renderer="prefigure" addSliders width="640px">
+<graph name="g" renderer="prefigure" addControls width="640px">
   <point name="P" labelIsName>(2,3)</point>
 </graph>
 `);
 
         cy.get("#ready").should("have.text", "ready");
         cy.get("#g")
-            .should("have.attr", "data-slider-position-requested", "left")
-            .and("have.attr", "data-slider-position-effective", "left")
-            .and("have.attr", "data-slider-position-side-fallback", "false");
+            .should("have.attr", "data-controls-position-requested", "left")
+            .and("have.attr", "data-controls-position-effective", "left")
+            .and("have.attr", "data-controls-position-side-fallback", "false");
 
         cy.get("#g > div").should("have.css", "flex-direction", "row");
         cy.get("#g .ChemAccess-element")
@@ -715,16 +837,16 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph name="g" renderer="prefigure" addSliders sliderPosition="left">
+<graph name="g" renderer="prefigure" addControls controlsPosition="left">
   <point name="P" labelIsName>(2,3)</point>
 </graph>
 `);
 
         cy.get("#ready").should("have.text", "ready");
         cy.get("#g")
-            .should("have.attr", "data-slider-position-requested", "left")
-            .and("have.attr", "data-slider-position-effective", "top")
-            .and("have.attr", "data-slider-position-side-fallback", "true");
+            .should("have.attr", "data-controls-position-requested", "left")
+            .and("have.attr", "data-controls-position-effective", "top")
+            .and("have.attr", "data-controls-position-side-fallback", "true");
 
         cy.get("#g > div").should("have.css", "flex-direction", "column");
     });
@@ -738,16 +860,16 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph name="g" renderer="prefigure" addSliders sliderPosition="right">
+<graph name="g" renderer="prefigure" addControls controlsPosition="right">
   <point name="P" labelIsName>(2,3)</point>
 </graph>
 `);
 
         cy.get("#ready").should("have.text", "ready");
         cy.get("#g")
-            .should("have.attr", "data-slider-position-requested", "right")
-            .and("have.attr", "data-slider-position-effective", "bottom")
-            .and("have.attr", "data-slider-position-side-fallback", "true");
+            .should("have.attr", "data-controls-position-requested", "right")
+            .and("have.attr", "data-controls-position-effective", "bottom")
+            .and("have.attr", "data-controls-position-side-fallback", "true");
 
         cy.get("#g > div").should("have.css", "flex-direction", "column");
         cy.get("#g .ChemAccess-element")
@@ -764,25 +886,25 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph name="g" renderer="prefigure" addSliders sliderPosition="left">
+<graph name="g" renderer="prefigure" addControls controlsPosition="left">
   <point name="P" labelIsName>(2,3)</point>
 </graph>
 `);
 
         cy.get("#ready").should("have.text", "ready");
         cy.get("#g")
-            .should("have.attr", "data-slider-position-effective", "left")
-            .and("have.attr", "data-slider-position-side-fallback", "false");
+            .should("have.attr", "data-controls-position-effective", "left")
+            .and("have.attr", "data-controls-position-side-fallback", "false");
 
         cy.viewport(420, 900);
         cy.get("#g")
-            .should("have.attr", "data-slider-position-effective", "top")
-            .and("have.attr", "data-slider-position-side-fallback", "true");
+            .should("have.attr", "data-controls-position-effective", "top")
+            .and("have.attr", "data-controls-position-side-fallback", "true");
 
         cy.viewport(1400, 900);
         cy.get("#g")
-            .should("have.attr", "data-slider-position-effective", "left")
-            .and("have.attr", "data-slider-position-side-fallback", "false");
+            .should("have.attr", "data-controls-position-effective", "left")
+            .and("have.attr", "data-controls-position-side-fallback", "false");
         cy.get("#g > div").should("have.css", "flex-direction", "row");
     });
 
@@ -794,7 +916,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph name="g" renderer="prefigure" addSliders sliderPosition="top">
+<graph name="g" renderer="prefigure" addControls controlsPosition="top">
   <shortDescription>Graph first semantic order test</shortDescription>
   <point name="P" labelIsName>(2,3)</point>
 </graph>
@@ -819,8 +941,8 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         });
 
         cy.get("#g")
-            .should("have.attr", "data-slider-position-effective", "top")
-            .and("have.attr", "data-slider-position-side-fallback", "false");
+            .should("have.attr", "data-controls-position-effective", "top")
+            .and("have.attr", "data-controls-position-side-fallback", "false");
         cy.get("#g .ChemAccess-element")
             .parent()
             .should("have.css", "order", "2");
@@ -835,8 +957,8 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph name="g" renderer="prefigure" addSliders sliderPosition="left" width="640px">
-  <point name="P" labelIsName addSliders="false">(2,3)</point>
+<graph name="g" renderer="prefigure" addControls controlsPosition="left" width="640px">
+  <point name="P" labelIsName addControls="false">(2,3)</point>
 </graph>
 `);
 
@@ -846,7 +968,7 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
         cy.get("#g > div > div .ChemAccess-element").should("have.length", 1);
     });
 
-    it("addSliders false on point is equivalent to none", () => {
+    it("addControls false on point is equivalent to none", () => {
         cy.clearIndexedDB();
         cy.visit("/");
 
@@ -854,8 +976,8 @@ describe("PreFigure sliders @group4", { tags: ["@group4"] }, () => {
 
         postDoenetML(`
 <text name="ready">ready</text>
-<graph renderer="prefigure" addSliders>
-    <point name="P" labelIsName addSliders="false">(3,4)</point>
+<graph renderer="prefigure" addControls>
+    <point name="P" labelIsName addControls="false">(3,4)</point>
     <point name="Q" labelIsName>(1,2)</point>
 </graph>
 `);


### PR DESCRIPTION
Generalize point slider controls into an `addControls` feature with graph-level rendering modes. Replace the boolean `addSliders` attribute with a text `addControls` attribute supporting `all`, `slidersOnly`, `inputsOnly`, and `none`.

## CHANGES

### Worker Components
- Rename `addSliders` → `addControls` in `Graph.js` and `Point.js`
- Change `Graph.addControls` to text type with valid values and fallback mappings (`true` → `"all"`, `false` → `"none"`)
- Rename `draggablePointsForSliders` → `draggablePointsForControls` state variable

### Renderer (`prefigure.tsx`)
- Implement control mode normalization (`normalizeGraphControlsMode`, `normalizePointControlsMode`) and active-input computation
- Add input parsing for single values (`parseSingleMathNumber`) and ordered pairs (`parseOrderedPair`)
- Implement input submission handlers (`submitAxisInput`, `submitPairInput`) with validation and error state management
- Guards: inputs only commit when a draft exists (blur on an untouched field is a no-op); no-op submits are skipped when the parsed value matches the current coordinate; `committingInputKeysRef` in-flight lock prevents Enter+blur duplicate dispatches
- Add inline axis inputs in `all` mode within slider labels
- Render pure input controls in `inputsOnly` mode
- Add error message display with proper ARIA associations (`aria-invalid`, `aria-describedby`)
- Fix layout jitter on invalid input by constraining label/card widths

### Accessibility & UX
- `aria-invalid` and `aria-describedby` for invalid inputs
- Per-point control card rendered as `role="group"` labelled by the point name heading (`aria-labelledby`)
- Outer controls section rendered as `role="group"` with `aria-label="Point controls"`
- Visually-hidden `aria-live="polite"` region for build/error status announcements, placed outside `role="img"` so announcements are not suppressed
- Graph `aria-label` defaults to `"Diagram"` when no `shortDescription` is provided
- Maintain DOM order for keyboard/screen-reader navigation
- Block `movePoint` on invalid input; show validation errors instead

### Tests
- Migrate `prefigureSliders.cy.js` tests to `addControls` semantics
- Add tests for `all`/`slidersOnly`/`inputsOnly`/`none` modes and validation behavior
- Add tests for position fallback and responsive layout

### Schema
- Regenerate schema artifacts with `addControls` attribute mappings and autocomplete values

### Maintenance
- Extract shared record pruning logic into `pruneRecordByActiveKeys` helper
- Hoist draft-update logic into `setInputDraftValue` helper

## FEATURE MODES

**`slidersOnly`**: Traditional slider interaction (existing behavior, renamed from `addSliders`)

**`inputsOnly`**: Text input controls where users enter single values or ordered pairs, validated as math expressions before committing

**`all`**: Sliders paired with editable inline axis inputs in slider labels; users can drag, type, or both

**`none`**: No controls rendered (default)

## TESTING
All existing Cypress tests pass. New tests cover all control modes, validation behavior, and responsive layout fallback.
