### PR TITLE
Fix responsive sizing of graph control input boxes

### DIFF
--- a/.changeset/upset-berries-poke.md
+++ b/.changeset/upset-berries-poke.md
@@ -4,4 +4,4 @@
 "@doenet/doenetml-iframe": patch
 ---
 
-Fix responsive styling of input boxes in graphics controls. Input boxes now properly shrink to fit available space when the screen width decreases, both for `addControls="all"` and `addControls="inputsOnly"` modes, including scalar controls and point controls.
+Fix responsive styling of input boxes in graph controls. Input boxes now properly shrink to fit available space when the screen width decreases, both for `addControls="all"` and `addControls="inputsOnly"` modes, including scalar controls and point controls.

--- a/.changeset/upset-berries-poke.md
+++ b/.changeset/upset-berries-poke.md
@@ -1,0 +1,7 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Fix responsive styling of input boxes in graphics controls. Input boxes now properly shrink to fit available space when the screen width decreases, both for `addControls="all"` and `addControls="inputsOnly"` modes, including scalar controls and point controls.

--- a/packages/doenetml/src/Viewer/renderers/graphControls/primitives/CommitTextInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/primitives/CommitTextInput.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { GRAPH_CONTROL_TEXT_INPUT_STYLE } from "./styles";
 
 type CommitTextInputProps = {
     id?: string;
@@ -45,6 +46,7 @@ export default function CommitTextInput({
             aria-label={ariaLabel}
             aria-invalid={ariaInvalid ? true : undefined}
             aria-describedby={ariaDescribedBy}
+            style={GRAPH_CONTROL_TEXT_INPUT_STYLE}
             onChange={(event) => {
                 suppressNextBlurCommitRef.current = false;
                 onChange(event.target.value);

--- a/packages/doenetml/src/Viewer/renderers/graphControls/primitives/styles.ts
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/primitives/styles.ts
@@ -22,8 +22,16 @@ export const GRAPH_CONTROL_INPUT_BLOCK_STYLE: React.CSSProperties = {
 };
 
 export const GRAPH_CONTROL_INLINE_INPUT_STACK_STYLE: React.CSSProperties = {
-    display: "inline-flex",
+    display: "flex",
     flexDirection: "column",
+    minWidth: 0,
+    width: "100%",
+};
+
+export const GRAPH_CONTROL_TEXT_INPUT_STYLE: React.CSSProperties = {
+    width: "100%",
+    boxSizing: "border-box",
+    minWidth: 0,
 };
 
 export const GRAPH_CONTROL_ERROR_TEXT_STYLE: React.CSSProperties = {


### PR DESCRIPTION
## Summary
Fix responsive styling for graph control text inputs so they shrink with their container on narrow screens.

### What changed
- Added a shared text input style for graph controls with width 100 percent, box sizing border box, and min width 0
- Applied the shared style in CommitTextInput
- Updated inline input stack layout to use a flex container that can shrink with display flex, min width 0, and width 100 percent

## Behavior fixed
- addControls="all": input boxes no longer overflow to the right when controls narrow
- addControls="inputsOnly": scalar control inputs now shrink correctly

## Validation
- npm run build -w @doenet/doenetml
- npm run build -w @doenet/test-cypress
- cypress/e2e/tagSpecific/graphicControls.cy.js with 44 passing
