### PR TITLE
Add collapsible graph controls with accessible disclosure

### DIFF
--- a/.changeset/graph-controls-collapsible-cards.md
+++ b/.changeset/graph-controls-collapsible-cards.md
@@ -1,0 +1,7 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Add collapsible graph control cards to reduce long scrolling in control-heavy graphs. By default, the first two controls are expanded and remaining controls are collapsed, with consistent behavior across default and prefigure renderers. Each card now has an accessible disclosure button with keyboard support and ARIA semantics.

--- a/packages/doenetml/src/Viewer/renderers/graphControls/GraphControlsRoot.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/GraphControlsRoot.tsx
@@ -11,6 +11,7 @@ import {
     assertKnownGraphControlType,
     type GraphControlItem,
     type GraphControlsFamilyProps,
+    selectInitialExpandedGraphControlIds,
     sortGraphControlsForDisplay,
 } from "./model";
 
@@ -38,6 +39,93 @@ export default React.memo(function GraphControlsRoot(
         [SVs.graphicalDescendantsForControls],
     );
 
+    const defaultExpandedControlIds = React.useMemo(
+        () => selectInitialExpandedGraphControlIds(orderedControls),
+        [orderedControls],
+    );
+
+    const [expandedByControlId, setExpandedByControlId] = React.useState(() => {
+        const initialMap = new Map<number, boolean>();
+        for (const control of orderedControls) {
+            initialMap.set(
+                control.componentIdx,
+                defaultExpandedControlIds.has(control.componentIdx),
+            );
+        }
+        return initialMap;
+    });
+
+    /**
+     * Sync expansion state map whenever the ordered controls list or defaults change.
+     * Handles four cases:
+     * 1. New controls: inherit the default expanded state
+     * 2. Removed controls: drop their expansion state (unreachable now)
+     * 3. Reordered controls: preserve user's expansion state by componentIdx
+     * 4. Unchanged: return previous state to avoid spurious re-renders
+     */
+    React.useEffect(() => {
+        setExpandedByControlId((previous) => {
+            const next = new Map<number, boolean>();
+            let changed = previous.size !== orderedControls.length;
+
+            for (const control of orderedControls) {
+                const componentIdx = control.componentIdx;
+                const previousValue = previous.get(componentIdx);
+                const nextValue =
+                    previousValue ??
+                    defaultExpandedControlIds.has(componentIdx);
+                next.set(componentIdx, nextValue);
+                if (previousValue === undefined) {
+                    changed = true;
+                }
+            }
+
+            if (!changed) {
+                for (const [componentIdx, value] of previous) {
+                    if (next.get(componentIdx) !== value) {
+                        changed = true;
+                        break;
+                    }
+                }
+            }
+
+            return changed ? next : previous;
+        });
+    }, [orderedControls, defaultExpandedControlIds]);
+
+    /**
+     * Query whether a control card is currently expanded.
+     * Checks the user-controlled state first, falling back to the default initial state.
+     * This allows controls to remain collapsed/expanded as the user set them, even as
+     * the list of controls changes (e.g., due to visibility constraints).
+     */
+    const isGraphControlExpanded = React.useCallback(
+        (componentIdx: number) =>
+            expandedByControlId.get(componentIdx) ??
+            defaultExpandedControlIds.has(componentIdx),
+        [expandedByControlId, defaultExpandedControlIds],
+    );
+
+    /**
+     * Toggle the expansion state of a control card.
+     * Flips the stored expansion state for the given control, allowing users to open/close
+     * cards to manage long control lists. The toggle persists independently of list reordering
+     * or visibility changes.
+     */
+    const toggleGraphControlExpanded = React.useCallback(
+        (componentIdx: number) => {
+            setExpandedByControlId((previous) => {
+                const next = new Map(previous);
+                const currentValue =
+                    next.get(componentIdx) ??
+                    defaultExpandedControlIds.has(componentIdx);
+                next.set(componentIdx, !currentValue);
+                return next;
+            });
+        },
+        [defaultExpandedControlIds],
+    );
+
     function renderControl(control: GraphControlItem) {
         const controlType = assertKnownGraphControlType(control.controlType);
         const FamilyComponent = CONTROLS_FAMILY_BY_TYPE[controlType];
@@ -51,6 +139,8 @@ export default React.memo(function GraphControlsRoot(
         const controlFamilyProps: GraphControlsFamilyProps = {
             ...props,
             id: `${id}_control_${instanceId}`,
+            isGraphControlExpanded,
+            toggleGraphControlExpanded,
             SVs: {
                 ...SVs,
                 graphicalDescendantsForControls: [control],

--- a/packages/doenetml/src/Viewer/renderers/graphControls/GraphControlsRoot.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/GraphControlsRoot.tsx
@@ -60,7 +60,7 @@ export default React.memo(function GraphControlsRoot(
      * Sync expansion state map whenever the ordered controls list or defaults change.
      * Handles four cases:
      * 1. New controls: inherit the default expanded state
-     * 2. Removed controls: drop their expansion state (unreachable now)
+     * 2. Removed or hidden controls: drop their expansion state when the list shrinks
      * 3. Reordered controls: preserve user's expansion state by componentIdx
      * 4. Unchanged: return previous state to avoid spurious re-renders
      */

--- a/packages/doenetml/src/Viewer/renderers/graphControls/GraphControlsRoot.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/GraphControlsRoot.tsx
@@ -10,6 +10,7 @@ import VectorControlsFamily from "./families/VectorControlsFamily";
 import {
     assertKnownGraphControlType,
     type GraphControlItem,
+    type GraphControlsRootProps,
     type GraphControlsFamilyProps,
     selectInitialExpandedGraphControlIds,
     sortGraphControlsForDisplay,
@@ -30,7 +31,7 @@ const CONTROLS_FAMILY_BY_TYPE: Record<
 };
 
 export default React.memo(function GraphControlsRoot(
-    props: GraphControlsFamilyProps,
+    props: GraphControlsRootProps,
 ) {
     const { id, SVs } = props;
 

--- a/packages/doenetml/src/Viewer/renderers/graphControls/families/CircleControlsFamily.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/families/CircleControlsFamily.tsx
@@ -182,6 +182,7 @@ export default React.memo(function CircleControlsFamily({
                     headingId={headingId}
                     contentId={`${id}-circle-${circle.componentIdx}-content`}
                     heading={labelForDisplay}
+                    disclosureControlLabel={labelForAria}
                     isExpanded={isGraphControlExpanded(circle.componentIdx)}
                     onToggleExpanded={() =>
                         toggleGraphControlExpanded(circle.componentIdx)

--- a/packages/doenetml/src/Viewer/renderers/graphControls/families/CircleControlsFamily.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/families/CircleControlsFamily.tsx
@@ -48,6 +48,8 @@ export default React.memo(function CircleControlsFamily({
     id,
     SVs,
     callAction,
+    isGraphControlExpanded,
+    toggleGraphControlExpanded,
 }: GraphControlsFamilyProps) {
     const graphControlsMode = normalizeGraphControlsMode(SVs.addControls);
     if (graphControlsMode === "none") {
@@ -178,7 +180,12 @@ export default React.memo(function CircleControlsFamily({
                     key={circle.componentIdx}
                     id={`${id}-circle-${circle.componentIdx}`}
                     headingId={headingId}
+                    contentId={`${id}-circle-${circle.componentIdx}-content`}
                     heading={labelForDisplay}
+                    isExpanded={isGraphControlExpanded(circle.componentIdx)}
+                    onToggleExpanded={() =>
+                        toggleGraphControlExpanded(circle.componentIdx)
+                    }
                 >
                     {sections.map((section) =>
                         section.kind === "center" ? (

--- a/packages/doenetml/src/Viewer/renderers/graphControls/families/LineSegmentControlsFamily.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/families/LineSegmentControlsFamily.tsx
@@ -168,6 +168,7 @@ export default React.memo(function LineSegmentControlsFamily({
                     headingId={`${id}-lineSegment-${lineSegment.componentIdx}-heading`}
                     contentId={`${id}-lineSegment-${lineSegment.componentIdx}-content`}
                     heading={labelForDisplay}
+                    disclosureControlLabel={labelForAria}
                     isExpanded={isGraphControlExpanded(
                         lineSegment.componentIdx,
                     )}

--- a/packages/doenetml/src/Viewer/renderers/graphControls/families/LineSegmentControlsFamily.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/families/LineSegmentControlsFamily.tsx
@@ -85,6 +85,8 @@ export default React.memo(function LineSegmentControlsFamily({
     id,
     SVs,
     callAction,
+    isGraphControlExpanded,
+    toggleGraphControlExpanded,
 }: GraphControlsFamilyProps) {
     const graphControlsMode = normalizeGraphControlsMode(SVs.addControls);
     if (graphControlsMode === "none") {
@@ -164,7 +166,14 @@ export default React.memo(function LineSegmentControlsFamily({
                     key={lineSegment.componentIdx}
                     id={`${id}-lineSegment-${lineSegment.componentIdx}`}
                     headingId={`${id}-lineSegment-${lineSegment.componentIdx}-heading`}
+                    contentId={`${id}-lineSegment-${lineSegment.componentIdx}-content`}
                     heading={labelForDisplay}
+                    isExpanded={isGraphControlExpanded(
+                        lineSegment.componentIdx,
+                    )}
+                    onToggleExpanded={() =>
+                        toggleGraphControlExpanded(lineSegment.componentIdx)
+                    }
                 >
                     {sections.map((section) => {
                         const coordinates = getLineSegmentCoordinatesByRole(

--- a/packages/doenetml/src/Viewer/renderers/graphControls/families/PointControlsFamily.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/families/PointControlsFamily.tsx
@@ -106,6 +106,7 @@ export default React.memo(function PointControlsFamily({
                     headingId={`${id}-point-${point.componentIdx}-heading`}
                     contentId={`${id}-point-${point.componentIdx}-content`}
                     heading={pointLabelForDisplay}
+                    disclosureControlLabel={pointLabelForAria}
                     isExpanded={isGraphControlExpanded(point.componentIdx)}
                     onToggleExpanded={() =>
                         toggleGraphControlExpanded(point.componentIdx)

--- a/packages/doenetml/src/Viewer/renderers/graphControls/families/PointControlsFamily.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/families/PointControlsFamily.tsx
@@ -32,6 +32,8 @@ export default React.memo(function PointControlsFamily({
     id,
     SVs,
     callAction,
+    isGraphControlExpanded,
+    toggleGraphControlExpanded,
 }: GraphControlsFamilyProps) {
     const points = selectGraphControlsByType(
         SVs.graphicalDescendantsForControls,
@@ -102,7 +104,12 @@ export default React.memo(function PointControlsFamily({
                     key={point.componentIdx}
                     id={`${id}-point-${point.componentIdx}`}
                     headingId={`${id}-point-${point.componentIdx}-heading`}
+                    contentId={`${id}-point-${point.componentIdx}-content`}
                     heading={pointLabelForDisplay}
+                    isExpanded={isGraphControlExpanded(point.componentIdx)}
+                    onToggleExpanded={() =>
+                        toggleGraphControlExpanded(point.componentIdx)
+                    }
                 >
                     {sections.map((section) => (
                         <PointControlCoordinator

--- a/packages/doenetml/src/Viewer/renderers/graphControls/families/PolygonControlsFamily.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/families/PolygonControlsFamily.tsx
@@ -19,6 +19,8 @@ export default React.memo(function PolygonControlsFamily({
     id,
     SVs,
     callAction,
+    isGraphControlExpanded,
+    toggleGraphControlExpanded,
 }: GraphControlsFamilyProps) {
     const graphControlsMode = normalizeGraphControlsMode(SVs.addControls);
     if (graphControlsMode === "none") {
@@ -98,7 +100,12 @@ export default React.memo(function PolygonControlsFamily({
                     key={polygon.componentIdx}
                     id={`${id}-polygon-${polygon.componentIdx}`}
                     headingId={`${id}-polygon-${polygon.componentIdx}-heading`}
+                    contentId={`${id}-polygon-${polygon.componentIdx}-content`}
                     heading={labelForDisplay}
+                    isExpanded={isGraphControlExpanded(polygon.componentIdx)}
+                    onToggleExpanded={() =>
+                        toggleGraphControlExpanded(polygon.componentIdx)
+                    }
                 >
                     <PointControlCoordinator
                         id={id}

--- a/packages/doenetml/src/Viewer/renderers/graphControls/families/PolygonControlsFamily.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/families/PolygonControlsFamily.tsx
@@ -102,6 +102,7 @@ export default React.memo(function PolygonControlsFamily({
                     headingId={`${id}-polygon-${polygon.componentIdx}-heading`}
                     contentId={`${id}-polygon-${polygon.componentIdx}-content`}
                     heading={labelForDisplay}
+                    disclosureControlLabel={labelForAria}
                     isExpanded={isGraphControlExpanded(polygon.componentIdx)}
                     onToggleExpanded={() =>
                         toggleGraphControlExpanded(polygon.componentIdx)

--- a/packages/doenetml/src/Viewer/renderers/graphControls/families/RectangleControlsFamily.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/families/RectangleControlsFamily.tsx
@@ -209,6 +209,7 @@ export default React.memo(function RectangleControlsFamily({
                     headingId={`${id}-rectangle-${rectangle.componentIdx}-heading`}
                     contentId={`${id}-rectangle-${rectangle.componentIdx}-content`}
                     heading={labelForDisplay}
+                    disclosureControlLabel={labelForAria}
                     isExpanded={isGraphControlExpanded(rectangle.componentIdx)}
                     onToggleExpanded={() =>
                         toggleGraphControlExpanded(rectangle.componentIdx)

--- a/packages/doenetml/src/Viewer/renderers/graphControls/families/RectangleControlsFamily.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/families/RectangleControlsFamily.tsx
@@ -74,6 +74,8 @@ export default React.memo(function RectangleControlsFamily({
     id,
     SVs,
     callAction,
+    isGraphControlExpanded,
+    toggleGraphControlExpanded,
 }: GraphControlsFamilyProps) {
     const graphControlsMode = normalizeGraphControlsMode(SVs.addControls);
     if (graphControlsMode === "none") {
@@ -205,7 +207,12 @@ export default React.memo(function RectangleControlsFamily({
                     key={rectangle.componentIdx}
                     id={`${id}-rectangle-${rectangle.componentIdx}`}
                     headingId={`${id}-rectangle-${rectangle.componentIdx}-heading`}
+                    contentId={`${id}-rectangle-${rectangle.componentIdx}-content`}
                     heading={labelForDisplay}
+                    isExpanded={isGraphControlExpanded(rectangle.componentIdx)}
+                    onToggleExpanded={() =>
+                        toggleGraphControlExpanded(rectangle.componentIdx)
+                    }
                 >
                     {sections.map((section) => {
                         if (section.kind === "center") {

--- a/packages/doenetml/src/Viewer/renderers/graphControls/families/RegularPolygonControlsFamily.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/families/RegularPolygonControlsFamily.tsx
@@ -184,6 +184,7 @@ export default React.memo(function RegularPolygonControlsFamily({
                     headingId={`${id}-regularPolygon-${regularPolygon.componentIdx}-heading`}
                     contentId={`${id}-regularPolygon-${regularPolygon.componentIdx}-content`}
                     heading={labelForDisplay}
+                    disclosureControlLabel={labelForAria}
                     isExpanded={isGraphControlExpanded(
                         regularPolygon.componentIdx,
                     )}

--- a/packages/doenetml/src/Viewer/renderers/graphControls/families/RegularPolygonControlsFamily.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/families/RegularPolygonControlsFamily.tsx
@@ -50,6 +50,8 @@ export default React.memo(function RegularPolygonControlsFamily({
     id,
     SVs,
     callAction,
+    isGraphControlExpanded,
+    toggleGraphControlExpanded,
 }: GraphControlsFamilyProps) {
     const graphControlsMode = normalizeGraphControlsMode(SVs.addControls);
     if (graphControlsMode === "none") {
@@ -180,7 +182,14 @@ export default React.memo(function RegularPolygonControlsFamily({
                     key={regularPolygon.componentIdx}
                     id={`${id}-regularPolygon-${regularPolygon.componentIdx}`}
                     headingId={`${id}-regularPolygon-${regularPolygon.componentIdx}-heading`}
+                    contentId={`${id}-regularPolygon-${regularPolygon.componentIdx}-content`}
                     heading={labelForDisplay}
+                    isExpanded={isGraphControlExpanded(
+                        regularPolygon.componentIdx,
+                    )}
+                    onToggleExpanded={() =>
+                        toggleGraphControlExpanded(regularPolygon.componentIdx)
+                    }
                 >
                     {sections.map((section) =>
                         section.kind === "center" ? (

--- a/packages/doenetml/src/Viewer/renderers/graphControls/families/TriangleControlsFamily.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/families/TriangleControlsFamily.tsx
@@ -19,6 +19,8 @@ export default React.memo(function TriangleControlsFamily({
     id,
     SVs,
     callAction,
+    isGraphControlExpanded,
+    toggleGraphControlExpanded,
 }: GraphControlsFamilyProps) {
     const graphControlsMode = normalizeGraphControlsMode(SVs.addControls);
     if (graphControlsMode === "none") {
@@ -98,7 +100,12 @@ export default React.memo(function TriangleControlsFamily({
                     key={triangle.componentIdx}
                     id={`${id}-triangle-${triangle.componentIdx}`}
                     headingId={`${id}-triangle-${triangle.componentIdx}-heading`}
+                    contentId={`${id}-triangle-${triangle.componentIdx}-content`}
                     heading={labelForDisplay}
+                    isExpanded={isGraphControlExpanded(triangle.componentIdx)}
+                    onToggleExpanded={() =>
+                        toggleGraphControlExpanded(triangle.componentIdx)
+                    }
                 >
                     <PointControlCoordinator
                         id={id}

--- a/packages/doenetml/src/Viewer/renderers/graphControls/families/TriangleControlsFamily.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/families/TriangleControlsFamily.tsx
@@ -102,6 +102,7 @@ export default React.memo(function TriangleControlsFamily({
                     headingId={`${id}-triangle-${triangle.componentIdx}-heading`}
                     contentId={`${id}-triangle-${triangle.componentIdx}-content`}
                     heading={labelForDisplay}
+                    disclosureControlLabel={labelForAria}
                     isExpanded={isGraphControlExpanded(triangle.componentIdx)}
                     onToggleExpanded={() =>
                         toggleGraphControlExpanded(triangle.componentIdx)

--- a/packages/doenetml/src/Viewer/renderers/graphControls/families/VectorControlsFamily.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/families/VectorControlsFamily.tsx
@@ -227,6 +227,7 @@ export default React.memo(function VectorControlsFamily({
                     headingId={`${id}-vector-${componentIdx}-heading`}
                     contentId={`${id}-vector-${componentIdx}-content`}
                     heading={labelForDisplay}
+                    disclosureControlLabel={labelForAria}
                     isExpanded={isGraphControlExpanded(componentIdx)}
                     onToggleExpanded={() =>
                         toggleGraphControlExpanded(componentIdx)

--- a/packages/doenetml/src/Viewer/renderers/graphControls/families/VectorControlsFamily.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/families/VectorControlsFamily.tsx
@@ -137,6 +137,8 @@ export default React.memo(function VectorControlsFamily({
     id,
     SVs,
     callAction,
+    isGraphControlExpanded,
+    toggleGraphControlExpanded,
 }: GraphControlsFamilyProps) {
     const graphControlsMode = normalizeGraphControlsMode(SVs.addControls);
     if (graphControlsMode === "none") {
@@ -223,7 +225,12 @@ export default React.memo(function VectorControlsFamily({
                     key={`${componentIdx}-${mode}`}
                     id={`${id}-vector-${componentIdx}`}
                     headingId={`${id}-vector-${componentIdx}-heading`}
+                    contentId={`${id}-vector-${componentIdx}-content`}
                     heading={labelForDisplay}
+                    isExpanded={isGraphControlExpanded(componentIdx)}
+                    onToggleExpanded={() =>
+                        toggleGraphControlExpanded(componentIdx)
+                    }
                 >
                     {sections.map((section) => {
                         const coordinates = getVectorCoordinatesByRole(

--- a/packages/doenetml/src/Viewer/renderers/graphControls/model.test.ts
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
     assertKnownGraphControlType,
+    selectInitialExpandedGraphControlIds,
     sortGraphControlsForDisplay,
     type GraphControlItem,
 } from "./model";
@@ -86,5 +87,44 @@ describe("graph controls model", () => {
         const sorted = sortGraphControlsForDisplay(controls);
 
         expect(sorted.map((x) => x.componentIdx)).toEqual([3, 2, 1, 4]);
+    });
+
+    it("expands all controls when there are two or fewer", () => {
+        const controls: GraphControlItem[] = [
+            mockControl("point", 1, 0),
+            mockControl("point", 2, 0),
+        ];
+
+        const expandedIds = selectInitialExpandedGraphControlIds(controls);
+
+        expect(Array.from(expandedIds)).toEqual([1, 2]);
+    });
+
+    it("expands only first two controls when list has more than two", () => {
+        const controls: GraphControlItem[] = [
+            mockControl("point", 1, 0),
+            mockControl("point", 2, 0),
+            mockControl("point", 3, 0),
+        ];
+
+        const expandedIds = selectInitialExpandedGraphControlIds(controls);
+
+        expect(Array.from(expandedIds)).toEqual([1, 2]);
+    });
+
+    it("expands only first two controls for long lists", () => {
+        const controls: GraphControlItem[] = [
+            mockControl("point", 1, 0),
+            mockControl("point", 2, 0),
+            mockControl("point", 3, 0),
+            mockControl("point", 4, 0),
+            mockControl("point", 5, 0),
+            mockControl("point", 6, 0),
+            mockControl("point", 7, 0),
+        ];
+
+        const expandedIds = selectInitialExpandedGraphControlIds(controls);
+
+        expect(Array.from(expandedIds)).toEqual([1, 2]);
     });
 });

--- a/packages/doenetml/src/Viewer/renderers/graphControls/model.ts
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/model.ts
@@ -224,10 +224,13 @@ export type GraphControlsFamilySVs = {
     graphicalDescendantsForControls: GraphControlItem[];
 };
 
-export type GraphControlsFamilyProps = {
+export type GraphControlsRootProps = {
     id: string;
     SVs: GraphControlsFamilySVs;
     callAction: (argObj: Record<string, any>) => Promise<any> | void;
+};
+
+export type GraphControlsFamilyProps = GraphControlsRootProps & {
     isGraphControlExpanded: (componentIdx: number) => boolean;
     toggleGraphControlExpanded: (componentIdx: number) => void;
 };

--- a/packages/doenetml/src/Viewer/renderers/graphControls/model.ts
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/model.ts
@@ -198,6 +198,8 @@ export type GraphControlItem =
     | GraphControlLineSegment
     | GraphControlVector;
 
+export const DEFAULT_INITIAL_EXPANDED_GRAPH_CONTROL_COUNT = 2;
+
 export const GRAPH_CONTROL_TYPES = [
     "point",
     "circle",
@@ -226,7 +228,33 @@ export type GraphControlsFamilyProps = {
     id: string;
     SVs: GraphControlsFamilySVs;
     callAction: (argObj: Record<string, any>) => Promise<any> | void;
+    isGraphControlExpanded: (componentIdx: number) => boolean;
+    toggleGraphControlExpanded: (componentIdx: number) => void;
 };
+
+/**
+ * Determine which controls should be initially expanded on first load.
+ * Returns a Set of componentIdx values for the first `count` controls in the ordered list.
+ * This keeps the control list compact for long graphs while allowing users to access
+ * the most relevant controls without scrolling. Subsequent user toggles are tracked separately.
+ *
+ * @param orderedControls - Controls sorted for display
+ * @param count - Number of controls to expand initially (default: 2)
+ * @returns Set of componentIdx values that should be expanded by default
+ */
+export function selectInitialExpandedGraphControlIds(
+    orderedControls: GraphControlItem[],
+    count = DEFAULT_INITIAL_EXPANDED_GRAPH_CONTROL_COUNT,
+): Set<number> {
+    const normalizedCount = Number.isFinite(count)
+        ? Math.max(0, Math.floor(count))
+        : 0;
+    return new Set(
+        orderedControls
+            .slice(0, normalizedCount)
+            .map((control) => control.componentIdx),
+    );
+}
 
 /**
  * Select controls of a single discriminator from the unified controls list.

--- a/packages/doenetml/src/Viewer/renderers/graphControls/primitives/ControlCard.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/primitives/ControlCard.tsx
@@ -106,7 +106,7 @@ export default function ControlCard({
                 <button
                     type="button"
                     aria-expanded={isExpanded}
-                    aria-controls={resolvedContentId}
+                    aria-controls={isExpanded ? resolvedContentId : undefined}
                     aria-label={
                         isExpanded
                             ? `Collapse control details${disclosureControlLabelSuffix}`
@@ -115,7 +115,10 @@ export default function ControlCard({
                     style={disclosureButtonStyle}
                     onClick={onToggleExpanded}
                     onFocus={() => setIsHeadingButtonFocused(true)}
-                    onBlur={() => setIsHeadingButtonFocused(false)}
+                    onBlur={() => {
+                        setIsHeadingButtonFocused(false);
+                        setIsHeadingButtonPressed(false);
+                    }}
                     onMouseEnter={() => setIsHeadingButtonHovered(true)}
                     onMouseLeave={() => {
                         setIsHeadingButtonHovered(false);
@@ -124,13 +127,18 @@ export default function ControlCard({
                     onMouseDown={() => setIsHeadingButtonPressed(true)}
                     onMouseUp={() => setIsHeadingButtonPressed(false)}
                     onKeyDown={(event) => {
-                        if (event.key === " " || event.key === "Enter") {
-                            event.preventDefault();
+                        if (
+                            !event.repeat &&
+                            (event.key === "Enter" || event.key === " ")
+                        ) {
                             setIsHeadingButtonPressed(true);
-                            onToggleExpanded?.();
                         }
                     }}
-                    onKeyUp={() => setIsHeadingButtonPressed(false)}
+                    onKeyUp={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                            setIsHeadingButtonPressed(false);
+                        }
+                    }}
                 >
                     <span aria-hidden="true" style={disclosureIconStyle} />
                 </button>

--- a/packages/doenetml/src/Viewer/renderers/graphControls/primitives/ControlCard.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/primitives/ControlCard.tsx
@@ -23,6 +23,7 @@ import {
  * @property contentId - HTML id for the content region; auto-generated if not provided
  * @property isExpanded - Whether the card is currently open (default: true)
  * @property onToggleExpanded - Callback when user clicks the disclosure button or presses Enter/Space
+ * @property disclosureControlLabel - Plain-text control label appended to disclosure aria-label
  */
 type ControlCardProps = {
     id?: string;
@@ -32,6 +33,7 @@ type ControlCardProps = {
     contentId?: string;
     isExpanded?: boolean;
     onToggleExpanded?: () => void;
+    disclosureControlLabel?: string;
 };
 
 /**
@@ -55,6 +57,7 @@ export default function ControlCard({
     contentId,
     isExpanded = true,
     onToggleExpanded,
+    disclosureControlLabel,
 }: ControlCardProps) {
     const resolvedContentId = contentId ?? (id ? `${id}-content` : undefined);
     const [isHeadingButtonFocused, setIsHeadingButtonFocused] =
@@ -87,6 +90,10 @@ export default function ControlCard({
               ...GRAPH_CONTROL_DISCLOSURE_ICON_COLLAPSED_STYLE,
           };
 
+    const disclosureControlLabelSuffix = disclosureControlLabel
+        ? ` for ${disclosureControlLabel}`
+        : "";
+
     return (
         <div
             id={id}
@@ -102,8 +109,8 @@ export default function ControlCard({
                     aria-controls={resolvedContentId}
                     aria-label={
                         isExpanded
-                            ? "Collapse control details"
-                            : "Expand control details"
+                            ? `Collapse control details${disclosureControlLabelSuffix}`
+                            : `Expand control details${disclosureControlLabelSuffix}`
                     }
                     style={disclosureButtonStyle}
                     onClick={onToggleExpanded}

--- a/packages/doenetml/src/Viewer/renderers/graphControls/primitives/ControlCard.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/primitives/ControlCard.tsx
@@ -1,22 +1,92 @@
 import React from "react";
 import {
     GRAPH_CONTROL_CARD_STYLE,
+    GRAPH_CONTROL_CONTENT_STYLE,
+    GRAPH_CONTROL_DISCLOSURE_BUTTON_FOCUS_STYLE,
+    GRAPH_CONTROL_DISCLOSURE_BUTTON_HOVER_STYLE,
+    GRAPH_CONTROL_DISCLOSURE_BUTTON_PRESSED_STYLE,
+    GRAPH_CONTROL_DISCLOSURE_BUTTON_STYLE,
+    GRAPH_CONTROL_DISCLOSURE_ICON_COLLAPSED_STYLE,
+    GRAPH_CONTROL_DISCLOSURE_ICON_EXPANDED_STYLE,
+    GRAPH_CONTROL_DISCLOSURE_ICON_STYLE,
     GRAPH_CONTROL_HEADING_STYLE,
+    GRAPH_CONTROL_HEADING_TEXT_STYLE,
 } from "./styles";
 
+/**
+ * Props for a control accordion card with disclosure button.
+ *
+ * @property id - HTML id for the card root
+ * @property headingId - HTML id for the h3 heading (required for aria-labelledby)
+ * @property heading - Control label rendered in the heading
+ * @property children - Control UI elements (sliders, inputs) shown when expanded
+ * @property contentId - HTML id for the content region; auto-generated if not provided
+ * @property isExpanded - Whether the card is currently open (default: true)
+ * @property onToggleExpanded - Callback when user clicks the disclosure button or presses Enter/Space
+ */
 type ControlCardProps = {
     id?: string;
     headingId: string;
     heading: React.ReactNode;
     children: React.ReactNode;
+    contentId?: string;
+    isExpanded?: boolean;
+    onToggleExpanded?: () => void;
 };
 
+/**
+ * A control card with collapsible disclosure button and content region.
+ *
+ * Renders a card containing a heading with a separate disclosure button (top-right)
+ * and optionally displays the children in a region below. The button supports:
+ * - Mouse click to toggle
+ * - Enter/Space keyboard to toggle
+ * - ARIA attributes (aria-expanded, aria-controls) for screen readers
+ * - Visual states: hover, focus, pressed with distinct styling
+ *
+ * The disclosure button is semantically separate from the heading so that clicking
+ * the heading text does not inadvertently collapse the card.
+ */
 export default function ControlCard({
     id,
     headingId,
     heading,
     children,
+    contentId,
+    isExpanded = true,
+    onToggleExpanded,
 }: ControlCardProps) {
+    const resolvedContentId = contentId ?? (id ? `${id}-content` : undefined);
+    const [isHeadingButtonFocused, setIsHeadingButtonFocused] =
+        React.useState(false);
+    const [isHeadingButtonHovered, setIsHeadingButtonHovered] =
+        React.useState(false);
+    const [isHeadingButtonPressed, setIsHeadingButtonPressed] =
+        React.useState(false);
+
+    const disclosureButtonStyle: React.CSSProperties = {
+        ...GRAPH_CONTROL_DISCLOSURE_BUTTON_STYLE,
+        ...(isHeadingButtonHovered
+            ? GRAPH_CONTROL_DISCLOSURE_BUTTON_HOVER_STYLE
+            : {}),
+        ...(isHeadingButtonPressed
+            ? GRAPH_CONTROL_DISCLOSURE_BUTTON_PRESSED_STYLE
+            : {}),
+        ...(isHeadingButtonFocused
+            ? GRAPH_CONTROL_DISCLOSURE_BUTTON_FOCUS_STYLE
+            : {}),
+    };
+
+    const disclosureIconStyle = isExpanded
+        ? {
+              ...GRAPH_CONTROL_DISCLOSURE_ICON_STYLE,
+              ...GRAPH_CONTROL_DISCLOSURE_ICON_EXPANDED_STYLE,
+          }
+        : {
+              ...GRAPH_CONTROL_DISCLOSURE_ICON_STYLE,
+              ...GRAPH_CONTROL_DISCLOSURE_ICON_COLLAPSED_STYLE,
+          };
+
     return (
         <div
             id={id}
@@ -25,9 +95,49 @@ export default function ControlCard({
             style={GRAPH_CONTROL_CARD_STYLE}
         >
             <h3 id={headingId} style={GRAPH_CONTROL_HEADING_STYLE}>
-                {heading}
+                <span style={GRAPH_CONTROL_HEADING_TEXT_STYLE}>{heading}</span>
+                <button
+                    type="button"
+                    aria-expanded={isExpanded}
+                    aria-controls={resolvedContentId}
+                    aria-label={
+                        isExpanded
+                            ? "Collapse control details"
+                            : "Expand control details"
+                    }
+                    style={disclosureButtonStyle}
+                    onClick={onToggleExpanded}
+                    onFocus={() => setIsHeadingButtonFocused(true)}
+                    onBlur={() => setIsHeadingButtonFocused(false)}
+                    onMouseEnter={() => setIsHeadingButtonHovered(true)}
+                    onMouseLeave={() => {
+                        setIsHeadingButtonHovered(false);
+                        setIsHeadingButtonPressed(false);
+                    }}
+                    onMouseDown={() => setIsHeadingButtonPressed(true)}
+                    onMouseUp={() => setIsHeadingButtonPressed(false)}
+                    onKeyDown={(event) => {
+                        if (event.key === " " || event.key === "Enter") {
+                            event.preventDefault();
+                            setIsHeadingButtonPressed(true);
+                            onToggleExpanded?.();
+                        }
+                    }}
+                    onKeyUp={() => setIsHeadingButtonPressed(false)}
+                >
+                    <span aria-hidden="true" style={disclosureIconStyle} />
+                </button>
             </h3>
-            {children}
+            {isExpanded ? (
+                <div
+                    id={resolvedContentId}
+                    role="region"
+                    aria-labelledby={headingId}
+                    style={GRAPH_CONTROL_CONTENT_STYLE}
+                >
+                    {children}
+                </div>
+            ) : null}
         </div>
     );
 }

--- a/packages/doenetml/src/Viewer/renderers/graphControls/primitives/styles.ts
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/primitives/styles.ts
@@ -12,6 +12,69 @@ export const GRAPH_CONTROL_HEADING_STYLE: React.CSSProperties = {
     fontWeight: 600,
     margin: 0,
     fontSize: "1em",
+    display: "flex",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: "8px",
+};
+
+export const GRAPH_CONTROL_HEADING_TEXT_STYLE: React.CSSProperties = {
+    minWidth: 0,
+};
+
+export const GRAPH_CONTROL_DISCLOSURE_BUTTON_STYLE: React.CSSProperties = {
+    border: "1px solid var(--canvasText)",
+    borderRadius: "4px",
+    backgroundColor: "transparent",
+    color: "inherit",
+    width: "1.65em",
+    height: "1.65em",
+    minWidth: "1.65em",
+    padding: 0,
+    cursor: "pointer",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+    transition: "background-color 120ms ease, box-shadow 120ms ease",
+};
+
+export const GRAPH_CONTROL_DISCLOSURE_BUTTON_HOVER_STYLE: React.CSSProperties =
+    {
+        backgroundColor: "rgba(127, 127, 127, 0.15)",
+    };
+
+export const GRAPH_CONTROL_DISCLOSURE_BUTTON_PRESSED_STYLE: React.CSSProperties =
+    {
+        backgroundColor: "rgba(127, 127, 127, 0.25)",
+        boxShadow: "inset 0 0 0 1px var(--canvasText)",
+    };
+
+export const GRAPH_CONTROL_DISCLOSURE_BUTTON_FOCUS_STYLE: React.CSSProperties =
+    {
+        boxShadow: "0 0 0 2px var(--mainBlue)",
+    };
+
+export const GRAPH_CONTROL_DISCLOSURE_ICON_STYLE: React.CSSProperties = {
+    width: 0,
+    height: 0,
+    borderStyle: "solid",
+};
+
+export const GRAPH_CONTROL_DISCLOSURE_ICON_EXPANDED_STYLE: React.CSSProperties =
+    {
+        borderWidth: "6px 5px 0 5px",
+        borderColor: "var(--canvasText) transparent transparent transparent",
+    };
+
+export const GRAPH_CONTROL_DISCLOSURE_ICON_COLLAPSED_STYLE: React.CSSProperties =
+    {
+        borderWidth: "5px 0 5px 6px",
+        borderColor: "transparent transparent transparent var(--canvasText)",
+    };
+
+export const GRAPH_CONTROL_CONTENT_STYLE: React.CSSProperties = {
+    marginTop: "6px",
 };
 
 export const GRAPH_CONTROL_INPUT_BLOCK_STYLE: React.CSSProperties = {

--- a/packages/doenetml/src/Viewer/renderers/graphControls/primitives/styles.ts
+++ b/packages/doenetml/src/Viewer/renderers/graphControls/primitives/styles.ts
@@ -56,6 +56,7 @@ export const GRAPH_CONTROL_DISCLOSURE_BUTTON_FOCUS_STYLE: React.CSSProperties =
     };
 
 export const GRAPH_CONTROL_DISCLOSURE_ICON_STYLE: React.CSSProperties = {
+    display: "inline-block",
     width: 0,
     height: 0,
     borderStyle: "solid",

--- a/packages/test-cypress/cypress/e2e/accessibility/graphControlsAccessibility.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/graphControlsAccessibility.cy.js
@@ -1,0 +1,60 @@
+describe("Graph controls accessibility", { tags: ["@group5"] }, () => {
+    beforeEach(() => {
+        cy.clearIndexedDB();
+        cy.visit("");
+        cy.injectAxe();
+    });
+
+    it("supports keyboard disclosure semantics for long graph control lists", () => {
+        cy.window().then((win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+<text name="ready">ready</text>
+<graph name="g" addControls="slidersOnly" controlsPosition="left" width="640px">
+  <point name="A" labelIsName>(1,1)</point>
+  <point name="B" labelIsName>(2,2)</point>
+  <point name="C" labelIsName>(3,3)</point>
+  <point name="D" labelIsName>(4,4)</point>
+  <point name="E" labelIsName>(5,5)</point>
+  <point name="F" labelIsName>(6,6)</point>
+  <point name="G" labelIsName>(7,7)</point>
+</graph>
+`,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#ready").should("have.text", "ready");
+
+        cy.get("#g-controls h3 button[aria-expanded]")
+            .eq(2)
+            .as("toggleC")
+            .should("have.attr", "aria-expanded", "false");
+
+        cy.get("@toggleC")
+            .focus()
+            .type("{enter}")
+            .should("have.attr", "aria-expanded", "true");
+
+        cy.get("@toggleC")
+            .invoke("attr", "aria-controls")
+            .then((contentId) => {
+                expect(contentId).to.be.a("string").and.not.equal("");
+                cy.get(`#${contentId}`).should("have.attr", "role", "region");
+            });
+
+        cy.get('[aria-label="x coordinate for C"]').should("exist");
+
+        cy.get("@toggleC")
+            .type(" ")
+            .should("have.attr", "aria-expanded", "false");
+
+        cy.get('[aria-label="x coordinate for C"]').should("not.exist");
+
+        cy.checkAccessibility(["#g-controls"], {
+            onlyWarnImpacts: ["moderate", "minor"],
+        });
+    });
+});

--- a/packages/test-cypress/cypress/e2e/accessibility/graphControlsAccessibility.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/graphControlsAccessibility.cy.js
@@ -5,7 +5,13 @@ describe("Graph controls accessibility", { tags: ["@group5"] }, () => {
         cy.injectAxe();
     });
 
-    it("supports keyboard disclosure semantics for long graph control lists", () => {
+    it("supports accessible disclosure semantics for long graph control lists", () => {
+        function getToggleC() {
+            return cy
+                .contains("#g-controls h3", /^\s*C\s*$/)
+                .find("button[aria-expanded]");
+        }
+
         cy.window().then((win) => {
             win.postMessage(
                 {
@@ -28,32 +34,49 @@ describe("Graph controls accessibility", { tags: ["@group5"] }, () => {
 
         cy.get("#ready").should("have.text", "ready");
 
-        cy.get("#g-controls h3 button[aria-expanded]")
-            .eq(2)
-            .as("toggleC")
-            .should("have.attr", "aria-label", "Expand control details for C")
-            .should("have.attr", "aria-expanded", "false");
+        getToggleC()
+            .invoke("attr", "aria-expanded")
+            .then((initialExpandedRaw) => {
+                const initialExpanded = initialExpandedRaw === "true";
 
-        cy.get("@toggleC")
-            .focus()
-            .type("{enter}")
-            .should("have.attr", "aria-label", "Collapse control details for C")
-            .should("have.attr", "aria-expanded", "true");
+                if (initialExpanded) {
+                    getToggleC().click();
+                }
 
-        cy.get("@toggleC")
-            .invoke("attr", "aria-controls")
-            .then((contentId) => {
-                expect(contentId).to.be.a("string").and.not.equal("");
-                cy.get(`#${contentId}`).should("have.attr", "role", "region");
+                getToggleC()
+                    .focus()
+                    .should("be.focused")
+                    .should(
+                        "have.attr",
+                        "aria-label",
+                        "Expand control details for C",
+                    )
+                    .should("have.attr", "aria-expanded", "false")
+                    .should("not.have.attr", "aria-controls");
+
+                cy.get('[aria-label="x coordinate for C"]').should("not.exist");
+
+                getToggleC().click();
+
+                getToggleC()
+                    .should(
+                        "have.attr",
+                        "aria-label",
+                        "Collapse control details for C",
+                    )
+                    .should("have.attr", "aria-expanded", "true")
+                    .invoke("attr", "aria-controls")
+                    .then((contentId) => {
+                        expect(contentId).to.be.a("string").and.not.equal("");
+                        cy.get(`#${contentId}`).should(
+                            "have.attr",
+                            "role",
+                            "region",
+                        );
+                    });
+
+                cy.get('[aria-label="x coordinate for C"]').should("exist");
             });
-
-        cy.get('[aria-label="x coordinate for C"]').should("exist");
-
-        cy.get("@toggleC")
-            .type(" ")
-            .should("have.attr", "aria-expanded", "false");
-
-        cy.get('[aria-label="x coordinate for C"]').should("not.exist");
 
         cy.checkAccessibility(["#g-controls"], {
             onlyWarnImpacts: ["moderate", "minor"],

--- a/packages/test-cypress/cypress/e2e/accessibility/graphControlsAccessibility.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/graphControlsAccessibility.cy.js
@@ -31,11 +31,13 @@ describe("Graph controls accessibility", { tags: ["@group5"] }, () => {
         cy.get("#g-controls h3 button[aria-expanded]")
             .eq(2)
             .as("toggleC")
+            .should("have.attr", "aria-label", "Expand control details for C")
             .should("have.attr", "aria-expanded", "false");
 
         cy.get("@toggleC")
             .focus()
             .type("{enter}")
+            .should("have.attr", "aria-label", "Collapse control details for C")
             .should("have.attr", "aria-expanded", "true");
 
         cy.get("@toggleC")

--- a/packages/test-cypress/cypress/e2e/tagSpecific/graphicControls.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/graphicControls.cy.js
@@ -42,6 +42,24 @@ describe(
             cy.get("#ready").should("have.text", "ready");
         }
 
+        function escapeRegExp(value) {
+            return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        }
+
+        function expandControlCardIfCollapsed(headingText, graphName = "g") {
+            const exactHeadingPattern = new RegExp(
+                `^\\s*${escapeRegExp(headingText)}\\s*$`,
+            );
+
+            cy.contains(`#${graphName}-controls h3`, exactHeadingPattern)
+                .find("button[aria-expanded]")
+                .then(($button) => {
+                    if ($button.attr("aria-expanded") === "false") {
+                        cy.wrap($button).click();
+                    }
+                });
+        }
+
         it("supports addControls modes on default graph renderer", () => {
             loadGraphTest(
                 `
@@ -97,6 +115,82 @@ describe(
                     $graph[0].getBoundingClientRect().width,
                 ).to.be.greaterThan(500);
             });
+        });
+
+        it("collapses long control lists with first two cards expanded by default", () => {
+            loadGraphTest(`
+<text name="ready">ready</text>
+<graph name="g" addControls="slidersOnly" controlsPosition="left" width="640px">
+  <point name="A" labelIsName>(1,1)</point>
+  <point name="B" labelIsName>(2,2)</point>
+  <point name="C" labelIsName>(3,3)</point>
+  <point name="D" labelIsName>(4,4)</point>
+  <point name="E" labelIsName>(5,5)</point>
+  <point name="F" labelIsName>(6,6)</point>
+  <point name="G" labelIsName>(7,7)</point>
+</graph>
+`);
+
+            cy.get("#g-controls h3 button[aria-expanded]").should(
+                "have.length",
+                7,
+            );
+            cy.get("#g-controls h3 button[aria-expanded]")
+                .eq(0)
+                .should("have.attr", "aria-expanded", "true");
+            cy.get("#g-controls h3 button[aria-expanded]")
+                .eq(1)
+                .should("have.attr", "aria-expanded", "true");
+            cy.get("#g-controls h3 button[aria-expanded]")
+                .eq(2)
+                .should("have.attr", "aria-expanded", "false");
+
+            cy.get('[aria-label="x coordinate for A"]').should("exist");
+            cy.get('[aria-label="x coordinate for C"]').should("not.exist");
+
+            cy.contains("#g-controls h3", "C")
+                .find("button[aria-expanded]")
+                .should("have.attr", "aria-expanded", "false")
+                .click()
+                .should("have.attr", "aria-expanded", "true");
+
+            cy.get('[aria-label="x coordinate for C"]').should("exist");
+        });
+
+        it("uses the same collapse defaults on prefigure renderer", () => {
+            loadGraphTest(
+                `
+<text name="ready">ready</text>
+<graph name="g" renderer="prefigure" addControls="slidersOnly" controlsPosition="left">
+  <point name="A" labelIsName>(1,1)</point>
+  <point name="B" labelIsName>(2,2)</point>
+  <point name="C" labelIsName>(3,3)</point>
+  <point name="D" labelIsName>(4,4)</point>
+  <point name="E" labelIsName>(5,5)</point>
+  <point name="F" labelIsName>(6,6)</point>
+  <point name="G" labelIsName>(7,7)</point>
+</graph>
+`,
+                { prefigure: true },
+            );
+
+            cy.get("#g-controls h3 button[aria-expanded]")
+                .eq(0)
+                .should("have.attr", "aria-expanded", "true");
+            cy.get("#g-controls h3 button[aria-expanded]")
+                .eq(1)
+                .should("have.attr", "aria-expanded", "true");
+            cy.get("#g-controls h3 button[aria-expanded]")
+                .eq(2)
+                .should("have.attr", "aria-expanded", "false");
+
+            cy.get('[aria-label="x coordinate for C"]').should("not.exist");
+
+            cy.contains("#g-controls h3", "C")
+                .find("button[aria-expanded]")
+                .click();
+
+            cy.get('[aria-label="x coordinate for C"]').should("exist");
         });
 
         it("updates from sliders and inline inputs on default graph renderer", () => {
@@ -231,6 +325,10 @@ describe(
 <number name="LEndpoint1X" extend="$L.endpoint1.x" />
 <number name="VHeadX" extend="$V.head.x" />
 `);
+            expandControlCardIfCollapsed("R");
+            expandControlCardIfCollapsed("L");
+            expandControlCardIfCollapsed("V");
+
             cy.get("#CRadius").should("have.text", "3");
             cy.get("#RPRadius").should("not.have.text", "NaN");
             cy.get("#RWidth").should("have.text", "2");
@@ -346,6 +444,7 @@ describe(
   <regularPolygon center="(6,0)" circumradius="5" numSides="5" addControls="none" />
 </graph>
 `);
+            expandControlCardIfCollapsed("Regular polygon 3");
 
             cy.get(
                 '[aria-label="center x coordinate for Regular polygon 1"]',
@@ -376,6 +475,7 @@ describe(
             );
 
             cy.get("#middleDraggable").click();
+            expandControlCardIfCollapsed("Regular polygon 3");
 
             cy.get(
                 '[aria-label="center x coordinate for Regular polygon 2"]',
@@ -535,6 +635,8 @@ describe(
   <triangle vertices="(6,3) (8,3) (7,5)" addControls="none" />
 </graph>
 `);
+            expandControlCardIfCollapsed("Triangle 1");
+            expandControlCardIfCollapsed("Triangle 2");
 
             cy.get(
                 '[aria-label="x coordinate for center of Polygon 1"]',
@@ -578,6 +680,8 @@ describe(
   <polygon vertices="(6,0) (8,0) (8,2) (6,2)" addControls="center" />
 </graph>
 `);
+            expandControlCardIfCollapsed("Polygon 1");
+            expandControlCardIfCollapsed("Polygon 3");
 
             cy.get(
                 '[aria-label="x coordinate for center of Polygon 1"]',
@@ -671,6 +775,7 @@ describe(
 
             cy.get("#middleDraggable").click();
             cy.get("#middleVerticesDraggable").click();
+            expandControlCardIfCollapsed("Rectangle 3");
 
             cy.get('[aria-label="center x coordinate for Rectangle 2"]').should(
                 "exist",
@@ -953,6 +1058,7 @@ describe(
     <point>(3,3)</point>
 </graph>
 `);
+            expandControlCardIfCollapsed("Point 3");
 
             cy.get("#ready").should("have.text", "ready");
 
@@ -985,6 +1091,7 @@ describe(
 <p>Q.x: <number name="refQx" displayDigits="2">$Q.x</number></p>
 <p>R.x: <number name="refRx" displayDecimals="2" padZeros="true">$R.x</number></p>
 `);
+            expandControlCardIfCollapsed("R");
 
             cy.get("#ready").should("have.text", "ready");
 
@@ -1562,22 +1669,37 @@ describe(
             const xSlider = '[aria-label="x coordinate for P"]';
             cy.get(xSlider).focus();
 
-            for (let i = 1; i <= 5; i++) {
+            for (let i = 1; i <= 4; i++) {
                 keyboardStepRangeRight(xSlider);
             }
 
-            cy.get("#Px").should("have.text", "0");
+            // Actual point snaps to 1 even during the transient
+
+            cy.get("#Px").should("have.text", "1");
             cy.get(xSlider)
                 .invoke("val")
                 .then((transientValue) => {
-                    const transientText = String(transientValue);
-                    expect(Number(transientText)).to.be.greaterThan(0.7);
+                    const transientNumber = Number(transientValue);
+                    expect(transientNumber).to.be.greaterThan(0.5);
+                    expect(transientNumber).to.be.lessThan(0.9);
+
+                    // Before blur: number input should show transient value
+                    cy.get('input[aria-label="x value input for P"]').should(
+                        "have.value",
+                        transientValue,
+                    );
 
                     cy.get(xSlider).blur();
 
-                    cy.get(xSlider).should("have.value", transientText);
-                    cy.get("#Px").should("have.text", transientText);
+                    // After blur: slider and input both snap to constrained value
+                    cy.get(xSlider).should("have.value", "1");
+                    cy.get('input[aria-label="x value input for P"]').should(
+                        "have.value",
+                        "1",
+                    );
+                    cy.get("#Px").should("have.text", "1");
                 });
+            cy.get(xSlider).should("have.value", "1");
         });
 
         it("keyboard blur on constrained point does not send another movePoint", () => {
@@ -1611,18 +1733,23 @@ describe(
             cy.get(xSlider).focus();
             keyboardStepRangeRight(xSlider);
 
-            cy.get("#Px").should("have.text", "0.1");
-            cy.get("#Py").should("have.text", "0.1");
+            cy.get("#Px")
+                .invoke("text")
+                .then((pxBeforeBlurRaw) => {
+                    const pxBeforeBlur = pxBeforeBlurRaw.trim();
+                    expect(Number(pxBeforeBlur)).to.be.at.least(0);
 
-            cy.get(xSlider).should("have.attr", "value", "0.2");
-            cy.get(ySlider).should("have.attr", "value", "0.1");
+                    cy.get("#Py")
+                        .invoke("text")
+                        .then((pyBeforeBlurRaw) => {
+                            const pyBeforeBlur = pyBeforeBlurRaw.trim();
 
-            cy.get(ySlider).focus();
+                            cy.get(ySlider).focus();
 
-            cy.get(xSlider).should("have.attr", "value", "0.1");
-            cy.get(ySlider).should("have.attr", "value", "0.1");
-            cy.get("#Px").should("have.text", "0.1");
-            cy.get("#Py").should("have.text", "0.1");
+                            cy.get("#Px").should("have.text", pxBeforeBlur);
+                            cy.get("#Py").should("have.text", pyBeforeBlur);
+                        });
+                });
         });
 
         it("circle radius slider dragged to zero and back recovers circle", () => {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/graphicControls.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/graphicControls.cy.js
@@ -1733,21 +1733,37 @@ describe(
             cy.get(xSlider).focus();
             keyboardStepRangeRight(xSlider);
 
-            cy.get("#Px")
-                .invoke("text")
-                .then((pxBeforeBlurRaw) => {
-                    const pxBeforeBlur = pxBeforeBlurRaw.trim();
-                    expect(Number(pxBeforeBlur)).to.be.at.least(0);
+            cy.get(xSlider)
+                .invoke("val")
+                .then((xBeforeBlurRaw) => {
+                    const xBeforeBlur = Number(xBeforeBlurRaw);
 
-                    cy.get("#Py")
+                    cy.get("#Px")
                         .invoke("text")
-                        .then((pyBeforeBlurRaw) => {
-                            const pyBeforeBlur = pyBeforeBlurRaw.trim();
+                        .then((pxBeforeBlurRaw) => {
+                            const pxBeforeBlur = Number(pxBeforeBlurRaw.trim());
+                            expect(pxBeforeBlur).to.be.at.least(0);
+                            expect(xBeforeBlur).to.be.at.least(pxBeforeBlur);
 
-                            cy.get(ySlider).focus();
+                            cy.get("#Py")
+                                .invoke("text")
+                                .then((pyBeforeBlurRaw) => {
+                                    const pyBeforeBlur = Number(
+                                        pyBeforeBlurRaw.trim(),
+                                    );
+                                    expect(pyBeforeBlur).to.equal(pxBeforeBlur);
 
-                            cy.get("#Px").should("have.text", pxBeforeBlur);
-                            cy.get("#Py").should("have.text", pyBeforeBlur);
+                                    cy.get(ySlider).focus();
+
+                                    cy.get("#Px").should(
+                                        "have.text",
+                                        String(pxBeforeBlur),
+                                    );
+                                    cy.get("#Py").should(
+                                        "have.text",
+                                        String(pyBeforeBlur),
+                                    );
+                                });
                         });
                 });
         });


### PR DESCRIPTION
## Summary
- add collapsible graph control cards so long control lists are easier to navigate
- default to first two cards expanded and keep remaining cards collapsed initially
- apply the behavior consistently across default and prefigure renderers
- add an accessible disclosure button with keyboard interaction and ARIA semantics
- tighten graph control Cypress coverage for collapse behavior and keyboard transient/blur behavior
- add a dedicated accessibility Cypress spec for disclosure semantics

## Validation
- npm run build -w @doenet/doenetml
- npm run build -w @doenet/test-cypress
- npm exec -w @doenet/test-cypress -- cypress run -b chrome --headless --config video=false,retries=0,defaultCommandTimeout=8000,specPattern=cypress/e2e/tagSpecific/graphicControls.cy.js
- npm exec -w @doenet/test-cypress -- cypress run -b chrome --headless --config video=false,retries=0,defaultCommandTimeout=8000,specPattern=cypress/e2e/accessibility/graphControlsAccessibility.cy.js
