### PR TITLE
Add consumeChanges support for dependency reads and fix polygon center move regressions

### DIFF
--- a/.changeset/consume-changes-regular-polygon-center.md
+++ b/.changeset/consume-changes-regular-polygon-center.md
@@ -1,0 +1,7 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Fix a graph controls regression affecting consecutive regularPolygon center moves. Dependency change flags are now handled so inverse-definition reads can avoid consuming changes during argument construction while still clearing stale flags afterward, preventing stale dependency state from interfering with follow-up center moves and restore-state flows.

--- a/.changeset/consume-changes-regular-polygon-center.md
+++ b/.changeset/consume-changes-regular-polygon-center.md
@@ -4,4 +4,4 @@
 "@doenet/doenetml-iframe": patch
 ---
 
-Fix a graph controls regression affecting consecutive regularPolygon center moves. Dependency change flags are now handled so inverse-definition reads can avoid consuming changes during argument construction while still clearing stale flags afterward, preventing stale dependency state from interfering with follow-up center moves and restore-state flows.
+Fix a graph controls regression that affected consecutive regularPolygon center moves. Dependency change flags are now preserved during inverse-definition argument construction and then consumed afterward to prevent stale flags from affecting follow-up center moves and restore-state flows.

--- a/packages/doenetml-worker-javascript/src/Core.js
+++ b/packages/doenetml-worker-javascript/src/Core.js
@@ -8082,6 +8082,7 @@ export default class Core {
         component,
         stateVariable,
         excludeDependencyValues,
+        consumeChanges = true,
     }) {
         // console.log(`get state variable dependencies of ${component.componentIdx}, ${stateVariable}`)
 
@@ -8092,6 +8093,7 @@ export default class Core {
             args = await this.dependencies.getStateVariableDependencyValues({
                 component,
                 stateVariable,
+                consumeChanges,
             });
         }
 
@@ -12478,6 +12480,7 @@ export default class Core {
                 stateVariable,
                 excludeDependencyValues:
                     stateVarObj.excludeDependencyValuesInInverseDefinition,
+                consumeChanges: false,
             });
         inverseDefinitionArgs.componentInfoObjects = this.componentInfoObjects;
         inverseDefinitionArgs.initialChange = initialChange;
