### PR TITLE
Fix sort/shuffle sugar fallback and diagnostics

### DIFF
--- a/.changeset/calm-pigs-smile.md
+++ b/.changeset/calm-pigs-smile.md
@@ -1,0 +1,12 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Fix `sort` and `shuffle` sugar handling when type information is missing or invalid, and improve diagnostics for mixed string/component children.
+
+- Default sugar-created replacements to `math` when `type` is omitted.
+- Fall back to `math` (with warning diagnostics) when `type` is invalid.
+- Ignore non-component string children in mixed-content cases with explicit warning diagnostics.
+- Add test coverage for the fallback and diagnostics behavior.

--- a/.changeset/calm-pigs-smile.md
+++ b/.changeset/calm-pigs-smile.md
@@ -6,7 +6,7 @@
 
 Fix `sort` and `shuffle` sugar handling when type information is missing or invalid, and improve diagnostics for mixed string/component children.
 
-- Default sugar-created replacements to `math` when `type` is omitted.
 - Fall back to `math` (with warning diagnostics) when `type` is invalid.
-- Ignore non-component string children in mixed-content cases with explicit warning diagnostics.
+- When `type` is omitted, do not apply sugar; instead, if a string child exists, emit warnings telling authors to specify a `type` attribute.
+- Ignore string children in mixed-content cases with explicit warning diagnostics.
 - Add test coverage for the fallback and diagnostics behavior.

