### PR TITLE
Add polyline/polygon/triangle center state variable and center-move actions

### DIFF
--- a/.changeset/polygon-triangle-center-state-variables.md
+++ b/.changeset/polygon-triangle-center-state-variables.md
@@ -4,9 +4,9 @@
 "@doenet/doenetml-iframe": patch
 ---
 
-Add center state-variable support for polygons and triangles in the worker layer.
+Add center state-variable support for polylines, polygons and triangles in the worker layer.
 
-- Polygon now exposes a public renderer-facing center location computed from the average of vertex coordinates, with symbolic math support.
-- Polygon now supports a movePolygonCenter action that updates center semantically and propagates through inverse definitions.
-- Triangle now supports moveTriangleCenter by delegating to polygon center movement behavior.
-- Add targeted worker tests covering polygon center computation, symbolic center behavior, center-driven translation, and triangle center movement.
+- Polyline now exposes a public renderer-facing center location computed from the average of vertex coordinates, with symbolic math support for derived polygon and triangle components.
+- Polyline now supports a semantic center-move action that polygon center movement delegates to through the shared base implementation.
+- Triangle now supports moveTriangleCenter by delegating to the shared polygon/polyline center movement behavior.
+- Add targeted worker tests covering polygon center computation, symbolic center behavior, center-driven translation, constrained center-driven translation, and triangle center movement.

--- a/.changeset/polygon-triangle-center-state-variables.md
+++ b/.changeset/polygon-triangle-center-state-variables.md
@@ -1,0 +1,12 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Add center state-variable support for polygons and triangles in the worker layer.
+
+- Polygon now exposes a public renderer-facing center location computed from the average of vertex coordinates, with symbolic math support.
+- Polygon now supports a movePolygonCenter action that updates center semantically and propagates through inverse definitions.
+- Triangle now supports moveTriangleCenter by delegating to polygon center movement behavior.
+- Add targeted worker tests covering polygon center computation, symbolic center behavior, center-driven translation, and triangle center movement.

--- a/packages/doenetml-worker-javascript/src/components/Polygon.js
+++ b/packages/doenetml-worker-javascript/src/components/Polygon.js
@@ -1,6 +1,5 @@
 import { returnRoundingAttributeComponentShadowing } from "../utils/rounding";
 import Polyline from "./Polyline";