@@ -12668,6 +12671,16 @@ export default class Core {
         let inverseResult = await stateVarObj.inverseDefinition(
             inverseDefinitionArgs,
         );
+
+        // Clear any change flags that were set during the inverse definition call
+        // This ensures stale flags don't accumulate, even though we didn't consume during the call
+        if (!stateVarObj.excludeDependencyValuesInInverseDefinition) {
+            await this.dependencies.getStateVariableDependencyValues({
+                component,
+                stateVariable,
+                consumeChanges: true,
+            });
+        }
 
         if (inverseResult.sendDiagnostics) {
             for (const diagnostic of inverseResult.sendDiagnostics) {

--- a/packages/doenetml-worker-javascript/src/Core.js
+++ b/packages/doenetml-worker-javascript/src/Core.js
@@ -8078,6 +8078,11 @@ export default class Core {
         return await stateVarObj.value;
     }
 
+    /**
+     * Build definition/inverse-definition args for a state variable.
+     * When consumeChanges is false, dependency change flags are observed but preserved
+     * for a later consuming read.
+     */
     async getStateVariableDefinitionArguments({
         component,
         stateVariable,

--- a/packages/doenetml-worker-javascript/src/Dependencies.js
+++ b/packages/doenetml-worker-javascript/src/Dependencies.js
@@ -3325,6 +3325,14 @@ class Dependency {
 
     deleteFromUpdateTriggers() {}
 
+    async getValueNoProxy({ verbose = false, consumeChanges = true } = {}) {
+        return await Dependency.prototype.getValue.call(this, {
+            verbose,
+            skipProxy: true,
+            consumeChanges,
+        });
+    }
+
     /**
      * Return current dependency value, change metadata, and used-default metadata.
      * When consumeChanges is false, this method reports current change flags without
@@ -4980,9 +4988,8 @@ class AttributeComponentDependency extends Dependency {
     }
 
     async getValue({ verbose, consumeChanges = true } = {}) {
-        let result = await super.getValue({
+        let result = await this.getValueNoProxy({
             verbose,
-            skipProxy: true,
             consumeChanges,
         });
 
@@ -5495,9 +5502,8 @@ class ChildDependency extends Dependency {
     }
 
     async getValue({ verbose, consumeChanges = true } = {}) {
-        let result = await super.getValue({
+        let result = await this.getValueNoProxy({
             verbose,
-            skipProxy: true,
             consumeChanges,
         });
 
@@ -7003,9 +7009,8 @@ class ReplacementDependency extends Dependency {
     }
 
     async getValue({ verbose, consumeChanges = true } = {}) {
-        let result = await super.getValue({
+        let result = await this.getValueNoProxy({
             verbose,
-            skipProxy: true,
             consumeChanges,
         });
 

--- a/packages/doenetml-worker-javascript/src/Dependencies.js
+++ b/packages/doenetml-worker-javascript/src/Dependencies.js
@@ -11,6 +11,10 @@ import {
 
 const dependencyTypeArray = [];
 
+function cloneChangeMetadataIfNeeded({ changeMetadata, consumeChanges }) {
+    return consumeChanges ? changeMetadata : deepClone(changeMetadata);
+}
+
 export class DependencyHandler {
     constructor({ _components, componentInfoObjects, core }) {
         this.upstreamDependencies = {};
@@ -3431,7 +3435,10 @@ class Dependency {
                                     }
                                     changes.valuesChanged[componentInd][
                                         nameForOutput
-                                    ] = valueChanged;
+                                    ] = cloneChangeMetadataIfNeeded({
+                                        changeMetadata: valueChanged,
+                                        consumeChanges,
+                                    });
                                 }
                                 if (consumeChanges) {
                                     this.valuesChanged[componentInd][
@@ -4240,7 +4247,10 @@ class StateVariableComponentTypeDependency extends StateVariableDependency {
                                 changes.valuesChanged[0] = {};
                             }
                             changes.valuesChanged[0][nameForOutput] =
-                                valueChanged0;
+                                cloneChangeMetadataIfNeeded({
+                                    changeMetadata: valueChanged0,
+                                    consumeChanges,
+                                });
                         }
                         if (consumeChanges) {
                             this.valuesChanged[0][mappedVarName] = {};

--- a/packages/doenetml-worker-javascript/src/Dependencies.js
+++ b/packages/doenetml-worker-javascript/src/Dependencies.js
@@ -1000,7 +1000,11 @@ export class DependencyHandler {
         return variablesChanged;
     }
 
-    async getStateVariableDependencyValues({ component, stateVariable }) {
+    async getStateVariableDependencyValues({
+        component,
+        stateVariable,
+        consumeChanges = true,
+    }) {
         let dependencyValues = {};
         let dependencyChanges = {};
         let dependencyUsedDefault = {};
@@ -1015,7 +1019,9 @@ export class DependencyHandler {
                 continue;
             }
 
-            let { value, changes, usedDefault } = await dep.getValue();
+            let { value, changes, usedDefault } = await dep.getValue({
+                consumeChanges,
+            });
 
             dependencyValues[dependencyName] = value;
             if (Object.keys(changes).length > 0) {
@@ -3314,14 +3320,20 @@ class Dependency {
 
     deleteFromUpdateTriggers() {}
 
-    async getValue({ verbose = false, skipProxy = false } = {}) {
+    async getValue({
+        verbose = false,
+        skipProxy = false,
+        consumeChanges = true,
+    } = {}) {
         let value = [];
         let changes = {};
         let usedDefault = [];
 
         if (this.componentIdentitiesChanged) {
             changes.componentIdentitiesChanged = true;
-            this.componentIdentitiesChanged = false;
+            if (consumeChanges) {
+                this.componentIdentitiesChanged = false;
+            }
         }
 
         for (let [
@@ -3387,11 +3399,11 @@ class Dependency {
                             if (!mappedStateVarObj.deferred) {
                                 componentObj.stateValues[nameForOutput] =
                                     await mappedStateVarObj.value;
-                                if (
+                                let valueChanged =
                                     this.valuesChanged[componentInd][
                                         mappedVarName
-                                    ].changed
-                                ) {
+                                    ];
+                                if (valueChanged.changed) {
                                     if (!changes.valuesChanged) {
                                         changes.valuesChanged = {};
                                     }
@@ -3401,14 +3413,13 @@ class Dependency {
                                     }
                                     changes.valuesChanged[componentInd][
                                         nameForOutput
-                                    ] =
-                                        this.valuesChanged[componentInd][
-                                            mappedVarName
-                                        ];
+                                    ] = valueChanged;
                                 }
-                                this.valuesChanged[componentInd][
-                                    mappedVarName
-                                ] = {};
+                                if (consumeChanges) {
+                                    this.valuesChanged[componentInd][
+                                        mappedVarName
+                                    ] = {};
+                                }
 
                                 if (mappedStateVarObj.usedDefault) {
                                     usedDefaultObj[nameForOutput] = true;
@@ -4139,7 +4150,7 @@ dependencyTypeArray.push(MultipleStateVariablesDependency);
 class StateVariableComponentTypeDependency extends StateVariableDependency {
     static dependencyType = "stateVariableComponentType";
 
-    async getValue({ verbose = false } = {}) {
+    async getValue({ verbose = false, consumeChanges = true } = {}) {
         let value = [];
         let changes = {};
 
@@ -4148,7 +4159,9 @@ class StateVariableComponentTypeDependency extends StateVariableDependency {
         } else {
             if (this.componentIdentitiesChanged) {
                 changes.componentIdentitiesChanged = true;
-                this.componentIdentitiesChanged = false;
+                if (consumeChanges) {
+                    this.componentIdentitiesChanged = false;
+                }
             }
 
             if (this.downstreamComponentIndices.length === 1) {
@@ -4199,7 +4212,9 @@ class StateVariableComponentTypeDependency extends StateVariableDependency {
                             }
                         }
 
-                        if (this.valuesChanged[0][mappedVarName].changed) {
+                        let valueChanged0 =
+                            this.valuesChanged[0][mappedVarName];
+                        if (valueChanged0.changed) {
                             if (!changes.valuesChanged) {
                                 changes.valuesChanged = {};
                             }
@@ -4207,9 +4222,11 @@ class StateVariableComponentTypeDependency extends StateVariableDependency {
                                 changes.valuesChanged[0] = {};
                             }
                             changes.valuesChanged[0][nameForOutput] =
-                                this.valuesChanged[0][mappedVarName];
+                                valueChanged0;
                         }
-                        this.valuesChanged[0][mappedVarName] = {};
+                        if (consumeChanges) {
+                            this.valuesChanged[0][mappedVarName] = {};
+                        }
 
                         let hasVariableComponentType =
                             stateVarObj.shadowingInstructions
@@ -4584,7 +4601,7 @@ class RecursiveDependencyValuesDependency extends Dependency {
         };
     }
 
-    async getValue() {
+    async getValue({ consumeChanges: consumeChanges = true } = {}) {
         this.gettingValue = true;
         this.varsWithUpdatedDeps = {};
 
@@ -4595,48 +4612,55 @@ class RecursiveDependencyValuesDependency extends Dependency {
 
         let changes = {};
 
-        while (foundNewUpdated) {
-            foundNewUpdated = false;
-            result = await super.getValue();
+        try {
+            while (foundNewUpdated) {
+                foundNewUpdated = false;
+                result = await super.getValue({
+                    consumeChanges: consumeChanges,
+                });
 
-            if (result.changes.valuesChanged) {
-                if (!changes.valuesChanged) {
-                    changes.valuesChanged = result.changes.valuesChanged;
-                } else {
-                    for (let ind in result.changes.valuesChanged) {
-                        let changeObj = result.changes.valuesChanged[ind];
-                        if (!changes.valuesChanged[ind]) {
-                            changes.valuesChanged[ind] = changeObj;
-                        } else {
-                            for (let depName in changeObj) {
-                                changes.valuesChanged[ind][depName] =
-                                    changeObj[depName];
+                if (result.changes.valuesChanged) {
+                    if (!changes.valuesChanged) {
+                        changes.valuesChanged = result.changes.valuesChanged;
+                    } else {
+                        for (let ind in result.changes.valuesChanged) {
+                            let changeObj = result.changes.valuesChanged[ind];
+                            if (!changes.valuesChanged[ind]) {
+                                changes.valuesChanged[ind] = changeObj;
+                            } else {
+                                for (let depName in changeObj) {
+                                    changes.valuesChanged[ind][depName] =
+                                        changeObj[depName];
+                                }
                             }
                         }
                     }
                 }
-            }
 
-            for (const cIdxStr in this.varsWithUpdatedDeps) {
-                let compAccumulated = accumulatedVarsWithUpdatedDeps[cIdxStr];
-                if (!compAccumulated) {
-                    compAccumulated = accumulatedVarsWithUpdatedDeps[cIdxStr] =
-                        [];
-                }
-                for (let vName of this.varsWithUpdatedDeps[cIdxStr]) {
-                    if (!compAccumulated.includes(vName)) {
-                        compAccumulated.push(vName);
-                        foundNewUpdated = true;
+                for (const cIdxStr in this.varsWithUpdatedDeps) {
+                    let compAccumulated =
+                        accumulatedVarsWithUpdatedDeps[cIdxStr];
+                    if (!compAccumulated) {
+                        compAccumulated = accumulatedVarsWithUpdatedDeps[
+                            cIdxStr
+                        ] = [];
+                    }
+                    for (let vName of this.varsWithUpdatedDeps[cIdxStr]) {
+                        if (!compAccumulated.includes(vName)) {
+                            compAccumulated.push(vName);
+                            foundNewUpdated = true;
+                        }
                     }
                 }
-            }
 
-            if (foundNewUpdated) {
-                await this.recalculateDownstreamComponents();
+                if (foundNewUpdated) {
+                    this.varsWithUpdatedDeps = {};
+                    await this.recalculateDownstreamComponents();
+                }
             }
+        } finally {
+            this.gettingValue = false;
         }
-
-        this.gettingValue = false;
 
         result.changes = changes;
 
@@ -4945,8 +4969,12 @@ class AttributeComponentDependency extends Dependency {
         };
     }
 
-    async getValue({ verbose } = {}) {
-        let result = await super.getValue({ verbose, skipProxy: true });
+    async getValue({ verbose, consumeChanges = true } = {}) {
+        let result = await super.getValue({
+            verbose,
+            skipProxy: true,
+            consumeChanges,
+        });
 
         // if (!this.doNotProxy) {
         //   result.value = new Proxy(result.value, readOnlyProxyHandler)
@@ -5456,8 +5484,12 @@ class ChildDependency extends Dependency {
         };
     }
 
-    async getValue({ verbose } = {}) {
-        let result = await super.getValue({ verbose, skipProxy: true });
+    async getValue({ verbose, consumeChanges = true } = {}) {
+        let result = await super.getValue({
+            verbose,
+            skipProxy: true,
+            consumeChanges,
+        });
 
         // TODO: do we have to adjust anything else from result
         // if we add primitives to result.value?
@@ -5509,7 +5541,11 @@ class ChildDependency extends Dependency {
             )
         ) {
             result.changes.componentIdentitiesChanged = true;
-            this.previousDownstreamPrimitives = [...this.downstreamPrimitives];
+            if (consumeChanges) {
+                this.previousDownstreamPrimitives = [
+                    ...this.downstreamPrimitives,
+                ];
+            }
         }
 
         // if (!this.doNotProxy) {
@@ -6956,8 +6992,12 @@ class ReplacementDependency extends Dependency {
         };
     }
 
-    async getValue({ verbose } = {}) {
-        let result = await super.getValue({ verbose, skipProxy: true });
+    async getValue({ verbose, consumeChanges = true } = {}) {
+        let result = await super.getValue({
+            verbose,
+            skipProxy: true,
+            consumeChanges,
+        });
 
         // TODO: do we have to adjust anything else from result
         // if we add primitives to result.value?
@@ -6984,9 +7024,11 @@ class ReplacementDependency extends Dependency {
             )
         ) {
             result.changes.componentIdentitiesChanged = true;
-            this.previousReplacementPrimitives = [
-                ...this.replacementPrimitives,
-            ];
+            if (consumeChanges) {
+                this.previousReplacementPrimitives = [
+                    ...this.replacementPrimitives,
+                ];
+            }
         }
 
         // if (!this.doNotProxy) {
@@ -7161,8 +7203,8 @@ class RefResolutionIndexDependencies extends Dependency {
         }
     }
 
-    async getValue() {
-        const result = await super.getValue();
+    async getValue({ consumeChanges = true } = {}) {
+        const result = await super.getValue({ consumeChanges });
 
         result.value = this.componentList;
 
@@ -7644,8 +7686,8 @@ class RefResolutionDependency extends Dependency {
         };
     }
 
-    async getValue() {
-        const result = await super.getValue();
+    async getValue({ consumeChanges = true } = {}) {
+        const result = await super.getValue({ consumeChanges });
 
         result.value = {
             extendIdx: this.extendIdx ?? -1,
@@ -7741,8 +7783,8 @@ class AttributeRefResolutions extends Dependency {
             };
         }
     }
-    async getValue() {
-        const result = await super.getValue();
+    async getValue({ consumeChanges = true } = {}) {
+        const result = await super.getValue({ consumeChanges });
 
         const newValue = [];
 
@@ -9520,13 +9562,15 @@ class DoenetAttributeDependency extends StateVariableDependency {
         }
     }
 
-    async getValue() {
+    async getValue({ consumeChanges = true } = {}) {
         let value = null;
         let changes = {};
 
         if (this.componentIdentitiesChanged) {
             changes.componentIdentitiesChanged = true;
-            this.componentIdentitiesChanged = false;
+            if (consumeChanges) {
+                this.componentIdentitiesChanged = false;
+            }
         }
 
         if (this.downstreamComponentIndices.length === 1) {
@@ -9562,13 +9606,15 @@ class ExtendingDependency extends StateVariableDependency {
         }
     }
 
-    async getValue() {
+    async getValue({ consumeChanges = true } = {}) {
         let value = null;
         let changes = {};
 
         if (this.componentIdentitiesChanged) {
             changes.componentIdentitiesChanged = true;
-            this.componentIdentitiesChanged = false;
+            if (consumeChanges) {
+                this.componentIdentitiesChanged = false;
+            }
         }
 
         if (this.downstreamComponentIndices.length === 1) {
@@ -9600,13 +9646,15 @@ class AttributePrimitiveDependency extends StateVariableDependency {
         }
     }
 
-    async getValue() {
+    async getValue({ consumeChanges = true } = {}) {
         let value = null;
         let changes = {};
 
         if (this.componentIdentitiesChanged) {
             changes.componentIdentitiesChanged = true;
-            this.componentIdentitiesChanged = false;
+            if (consumeChanges) {
+                this.componentIdentitiesChanged = false;
+            }
         }
 
         if (this.downstreamComponentIndices.length === 1) {

--- a/packages/doenetml-worker-javascript/src/Dependencies.js
+++ b/packages/doenetml-worker-javascript/src/Dependencies.js
@@ -1000,6 +1000,11 @@ export class DependencyHandler {
         return variablesChanged;
     }
 
+    /**
+     * Get dependency values for a state variable.
+     * By default this consumes dependency change flags; set consumeChanges to false
+     * to inspect dependencies without clearing pending change markers.
+     */
     async getStateVariableDependencyValues({
         component,
         stateVariable,
@@ -3320,6 +3325,11 @@ class Dependency {
 
     deleteFromUpdateTriggers() {}
 
+    /**
+     * Return current dependency value, change metadata, and used-default metadata.
+     * When consumeChanges is false, this method reports current change flags without
+     * clearing them from dependency state.
+     */
     async getValue({
         verbose = false,
         skipProxy = false,

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
@@ -7,6 +7,7 @@ import {
     updateSelectedIndices,
     updateTextInputValue,
     updateValue,
+    movePolygonCenter,
 } from "../utils/actions";
 import { widthsBySize } from "@doenet/utils";
 import { PublicDoenetMLCore } from "../../CoreWorker";
@@ -1767,5 +1768,168 @@ describe("Graph tag tests @group2", async () => {
             stateVariables[await resolvePathToNodeIdx("graph")]
                 .activeChildren[1].componentType,
         ).eq("description");
+    });
+
+    it("regularPolygon center control with consecutive moves and no intermediate state read (with $rg.center)", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <graph name="g" addControls>
+      <regularPolygon name="rg" vertices="(4,5) (-3,2)" numSides="3" />
+    </graph>
+    <p>Vertices: $rg.vertices</p>
+    <p>Center: $rg.center</p>
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        let rgStateVars =
+            stateVariables[await resolvePathToNodeIdx("rg")].stateValues;
+
+        // Read initial values once, then perform back-to-back actions.
+        let initialCenter = rgStateVars.center.map((x: any) =>
+            x.evaluate_to_constant(),
+        );
+        let initialCircumradius = rgStateVars.circumradius;
+
+        // Move center to (-1, initialCenter[1])
+        await movePolygonCenter({
+            componentIdx: await resolvePathToNodeIdx("rg"),
+            center: [-1, initialCenter[1]],
+            core,
+        });
+
+        // Now move center to (-2, initialCenter[1]) — this is where the bug appears
+        await movePolygonCenter({
+            componentIdx: await resolvePathToNodeIdx("rg"),
+            center: [-2, initialCenter[1]],
+            core,
+        });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        rgStateVars =
+            stateVariables[await resolvePathToNodeIdx("rg")].stateValues;
+
+        let center2 = rgStateVars.center.map((x: any) =>
+            x.evaluate_to_constant(),
+        );
+        let circumradius2 = rgStateVars.circumradius;
+
+        expect(center2[0]).toBeCloseTo(-2, 5);
+        expect(center2[1]).toBeCloseTo(initialCenter[1], 5);
+        expect(circumradius2).toBeCloseTo(initialCircumradius, 5);
+    });
+
+    it("regularPolygon center control with consecutive moves and no intermediate state read (without $rg.center)", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <graph name="g" addControls>
+      <regularPolygon name="rg" vertices="(4,5) (-3,2)" numSides="3" />
+    </graph>
+    <p>Vertices: $rg.vertices</p>
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        let rgStateVars =
+            stateVariables[await resolvePathToNodeIdx("rg")].stateValues;
+
+        // Read initial values once, then perform back-to-back actions.
+        let initialCenter = rgStateVars.center.map((x: any) =>
+            x.evaluate_to_constant(),
+        );
+        let initialCircumradius = rgStateVars.circumradius;
+
+        // Move center to (-1, initialCenter[1])
+        await movePolygonCenter({
+            componentIdx: await resolvePathToNodeIdx("rg"),
+            center: [-1, initialCenter[1]],
+            core,
+        });
+
+        // Now move center to (-2, initialCenter[1]) — this is where the bug appears
+        await movePolygonCenter({
+            componentIdx: await resolvePathToNodeIdx("rg"),
+            center: [-2, initialCenter[1]],
+            core,
+        });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        rgStateVars =
+            stateVariables[await resolvePathToNodeIdx("rg")].stateValues;
+
+        let center2 = rgStateVars.center.map((x: any) =>
+            x.evaluate_to_constant(),
+        );
+        let circumradius2 = rgStateVars.circumradius;
+
+        expect(center2[0]).toBeCloseTo(-2, 5);
+        expect(center2[1]).toBeCloseTo(initialCenter[1], 5);
+        expect(circumradius2).toBeCloseTo(initialCircumradius, 5);
+    });
+
+    it("regularPolygon one move diagnostics without $rg.center", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <graph name="g" addControls>
+      <regularPolygon name="rg" vertices="(4,5) (-3,2)" numSides="3" />
+    </graph>
+    <p>Vertices: $rg.vertices</p>
+    `,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        const rgIdx = await resolvePathToNodeIdx("rg");
+        const rgStateVars = stateVariables[rgIdx].stateValues;
+
+        const initialCenter = rgStateVars.center.map((x: any) =>
+            x.evaluate_to_constant(),
+        );
+
+        await movePolygonCenter({
+            componentIdx: rgIdx,
+            center: [-1, initialCenter[1]],
+            core,
+        });
+
+        const rgState = core.core?._components?.[rgIdx].state;
+        expect(rgState).toBeDefined();
+
+        const verticesHasGetter = !!Object.getOwnPropertyDescriptor(
+            rgState.vertices,
+            "value",
+        )?.get;
+
+        const verticesValue = await rgState.vertices.value;
+        const numericalVertices = verticesValue.map((vertex: any) =>
+            vertex.map((v: any) => v.evaluate_to_constant()),
+        );
+
+        const centerFromVertices = [0, 1].map(
+            (dim) =>
+                numericalVertices.reduce(
+                    (acc: number, vertex: number[]) => acc + vertex[dim],
+                    0,
+                ) / numericalVertices.length,
+        );
+
+        const centerHasGetter = !!Object.getOwnPropertyDescriptor(
+            rgState.center,
+            "value",
+        )?.get;
+
+        let centerValue = await rgState.center.value;
+        let numericalCenter = centerValue.map((v: any) =>
+            v.evaluate_to_constant(),
+        );
+
+        // Check state right after first move before any returnAllStateVariables call.
+        // We expect vertices to already be concrete and center to still be stale.
+        expect(verticesHasGetter).eq(false);
+        expect(centerHasGetter).eq(true);
+
+        // Reading center should trigger definition and match the shifted vertices center.
+        expect(numericalCenter[0]).toBeCloseTo(centerFromVertices[0], 10);
+        expect(numericalCenter[1]).toBeCloseTo(centerFromVertices[1], 10);
+        expect(numericalCenter[0]).toBeCloseTo(-1, 10);
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
@@ -1775,6 +1775,15 @@ describe("Graph tag tests @group2", async () => {
     }: {
         includeCenterParagraph: boolean;
     }) {
+        function evaluateCoordinatePair(
+            values: {
+                evaluate_to_constant: () => number;
+            }[],
+        ): [number, number] {
+            const [x, y] = values.map((value) => value.evaluate_to_constant());
+            return [x, y];
+        }
+
         const centerParagraph = includeCenterParagraph
             ? "\n    <p>Center: $rg.center</p>"
             : "";
@@ -1794,9 +1803,7 @@ describe("Graph tag tests @group2", async () => {
         let rgStateVars = stateVariables[rgIdx].stateValues;
 
         // Read initial values once, then perform back-to-back actions.
-        let initialCenter = rgStateVars.center.map((x: any) =>
-            x.evaluate_to_constant(),
-        );
+        let initialCenter = evaluateCoordinatePair(rgStateVars.center);
         let initialCircumradius = rgStateVars.circumradius;
 
         // Move center to (-1, initialCenter[1])
@@ -1806,7 +1813,7 @@ describe("Graph tag tests @group2", async () => {
             core,
         });
 
-        // Now move center to (-2, initialCenter[1]) — this is where the bug appears
+        // Now move center to (-2, initialCenter[1]) -- this is where the bug appeared
         await movePolygonCenter({
             componentIdx: rgIdx,
             center: [-2, initialCenter[1]],
@@ -1816,9 +1823,7 @@ describe("Graph tag tests @group2", async () => {
         stateVariables = await core.returnAllStateVariables(false, true);
         rgStateVars = stateVariables[rgIdx].stateValues;
 
-        let center2 = rgStateVars.center.map((x: any) =>
-            x.evaluate_to_constant(),
-        );
+        let center2 = evaluateCoordinatePair(rgStateVars.center);
         let circumradius2 = rgStateVars.circumradius;
 
         expect(center2[0]).toBeCloseTo(-2, 5);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
@@ -1770,166 +1770,71 @@ describe("Graph tag tests @group2", async () => {
         ).eq("description");
     });
 
-    it("regularPolygon center control with consecutive moves and no intermediate state read (with $rg.center)", async () => {
+    async function runConsecutiveRegularPolygonCenterMoves({
+        includeCenterParagraph,
+    }: {
+        includeCenterParagraph: boolean;
+    }) {
+        const centerParagraph = includeCenterParagraph
+            ? "\n    <p>Center: $rg.center</p>"
+            : "";
+
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
     <graph name="g" addControls>
       <regularPolygon name="rg" vertices="(4,5) (-3,2)" numSides="3" />
     </graph>
-    <p>Vertices: $rg.vertices</p>
-    <p>Center: $rg.center</p>
+    <p>Vertices: $rg.vertices</p>${centerParagraph}
     `,
         });
 
-        let stateVariables = await core.returnAllStateVariables(false, true);
-        let rgStateVars =
-            stateVariables[await resolvePathToNodeIdx("rg")].stateValues;
-
-        // Read initial values once, then perform back-to-back actions.
-        let initialCenter = rgStateVars.center.map((x: any) =>
-            x.evaluate_to_constant(),
-        );
-        let initialCircumradius = rgStateVars.circumradius;
-
-        // Move center to (-1, initialCenter[1])
-        await movePolygonCenter({
-            componentIdx: await resolvePathToNodeIdx("rg"),
-            center: [-1, initialCenter[1]],
-            core,
-        });
-
-        // Now move center to (-2, initialCenter[1]) — this is where the bug appears
-        await movePolygonCenter({
-            componentIdx: await resolvePathToNodeIdx("rg"),
-            center: [-2, initialCenter[1]],
-            core,
-        });
-
-        stateVariables = await core.returnAllStateVariables(false, true);
-        rgStateVars =
-            stateVariables[await resolvePathToNodeIdx("rg")].stateValues;
-
-        let center2 = rgStateVars.center.map((x: any) =>
-            x.evaluate_to_constant(),
-        );
-        let circumradius2 = rgStateVars.circumradius;
-
-        expect(center2[0]).toBeCloseTo(-2, 5);
-        expect(center2[1]).toBeCloseTo(initialCenter[1], 5);
-        expect(circumradius2).toBeCloseTo(initialCircumradius, 5);
-    });
-
-    it("regularPolygon center control with consecutive moves and no intermediate state read (without $rg.center)", async () => {
-        let { core, resolvePathToNodeIdx } = await createTestCore({
-            doenetML: `
-    <graph name="g" addControls>
-      <regularPolygon name="rg" vertices="(4,5) (-3,2)" numSides="3" />
-    </graph>
-    <p>Vertices: $rg.vertices</p>
-    `,
-        });
-
-        let stateVariables = await core.returnAllStateVariables(false, true);
-        let rgStateVars =
-            stateVariables[await resolvePathToNodeIdx("rg")].stateValues;
-
-        // Read initial values once, then perform back-to-back actions.
-        let initialCenter = rgStateVars.center.map((x: any) =>
-            x.evaluate_to_constant(),
-        );
-        let initialCircumradius = rgStateVars.circumradius;
-
-        // Move center to (-1, initialCenter[1])
-        await movePolygonCenter({
-            componentIdx: await resolvePathToNodeIdx("rg"),
-            center: [-1, initialCenter[1]],
-            core,
-        });
-
-        // Now move center to (-2, initialCenter[1]) — this is where the bug appears
-        await movePolygonCenter({
-            componentIdx: await resolvePathToNodeIdx("rg"),
-            center: [-2, initialCenter[1]],
-            core,
-        });
-
-        stateVariables = await core.returnAllStateVariables(false, true);
-        rgStateVars =
-            stateVariables[await resolvePathToNodeIdx("rg")].stateValues;
-
-        let center2 = rgStateVars.center.map((x: any) =>
-            x.evaluate_to_constant(),
-        );
-        let circumradius2 = rgStateVars.circumradius;
-
-        expect(center2[0]).toBeCloseTo(-2, 5);
-        expect(center2[1]).toBeCloseTo(initialCenter[1], 5);
-        expect(circumradius2).toBeCloseTo(initialCircumradius, 5);
-    });
-
-    it("regularPolygon one move diagnostics without $rg.center", async () => {
-        let { core, resolvePathToNodeIdx } = await createTestCore({
-            doenetML: `
-    <graph name="g" addControls>
-      <regularPolygon name="rg" vertices="(4,5) (-3,2)" numSides="3" />
-    </graph>
-    <p>Vertices: $rg.vertices</p>
-    `,
-        });
-
-        const stateVariables = await core.returnAllStateVariables(false, true);
         const rgIdx = await resolvePathToNodeIdx("rg");
-        const rgStateVars = stateVariables[rgIdx].stateValues;
 
-        const initialCenter = rgStateVars.center.map((x: any) =>
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        let rgStateVars = stateVariables[rgIdx].stateValues;
+
+        // Read initial values once, then perform back-to-back actions.
+        let initialCenter = rgStateVars.center.map((x: any) =>
             x.evaluate_to_constant(),
         );
+        let initialCircumradius = rgStateVars.circumradius;
 
+        // Move center to (-1, initialCenter[1])
         await movePolygonCenter({
             componentIdx: rgIdx,
             center: [-1, initialCenter[1]],
             core,
         });
 
-        const rgState = core.core?._components?.[rgIdx].state;
-        expect(rgState).toBeDefined();
+        // Now move center to (-2, initialCenter[1]) — this is where the bug appears
+        await movePolygonCenter({
+            componentIdx: rgIdx,
+            center: [-2, initialCenter[1]],
+            core,
+        });
 
-        const verticesHasGetter = !!Object.getOwnPropertyDescriptor(
-            rgState.vertices,
-            "value",
-        )?.get;
+        stateVariables = await core.returnAllStateVariables(false, true);
+        rgStateVars = stateVariables[rgIdx].stateValues;
 
-        const verticesValue = await rgState.vertices.value;
-        const numericalVertices = verticesValue.map((vertex: any) =>
-            vertex.map((v: any) => v.evaluate_to_constant()),
+        let center2 = rgStateVars.center.map((x: any) =>
+            x.evaluate_to_constant(),
         );
+        let circumradius2 = rgStateVars.circumradius;
 
-        const centerFromVertices = [0, 1].map(
-            (dim) =>
-                numericalVertices.reduce(
-                    (acc: number, vertex: number[]) => acc + vertex[dim],
-                    0,
-                ) / numericalVertices.length,
-        );
+        expect(center2[0]).toBeCloseTo(-2, 5);
+        expect(center2[1]).toBeCloseTo(initialCenter[1], 5);
+        expect(circumradius2).toBeCloseTo(initialCircumradius, 5);
+    }
 
-        const centerHasGetter = !!Object.getOwnPropertyDescriptor(
-            rgState.center,
-            "value",
-        )?.get;
+    it("regularPolygon center control with consecutive moves and no intermediate state read (with $rg.center)", async () => {
+        await runConsecutiveRegularPolygonCenterMoves({
+            includeCenterParagraph: true,
+        });
+    });
 
-        let centerValue = await rgState.center.value;
-        let numericalCenter = centerValue.map((v: any) =>
-            v.evaluate_to_constant(),
-        );
-
-        // Check state right after first move before any returnAllStateVariables call.
-        // We expect vertices to already be concrete and center to still be stale.
-        expect(verticesHasGetter).eq(false);
-        expect(centerHasGetter).eq(true);
-
-        // Reading center should trigger definition and match the shifted vertices center.
-        expect(numericalCenter[0]).toBeCloseTo(centerFromVertices[0], 10);
-        expect(numericalCenter[1]).toBeCloseTo(centerFromVertices[1], 10);
-        expect(numericalCenter[0]).toBeCloseTo(-1, 10);
+    it("regularPolygon center control with consecutive moves and no intermediate state read (without $rg.center)", async () => {
+        await runConsecutiveRegularPolygonCenterMoves({
+            includeCenterParagraph: false,
+        });
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/utils/actions.ts
+++ b/packages/doenetml-worker-javascript/src/test/utils/actions.ts
@@ -661,3 +661,19 @@ export async function focusChanged({
         args: { focused },
     });
 }
+
+export async function movePolygonCenter({
+    componentIdx,
+    center,
+    core,
+}: {
+    componentIdx: number;
+    center: number[];
+    core: PublicDoenetMLCore;
+}) {
+    await core.requestAction({
+        componentIdx,
+        actionName: "movePolygonCenter",
+        args: { center },
+    });
+}

--- a/packages/doenetml-worker-javascript/src/test/utils/actions.ts
+++ b/packages/doenetml-worker-javascript/src/test/utils/actions.ts
@@ -668,7 +668,7 @@ export async function movePolygonCenter({
     core,
 }: {
     componentIdx: number;
-    center: number[];
+    center: [number, number];
     core: PublicDoenetMLCore;
 }) {
     await core.requestAction({


### PR DESCRIPTION
## Summary
- add consumeChanges support to worker dependency value retrieval
- use non-consuming reads for inverse-definition dependency access, then explicitly drain change flags afterward to keep snapshot behavior correct
- preserve the simpler recursive dependency traversal while keeping cleanup paths robust
- add regression coverage for consecutive regularPolygon center moves, including a dedicated movePolygonCenter test helper

## Validation
- npm run test graph (in packages/doenetml-worker-javascript)