--- a/packages/doenetml-worker-javascript/src/components/Shuffle.js
+++ b/packages/doenetml-worker-javascript/src/components/Shuffle.js
@@ -58,7 +58,15 @@ export default class Shuffle extends CompositeComponent {
             if (componentAttributes.type?.value) {
                 type = componentAttributes.type.value;
             } else {
-                type = "math";
+                if (
+                    matchedChildren.some((child) => typeof child === "string")
+                ) {
+                    diagnostics.push({
+                        type: "warning",
+                        message: `For \`<shuffle>\` to work with string children, a \`type\` attribute must be specified.`,
+                    });
+                }
+                return { success: false, diagnostics };
             }
 
             if (!["math", "text", "number", "boolean"].includes(type)) {

--- a/packages/doenetml-worker-javascript/src/components/Shuffle.js
+++ b/packages/doenetml-worker-javascript/src/components/Shuffle.js
@@ -42,6 +42,7 @@ export default class Shuffle extends CompositeComponent {
             componentInfoObjects,
             nComponents,
         }) {
+            const diagnostics = [];
             // only if all children are strings or macros
             if (
                 !matchedChildren.every(
@@ -57,12 +58,16 @@ export default class Shuffle extends CompositeComponent {
             if (componentAttributes.type?.value) {
                 type = componentAttributes.type.value;
             } else {
-                return { success: false };
+                type = "math";
             }
 
             if (!["math", "text", "number", "boolean"].includes(type)) {
                 console.warn(`Invalid type ${type}`);
-                return { success: false };
+                diagnostics.push({
+                    type: "warning",
+                    message: `Invalid type ${type} for sort component. Must be one of math, text, number, or boolean. Defaulting to math.`,
+                });
+                type = "math";
             }
 
             // break any string by white space and wrap pieces with type
@@ -84,6 +89,7 @@ export default class Shuffle extends CompositeComponent {
                     success: true,
                     newChildren,
                     nComponents: result.nComponents,
+                    diagnostics,
                 };
             } else {
                 return { success: false };
@@ -121,7 +127,14 @@ export default class Shuffle extends CompositeComponent {
             }),
             definition({ dependencyValues }) {
                 let originalComponentIndices = [];
+                const diagnostics = [];
                 for (let child of dependencyValues.children) {
+                    if (typeof child === "string") {
+                        diagnostics.push({
+                            type: "warning",
+                            message: `String "${child}" is not a valid component to shuffle. Ignoring.`,
+                        });
+                    }
                     if (child.stateValues?.componentIndicesInList) {
                         originalComponentIndices.push(
                             ...child.stateValues.componentIndicesInList,
@@ -136,6 +149,7 @@ export default class Shuffle extends CompositeComponent {
                         originalComponentIndices,
                         numComponents: originalComponentIndices.length,
                     },
+                    sendDiagnostics: diagnostics,
                 };
             },
         };
@@ -167,7 +181,7 @@ export default class Shuffle extends CompositeComponent {
 
                 let numComponents = dependencyValues.numComponents;
 
-                // if desiredIndices is specfied, use those
+                // if desiredIndices is specified, use those
                 let desiredComponentOrder =
                     dependencyValues.variants?.desiredVariant?.indices;
                 if (desiredComponentOrder !== undefined) {
@@ -198,7 +212,10 @@ export default class Shuffle extends CompositeComponent {
                         } else {
                             return {
                                 setValue: {
-                                    componentOrder: desiredComponentOrder,
+                                    componentOrder:
+                                        desiredComponentOrder.filter(
+                                            (x) => x !== undefined,
+                                        ),
                                 },
                             };
                         }

--- a/packages/doenetml-worker-javascript/src/components/Shuffle.js
+++ b/packages/doenetml-worker-javascript/src/components/Shuffle.js
@@ -65,7 +65,7 @@ export default class Shuffle extends CompositeComponent {
                 console.warn(`Invalid type ${type}`);
                 diagnostics.push({
                     type: "warning",
-                    message: `Invalid type ${type} for sort component. Must be one of math, text, number, or boolean. Defaulting to math.`,
+                    message: `Invalid type ${type} for shuffle component. Must be one of math, text, number, or boolean. Defaulting to math.`,
                 });
                 type = "math";
             }

--- a/packages/doenetml-worker-javascript/src/components/Sort.js
+++ b/packages/doenetml-worker-javascript/src/components/Sort.js
@@ -58,6 +58,7 @@ export default class Sort extends CompositeComponent {
             componentInfoObjects,
             nComponents,
         }) {
+            const diagnostics = [];
             // only if all children are strings or macros
             if (
                 !matchedChildren.every(
@@ -73,12 +74,16 @@ export default class Sort extends CompositeComponent {
             if (componentAttributes.type?.value) {
                 type = componentAttributes.type.value;
             } else {
-                return { success: false };
+                type = "math";
             }
 
             if (!["math", "text", "number", "boolean"].includes(type)) {
                 console.warn(`Invalid type ${type}`);
-                return { success: false };
+                diagnostics.push({
+                    type: "warning",
+                    message: `Invalid type ${type} for sort component. Must be one of math, text, number, or boolean. Defaulting to math.`,
+                });
+                type = "math";
             }
 
             // break any string by white space and wrap pieces with type
@@ -100,6 +105,7 @@ export default class Sort extends CompositeComponent {
                     success: true,
                     newChildren,
                     nComponents: result.nComponents,
+                    diagnostics,
                 };
             } else {
                 return { success: false };
@@ -148,7 +154,15 @@ export default class Sort extends CompositeComponent {
             }),
             definition({ dependencyValues }) {
                 let componentIndicesForValues = [];
+                const diagnostics = [];
                 for (let child of dependencyValues.children) {
+                    if (typeof child === "string") {
+                        diagnostics.push({
+                            type: "warning",
+                            message: `String "${child}" is not a valid component to sort. Ignoring.`,
+                        });
+                        continue;
+                    }
                     if (child.stateValues.componentIndicesInList) {
                         componentIndicesForValues.push(
                             ...child.stateValues.componentIndicesInList,
@@ -158,7 +172,10 @@ export default class Sort extends CompositeComponent {
                     }
                 }
 
-                return { setValue: { componentIndicesForValues } };
+                return {
+                    setValue: { componentIndicesForValues },
+                    sendDiagnostics: diagnostics,
+                };
             },
         };
 

--- a/packages/doenetml-worker-javascript/src/components/Sort.js
+++ b/packages/doenetml-worker-javascript/src/components/Sort.js
@@ -74,7 +74,15 @@ export default class Sort extends CompositeComponent {
             if (componentAttributes.type?.value) {
                 type = componentAttributes.type.value;
             } else {
-                type = "math";
+                if (
+                    matchedChildren.some((child) => typeof child === "string")
+                ) {
+                    diagnostics.push({
+                        type: "warning",
+                        message: `For \`<sort>\` to work with string children, a \`type\` attribute must be specified.`,
+                    });
+                }
+                return { success: false, diagnostics };
             }
 
             if (!["math", "text", "number", "boolean"].includes(type)) {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/shuffle.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/shuffle.test.ts
@@ -607,10 +607,6 @@ describe("Shuffle tag tests @group1", async () => {
     });
 
     it("sugar with invalid type specified defaults to math type with warning", async () => {
-        const consoleWarnSpy = vi
-            .spyOn(console, "warn")
-            .mockImplementation(() => {});
-
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
     <p name="pList"><shuffle name="sh" type="bad">d a b</shuffle></p>
@@ -627,9 +623,14 @@ describe("Shuffle tag tests @group1", async () => {
             replacements_all_of_type: "math",
         });
 
-        // Invalid sugar type currently warns via console.warn
-        expect(consoleWarnSpy).toHaveBeenCalledWith("Invalid type bad");
-        consoleWarnSpy.mockRestore();
+        let diagnosticsByType = getDiagnosticsByType(core);
+        expect(diagnosticsByType.warnings.length).eq(1);
+        expect(diagnosticsByType.warnings[0].message).contain(
+            "Invalid type bad for shuffle component",
+        );
+        expect(diagnosticsByType.warnings[0].message).contain(
+            "Defaulting to math",
+        );
     });
 
     it("string children ignored when mixed with non-string children with warning", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/shuffle.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/shuffle.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
 import { createTestCore, ResolvePathToNodeIdx } from "../utils/test-core";
 import { updateMathInputValue } from "../utils/actions";
+import { getDiagnosticsByType } from "../utils/diagnostics";
+import { PublicDoenetMLCore } from "../../CoreWorker";
 
 const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);
 vi.mock("hyperformula");
 
 describe("Shuffle tag tests @group1", async () => {
+    type VariantKey = `${number},${number}`;
+
     it("consistent order for n elements for given variant", async () => {
         const doenetML = `
   <p>m: <mathInput prefill="1" name="m" /></p>
@@ -22,14 +26,14 @@ describe("Shuffle tag tests @group1", async () => {
             requestedVariantIndex: 1,
         });
 
-        let texts = {};
-        let orders = {};
+        let texts: Record<VariantKey, string> = {};
+        let orders: Record<VariantKey, number[]> = {};
 
         let m = 1,
             n = 6;
 
         let stateVariables = await core.returnAllStateVariables(false, true);
-        let componentOrder =
+        let componentOrder: number[] =
             stateVariables[await resolvePathToNodeIdx("sh")].stateValues
                 .componentOrder;
 
@@ -39,7 +43,7 @@ describe("Shuffle tag tests @group1", async () => {
 
         orders[`${m},${n}`] = componentOrder;
 
-        let pText = componentOrder.map((x) => x + m - 1).join(", ");
+        let pText = componentOrder.map((x: number) => x + m - 1).join(", ");
         expect(
             stateVariables[await resolvePathToNodeIdx("pList")].stateValues
                 .text,
@@ -70,7 +74,7 @@ describe("Shuffle tag tests @group1", async () => {
 
         orders[`${m},${n}`] = componentOrder;
 
-        pText = componentOrder.map((x) => x + m - 1).join(", ");
+        pText = componentOrder.map((x: number) => x + m - 1).join(", ");
         expect(
             stateVariables[await resolvePathToNodeIdx("pList")].stateValues
                 .text,
@@ -99,7 +103,7 @@ describe("Shuffle tag tests @group1", async () => {
 
         orders[`${m},${n}`] = componentOrder;
 
-        pText = componentOrder.map((x) => x + m - 1).join(", ");
+        pText = componentOrder.map((x: number) => x + m - 1).join(", ");
         expect(
             stateVariables[await resolvePathToNodeIdx("pList")].stateValues
                 .text,
@@ -128,7 +132,7 @@ describe("Shuffle tag tests @group1", async () => {
 
         orders[`${m},${n}`] = componentOrder;
 
-        pText = componentOrder.map((x) => x + m - 1).join(", ");
+        pText = componentOrder.map((x: number) => x + m - 1).join(", ");
         expect(
             stateVariables[await resolvePathToNodeIdx("pList")].stateValues
                 .text,
@@ -163,7 +167,7 @@ describe("Shuffle tag tests @group1", async () => {
 
         orders[`${m},${n}`] = componentOrder;
 
-        pText = componentOrder.map((x) => x + m - 1).join(", ");
+        pText = componentOrder.map((x: number) => x + m - 1).join(", ");
         expect(
             stateVariables[await resolvePathToNodeIdx("pList")].stateValues
                 .text,
@@ -196,7 +200,7 @@ describe("Shuffle tag tests @group1", async () => {
 
         orders[`${m},${n}`] = componentOrder;
 
-        pText = componentOrder.map((x) => x + m - 1).join(", ");
+        pText = componentOrder.map((x: number) => x + m - 1).join(", ");
         expect(
             stateVariables[await resolvePathToNodeIdx("pList")].stateValues
                 .text,
@@ -225,7 +229,7 @@ describe("Shuffle tag tests @group1", async () => {
 
         orders[`${m},${n}`] = componentOrder;
 
-        pText = componentOrder.map((x) => x + m - 1).join(", ");
+        pText = componentOrder.map((x: number) => x + m - 1).join(", ");
         expect(
             stateVariables[await resolvePathToNodeIdx("pList")].stateValues
                 .text,
@@ -254,7 +258,7 @@ describe("Shuffle tag tests @group1", async () => {
 
         orders[`${m},${n}`] = componentOrder;
 
-        pText = componentOrder.map((x) => x + m - 1).join(", ");
+        pText = componentOrder.map((x: number) => x + m - 1).join(", ");
         expect(
             stateVariables[await resolvePathToNodeIdx("pList")].stateValues
                 .text,
@@ -274,9 +278,9 @@ describe("Shuffle tag tests @group1", async () => {
         must_be_reordered,
         replacements_all_of_type,
     }: {
-        core;
+        core: PublicDoenetMLCore;
         resolvePathToNodeIdx: ResolvePathToNodeIdx;
-        options: string[];
+        options: (string | undefined)[];
         must_be_reordered: string[][];
         replacements_all_of_type?: string;
     }) {
@@ -289,7 +293,9 @@ describe("Shuffle tag tests @group1", async () => {
             [...Array(options.length).keys()].map((x) => x + 1),
         );
 
-        const orderedOptions = componentOrder.map((x) => options[x - 1]);
+        const orderedOptions = componentOrder
+            .map((x) => options[x - 1])
+            .filter((x) => x !== undefined);
 
         for (let reorder_list of must_be_reordered) {
             let indices = reorder_list.map((item) =>
@@ -313,11 +319,12 @@ describe("Shuffle tag tests @group1", async () => {
             let replacementTypes = stateVariables[
                 await resolvePathToNodeIdx("pList")
             ].activeChildren.map(
-                (child) => stateVariables[child.componentIdx].componentType,
+                (child: { componentIdx: number }) =>
+                    stateVariables[child.componentIdx].componentType,
             );
 
             expect(replacementTypes).eqls(
-                Array(options.length).fill(replacements_all_of_type),
+                Array(orderedOptions.length).fill(replacements_all_of_type),
             );
         }
 
@@ -575,5 +582,82 @@ describe("Shuffle tag tests @group1", async () => {
         }
 
         expect(result.sort()).eqls(options.sort());
+    });
+
+    it("sugar with no type specified defaults to math type", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p name="pList"><shuffle name="sh">d a b</shuffle></p>
+  `,
+        });
+
+        const options = ["d", "a", "b"];
+
+        await test_shuffle({
+            core,
+            resolvePathToNodeIdx,
+            options,
+            must_be_reordered: [],
+            replacements_all_of_type: "math",
+        });
+
+        // Check no warnings
+        let diagnosticsByType = getDiagnosticsByType(core);
+        expect(diagnosticsByType.warnings.length).eq(0);
+    });
+
+    it("sugar with invalid type specified defaults to math type with warning", async () => {
+        const consoleWarnSpy = vi
+            .spyOn(console, "warn")
+            .mockImplementation(() => {});
+
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p name="pList"><shuffle name="sh" type="bad">d a b</shuffle></p>
+  `,
+        });
+
+        const options = ["d", "a", "b"];
+
+        await test_shuffle({
+            core,
+            resolvePathToNodeIdx,
+            options,
+            must_be_reordered: [],
+            replacements_all_of_type: "math",
+        });
+
+        // Invalid sugar type currently warns via console.warn
+        expect(consoleWarnSpy).toHaveBeenCalledWith("Invalid type bad");
+        consoleWarnSpy.mockRestore();
+    });
+
+    it("string children ignored when mixed with non-string children with warning", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p name="pList"><shuffle name="sh">
+        <math>d</math> a <math>b</math>
+    </shuffle></p>
+  `,
+        });
+
+        const options = ["d", undefined, "b"];
+
+        await test_shuffle({
+            core,
+            resolvePathToNodeIdx,
+            options,
+            must_be_reordered: [],
+            replacements_all_of_type: "math",
+        });
+
+        // Check for warning about string being ignored
+        let diagnosticsByType = getDiagnosticsByType(core);
+        expect(diagnosticsByType.warnings.length).eq(1);
+        expect(diagnosticsByType.warnings[0].message).contain('String " a "');
+        expect(diagnosticsByType.warnings[0].message).contain(
+            "not a valid component",
+        );
+        expect(diagnosticsByType.warnings[0].message).contain("Ignoring");
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/shuffle.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/shuffle.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createTestCore, ResolvePathToNodeIdx } from "../utils/test-core";
-import { updateMathInputValue } from "../utils/actions";
+import { movePoint, updateMathInputValue } from "../utils/actions";
 import { getDiagnosticsByType } from "../utils/diagnostics";
 import { PublicDoenetMLCore } from "../../CoreWorker";
 
@@ -269,6 +269,93 @@ describe("Shuffle tag tests @group1", async () => {
         ).eq(pText);
 
         texts[`${m},${n}`] = pText;
+    });
+
+    it("shuffle points", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <point name="A">(0,1)</point>
+    <point name="B">(-2,1)</point>
+    <point name="C">(7,1)</point>
+    <point name="D">(3,1)</point>
+    <point name="E">(5,1)</point>
+
+    <p name="pList"><shuffle name="sh">$A$B$C$D$E</shuffle></p>
+  `,
+            requestedVariantIndex: 1,
+        });
+
+        const pointNames = ["A", "B", "C", "D", "E"];
+        const pointTexts: Record<string, string> = {
+            A: "( 0, 1 )",
+            B: "( -2, 1 )",
+            C: "( 7, 1 )",
+            D: "( 3, 1 )",
+            E: "( 5, 1 )",
+        };
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        const componentOrder: number[] =
+            stateVariables[await resolvePathToNodeIdx("sh")].stateValues
+                .componentOrder;
+        const orderedPointNames = componentOrder.map(
+            (x: number) => pointNames[x - 1],
+        );
+
+        async function expectCurrentPointOrder() {
+            stateVariables = await core.returnAllStateVariables(false, true);
+            expect(
+                stateVariables[await resolvePathToNodeIdx("pList")].stateValues
+                    .text,
+            ).eq(orderedPointNames.map((name) => pointTexts[name]).join(", "));
+        }
+
+        await expectCurrentPointOrder();
+
+        await movePoint({
+            componentIdx: await resolvePathToNodeIdx("A"),
+            x: -8,
+            y: 9,
+            core,
+        });
+        pointTexts.A = "( -8, 9 )";
+        await expectCurrentPointOrder();
+
+        await movePoint({
+            componentIdx: await resolvePathToNodeIdx("B"),
+            x: 8,
+            y: -3,
+            core,
+        });
+        pointTexts.B = "( 8, -3 )";
+        await expectCurrentPointOrder();
+
+        await movePoint({
+            componentIdx: await resolvePathToNodeIdx("C"),
+            x: 4,
+            y: 5,
+            core,
+        });
+        pointTexts.C = "( 4, 5 )";
+        await expectCurrentPointOrder();
+
+        await movePoint({
+            componentIdx: await resolvePathToNodeIdx("D"),
+            x: -9,
+            y: 0,
+            core,
+        });
+        pointTexts.D = "( -9, 0 )";
+        await expectCurrentPointOrder();
+
+        await movePoint({
+            componentIdx: await resolvePathToNodeIdx("E"),
+            x: -2,
+            y: -1,
+            core,
+        });
+        pointTexts.E = "( -2, -1 )";
+        await expectCurrentPointOrder();
     });
 
     async function test_shuffle({
@@ -584,26 +671,32 @@ describe("Shuffle tag tests @group1", async () => {
         expect(result.sort()).eqls(options.sort());
     });
 
-    it("sugar with no type specified defaults to math type", async () => {
+    it("string children without type emit warning", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
     <p name="pList"><shuffle name="sh">d a b</shuffle></p>
   `,
         });
 
-        const options = ["d", "a", "b"];
-
-        await test_shuffle({
-            core,
-            resolvePathToNodeIdx,
-            options,
-            must_be_reordered: [],
-            replacements_all_of_type: "math",
-        });
-
-        // Check no warnings
+        const stateVariables = await core.returnAllStateVariables(false, true);
         let diagnosticsByType = getDiagnosticsByType(core);
-        expect(diagnosticsByType.warnings.length).eq(0);
+        expect(diagnosticsByType.warnings.length).gte(1);
+        expect(
+            diagnosticsByType.warnings.some((w) =>
+                w.message.includes("a `type` attribute must be specified"),
+            ),
+        ).eq(true);
+        expect(
+            diagnosticsByType.warnings.some((w) =>
+                w.message.includes(
+                    'String "d a b" is not a valid component to shuffle.',
+                ),
+            ),
+        ).eq(true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("pList")].stateValues
+                .text,
+        ).eq("");
     });
 
     it("sugar with invalid type specified defaults to math type with warning", async () => {
@@ -652,13 +745,14 @@ describe("Shuffle tag tests @group1", async () => {
             replacements_all_of_type: "math",
         });
 
-        // Check for warning about string being ignored
         let diagnosticsByType = getDiagnosticsByType(core);
-        expect(diagnosticsByType.warnings.length).eq(1);
-        expect(diagnosticsByType.warnings[0].message).contain('String " a "');
-        expect(diagnosticsByType.warnings[0].message).contain(
-            "not a valid component",
-        );
-        expect(diagnosticsByType.warnings[0].message).contain("Ignoring");
+        expect(diagnosticsByType.warnings.length).gte(1);
+        expect(
+            diagnosticsByType.warnings.some((w) =>
+                w.message.includes(
+                    'String " a " is not a valid component to shuffle.',
+                ),
+            ),
+        ).eq(true);
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sort.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sort.test.ts
@@ -6,6 +6,7 @@ import {
     updateMathInputValue,
 } from "../utils/actions";
 import { PublicDoenetMLCore } from "../../CoreWorker";
+import { getDiagnosticsByType } from "../utils/diagnostics";
 
 const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);
@@ -799,5 +800,80 @@ describe("Sort tag tests @group4", async () => {
         const stateVariables = await core.returnAllStateVariables(false, true);
 
         expect(stateVariables[ansIdx].stateValues.creditAchieved).eq(1);
+    });
+
+    it("sugar with no type specified defaults to math type", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p name="pList"><sort>d a b</sort></p>
+  `,
+        });
+
+        const sorted_result = ["a", "b", "d"];
+
+        await test_sort({
+            core,
+            resolvePathToNodeIdx,
+            sorted_result,
+            replacements_all_of_type: "math",
+        });
+
+        // Check no warnings
+        let diagnosticsByType = getDiagnosticsByType(core);
+        expect(diagnosticsByType.warnings.length).eq(0);
+    });
+
+    it("sugar with invalid type specified defaults to math type with warning", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p name="pList"><sort type="bad">d a b</sort></p>
+  `,
+        });
+
+        const sorted_result = ["a", "b", "d"];
+
+        await test_sort({
+            core,
+            resolvePathToNodeIdx,
+            sorted_result,
+            replacements_all_of_type: "math",
+        });
+
+        let diagnosticsByType = getDiagnosticsByType(core);
+        expect(diagnosticsByType.warnings.length).eq(1);
+        expect(diagnosticsByType.warnings[0].message).contain(
+            "Invalid type bad for sort component",
+        );
+        expect(diagnosticsByType.warnings[0].message).contain(
+            "Defaulting to math",
+        );
+    });
+
+    it("string children ignored when mixed with non-string children with warning", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <p name="pList"><sort>
+        <math>d</math> a <math>b</math>
+    </sort></p>
+  `,
+        });
+
+        const sorted_result = ["b", "d"];
+
+        await test_sort({
+            core,
+            resolvePathToNodeIdx,
+            sorted_result,
+            replacements_all_of_type: "math",
+        });
+
+        // Check for warning about string being ignored
+        let diagnosticsByType = getDiagnosticsByType(core);
+        expect(diagnosticsByType.warnings.length).eq(1);
+        expect(diagnosticsByType.warnings[0].message).contain('String " a "');
+        expect(diagnosticsByType.warnings[0].message).contain(
+            "not a valid component",
+        );
+        expect(diagnosticsByType.warnings[0].message).contain("Ignoring");
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/sort.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/sort.test.ts
@@ -802,25 +802,32 @@ describe("Sort tag tests @group4", async () => {
         expect(stateVariables[ansIdx].stateValues.creditAchieved).eq(1);
     });
 
-    it("sugar with no type specified defaults to math type", async () => {
+    it("string children without type emit warning", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
     <p name="pList"><sort>d a b</sort></p>
   `,
         });
 
-        const sorted_result = ["a", "b", "d"];
-
-        await test_sort({
-            core,
-            resolvePathToNodeIdx,
-            sorted_result,
-            replacements_all_of_type: "math",
-        });
-
-        // Check no warnings
+        const stateVariables = await core.returnAllStateVariables(false, true);
         let diagnosticsByType = getDiagnosticsByType(core);
-        expect(diagnosticsByType.warnings.length).eq(0);
+        expect(diagnosticsByType.warnings.length).gte(1);
+        expect(
+            diagnosticsByType.warnings.some((w) =>
+                w.message.includes("a `type` attribute must be specified"),
+            ),
+        ).eq(true);
+        expect(
+            diagnosticsByType.warnings.some((w) =>
+                w.message.includes(
+                    'String "d a b" is not a valid component to sort.',
+                ),
+            ),
+        ).eq(true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("pList")].stateValues
+                .text,
+        ).eq("");
     });
 
     it("sugar with invalid type specified defaults to math type with warning", async () => {
@@ -867,13 +874,14 @@ describe("Sort tag tests @group4", async () => {
             replacements_all_of_type: "math",
         });
 
-        // Check for warning about string being ignored
         let diagnosticsByType = getDiagnosticsByType(core);
-        expect(diagnosticsByType.warnings.length).eq(1);
-        expect(diagnosticsByType.warnings[0].message).contain('String " a "');
-        expect(diagnosticsByType.warnings[0].message).contain(
-            "not a valid component",
-        );
-        expect(diagnosticsByType.warnings[0].message).contain("Ignoring");
+        expect(diagnosticsByType.warnings.length).gte(1);
+        expect(
+            diagnosticsByType.warnings.some((w) =>
+                w.message.includes(
+                    'String " a " is not a valid component to sort.',
+                ),
+            ),
+        ).eq(true);
     });
 });


### PR DESCRIPTION
## Summary
- fall back to math for invalid type values and emit warning diagnostics
- ignore string children in sort/shuffle component lists with explicit warnings
- add tests covering defaulting, invalid-type fallback, and mixed-content diagnostics
- add a changeset for patch releases of affected published packages

## Testing
- added targeted worker tests in sort and shuffle suites

Fixes #1024