-import me from "math-expressions";
 
 export default class Polygon extends Polyline {
     constructor(args) {
@@ -19,6 +18,10 @@ export default class Polygon extends Polyline {
 
     get movePolygon() {
         return this.movePolyline;
+    }
+
+    get movePolygonCenter() {
+        return this.movePolylineCenter;
     }
 
     get reflectPolygon() {
@@ -360,125 +363,6 @@ export default class Polygon extends Polyline {
             },
         };
 
-        stateVariableDefinitions.center = {
-            public: true,
-            forRenderer: true,
-            isLocation: true,
-            isArray: true,
-            entryPrefixes: ["centerX"],
-            shadowingInstructions: {
-                createComponentOfType: "math",
-                addAttributeComponentsShadowingStateVariables:
-                    returnRoundingAttributeComponentShadowing(),
-                returnWrappingComponents(prefix) {
-                    if (prefix === "centerX") {
-                        return [];
-                    } else {
-                        // entire array
-                        // wrap by both <point> and <xs>
-                        return [
-                            [
-                                "point",
-                                {
-                                    componentType: "mathList",
-                                    isAttributeNamed: "xs",
-                                },
-                            ],
-                        ];
-                    }
-                },
-            },
-
-            returnArraySizeDependencies: () => ({}),
-            returnArraySize: () => [2],
-
-            returnArrayDependenciesByKey() {
-                let globalDependencies = {
-                    vertices: {
-                        dependencyType: "stateVariable",
-                        variableName: "vertices",
-                    },
-                    numVertices: {
-                        dependencyType: "stateVariable",
-                        variableName: "numVertices",
-                    },
-                };
-
-                return { globalDependencies };
-            },
-
-            arrayDefinitionByKey({ globalDependencyValues, arrayKeys }) {
-                let center = {};
-                let numVertices = globalDependencyValues.numVertices;
-
-                for (let arrayKey of arrayKeys) {
-                    let dim = Number(arrayKey);
-
-                    if (!(numVertices > 0)) {
-                        center[arrayKey] = me.fromAst(NaN);
-                        continue;
-                    }
-
-                    let centerComponent =
-                        globalDependencyValues.vertices[0][dim];
-
-                    for (let pointInd = 1; pointInd < numVertices; pointInd++) {
-                        centerComponent = centerComponent.add(
-                            globalDependencyValues.vertices[pointInd][dim],
-                        );
-                    }
-
-                    center[arrayKey] = centerComponent
-                        .divide(numVertices)
-                        .simplify();
-                }
-
-                return { setValue: { center } };
-            },
-
-            async inverseArrayDefinitionByKey({
-                desiredStateVariableValues,
-                globalDependencyValues,
-                stateValues,
-            }) {
-                let center = await stateValues.center;
-
-                let desiredVertices = globalDependencyValues.vertices.map(
-                    (v) => [...v],
-                );
-
-                for (let arrayKey in desiredStateVariableValues.center) {
-                    let dim = Number(arrayKey);
-
-                    let offset = desiredStateVariableValues.center[arrayKey]
-                        .subtract(center[dim])
-                        .simplify();
-
-                    for (
-                        let pointInd = 0;
-                        pointInd < desiredVertices.length;
-                        pointInd++
-                    ) {
-                        desiredVertices[pointInd][dim] = desiredVertices[
-                            pointInd
-                        ][dim]
-                            .add(offset)
-                            .simplify();
-                    }
-                }
-
-                return {
-                    success: true,
-                    instructions: [
-                        {
-                            setDependency: "vertices",
-                            desiredValue: desiredVertices,
-                        },
-                    ],
-                };
-            },
-        };
-
         // overwrite nearestPoint so that it includes
         // segment between first and last vertex
         stateVariableDefinitions.nearestPoint = {
@@ -731,69 +615,5 @@ export default class Polygon extends Polyline {
         };
 
         return stateVariableDefinitions;
-    }
-
-    async movePolygonCenter({
-        center,
-        transient,
-        skippable,
-        sourceDetails,
-        actionId,
-        sourceInformation = {},
-        skipRendererUpdate = false,
-    }) {
-        if (!(await this.stateValues.draggable)) {
-            return;
-        }
-
-        if (!Array.isArray(center) || center.length < 2) {
-            return;
-        }
-
-        let updateInstructions = [
-            {
-                updateType: "updateValue",
-                componentIdx: this.componentIdx,
-                stateVariable: "center",
-                value: center.map((x) => me.fromAst(x)),
-                sourceDetails,
-            },
-        ];
-
-        // Note: we set skipRendererUpdate to true
-        // so that renderer updates are consolidated at the end of the action.
-        if (transient) {
-            await this.coreFunctions.performUpdate({
-                updateInstructions,
-                transient,
-                skippable,
-                actionId,
-                sourceInformation,
-                skipRendererUpdate: true,
-            });
-        } else {
-            await this.coreFunctions.performUpdate({
-                updateInstructions,
-                actionId,
-                sourceInformation,
-                skipRendererUpdate: true,
-                event: {
-                    verb: "interacted",
-                    object: {
-                        componentIdx: this.componentIdx,
-                        componentType: this.componentType,
-                    },
-                    result: {
-                        center,
-                    },
-                },
-            });
-        }
-
-        return await this.coreFunctions.updateRenderers({
-            actionId,
-            sourceInformation,
-            skipRendererUpdate,
-        });
     }
 }

--- a/packages/doenetml-worker-javascript/src/components/Polygon.js
+++ b/packages/doenetml-worker-javascript/src/components/Polygon.js
@@ -1,5 +1,6 @@
 import { returnRoundingAttributeComponentShadowing } from "../utils/rounding";
 import Polyline from "./Polyline";
+import me from "math-expressions";
 
 export default class Polygon extends Polyline {
     constructor(args) {
@@ -7,6 +8,7 @@ export default class Polygon extends Polyline {
 
         Object.assign(this.actions, {
             movePolygon: this.movePolygon.bind(this),
+            movePolygonCenter: this.movePolygonCenter.bind(this),
             reflectPolygon: this.reflectPolygon.bind(this),
             polygonClicked: this.polygonClicked.bind(this),
             polygonFocused: this.polygonFocused.bind(this),
@@ -358,6 +360,125 @@ export default class Polygon extends Polyline {
             },
         };
 
+        stateVariableDefinitions.center = {
+            public: true,
+            forRenderer: true,
+            isLocation: true,
+            isArray: true,
+            entryPrefixes: ["centerX"],
+            shadowingInstructions: {
+                createComponentOfType: "math",
+                addAttributeComponentsShadowingStateVariables:
+                    returnRoundingAttributeComponentShadowing(),
+                returnWrappingComponents(prefix) {
+                    if (prefix === "centerX") {
+                        return [];
+                    } else {
+                        // entire array
+                        // wrap by both <point> and <xs>
+                        return [
+                            [
+                                "point",
+                                {
+                                    componentType: "mathList",
+                                    isAttributeNamed: "xs",
+                                },
+                            ],
+                        ];
+                    }
+                },
+            },
+
+            returnArraySizeDependencies: () => ({}),
+            returnArraySize: () => [2],
+
+            returnArrayDependenciesByKey() {
+                let globalDependencies = {
+                    vertices: {
+                        dependencyType: "stateVariable",
+                        variableName: "vertices",
+                    },
+                    numVertices: {
+                        dependencyType: "stateVariable",
+                        variableName: "numVertices",
+                    },
+                };
+
+                return { globalDependencies };
+            },
+
+            arrayDefinitionByKey({ globalDependencyValues, arrayKeys }) {
+                let center = {};
+                let numVertices = globalDependencyValues.numVertices;
+
+                for (let arrayKey of arrayKeys) {
+                    let dim = Number(arrayKey);
+
+                    if (!(numVertices > 0)) {
+                        center[arrayKey] = me.fromAst(NaN);
+                        continue;
+                    }
+
+                    let centerComponent =
+                        globalDependencyValues.vertices[0][dim];
+
+                    for (let pointInd = 1; pointInd < numVertices; pointInd++) {
+                        centerComponent = centerComponent.add(
+                            globalDependencyValues.vertices[pointInd][dim],
+                        );
+                    }
+
+                    center[arrayKey] = centerComponent
+                        .divide(numVertices)
+                        .simplify();
+                }
+
+                return { setValue: { center } };
+            },
+
+            async inverseArrayDefinitionByKey({
+                desiredStateVariableValues,
+                globalDependencyValues,
+                stateValues,
+            }) {
+                let center = await stateValues.center;
+
+                let desiredVertices = globalDependencyValues.vertices.map(
+                    (v) => [...v],
+                );
+
+                for (let arrayKey in desiredStateVariableValues.center) {
+                    let dim = Number(arrayKey);
+
+                    let offset = desiredStateVariableValues.center[arrayKey]
+                        .subtract(center[dim])
+                        .simplify();
+
+                    for (
+                        let pointInd = 0;
+                        pointInd < desiredVertices.length;
+                        pointInd++
+                    ) {
+                        desiredVertices[pointInd][dim] = desiredVertices[
+                            pointInd
+                        ][dim]
+                            .add(offset)
+                            .simplify();
+                    }
+                }
+
+                return {
+                    success: true,
+                    instructions: [
+                        {
+                            setDependency: "vertices",
+                            desiredValue: desiredVertices,
+                        },
+                    ],
+                };
+            },
+        };
+
         // overwrite nearestPoint so that it includes
         // segment between first and last vertex
         stateVariableDefinitions.nearestPoint = {
@@ -610,5 +731,69 @@ export default class Polygon extends Polyline {
         };
 
         return stateVariableDefinitions;
+    }
+
+    async movePolygonCenter({
+        center,
+        transient,
+        skippable,
+        sourceDetails,
+        actionId,
+        sourceInformation = {},
+        skipRendererUpdate = false,
+    }) {
+        if (!(await this.stateValues.draggable)) {
+            return;
+        }
+
+        if (!Array.isArray(center) || center.length < 2) {
+            return;
+        }
+
+        let updateInstructions = [
+            {
+                updateType: "updateValue",
+                componentIdx: this.componentIdx,
+                stateVariable: "center",
+                value: center.map((x) => me.fromAst(x)),
+                sourceDetails,
+            },
+        ];
+
+        // Note: we set skipRendererUpdate to true
+        // so that renderer updates are consolidated at the end of the action.
+        if (transient) {
+            await this.coreFunctions.performUpdate({
+                updateInstructions,
+                transient,
+                skippable,
+                actionId,
+                sourceInformation,
+                skipRendererUpdate: true,
+            });
+        } else {
+            await this.coreFunctions.performUpdate({
+                updateInstructions,
+                actionId,
+                sourceInformation,
+                skipRendererUpdate: true,
+                event: {
+                    verb: "interacted",
+                    object: {
+                        componentIdx: this.componentIdx,
+                        componentType: this.componentType,
+                    },
+                    result: {
+                        center,
+                    },
+                },
+            });
+        }
+
+        return await this.coreFunctions.updateRenderers({
+            actionId,
+            sourceInformation,
+            skipRendererUpdate,
+        });
     }
 }

--- a/packages/doenetml-worker-javascript/src/components/Polygon.js
+++ b/packages/doenetml-worker-javascript/src/components/Polygon.js
@@ -20,6 +20,10 @@ export default class Polygon extends Polyline {
         return this.movePolyline;
     }
 
+    /**
+     * Delegates to parent Polyline's movePolylineCenter action.
+     * Provides polygon-specific naming for semantic clarity.
+     */
     get movePolygonCenter() {
         return this.movePolylineCenter;
     }

--- a/packages/doenetml-worker-javascript/src/components/Polyline.js
+++ b/packages/doenetml-worker-javascript/src/components/Polyline.js
@@ -14,6 +14,7 @@ export default class Polyline extends GraphicalComponent {
 
         Object.assign(this.actions, {
             movePolyline: this.movePolyline.bind(this),
+            movePolylineCenter: this.movePolylineCenter.bind(this),
             finalizePolylinePosition: this.finalizePolylinePosition.bind(this),
             reflectPolyline: this.reflectPolyline.bind(this),
             polylineClicked: this.polylineClicked.bind(this),
@@ -1968,6 +1969,114 @@ export default class Polyline extends GraphicalComponent {
             },
         };
 
+        stateVariableDefinitions.center = {
+            public: true,
+            forRenderer: true,
+            isLocation: true,
+            isArray: true,
+            entryPrefixes: ["centerX"],
+            shadowingInstructions: {
+                createComponentOfType: "math",
+                addAttributeComponentsShadowingStateVariables:
+                    returnRoundingAttributeComponentShadowing(),
+                returnWrappingComponents(prefix) {
+                    if (prefix === "centerX") {
+                        return [];
+                    } else {
+                        // entire array
+                        // wrap by both <point> and <xs>
+                        return [
+                            [
+                                "point",
+                                {
+                                    componentType: "mathList",
+                                    isAttributeNamed: "xs",
+                                },
+                            ],
+                        ];
+                    }
+                },
+            },
+
+            returnArraySizeDependencies: () => ({}),
+            returnArraySize: () => [2],
+
+            returnArrayDependenciesByKey() {
+                let globalDependencies = {
+                    vertices: {
+                        dependencyType: "stateVariable",
+                        variableName: "vertices",
+                    },
+                    numVertices: {
+                        dependencyType: "stateVariable",
+                        variableName: "numVertices",
+                    },
+                };
+
+                return { globalDependencies };
+            },
+
+            arrayDefinitionByKey({ globalDependencyValues, arrayKeys }) {
+                let center = {};
+                let numVertices = globalDependencyValues.numVertices;
+
+                for (let arrayKey of arrayKeys) {
+                    let dim = Number(arrayKey);
+
+                    if (!(numVertices > 0)) {
+                        center[arrayKey] = me.fromAst(NaN);
+                        continue;
+                    }
+
+                    let centerComponent = globalDependencyValues.vertices[0][dim];
+
+                    for (let pointInd = 1; pointInd < numVertices; pointInd++) {
+                        centerComponent = centerComponent.add(
+                            globalDependencyValues.vertices[pointInd][dim],
+                        );
+                    }
+
+                    center[arrayKey] = centerComponent.divide(numVertices).simplify();
+                }
+
+                return { setValue: { center } };
+            },
+
+            async inverseArrayDefinitionByKey({
+                desiredStateVariableValues,
+                globalDependencyValues,
+                stateValues,
+            }) {
+                let center = await stateValues.center;
+
+                let desiredVertices = globalDependencyValues.vertices.map((v) => [...v]);
+
+                for (let arrayKey in desiredStateVariableValues.center) {
+                    let dim = Number(arrayKey);
+
+                    let offset = desiredStateVariableValues.center[arrayKey]
+                        .subtract(center[dim])
+                        .simplify();
+
+                    for (let pointInd = 0; pointInd < desiredVertices.length; pointInd++) {
+                        desiredVertices[pointInd][dim] = desiredVertices[pointInd][dim]
+                            .add(offset)
+                            .simplify();
+                    }
+                }
+
+                return {
+                    success: true,
+                    instructions: [
+                        {
+                            setDependency: "vertices",
+                            desiredValue: desiredVertices,
+                        },
+                    ],
+                };
+            },
+        };
+
         stateVariableDefinitions.numericalCentroidUnconstrained = {
             returnDependencies: () => ({
                 unconstrainedVertices: {
@@ -2019,6 +2128,201 @@ export default class Polyline extends GraphicalComponent {
         };
 
         return stateVariableDefinitions;
+    }
+
+    async _attemptConstrainedRigidTranslationReconciliation({
+        transient,
+        actionId,
+        sourceInformation = {},
+        skipRendererUpdate = false,
+    }) {
+        let desiredUnconstrainedVertices =
+            await this.stateValues.desiredUnconstrainedVertices;
+
+        if (
+            desiredUnconstrainedVertices.length === 0 ||
+            desiredUnconstrainedVertices[0][0] == null
+        ) {
+            return null;
+        }
+
+        let desiredNumericalVertices = desiredUnconstrainedVertices.map(
+            (vertex) => vertex.map((v) => v.evaluate_to_constant()),
+        );
+        let resultingNumericalVertices =
+            await this.stateValues.numericalVertices;
+        let numVertices = await this.stateValues.numVertices;
+
+        let verticesChanged = [];
+        let numVerticesChanged = 0;
+        let tol = 1e-6;
+
+        for (let [ind, vrtx] of desiredNumericalVertices.entries()) {
+            if (
+                !vrtx.every(
+                    (v, i) =>
+                        Math.abs(v - resultingNumericalVertices[ind][i]) < tol,
+                )
+            ) {
+                verticesChanged.push(ind);
+                numVerticesChanged++;
+            }
+        }
+
+        if (!(numVerticesChanged > 0 && numVerticesChanged < numVertices)) {
+            return null;
+        }
+
+        // A subset of points were altered from the requested location.
+        // Check to see if the relationship among them is preserved
+        let changedInd1 = verticesChanged[0];
+        let relationshipPreserved = true;
+
+        let orig1 = desiredNumericalVertices[changedInd1];
+        let changed1 = resultingNumericalVertices[changedInd1];
+        let changevec1 = orig1.map((v, i) => v - changed1[i]);
+
+        if (numVerticesChanged > 1) {
+            for (let ind of verticesChanged.slice(1)) {
+                let orig2 = desiredNumericalVertices[ind];
+                let changed2 = resultingNumericalVertices[ind];
+                let changevec2 = orig2.map((v, i) => v - changed2[i]);
+
+                if (
+                    !changevec1.every(
+                        (v, i) => Math.abs(v - changevec2[i]) < tol,
+                    )
+                ) {
+                    relationshipPreserved = false;
+                    break;
+                }
+            }
+        }
+
+        if (!relationshipPreserved) {
+            return null;
+        }
+
+        // All the vertices that were altered from their requested location
+        // were altered in a way consistent with a rigid translation.
+        // Attempt to move the remaining vertices to achieve a rigid translation
+        // of the whole polyline.
+        let newNumericalVertices = [];
+
+        for (let i = 0; i < numVertices; i++) {
+            if (verticesChanged.includes(i)) {
+                newNumericalVertices.push(resultingNumericalVertices[i]);
+            } else {
+                newNumericalVertices.push(
+                    desiredNumericalVertices[i].map(
+                        (v, j) => v - changevec1[j],
+                    ),
+                );
+            }
+        }
+
+        let newVertexComponents = {};
+        for (let ind in newNumericalVertices) {
+            newVertexComponents[ind + ",0"] = me.fromAst(
+                newNumericalVertices[ind][0],
+            );
+            newVertexComponents[ind + ",1"] = me.fromAst(
+                newNumericalVertices[ind][1],
+            );
+        }
+
+        return await this.coreFunctions.performUpdate({
+            updateInstructions: [
+                {
+                    updateType: "updateValue",
+                    componentIdx: this.componentIdx,
+                    stateVariable: "unconstrainedVertices",
+                    value: newVertexComponents,
+                },
+            ],
+            transient,
+            actionId,
+            sourceInformation,
+            skipRendererUpdate,
+        });
+    }
+
+    async movePolylineCenter({
+        center,
+        transient,
+        skippable,
+        sourceDetails,
+        actionId,
+        sourceInformation = {},
+        skipRendererUpdate = false,
+    }) {
+        if (!(await this.stateValues.draggable)) {
+            return;
+        }
+
+        if (!Array.isArray(center) || center.length < 2) {
+            return;
+        }
+
+        let updateInstructions = [
+            {
+                updateType: "updateValue",
+                componentIdx: this.componentIdx,
+                stateVariable: "center",
+                value: center.map((x) => me.fromAst(x)),
+                sourceDetails,
+            },
+        ];
+
+        // Note: we set skipRendererUpdate to true
+        // so that renderer updates are consolidated at the end of the action.
+        if (transient) {
+            await this.coreFunctions.performUpdate({
+                updateInstructions,
+                transient,
+                skippable,
+                actionId,
+                sourceInformation,
+                skipRendererUpdate: true,
+            });
+        } else {
+            await this.coreFunctions.performUpdate({
+                updateInstructions,
+                actionId,
+                sourceInformation,
+                skipRendererUpdate: true,
+                event: {
+                    verb: "interacted",
+                    object: {
+                        componentIdx: this.componentIdx,
+                        componentType: this.componentType,
+                    },
+                    result: {
+                        center,
+                    },
+                },
+            });
+        }
+
+        // Attempt to preserve rigid translation when constraints alter
+        // a subset of vertices during a center move.
+        let reconciliationResult =
+            await this._attemptConstrainedRigidTranslationReconciliation({
+                transient,
+                actionId,
+                sourceInformation,
+                skipRendererUpdate,
+            });
+
+        if (reconciliationResult !== null) {
+            return reconciliationResult;
+        }
+
+        return await this.coreFunctions.updateRenderers({
+            actionId,
+            sourceInformation,
+            skipRendererUpdate,
+        });
     }
 
     async movePolyline({
@@ -2099,113 +2403,22 @@ export default class Polyline extends GraphicalComponent {
         // when the whole polyline is moved or preserveSimilarity is true.
         // This procedure may preserve the rigid/similarity transformation
         // even if a subset of the vertices are constrained.
-        // Note: If desiredUnconstrainedVertices has null components, then the original update was not successful.
-        let desiredUnconstrainedVertices =
-            await this.stateValues.desiredUnconstrainedVertices;
+        // Note: If desiredUnconstrainedVertices has null components,
+        // then the original update was not successful.
         if (
-            (numVerticesMoved > 1 ||
-                (await this.stateValues.preserveSimilarity)) &&
-            desiredUnconstrainedVertices[0][0] != null
+            numVerticesMoved > 1 ||
+            (await this.stateValues.preserveSimilarity)
         ) {
-            let desiredNumericalVertices = desiredUnconstrainedVertices.map(
-                (vertex) => vertex.map((v) => v.evaluate_to_constant()),
-            );
-            let resultingNumericalVertices =
-                await this.stateValues.numericalVertices;
-            let numVertices = await this.stateValues.numVertices;
+            let reconciliationResult =
+                await this._attemptConstrainedRigidTranslationReconciliation({
+                    transient,
+                    actionId,
+                    sourceInformation,
+                    skipRendererUpdate,
+                });
 
-            let verticesChanged = [];
-            let numVerticesChanged = 0;
-            let tol = 1e-6;
-
-            for (let [ind, vrtx] of desiredNumericalVertices.entries()) {
-                if (
-                    !vrtx.every(
-                        (v, i) =>
-                            Math.abs(v - resultingNumericalVertices[ind][i]) <
-                            tol,
-                    )
-                ) {
-                    verticesChanged.push(ind);
-                    numVerticesChanged++;
-                }
-            }
-
-            if (numVerticesChanged > 0 && numVerticesChanged < numVertices) {
-                // A subset of points were altered from the requested location.
-                // Check to see if the relationship among them is preserved
-
-                let changedInd1 = verticesChanged[0];
-                let relationshipPreserved = true;
-
-                let orig1 = desiredNumericalVertices[changedInd1];
-                let changed1 = resultingNumericalVertices[changedInd1];
-                let changevec1 = orig1.map((v, i) => v - changed1[i]);
-
-                if (numVerticesChanged > 1) {
-                    for (let ind of verticesChanged.slice(1)) {
-                        let orig2 = desiredNumericalVertices[ind];
-                        let changed2 = resultingNumericalVertices[ind];
-                        let changevec2 = orig2.map((v, i) => v - changed2[i]);
-
-                        if (
-                            !changevec1.every(
-                                (v, i) => Math.abs(v - changevec2[i]) < tol,
-                            )
-                        ) {
-                            relationshipPreserved = false;
-                            break;
-                        }
-                    }
-                }
-
-                if (relationshipPreserved) {
-                    // All the vertices that were altered from their requested location
-                    // were altered in a way consistent with a rigid translation.
-                    // Attempt to move the remaining vertices to achieve a rigid translation
-                    // of the whole polyline.
-                    let newNumericalVertices = [];
-
-                    for (let i = 0; i < numVertices; i++) {
-                        if (verticesChanged.includes(i)) {
-                            newNumericalVertices.push(
-                                resultingNumericalVertices[i],
-                            );
-                        } else {
-                            newNumericalVertices.push(
-                                desiredNumericalVertices[i].map(
-                                    (v, j) => v - changevec1[j],
-                                ),
-                            );
-                        }
-                    }
-
-                    let newVertexComponents = {};
-                    for (let ind in newNumericalVertices) {
-                        newVertexComponents[ind + ",0"] = me.fromAst(
-                            newNumericalVertices[ind][0],
-                        );
-                        newVertexComponents[ind + ",1"] = me.fromAst(
-                            newNumericalVertices[ind][1],
-                        );
-                    }
-
-                    let newInstructions = [
-                        {
-                            updateType: "updateValue",
-                            componentIdx: this.componentIdx,
-                            stateVariable: "unconstrainedVertices",
-                            value: newVertexComponents,
-                        },
-                    ];
-                    return await this.coreFunctions.performUpdate({
-                        updateInstructions: newInstructions,
-                        transient,
-                        actionId,
-                        sourceInformation,
-                        skipRendererUpdate,
-                    });
-                }
+            if (reconciliationResult !== null) {
+                return reconciliationResult;
             }
         }
 

--- a/packages/doenetml-worker-javascript/src/components/Polyline.js
+++ b/packages/doenetml-worker-javascript/src/components/Polyline.js
@@ -1998,8 +1998,15 @@ export default class Polyline extends GraphicalComponent {
                 },
             },
 
-            returnArraySizeDependencies: () => ({}),
-            returnArraySize: () => [2],
+            returnArraySizeDependencies: () => ({
+                numDimensions: {
+                    dependencyType: "stateVariable",
+                    variableName: "numDimensions",
+                },
+            }),
+            returnArraySize({ dependencyValues }) {
+                return [dependencyValues.numDimensions];
+            },
 
             returnArrayDependenciesByKey() {
                 let globalDependencies = {
@@ -2234,12 +2241,11 @@ export default class Polyline extends GraphicalComponent {
 
         let newVertexComponents = {};
         for (let ind in newNumericalVertices) {
-            newVertexComponents[ind + ",0"] = me.fromAst(
-                newNumericalVertices[ind][0],
-            );
-            newVertexComponents[ind + ",1"] = me.fromAst(
-                newNumericalVertices[ind][1],
-            );
+            for (let dim = 0; dim < newNumericalVertices[ind].length; dim++) {
+                newVertexComponents[`${ind},${dim}`] = me.fromAst(
+                    newNumericalVertices[ind][dim],
+                );
+            }
         }
 
         return await this.coreFunctions.performUpdate({
@@ -2272,8 +2278,10 @@ export default class Polyline extends GraphicalComponent {
             return;
         }
 
-        // Center must be a 2D array
-        if (!Array.isArray(center) || center.length < 2) {
+        let numDimensions = await this.stateValues.numDimensions;
+
+        // Center must match the polyline dimensionality exactly.
+        if (!Array.isArray(center) || center.length !== numDimensions) {
             return;
         }
 

--- a/packages/doenetml-worker-javascript/src/components/Polyline.js
+++ b/packages/doenetml-worker-javascript/src/components/Polyline.js
@@ -2148,6 +2148,17 @@ export default class Polyline extends GraphicalComponent {
         return stateVariableDefinitions;
     }
 
+    /**
+     * After a move action has been applied, checks whether constraints caused
+     * a strict subset of vertices to land at positions other than the ones
+     * requested.  If so, and if all displaced vertices share the same
+     * translational offset (i.e. the displacement is a rigid translation),
+     * the remaining (unconstrained) vertices are adjusted by that same offset
+     * so the polyline moves as a rigid body.
+     *
+     * Returns the result of the follow-up `performUpdate` call when a
+     * correction was applied, or `null` when no correction was needed.
+     */
     async _attemptConstrainedRigidTranslationReconciliation({
         transient,
         actionId,

--- a/packages/doenetml-worker-javascript/src/components/Polyline.js
+++ b/packages/doenetml-worker-javascript/src/components/Polyline.js
@@ -2028,7 +2028,8 @@ export default class Polyline extends GraphicalComponent {
                         continue;
                     }
 
-                    let centerComponent = globalDependencyValues.vertices[0][dim];
+                    let centerComponent =
+                        globalDependencyValues.vertices[0][dim];
 
                     for (let pointInd = 1; pointInd < numVertices; pointInd++) {
                         centerComponent = centerComponent.add(
@@ -2036,7 +2037,9 @@ export default class Polyline extends GraphicalComponent {
                         );
                     }
 
-                    center[arrayKey] = centerComponent.divide(numVertices).simplify();
+                    center[arrayKey] = centerComponent
+                        .divide(numVertices)
+                        .simplify();
                 }
 
                 return { setValue: { center } };
@@ -2049,7 +2052,9 @@ export default class Polyline extends GraphicalComponent {
             }) {
                 let center = await stateValues.center;
 
-                let desiredVertices = globalDependencyValues.vertices.map((v) => [...v]);
+                let desiredVertices = globalDependencyValues.vertices.map(
+                    (v) => [...v],
+                );
 
                 for (let arrayKey in desiredStateVariableValues.center) {
                     let dim = Number(arrayKey);
@@ -2058,8 +2063,14 @@ export default class Polyline extends GraphicalComponent {
                         .subtract(center[dim])
                         .simplify();
 
-                    for (let pointInd = 0; pointInd < desiredVertices.length; pointInd++) {
-                        desiredVertices[pointInd][dim] = desiredVertices[pointInd][dim]
+                    for (
+                        let pointInd = 0;
+                        pointInd < desiredVertices.length;
+                        pointInd++
+                    ) {
+                        desiredVertices[pointInd][dim] = desiredVertices[
+                            pointInd
+                        ][dim]
                             .add(offset)
                             .simplify();
                     }
@@ -2256,10 +2267,12 @@ export default class Polyline extends GraphicalComponent {
         sourceInformation = {},
         skipRendererUpdate = false,
     }) {
+        // Polyline must be draggable for center movement to work
         if (!(await this.stateValues.draggable)) {
             return;
         }
 
+        // Center must be a 2D array
         if (!Array.isArray(center) || center.length < 2) {
             return;
         }
@@ -2276,36 +2289,35 @@ export default class Polyline extends GraphicalComponent {
 
         // Note: we set skipRendererUpdate to true
         // so that renderer updates are consolidated at the end of the action.
+        const performUpdateArgs = {
+            updateInstructions,
+            actionId,
+            sourceInformation,
+            skipRendererUpdate: true,
+        };
+
         if (transient) {
-            await this.coreFunctions.performUpdate({
-                updateInstructions,
-                transient,
-                skippable,
-                actionId,
-                sourceInformation,
-                skipRendererUpdate: true,
-            });
+            performUpdateArgs.transient = true;
+            performUpdateArgs.skippable = skippable;
         } else {
-            await this.coreFunctions.performUpdate({
-                updateInstructions,
-                actionId,
-                sourceInformation,
-                skipRendererUpdate: true,
-                event: {
-                    verb: "interacted",
-                    object: {
-                        componentIdx: this.componentIdx,
-                        componentType: this.componentType,
-                    },
-                    result: {
-                        center,
-                    },
+            performUpdateArgs.event = {
+                verb: "interacted",
+                object: {
+                    componentIdx: this.componentIdx,
+                    componentType: this.componentType,
                 },
-            });
+                result: {
+                    center,
+                },
+            };
         }
+
+        await this.coreFunctions.performUpdate(performUpdateArgs);
 
         // Attempt to preserve rigid translation when constraints alter
         // a subset of vertices during a center move.
+        // E.g., if moving center causes some vertices to snap to a grid,
+        // we adjust other vertices to maintain the translation offset.
         let reconciliationResult =
             await this._attemptConstrainedRigidTranslationReconciliation({
                 transient,

--- a/packages/doenetml-worker-javascript/src/components/Triangle.js
+++ b/packages/doenetml-worker-javascript/src/components/Triangle.js
@@ -2,8 +2,20 @@ import Polygon from "./Polygon";
 import me from "math-expressions";
 
 export default class Triangle extends Polygon {
+    constructor(args) {
+        super(args);
+
+        Object.assign(this.actions, {
+            moveTriangleCenter: this.moveTriangleCenter.bind(this),
+        });
+    }
+
     static componentType = "triangle";
     static rendererType = "polygon";
+
+    get moveTriangleCenter() {
+        return this.movePolygonCenter;
+    }
 
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();

--- a/packages/doenetml-worker-javascript/src/components/Triangle.js
+++ b/packages/doenetml-worker-javascript/src/components/Triangle.js
@@ -13,6 +13,10 @@ export default class Triangle extends Polygon {
     static componentType = "triangle";
     static rendererType = "polygon";
 
+    /**
+     * Delegates to parent Polygon's movePolygonCenter action.
+     * Provides triangle-specific naming for semantic clarity.
+     */
     get moveTriangleCenter() {
         return this.movePolygonCenter;
     }

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/polygonTriangleCenter.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/polygonTriangleCenter.test.ts
@@ -5,7 +5,7 @@ const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);
 vi.mock("hyperformula");
 
-async function getPolygonVerticesAndCenter(core: any, componentIdx: number) {
+async function getShapeVerticesAndCenter(core: any, componentIdx: number) {
     const stateVariables = await core.returnAllStateVariables(false, true);
     const polygonState = stateVariables[componentIdx].stateValues;
 
@@ -29,10 +29,7 @@ describe("Polyline/Polygon/Triangle center actions @group2", async () => {
 
         const plIdx = await resolvePathToNodeIdx("pl");
 
-        let { vertices, center } = await getPolygonVerticesAndCenter(
-            core,
-            plIdx,
-        );
+        let { vertices, center } = await getShapeVerticesAndCenter(core, plIdx);
         expect(vertices).eqls([
             [0, 0, 0],
             [4, 0, 2],
@@ -45,7 +42,7 @@ describe("Polyline/Polygon/Triangle center actions @group2", async () => {
             args: { center: [5, 3, 7] },
         });
 
-        ({ vertices, center } = await getPolygonVerticesAndCenter(core, plIdx));
+        ({ vertices, center } = await getShapeVerticesAndCenter(core, plIdx));
         expect(vertices).eqls([
             [3, 3, 6],
             [7, 3, 8],
@@ -68,7 +65,7 @@ describe("Polyline/Polygon/Triangle center actions @group2", async () => {
         const sourceIdx = await resolvePathToNodeIdx("g1.pg");
         const copyIdx = await resolvePathToNodeIdx("g2.pg");
 
-        let { vertices, center } = await getPolygonVerticesAndCenter(
+        let { vertices, center } = await getShapeVerticesAndCenter(
             core,
             sourceIdx,
         );
@@ -87,7 +84,7 @@ describe("Polyline/Polygon/Triangle center actions @group2", async () => {
             args: { center: [5, -3] },
         });
 
-        ({ vertices, center } = await getPolygonVerticesAndCenter(
+        ({ vertices, center } = await getShapeVerticesAndCenter(
             core,
             sourceIdx,
         ));
@@ -99,7 +96,7 @@ describe("Polyline/Polygon/Triangle center actions @group2", async () => {
         ]);
         expect(center).eqls([5, -3]);
 
-        const copied = await getPolygonVerticesAndCenter(core, copyIdx);
+        const copied = await getShapeVerticesAndCenter(core, copyIdx);
         expect(copied.vertices).eqls(vertices);
         expect(copied.center).eqls(center);
     });
@@ -121,7 +118,7 @@ describe("Polyline/Polygon/Triangle center actions @group2", async () => {
             args: { center: [5, -3, 99] },
         });
 
-        const { vertices, center } = await getPolygonVerticesAndCenter(
+        const { vertices, center } = await getShapeVerticesAndCenter(
             core,
             pgIdx,
         );
@@ -145,7 +142,7 @@ describe("Polyline/Polygon/Triangle center actions @group2", async () => {
         });
 
         const pgIdx = await resolvePathToNodeIdx("pg");
-        const { polygonState } = await getPolygonVerticesAndCenter(core, pgIdx);
+        const { polygonState } = await getShapeVerticesAndCenter(core, pgIdx);
 
         expect(JSON.stringify(polygonState.center[0].tree)).contain("a");
         expect(polygonState.center[1].evaluate_to_constant()).closeTo(
@@ -165,7 +162,7 @@ describe("Polyline/Polygon/Triangle center actions @group2", async () => {
 
         const triIdx = await resolvePathToNodeIdx("tri");
 
-        let { vertices, center } = await getPolygonVerticesAndCenter(
+        let { vertices, center } = await getShapeVerticesAndCenter(
             core,
             triIdx,
         );
@@ -182,10 +179,7 @@ describe("Polyline/Polygon/Triangle center actions @group2", async () => {
             args: { center: [4, 5] },
         });
 
-        ({ vertices, center } = await getPolygonVerticesAndCenter(
-            core,
-            triIdx,
-        ));
+        ({ vertices, center } = await getShapeVerticesAndCenter(core, triIdx));
         expect(vertices).eqls([
             [2, 4],
             [8, 4],
@@ -211,10 +205,7 @@ describe("Polyline/Polygon/Triangle center actions @group2", async () => {
 
         const pgIdx = await resolvePathToNodeIdx("pg");
 
-        let { vertices, center } = await getPolygonVerticesAndCenter(
-            core,
-            pgIdx,
-        );
+        let { vertices, center } = await getShapeVerticesAndCenter(core, pgIdx);
         expect(vertices).eqls([
             [3, 5],
             [-4, -1],
@@ -229,7 +220,7 @@ describe("Polyline/Polygon/Triangle center actions @group2", async () => {
             args: { center: [4.5, 6] },
         });
 
-        ({ vertices, center } = await getPolygonVerticesAndCenter(core, pgIdx));
+        ({ vertices, center } = await getShapeVerticesAndCenter(core, pgIdx));
         // Constrained vertex snaps to the grid, so the rigid-translation correction
         // applies the same adjusted offset to the other vertices.
         expect(vertices).eqls([

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/polygonTriangleCenter.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/polygonTriangleCenter.test.ts
@@ -17,7 +17,42 @@ async function getPolygonVerticesAndCenter(core: any, componentIdx: number) {
     return { vertices, center, polygonState };
 }
 
-describe("Polygon/Triangle center actions @group2", async () => {
+describe("Polyline/Polygon/Triangle center actions @group2", async () => {
+    it("polyline center matches dimensionality and translates all coordinates", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <graph>
+    <polyline name="pl" vertices="(0,0,0) (4,0,2)" />
+  </graph>
+  `,
+        });
+
+        const plIdx = await resolvePathToNodeIdx("pl");
+
+        let { vertices, center } = await getPolygonVerticesAndCenter(
+            core,
+            plIdx,
+        );
+        expect(vertices).eqls([
+            [0, 0, 0],
+            [4, 0, 2],
+        ]);
+        expect(center).eqls([2, 0, 1]);
+
+        await core.requestAction({
+            componentIdx: plIdx,
+            actionName: "movePolylineCenter",
+            args: { center: [5, 3, 7] },
+        });
+
+        ({ vertices, center } = await getPolygonVerticesAndCenter(core, plIdx));
+        expect(vertices).eqls([
+            [3, 3, 6],
+            [7, 3, 8],
+        ]);
+        expect(center).eqls([5, 3, 7]);
+    });
+
     it("polygon has center and movePolygonCenter translates vertices", async () => {
         const { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
@@ -67,6 +102,36 @@ describe("Polygon/Triangle center actions @group2", async () => {
         const copied = await getPolygonVerticesAndCenter(core, copyIdx);
         expect(copied.vertices).eqls(vertices);
         expect(copied.center).eqls(center);
+    });
+
+    it("movePolygonCenter ignores malformed center payloads", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <graph>
+    <polygon name="pg" vertices="(0,0) (4,0) (4,2) (0,2)" />
+  </graph>
+  `,
+        });
+
+        const pgIdx = await resolvePathToNodeIdx("pg");
+
+        await core.requestAction({
+            componentIdx: pgIdx,
+            actionName: "movePolygonCenter",
+            args: { center: [5, -3, 99] },
+        });
+
+        const { vertices, center } = await getPolygonVerticesAndCenter(
+            core,
+            pgIdx,
+        );
+        expect(vertices).eqls([
+            [0, 0],
+            [4, 0],
+            [4, 2],
+            [0, 2],
+        ]);
+        expect(center).eqls([2, 1]);
     });
 
     it("polygon center remains symbolic when vertices are symbolic", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/polygonTriangleCenter.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/polygonTriangleCenter.test.ts
@@ -128,4 +128,51 @@ describe("Polygon/Triangle center actions @group2", async () => {
         ]);
         expect(center).eqls([4, 5]);
     });
+
+    it("movePolygonCenter preserves rigid translation with constrained vertices", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <graph>
+    <point>(3,5)</point>
+    <point>(-4,-1)</point>
+    <point>(5,2)
+      <constrainToGrid dx="3" dy="4" />
+    </point>
+    <point>(-3,4)</point>
+    <polygon vertices="$_point1 $_point2 $_point3 $_point4" name="pg" />
+  </graph>
+  `,
+        });
+
+        const pgIdx = await resolvePathToNodeIdx("pg");
+
+        let { vertices, center } = await getPolygonVerticesAndCenter(
+            core,
+            pgIdx,
+        );
+        expect(vertices).eqls([
+            [3, 5],
+            [-4, -1],
+            [6, 4],
+            [-3, 4],
+        ]);
+        expect(center).eqls([0.5, 3]);
+
+        await core.requestAction({
+            componentIdx: pgIdx,
+            actionName: "movePolygonCenter",
+            args: { center: [4.5, 6] },
+        });
+
+        ({ vertices, center } = await getPolygonVerticesAndCenter(core, pgIdx));
+        // Constrained vertex snaps to the grid, so the rigid-translation correction
+        // applies the same adjusted offset to the other vertices.
+        expect(vertices).eqls([
+            [6, 9],
+            [-1, 3],
+            [9, 8],
+            [0, 8],
+        ]);
+        expect(center).eqls([3.5, 7]);
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/polygonTriangleCenter.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/polygonTriangleCenter.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestCore } from "../utils/test-core";
+
+const Mock = vi.fn();
+vi.stubGlobal("postMessage", Mock);
+vi.mock("hyperformula");
+
+async function getPolygonVerticesAndCenter(core: any, componentIdx: number) {
+    const stateVariables = await core.returnAllStateVariables(false, true);
+    const polygonState = stateVariables[componentIdx].stateValues;
+
+    const vertices = polygonState.vertices.map((vertex: any[]) =>
+        vertex.map((x) => x.evaluate_to_constant()),
+    );
+    const center = polygonState.center.map((x) => x.evaluate_to_constant());
+
+    return { vertices, center, polygonState };
+}
+
+describe("Polygon/Triangle center actions @group2", async () => {
+    it("polygon has center and movePolygonCenter translates vertices", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <graph name="g1">
+    <polygon name="pg" vertices="(0,0) (4,0) (4,2) (0,2)" />
+  </graph>
+  <graph name="g2">
+    <polygon extend="$g1.pg" name="pg" />
+  </graph>
+  `,
+        });
+
+        const sourceIdx = await resolvePathToNodeIdx("g1.pg");
+        const copyIdx = await resolvePathToNodeIdx("g2.pg");
+
+        let { vertices, center } = await getPolygonVerticesAndCenter(
+            core,
+            sourceIdx,
+        );
+
+        expect(vertices).eqls([
+            [0, 0],
+            [4, 0],
+            [4, 2],
+            [0, 2],
+        ]);
+        expect(center).eqls([2, 1]);
+
+        await core.requestAction({
+            componentIdx: sourceIdx,
+            actionName: "movePolygonCenter",
+            args: { center: [5, -3] },
+        });
+
+        ({ vertices, center } = await getPolygonVerticesAndCenter(
+            core,
+            sourceIdx,
+        ));
+        expect(vertices).eqls([
+            [3, -4],
+            [7, -4],
+            [7, -2],
+            [3, -2],
+        ]);
+        expect(center).eqls([5, -3]);
+
+        const copied = await getPolygonVerticesAndCenter(core, copyIdx);
+        expect(copied.vertices).eqls(vertices);
+        expect(copied.center).eqls(center);
+    });
+
+    it("polygon center remains symbolic when vertices are symbolic", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <math name="a">a</math>
+  <graph>
+    <polygon name="pg" vertices="($a,0) (2,2) (4,0)" />
+  </graph>
+  `,
+        });
+
+        const pgIdx = await resolvePathToNodeIdx("pg");
+        const { polygonState } = await getPolygonVerticesAndCenter(core, pgIdx);
+
+        expect(JSON.stringify(polygonState.center[0].tree)).contain("a");
+        expect(polygonState.center[1].evaluate_to_constant()).closeTo(
+            2 / 3,
+            1e-12,
+        );
+    });
+
+    it("moveTriangleCenter updates triangle center and vertices", async () => {
+        const { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+  <graph>
+    <triangle name="tri" vertices="(0,0) (6,0) (0,3)" />
+  </graph>
+  `,
+        });
+
+        const triIdx = await resolvePathToNodeIdx("tri");
+
+        let { vertices, center } = await getPolygonVerticesAndCenter(
+            core,
+            triIdx,
+        );
+        expect(vertices).eqls([
+            [0, 0],
+            [6, 0],
+            [0, 3],
+        ]);
+        expect(center).eqls([2, 1]);
+
+        await core.requestAction({
+            componentIdx: triIdx,
+            actionName: "moveTriangleCenter",
+            args: { center: [4, 5] },
+        });
+
+        ({ vertices, center } = await getPolygonVerticesAndCenter(
+            core,
+            triIdx,
+        ));
+        expect(vertices).eqls([
+            [2, 4],
+            [8, 4],
+            [2, 7],
+        ]);
+        expect(center).eqls([4, 5]);
+    });
+});


### PR DESCRIPTION
## Summary
- add a public renderer-facing `center` state variable to `Polyline` with symbolic average-of-vertices definition for shared polygon/triangle behavior
- add a shared `movePolylineCenter` action in the polyline base and delegate `movePolygonCenter`/`moveTriangleCenter` to that implementation
- preserve rigid translation when center moves interact with partially constrained vertices via shared reconciliation logic
- add worker tests for polygon/triangle center behavior, symbolic center handling, and constrained center-driven translation
- add changeset for published packages where this user-visible behavior appears

## Validation
- `npm run test -w @doenet/doenetml-worker-javascript -- --run src/test/tagSpecific/polyline.test.ts`
- `npm run test -w @doenet/doenetml-worker-javascript -- --run src/test/tagSpecific/polygonTriangleCenter.test.ts`
- `npm run test -w @doenet/doenetml-worker-javascript -- --run src/test/tagSpecific/polygon.test.ts`
- `npm run test -w @doenet/doenetml-worker-javascript -- --run src/test/tagSpecific/triangle.test.ts`
