### PR TITLE
Fix CSP to allow MathJax to render math in VS Code extension preview

### DIFF
--- a/.changeset/vscode-extension-mathjax-csp.md
+++ b/.changeset/vscode-extension-mathjax-csp.md
@@ -1,0 +1,6 @@
+---
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Fix Content Security Policy in VS Code extension preview to allow MathJax to render math. Previously, math was displayed as raw LaTeX instead of typeset equations.

--- a/packages/vscode-extension/src/extension/preview-panel/doenet-preview-panel.ts
+++ b/packages/vscode-extension/src/extension/preview-panel/doenet-preview-panel.ts
@@ -139,12 +139,12 @@ export class DoenetPreviewPanel {
                 `default-src 'none';`,
                 `style-src ${webview.cspSource} 'unsafe-inline' 'self';`,
                 // Note: If there is a path-name, it must end with a slash to include subfolders (e.g., https://example.com/foo will not match https://example.com/foo/bar)
-                `script-src 'nonce-${nonce}' 'unsafe-eval' vscode-webview: https://*.vscode-resource.vscode-cdn.net https://cdn.jsdelivr.net/npm/mathjax@4 https://doenet.vscode-unpkg.net;`,
-                `script-src-elem 'nonce-${nonce}' 'unsafe-eval' vscode-webview: https://*.vscode-resource.vscode-cdn.net https://cdn.jsdelivr.net/npm/mathjax@4 https://doenet.vscode-unpkg.net http://localhost:3000/static/devextensions/;`,
+                `script-src 'nonce-${nonce}' 'unsafe-eval' vscode-webview: https://*.vscode-resource.vscode-cdn.net https://cdn.jsdelivr.net/npm/ https://doenet.vscode-unpkg.net;`,
+                `script-src-elem 'nonce-${nonce}' 'unsafe-eval' vscode-webview: https://*.vscode-resource.vscode-cdn.net https://cdn.jsdelivr.net/npm/ https://doenet.vscode-unpkg.net http://localhost:3000/static/devextensions/;`,
                 `worker-src blob:;`,
-                `connect-src blob: data:;`,
+                `connect-src blob: data: https://cdn.jsdelivr.net/npm/;`,
                 `img-src 'self';`,
-                `font-src https://cdn.jsdelivr.net/npm/mathjax@4 https://*.vscode-resource.vscode-cdn.net https://doenet.vscode-unpkg.net http://localhost:3000/static/devextensions/;`,
+                `font-src data: https://cdn.jsdelivr.net/npm/ https://*.vscode-resource.vscode-cdn.net https://doenet.vscode-unpkg.net http://localhost:3000/static/devextensions/;`,
             ].join(" ")}"
           />
           <link rel="stylesheet" type="text/css" href="${stylesUri}">

--- a/packages/vscode-extension/src/extension/preview-panel/doenet-preview-panel.ts
+++ b/packages/vscode-extension/src/extension/preview-panel/doenet-preview-panel.ts
@@ -139,12 +139,12 @@ export class DoenetPreviewPanel {
                 `default-src 'none';`,
                 `style-src ${webview.cspSource} 'unsafe-inline' 'self';`,
                 // Note: If there is a path-name, it must end with a slash to include subfolders (e.g., https://example.com/foo will not match https://example.com/foo/bar)
-                `script-src 'nonce-${nonce}' 'unsafe-eval' vscode-webview: https://*.vscode-resource.vscode-cdn.net https://cdn.jsdelivr.net/npm/ https://doenet.vscode-unpkg.net;`,
-                `script-src-elem 'nonce-${nonce}' 'unsafe-eval' vscode-webview: https://*.vscode-resource.vscode-cdn.net https://cdn.jsdelivr.net/npm/ https://doenet.vscode-unpkg.net http://localhost:3000/static/devextensions/;`,
+                `script-src 'nonce-${nonce}' 'unsafe-eval' vscode-webview: https://*.vscode-resource.vscode-cdn.net https://cdn.jsdelivr.net/npm/mathjax@4.1.0/ https://doenet.vscode-unpkg.net;`,
+                `script-src-elem 'nonce-${nonce}' 'unsafe-eval' vscode-webview: https://*.vscode-resource.vscode-cdn.net https://cdn.jsdelivr.net/npm/mathjax@4.1.0/ https://doenet.vscode-unpkg.net http://localhost:3000/static/devextensions/;`,
                 `worker-src blob:;`,
-                `connect-src blob: data: https://cdn.jsdelivr.net/npm/;`,
+                `connect-src blob: data: https://cdn.jsdelivr.net/npm/mathjax@4.1.0/;`,
                 `img-src 'self';`,
-                `font-src data: https://cdn.jsdelivr.net/npm/ https://*.vscode-resource.vscode-cdn.net https://doenet.vscode-unpkg.net http://localhost:3000/static/devextensions/;`,
+                `font-src data: https://cdn.jsdelivr.net/npm/@mathjax/ https://*.vscode-resource.vscode-cdn.net https://doenet.vscode-unpkg.net http://localhost:3000/static/devextensions/;`,
             ].join(" ")}"
           />
           <link rel="stylesheet" type="text/css" href="${stylesUri}">


### PR DESCRIPTION
## Summary

Fix VS Code preview CSP so MathJax renders typeset math instead of showing raw LaTeX.

## Root Cause

The webview CSP blocked resources that MathJax v4 needs at runtime:

1. `script-src` / `script-src-elem` did not allow the versioned MathJax script URL that is loaded (`.../mathjax@4.1.0/...`).
2. `font-src` did not allow `data:` URIs used for embedded MathJax fonts.
3. `connect-src` did not allow runtime fetches needed by MathJax/SRE assets.

## Changes

Updated 4 CSP directives in `packages/vscode-extension/src/extension/preview-panel/doenet-preview-panel.ts`:

- `script-src`: allow `https://cdn.jsdelivr.net/npm/mathjax@4.1.0/`
- `script-src-elem`: allow `https://cdn.jsdelivr.net/npm/mathjax@4.1.0/`
- `connect-src`: allow `https://cdn.jsdelivr.net/npm/mathjax@4.1.0/`
- `font-src`: add `data:` and allow MathJax font path

This keeps the policy tighter than opening all of jsDelivr by pinning to MathJax 4.1.0 paths.

## Verification

- Reproduced issue in Extension Development Host: math displayed as raw LaTeX.
- After CSP updates, preview renders typeset math correctly.

## Release Notes

Added changeset:
- `.changeset/vscode-extension-mathjax-csp.md`
- Patch bump for `@doenet/vscode-extension` and `doenet-vscode-extension`.
