### PR TITLE
fix: Improve list-item first-child alignment handling

### DIFF
--- a/.changeset/list-item-first-child-alignment.md
+++ b/.changeset/list-item-first-child-alignment.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Improve list-item first-child alignment for section/task/problem-style numbering when content starts with block renderers.
+
+This update standardizes list-item alignment signals across block components, updates section and sideBySide rendering to top-align numbering with block-first content, and adds Cypress coverage for the new behavior (including answer and choiceInput cases).

--- a/packages/doenetml-worker-javascript/src/components/Answer.js
+++ b/packages/doenetml-worker-javascript/src/components/Answer.js
@@ -785,13 +785,14 @@ export default class Answer extends InlineComponent {
             returnSimplifyExpandOnCompareWarning(),
         );
 
-        // <answer> participates in list-item alignment only for the specific case where
-        // its first input child is a non-inline <choiceInput>. In that case the signal is
-        // forwarded so the choiceInput can suppress its own top margin and the surrounding
-        // section number top-aligns with the control. For every other configuration
-        // (inline choiceInput, mathInput, etc.) <answer> returns "none" so the section
-        // falls back to its standard baseline flex layout without any block-control
-        // adjustment.
+        /**
+         * <answer> participates in list-item alignment only when its first input child
+         * is a non-inline <choiceInput>. In that case, <answer> forwards alignment so
+         * the choiceInput can suppress top margin and section numbering top-aligns.
+         *
+         * For other input configurations (for example inline choiceInput or mathInput),
+         * <answer> returns "none" and the section keeps baseline alignment.
+         */
         stateVariableDefinitions.renderInlineForListItem = {
             forRenderer: true,
             additionalStateVariablesDefined: [

--- a/packages/doenetml-worker-javascript/src/components/Answer.js
+++ b/packages/doenetml-worker-javascript/src/components/Answer.js
@@ -785,6 +785,71 @@ export default class Answer extends InlineComponent {
             returnSimplifyExpandOnCompareWarning(),
         );
 
+        // <answer> participates in list-item alignment only for the specific case where
+        // its first input child is a non-inline <choiceInput>. In that case the signal is
+        // forwarded so the choiceInput can suppress its own top margin and the surrounding
+        // section number top-aligns with the control. For every other configuration
+        // (inline choiceInput, mathInput, etc.) <answer> returns "none" so the section
+        // falls back to its standard baseline flex layout without any block-control
+        // adjustment.
+        stateVariableDefinitions.renderInlineForListItem = {
+            forRenderer: true,
+            additionalStateVariablesDefined: [
+                { variableName: "listItemInlineAlignment", forRenderer: true },
+                { variableName: "childrenToRenderInlineForListItem" },
+            ],
+            returnDependencies: () => ({
+                parentChildrenToRenderInlineForListItem: {
+                    dependencyType: "parentStateVariable",
+                    variableName: "childrenToRenderInlineForListItem",
+                },
+                inputChildren: {
+                    dependencyType: "child",
+                    childGroups: ["inputs"],
+                    variableNames: ["inline"],
+                    variablesOptional: true,
+                },
+            }),
+            definition({ dependencyValues, componentIdx }) {
+                const isInParentList = Boolean(
+                    dependencyValues.parentChildrenToRenderInlineForListItem
+                        ?.map((c) => c.componentIdx)
+                        .includes(componentIdx),
+                );
+
+                if (!isInParentList) {
+                    return {
+                        setValue: {
+                            renderInlineForListItem: false,
+                            listItemInlineAlignment: "none",
+                            childrenToRenderInlineForListItem: [],
+                        },
+                    };
+                }
+
+                // Propagate only to the first non-inline choiceInput input child.
+                // <answer> itself has no top margin to suppress.
+                const firstBlockChoiceInput =
+                    dependencyValues.inputChildren?.find(
+                        (child) =>
+                            child.componentType === "choiceInput" &&
+                            child.stateValues.inline === false,
+                    );
+
+                return {
+                    setValue: {
+                        renderInlineForListItem: false,
+                        listItemInlineAlignment: firstBlockChoiceInput
+                            ? "flex-start"
+                            : "none",
+                        childrenToRenderInlineForListItem: firstBlockChoiceInput
+                            ? [firstBlockChoiceInput]
+                            : [],
+                    },
+                };
+            },
+        };
+
         const labelDefinitions = returnLabelStateVariableDefinitions();
         Object.assign(stateVariableDefinitions, labelDefinitions);
 

--- a/packages/doenetml-worker-javascript/src/components/BlockQuote.js
+++ b/packages/doenetml-worker-javascript/src/components/BlockQuote.js
@@ -1,4 +1,5 @@
 import BlockComponent from "./abstract/BlockComponent";
+import { returnPassThroughListItemChildStateVariableDefinitions } from "../utils/listItemChild";
 
 export default class BlockQuote extends BlockComponent {
     constructor(args) {
@@ -19,6 +20,17 @@ export default class BlockQuote extends BlockComponent {
                 componentTypes: ["_base"],
             },
         ];
+    }
+
+    static returnStateVariableDefinitions() {
+        let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        Object.assign(
+            stateVariableDefinitions,
+            returnPassThroughListItemChildStateVariableDefinitions(),
+        );
+
+        return stateVariableDefinitions;
     }
 
     recordVisibilityChange({ isVisible }) {

--- a/packages/doenetml-worker-javascript/src/components/ChoiceInput.js
+++ b/packages/doenetml-worker-javascript/src/components/ChoiceInput.js
@@ -2,6 +2,7 @@ import Input from "./abstract/Input";
 import me from "math-expressions";
 import { enumerateCombinations, enumeratePermutations } from "@doenet/utils";
 import { setUpVariantSeedAndRng } from "../utils/variants";
+import { returnListItemChildStateVariableDefinitions } from "../utils/listItemChild";
 
 export default class Choiceinput extends Input {
     constructor(args) {
@@ -115,6 +116,14 @@ export default class Choiceinput extends Input {
 
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        Object.assign(
+            stateVariableDefinitions,
+            returnListItemChildStateVariableDefinitions({
+                checkInlineVariable: true,
+                listItemInlineAlignment: "flex-start",
+            }),
+        );
 
         stateVariableDefinitions.inline = {
             public: true,

--- a/packages/doenetml-worker-javascript/src/components/Column.js
+++ b/packages/doenetml-worker-javascript/src/components/Column.js
@@ -1,4 +1,5 @@
 import BaseComponent from "./abstract/BaseComponent";
+import { returnPassThroughListItemChildStateVariableDefinitions } from "../utils/listItemChild";
 
 export default class Column extends BaseComponent {
     static componentType = "column";
@@ -45,6 +46,11 @@ export default class Column extends BaseComponent {
 
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        Object.assign(
+            stateVariableDefinitions,
+            returnPassThroughListItemChildStateVariableDefinitions(),
+        );
 
         stateVariableDefinitions.prescribedCellsWithRowNum = {
             returnDependencies: () => ({

--- a/packages/doenetml-worker-javascript/src/components/Divisions.js
+++ b/packages/doenetml-worker-javascript/src/components/Divisions.js
@@ -3,6 +3,7 @@ import {
     returnScoredSectionStateVariableDefinition,
     submitAllAnswers,
 } from "../utils/scoredSection";
+import { returnPassThroughListItemChildStateVariableDefinitions } from "../utils/listItemChild";
 import BlockComponent from "./abstract/BlockComponent";
 import InlineComponent from "./abstract/InlineComponent";
 
@@ -46,6 +47,11 @@ export class Div extends BlockComponent {
         Object.assign(
             stateVariableDefinitions,
             returnScoredSectionStateVariableDefinition(),
+        );
+
+        Object.assign(
+            stateVariableDefinitions,
+            returnPassThroughListItemChildStateVariableDefinitions(),
         );
 
         return stateVariableDefinitions;

--- a/packages/doenetml-worker-javascript/src/components/Graph.js
+++ b/packages/doenetml-worker-javascript/src/components/Graph.js
@@ -16,6 +16,7 @@ import {
     GRAPH_CONTROL_DESCENDANT_CONFIGS,
     GRAPH_CONTROL_VARIABLE_NAMES,
 } from "../utils/graphControls";
+import { returnListItemChildStateVariableDefinitions } from "../utils/listItemChild";
 // PreFigure conversion architecture and extension guide:
 // see src/utils/prefigure/README.md
 import { returnGraphPrefigureStateVariableDefinitions } from "../utils/prefigure/stateVariable";
@@ -299,6 +300,13 @@ export default class Graph extends BlockComponent {
 
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        Object.assign(
+            stateVariableDefinitions,
+            returnListItemChildStateVariableDefinitions({
+                listItemInlineAlignment: "flex-start",
+            }),
+        );
 
         Object.assign(
             stateVariableDefinitions,

--- a/packages/doenetml-worker-javascript/src/components/Image.js
+++ b/packages/doenetml-worker-javascript/src/components/Image.js
@@ -12,6 +12,7 @@ import {
     returnAnchorAttributes,
     returnAnchorStateVariableDefinition,
 } from "../utils/graphical";
+import { returnListItemChildStateVariableDefinitions } from "../utils/listItemChild";
 
 export default class Image extends BlockComponent {
     constructor(args) {
@@ -139,6 +140,13 @@ export default class Image extends BlockComponent {
 
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        Object.assign(
+            stateVariableDefinitions,
+            returnListItemChildStateVariableDefinitions({
+                listItemInlineAlignment: "flex-start",
+            }),
+        );
 
         let selectedStyleDefinition =
             returnSelectedStyleStateVariableDefinition();

--- a/packages/doenetml-worker-javascript/src/components/P.js
+++ b/packages/doenetml-worker-javascript/src/components/P.js
@@ -1,3 +1,4 @@
+import { returnListItemChildStateVariableDefinitions } from "../utils/listItemChild";
 import {
     returnScoredSectionAttributes,
     returnScoredSectionStateVariableDefinition,
@@ -49,6 +50,11 @@ export default class P extends BlockComponent {
         Object.assign(
             stateVariableDefinitions,
             returnScoredSectionStateVariableDefinition(),
+        );
+
+        Object.assign(
+            stateVariableDefinitions,
+            returnListItemChildStateVariableDefinitions(),
         );
 
         stateVariableDefinitions.text = {

--- a/packages/doenetml-worker-javascript/src/components/SideBySide.js
+++ b/packages/doenetml-worker-javascript/src/components/SideBySide.js
@@ -1,3 +1,6 @@
+import {
+    returnPassThroughListItemChildStateVariableDefinitions,
+} from "../utils/listItemChild";
 import BlockComponent from "./abstract/BlockComponent";
 import me from "math-expressions";
 
@@ -52,6 +55,75 @@ export class SideBySide extends BlockComponent {
 
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        stateVariableDefinitions.childrenToRenderInlineForListItem = {
+            returnDependencies: () => ({
+                parentChildrenToRenderInlineForListItem: {
+                    dependencyType: "parentStateVariable",
+                    variableName: "childrenToRenderInlineForListItem",
+                },
+                blockChildren: {
+                    dependencyType: "child",
+                    childGroups: ["blocks"],
+                },
+            }),
+            definition({ dependencyValues, componentIdx }) {
+                let childrenToRenderInlineForListItem = [];
+
+                // If component is in the list of children to render inline,
+                // then set its childrenToRenderInlineForListItem to all its block children
+
+                if (
+                    dependencyValues.parentChildrenToRenderInlineForListItem
+                        ?.map((c) => c.componentIdx)
+                        .includes(componentIdx)
+                ) {
+                    childrenToRenderInlineForListItem =
+                        dependencyValues.blockChildren;
+                }
+
+                return {
+                    setValue: {
+                        childrenToRenderInlineForListItem,
+                    },
+                };
+            },
+        };
+
+        stateVariableDefinitions.listItemInlineAlignment = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                parentChildrenToRenderInlineForListItem: {
+                    dependencyType: "parentStateVariable",
+                    variableName: "childrenToRenderInlineForListItem",
+                },
+                blockChildren: {
+                    dependencyType: "child",
+                    childGroups: ["blocks"],
+                },
+            }),
+            definition({ dependencyValues, componentIdx }) {
+                const shouldRenderInline =
+                    dependencyValues.parentChildrenToRenderInlineForListItem
+                        ?.map((c) => c.componentIdx)
+                        .includes(componentIdx);
+
+                let listItemInlineAlignment = "none";
+                if (shouldRenderInline) {
+                    const firstPanel = dependencyValues.blockChildren?.[0];
+                    listItemInlineAlignment =
+                        firstPanel?.componentType === "p"
+                            ? "baseline"
+                            : "flex-start";
+                }
+
+                return {
+                    setValue: {
+                        listItemInlineAlignment,
+                    },
+                };
+            },
+        };
 
         stateVariableDefinitions.numPanels = {
             forRenderer: true,
@@ -1229,6 +1301,11 @@ export class SbsGroup extends BlockComponent {
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
 
+        Object.assign(
+            stateVariableDefinitions,
+            returnPassThroughListItemChildStateVariableDefinitions(),
+        );
+
         stateVariableDefinitions.maxNPanelsPerRow = {
             // forRenderer: true,
             returnDependencies: () => ({
@@ -2280,6 +2357,17 @@ export class Stack extends BlockComponent {
                 componentTypes: ["_base"],
             },
         ];
+    }
+
+    static returnStateVariableDefinitions() {
+        let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        Object.assign(
+            stateVariableDefinitions,
+            returnPassThroughListItemChildStateVariableDefinitions(),
+        );
+
+        return stateVariableDefinitions;
     }
 
     recordVisibilityChange({ isVisible }) {

--- a/packages/doenetml-worker-javascript/src/components/SideBySide.js
+++ b/packages/doenetml-worker-javascript/src/components/SideBySide.js
@@ -54,42 +54,13 @@ export class SideBySide extends BlockComponent {
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
 
-        stateVariableDefinitions.childrenToRenderInlineForListItem = {
-            returnDependencies: () => ({
-                parentChildrenToRenderInlineForListItem: {
-                    dependencyType: "parentStateVariable",
-                    variableName: "childrenToRenderInlineForListItem",
-                },
-                blockChildren: {
-                    dependencyType: "child",
-                    childGroups: ["blocks"],
-                },
-            }),
-            definition({ dependencyValues, componentIdx }) {
-                let childrenToRenderInlineForListItem = [];
-
-                // If component is in the list of children to render inline,
-                // then set its childrenToRenderInlineForListItem to all its block children
-
-                if (
-                    dependencyValues.parentChildrenToRenderInlineForListItem
-                        ?.map((c) => c.componentIdx)
-                        .includes(componentIdx)
-                ) {
-                    childrenToRenderInlineForListItem =
-                        dependencyValues.blockChildren;
-                }
-
-                return {
-                    setValue: {
-                        childrenToRenderInlineForListItem,
-                    },
-                };
-            },
-        };
-
+        // listItemInlineAlignment and childrenToRenderInlineForListItem share the same
+        // parent-list membership check, so they are computed together.
         stateVariableDefinitions.listItemInlineAlignment = {
             forRenderer: true,
+            additionalStateVariablesDefined: [
+                { variableName: "childrenToRenderInlineForListItem" },
+            ],
             returnDependencies: () => ({
                 parentChildrenToRenderInlineForListItem: {
                     dependencyType: "parentStateVariable",
@@ -106,18 +77,28 @@ export class SideBySide extends BlockComponent {
                         ?.map((c) => c.componentIdx)
                         .includes(componentIdx);
 
-                let listItemInlineAlignment = "none";
-                if (shouldRenderInline) {
-                    const firstPanel = dependencyValues.blockChildren?.[0];
-                    listItemInlineAlignment =
-                        firstPanel?.componentType === "p"
-                            ? "baseline"
-                            : "flex-start";
+                if (!shouldRenderInline) {
+                    return {
+                        setValue: {
+                            listItemInlineAlignment: "none",
+                            childrenToRenderInlineForListItem: [],
+                        },
+                    };
                 }
 
+                // Use baseline alignment when the first panel is a plain paragraph
+                // so the list-item number aligns with its text; use flex-start for
+                // block-level content (graphs, choiceInputs, etc.) so the number
+                // aligns with the top of the content instead.
+                const firstPanel = dependencyValues.blockChildren?.[0];
                 return {
                     setValue: {
-                        listItemInlineAlignment,
+                        listItemInlineAlignment:
+                            firstPanel?.componentType === "p"
+                                ? "baseline"
+                                : "flex-start",
+                        childrenToRenderInlineForListItem:
+                            dependencyValues.blockChildren,
                     },
                 };
             },

--- a/packages/doenetml-worker-javascript/src/components/SideBySide.js
+++ b/packages/doenetml-worker-javascript/src/components/SideBySide.js
@@ -1,6 +1,4 @@
-import {
-    returnPassThroughListItemChildStateVariableDefinitions,
-} from "../utils/listItemChild";
+import { returnPassThroughListItemChildStateVariableDefinitions } from "../utils/listItemChild";
 import BlockComponent from "./abstract/BlockComponent";
 import me from "math-expressions";
 

--- a/packages/doenetml-worker-javascript/src/components/Spreadsheet.js
+++ b/packages/doenetml-worker-javascript/src/components/Spreadsheet.js
@@ -123,7 +123,9 @@ export default class Spreadsheet extends BlockComponent {
 
         Object.assign(
             stateVariableDefinitions,
-            returnListItemChildStateVariableDefinitions(),
+            returnListItemChildStateVariableDefinitions({
+                listItemInlineAlignment: "flex-start",
+            }),
         );
 
         stateVariableDefinitions.cellIdxToRowCol = {

--- a/packages/doenetml-worker-javascript/src/components/Spreadsheet.js
+++ b/packages/doenetml-worker-javascript/src/components/Spreadsheet.js
@@ -4,6 +4,7 @@ import BlockComponent from "./abstract/BlockComponent";
 import { vectorOperators } from "@doenet/utils";
 import me from "math-expressions";
 import { HyperFormula } from "hyperformula";
+import { returnListItemChildStateVariableDefinitions } from "../utils/listItemChild";
 
 export default class Spreadsheet extends BlockComponent {
     constructor(args) {
@@ -119,6 +120,11 @@ export default class Spreadsheet extends BlockComponent {
 
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        Object.assign(
+            stateVariableDefinitions,
+            returnListItemChildStateVariableDefinitions(),
+        );
 
         stateVariableDefinitions.cellIdxToRowCol = {
             additionalStateVariablesDefined: ["cellIndicesByRowCol"],

--- a/packages/doenetml-worker-javascript/src/components/Tabular.js
+++ b/packages/doenetml-worker-javascript/src/components/Tabular.js
@@ -1,4 +1,5 @@
 import BlockComponent from "./abstract/BlockComponent";
+import { returnListItemChildStateVariableDefinitions } from "../utils/listItemChild";
 
 export default class Tabular extends BlockComponent {
     constructor(args) {
@@ -105,6 +106,13 @@ export default class Tabular extends BlockComponent {
 
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        Object.assign(
+            stateVariableDefinitions,
+            returnListItemChildStateVariableDefinitions({
+                listItemInlineAlignment: "flex-start",
+            }),
+        );
 
         // stateVariableDefinitions.numRows = {
         //   public: true,

--- a/packages/doenetml-worker-javascript/src/components/Verbatim.js
+++ b/packages/doenetml-worker-javascript/src/components/Verbatim.js
@@ -4,6 +4,7 @@ import {
 } from "@doenet/utils";
 import BlockComponent from "./abstract/BlockComponent";
 import InlineComponent from "./abstract/InlineComponent";
+import { returnPassThroughListItemChildStateVariableDefinitions } from "../utils/listItemChild";
 
 export class Pre extends BlockComponent {
     constructor(args) {
@@ -29,6 +30,11 @@ export class Pre extends BlockComponent {
 
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        Object.assign(
+            stateVariableDefinitions,
+            returnPassThroughListItemChildStateVariableDefinitions(),
+        );
 
         stateVariableDefinitions.displayDoenetMLIndices = {
             forRenderer: true,

--- a/packages/doenetml-worker-javascript/src/components/Video.js
+++ b/packages/doenetml-worker-javascript/src/components/Video.js
@@ -5,6 +5,7 @@ import {
     widthsBySize,
     sizePossibilities,
 } from "@doenet/utils";
+import { returnListItemChildStateVariableDefinitions } from "../utils/listItemChild";
 
 export default class Video extends BlockComponent {
     constructor(args) {
@@ -97,6 +98,13 @@ export default class Video extends BlockComponent {
 
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        Object.assign(
+            stateVariableDefinitions,
+            returnListItemChildStateVariableDefinitions({
+                listItemInlineAlignment: "flex-start",
+            }),
+        );
 
         stateVariableDefinitions.shortDescription = {
             forRenderer: true,

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -338,6 +338,7 @@ export class SectioningComponent extends BlockComponent {
         };
 
         stateVariableDefinitions.childIndicesToRender = {
+            additionalStateVariablesDefined: ["firstVisibleChild"],
             returnDependencies: () => ({
                 titleChildren: {
                     dependencyType: "child",
@@ -368,6 +369,7 @@ export class SectioningComponent extends BlockComponent {
             }),
             definition({ dependencyValues, componentInfoObjects }) {
                 const childIndicesToRender = [];
+                let firstVisibleChild = null;
 
                 let allTitleChildNames = dependencyValues.titleChildren.map(
                     (x) => x.componentIdx,
@@ -402,6 +404,12 @@ export class SectioningComponent extends BlockComponent {
                             )
                         ) {
                             childIndicesToRender.push(ind);
+                            if (
+                                firstVisibleChild === null &&
+                                !dependencyValues.hideChildren
+                            ) {
+                                firstVisibleChild = child;
+                            }
                         }
                     } else if (
                         typeof child !== "object" ||
@@ -409,10 +417,19 @@ export class SectioningComponent extends BlockComponent {
                         child.componentIdx === dependencyValues.titleChildName
                     ) {
                         childIndicesToRender.push(ind);
+                        if (
+                            firstVisibleChild === null &&
+                            !dependencyValues.hideChildren &&
+                            (typeof child === "object" || child.trim() !== "")
+                        ) {
+                            firstVisibleChild = child;
+                        }
                     }
                 }
 
-                return { setValue: { childIndicesToRender } };
+                return {
+                    setValue: { childIndicesToRender, firstVisibleChild },
+                };
             },
             markStale: () => ({ updateRenderedChildren: true }),
         };
@@ -465,6 +482,131 @@ export class SectioningComponent extends BlockComponent {
                 return { setValue: { childrenToHide } };
             },
             markStale: () => ({ updateRenderedChildren: true }),
+        };
+
+        stateVariableDefinitions.nonBoxedListItemWithoutTitle = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                isListItem: {
+                    dependencyType: "stateVariable",
+                    variableName: "isListItem",
+                },
+                boxed: {
+                    dependencyType: "stateVariable",
+                    variableName: "boxed",
+                },
+                titleChildName: {
+                    dependencyType: "stateVariable",
+                    variableName: "titleChildName",
+                },
+                collapsible: {
+                    dependencyType: "stateVariable",
+                    variableName: "collapsible",
+                },
+            }),
+            definition({ dependencyValues }) {
+                const nonBoxedListItemWithoutTitle = Boolean(
+                    dependencyValues.isListItem &&
+                    !dependencyValues.boxed &&
+                    !dependencyValues.collapsible &&
+                    dependencyValues.titleChildName === null,
+                );
+
+                return { setValue: { nonBoxedListItemWithoutTitle } };
+            },
+        };
+
+        stateVariableDefinitions.childrenToRenderInlineForListItem = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                firstVisibleChild: {
+                    dependencyType: "stateVariable",
+                    variableName: "firstVisibleChild",
+                },
+                nonBoxedListItemWithoutTitle: {
+                    dependencyType: "stateVariable",
+                    variableName: "nonBoxedListItemWithoutTitle",
+                },
+            }),
+            definition({ dependencyValues }) {
+                let childrenToRenderInlineForListItem = [];
+                if (dependencyValues.nonBoxedListItemWithoutTitle) {
+                    childrenToRenderInlineForListItem = [
+                        dependencyValues.firstVisibleChild,
+                    ];
+                }
+                return { setValue: { childrenToRenderInlineForListItem } };
+            },
+        };
+
+        stateVariableDefinitions.firstVisibleChildAdjustedForListItem = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                nonBoxedListItemWithoutTitle: {
+                    dependencyType: "stateVariable",
+                    variableName: "nonBoxedListItemWithoutTitle",
+                },
+                firstVisibleChild: {
+                    dependencyType: "stateVariable",
+                    variableName: "firstVisibleChild",
+                },
+            }),
+            definition({ dependencyValues }) {
+                const firstVisibleChildAdjustedForListItem = Boolean(
+                    dependencyValues.nonBoxedListItemWithoutTitle &&
+                    typeof dependencyValues.firstVisibleChild === "object",
+                );
+
+                return {
+                    setValue: {
+                        firstVisibleChildAdjustedForListItem,
+                    },
+                };
+            },
+        };
+
+        stateVariableDefinitions.firstChildListItemAlignment = {
+            stateVariablesDeterminingDependencies: ["firstVisibleChild"],
+            forRenderer: true,
+            returnDependencies: ({ stateValues }) => {
+                const dependencies = {
+                    firstVisibleChildAdjustedForListItem: {
+                        dependencyType: "stateVariable",
+                        variableName: "firstVisibleChildAdjustedForListItem",
+                    },
+                };
+
+                if (stateValues.firstVisibleChild?.componentIdx !== undefined) {
+                    dependencies.firstVisibleChildListItemInlineAlignment = {
+                        dependencyType: "stateVariable",
+                        componentIdx:
+                            stateValues.firstVisibleChild.componentIdx,
+                        variableName: "listItemInlineAlignment",
+                        variablesOptional: true,
+                    };
+                }
+
+                return dependencies;
+            },
+            definition({ dependencyValues }) {
+                let firstChildListItemAlignment = "none";
+
+                if (dependencyValues.firstVisibleChildAdjustedForListItem) {
+                    const alignmentFromFirstChild =
+                        dependencyValues.firstVisibleChildListItemInlineAlignment;
+
+                    if (
+                        alignmentFromFirstChild === "baseline" ||
+                        alignmentFromFirstChild === "flex-start"
+                    ) {
+                        firstChildListItemAlignment = alignmentFromFirstChild;
+                    } else {
+                        firstChildListItemAlignment = "baseline";
+                    }
+                }
+
+                return { setValue: { firstChildListItemAlignment } };
+            },
         };
 
         // Determine if the rendered children start with an `<introduction>`

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -533,7 +533,11 @@ export class SectioningComponent extends BlockComponent {
             definition({ dependencyValues }) {
                 // Delegate list-item inline rendering to the first visible child only.
                 let childrenToRenderInlineForListItem = [];
-                if (dependencyValues.nonBoxedListItemWithoutTitle) {
+                if (
+                    dependencyValues.nonBoxedListItemWithoutTitle &&
+                    dependencyValues.firstVisibleChild &&
+                    typeof dependencyValues.firstVisibleChild === "object"
+                ) {
                     childrenToRenderInlineForListItem = [
                         dependencyValues.firstVisibleChild,
                     ];

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -487,7 +487,6 @@ export class SectioningComponent extends BlockComponent {
         };
 
         stateVariableDefinitions.nonBoxedListItemWithoutTitle = {
-            forRenderer: true,
             returnDependencies: () => ({
                 isListItem: {
                     dependencyType: "stateVariable",
@@ -521,7 +520,6 @@ export class SectioningComponent extends BlockComponent {
         };
 
         stateVariableDefinitions.childrenToRenderInlineForListItem = {
-            forRenderer: true,
             returnDependencies: () => ({
                 firstVisibleChild: {
                     dependencyType: "stateVariable",

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -369,6 +369,8 @@ export class SectioningComponent extends BlockComponent {
             }),
             definition({ dependencyValues, componentInfoObjects }) {
                 const childIndicesToRender = [];
+                // Tracks first non-hidden rendered child (including non-blank strings)
+                // so list-item sections can delegate alignment behavior to that child.
                 let firstVisibleChild = null;
 
                 let allTitleChildNames = dependencyValues.titleChildren.map(
@@ -505,6 +507,8 @@ export class SectioningComponent extends BlockComponent {
                 },
             }),
             definition({ dependencyValues }) {
+                // This is the only section mode that performs first-child list-item
+                // alignment delegation on the root section container.
                 const nonBoxedListItemWithoutTitle = Boolean(
                     dependencyValues.isListItem &&
                     !dependencyValues.boxed &&
@@ -529,6 +533,7 @@ export class SectioningComponent extends BlockComponent {
                 },
             }),
             definition({ dependencyValues }) {
+                // Delegate list-item inline rendering to the first visible child only.
                 let childrenToRenderInlineForListItem = [];
                 if (dependencyValues.nonBoxedListItemWithoutTitle) {
                     childrenToRenderInlineForListItem = [
@@ -552,6 +557,8 @@ export class SectioningComponent extends BlockComponent {
                 },
             }),
             definition({ dependencyValues }) {
+                // Alignment adjustments only apply when the first visible child
+                // is a component object (not plain text).
                 const firstVisibleChildAdjustedForListItem = Boolean(
                     dependencyValues.nonBoxedListItemWithoutTitle &&
                     typeof dependencyValues.firstVisibleChild === "object",
@@ -589,6 +596,8 @@ export class SectioningComponent extends BlockComponent {
                 return dependencies;
             },
             definition({ dependencyValues }) {
+                // Baseline is a safe fallback if the first child does not expose
+                // an explicit list-item alignment signal.
                 let firstChildListItemAlignment = "none";
 
                 if (dependencyValues.firstVisibleChildAdjustedForListItem) {

--- a/packages/doenetml-worker-javascript/src/utils/listItemChild.ts
+++ b/packages/doenetml-worker-javascript/src/utils/listItemChild.ts
@@ -1,3 +1,7 @@
+/**
+ * Adds list-item inline-rendering state variables for components that may suppress
+ * their top margin when they are the first visible child in a list item.
+ */
 export function returnListItemChildStateVariableDefinitions({
     checkInlineVariable = false,
     listItemInlineAlignment = "baseline",
@@ -50,6 +54,12 @@ export function returnListItemChildStateVariableDefinitions({
     };
 }
 
+/**
+ * Adds pass-through list-item state variables for wrapper components.
+ *
+ * Wrappers forward list-item inline rendering to their first meaningful child
+ * so nested block components can adjust spacing and alignment.
+ */
 export function returnPassThroughListItemChildStateVariableDefinitions() {
     const stateVariableDefinitions: Record<string, any> = {};
     stateVariableDefinitions.renderInlineForListItem = {
@@ -146,9 +156,10 @@ export function returnPassThroughListItemChildStateVariableDefinitions() {
     return stateVariableDefinitions;
 }
 
-function returnPassThroughListItemAlignmentStateVariableDefinitions(
-    defaultAlignment = "none",
-) {
+/**
+ * Computes list-item inline alignment by forwarding alignment from the selected child.
+ */
+function returnPassThroughListItemAlignmentStateVariableDefinitions() {
     return {
         listItemInlineAlignment: {
             forRenderer: true,
@@ -213,7 +224,7 @@ function returnPassThroughListItemAlignmentStateVariableDefinitions(
 
                 return {
                     setValue: {
-                        listItemInlineAlignment: defaultAlignment,
+                        listItemInlineAlignment: "none",
                     },
                 };
             },
@@ -221,6 +232,9 @@ function returnPassThroughListItemAlignmentStateVariableDefinitions(
     };
 }
 
+/**
+ * Determines if this component is selected by its parent to render inline for list-item layout.
+ */
 function returnShouldRenderInline({
     dependencyValues,
     componentIdx,

--- a/packages/doenetml-worker-javascript/src/utils/listItemChild.ts
+++ b/packages/doenetml-worker-javascript/src/utils/listItemChild.ts
@@ -1,0 +1,239 @@
+export function returnListItemChildStateVariableDefinitions({
+    checkInlineVariable = false,
+    listItemInlineAlignment = "baseline",
+} = {}) {
+    return {
+        renderInlineForListItem: {
+            forRenderer: true,
+            additionalStateVariablesDefined: [
+                { variableName: "listItemInlineAlignment", forRenderer: true },
+            ],
+            returnDependencies: () => {
+                const dependencies: Record<string, any> = {
+                    parentChildrenToRenderInlineForListItem: {
+                        dependencyType: "parentStateVariable",
+                        variableName: "childrenToRenderInlineForListItem",
+                    },
+                };
+
+                if (checkInlineVariable) {
+                    dependencies.inline = {
+                        dependencyType: "stateVariable",
+                        variableName: "inline",
+                    };
+                }
+
+                return dependencies;
+            },
+            definition({
+                dependencyValues,
+                componentIdx,
+            }: {
+                dependencyValues: Record<string, any>;
+                componentIdx: number;
+            }) {
+                const shouldRenderInline = returnShouldRenderInline({
+                    dependencyValues,
+                    componentIdx,
+                });
+
+                return {
+                    setValue: {
+                        renderInlineForListItem: shouldRenderInline,
+                        listItemInlineAlignment: shouldRenderInline
+                            ? listItemInlineAlignment
+                            : "none",
+                    },
+                };
+            },
+        },
+    };
+}
+
+export function returnPassThroughListItemChildStateVariableDefinitions() {
+    const stateVariableDefinitions: Record<string, any> = {};
+    stateVariableDefinitions.renderInlineForListItem = {
+        forRenderer: true,
+        returnDependencies: () => ({
+            parentChildrenToRenderInlineForListItem: {
+                dependencyType: "parentStateVariable",
+                variableName: "childrenToRenderInlineForListItem",
+            },
+        }),
+        definition({
+            dependencyValues,
+            componentIdx,
+        }: {
+            dependencyValues: Record<string, any>;
+            componentIdx: number;
+        }) {
+            const shouldRenderInline = returnShouldRenderInline({
+                dependencyValues,
+                componentIdx,
+            });
+
+            return {
+                setValue: {
+                    renderInlineForListItem: shouldRenderInline,
+                },
+            };
+        },
+    };
+
+    stateVariableDefinitions.childrenToRenderInlineForListItem = {
+        forRenderer: true,
+        returnDependencies: () => ({
+            parentChildrenToRenderInlineForListItem: {
+                dependencyType: "parentStateVariable",
+                variableName: "childrenToRenderInlineForListItem",
+            },
+            allChildren: {
+                dependencyType: "child",
+                includeAllChildren: true,
+            },
+        }),
+        definition({
+            dependencyValues,
+            componentIdx,
+        }: {
+            dependencyValues: Record<string, any>;
+            componentIdx: number;
+        }) {
+            let childrenToRenderInlineForListItem: any[] = [];
+            const shouldRenderInline = returnShouldRenderInline({
+                dependencyValues,
+                componentIdx,
+            });
+
+            // If component is in the list of children to render inline,
+            // then set its childrenToRenderInlineForListItem to be its first non-blank child
+
+            if (shouldRenderInline) {
+                const firstNonBlankNonLabelChild =
+                    dependencyValues.allChildren.find((child: any) => {
+                        if (typeof child === "object") {
+                            return child.componentType !== "label";
+                        }
+                        if (typeof child === "string") {
+                            return child.trim() !== "";
+                        }
+                        return false;
+                    });
+
+                if (
+                    firstNonBlankNonLabelChild &&
+                    typeof firstNonBlankNonLabelChild === "object"
+                ) {
+                    childrenToRenderInlineForListItem = [
+                        firstNonBlankNonLabelChild,
+                    ];
+                }
+            }
+
+            return {
+                setValue: {
+                    childrenToRenderInlineForListItem,
+                },
+            };
+        },
+    };
+
+    Object.assign(
+        stateVariableDefinitions,
+        returnPassThroughListItemAlignmentStateVariableDefinitions(),
+    );
+
+    return stateVariableDefinitions;
+}
+
+function returnPassThroughListItemAlignmentStateVariableDefinitions(
+    defaultAlignment = "none",
+) {
+    return {
+        listItemInlineAlignment: {
+            forRenderer: true,
+            stateVariablesDeterminingDependencies: [
+                "childrenToRenderInlineForListItem",
+            ],
+            returnDependencies: ({
+                stateValues,
+            }: {
+                stateValues: Record<string, any>;
+            }) => {
+                const dependencies: Record<string, any> = {
+                    parentChildrenToRenderInlineForListItem: {
+                        dependencyType: "parentStateVariable",
+                        variableName: "childrenToRenderInlineForListItem",
+                    },
+                };
+
+                const child =
+                    stateValues.childrenToRenderInlineForListItem?.[0];
+                if (child && typeof child === "object") {
+                    dependencies[`childListItemInlineAlignment`] = {
+                        dependencyType: "stateVariable",
+                        componentIdx: child.componentIdx,
+                        variableName: "listItemInlineAlignment",
+                        variablesOptional: true,
+                    };
+                }
+
+                return dependencies;
+            },
+            definition({
+                dependencyValues,
+                componentIdx,
+            }: {
+                dependencyValues: Record<string, any>;
+                componentIdx: number;
+            }) {
+                const shouldRenderInline = returnShouldRenderInline({
+                    dependencyValues,
+                    componentIdx,
+                });
+
+                if (!shouldRenderInline) {
+                    return {
+                        setValue: { listItemInlineAlignment: "none" },
+                    };
+                }
+
+                const childAlignment =
+                    dependencyValues[`childListItemInlineAlignment`];
+                if (
+                    childAlignment === "baseline" ||
+                    childAlignment === "flex-start"
+                ) {
+                    return {
+                        setValue: {
+                            listItemInlineAlignment: childAlignment,
+                        },
+                    };
+                }
+
+                return {
+                    setValue: {
+                        listItemInlineAlignment: defaultAlignment,
+                    },
+                };
+            },
+        },
+    };
+}
+
+function returnShouldRenderInline({
+    dependencyValues,
+    componentIdx,
+}: {
+    dependencyValues: Record<string, any>;
+    componentIdx: number;
+}) {
+    const parentChildrenToRenderInlineForListItem =
+        dependencyValues.parentChildrenToRenderInlineForListItem;
+    return Boolean(
+        !dependencyValues.inline &&
+        parentChildrenToRenderInlineForListItem
+            ?.map((c: { componentIdx: number }) => c.componentIdx)
+            .includes(componentIdx),
+    );
+}

--- a/packages/doenetml-worker-javascript/src/utils/listItemChild.ts
+++ b/packages/doenetml-worker-javascript/src/utils/listItemChild.ts
@@ -57,8 +57,9 @@ export function returnListItemChildStateVariableDefinitions({
 /**
  * Adds pass-through list-item state variables for wrapper components.
  *
- * Wrappers forward list-item inline rendering to their first meaningful child
- * so nested block components can adjust spacing and alignment.
+ * Wrappers forward list-item inline rendering to the first non-blank,
+ * non-label child component so nested block components can adjust spacing
+ * and alignment.
  */
 export function returnPassThroughListItemChildStateVariableDefinitions() {
     const stateVariableDefinitions: Record<string, any> = {};
@@ -91,7 +92,6 @@ export function returnPassThroughListItemChildStateVariableDefinitions() {
     };
 
     stateVariableDefinitions.childrenToRenderInlineForListItem = {
-        forRenderer: true,
         returnDependencies: () => ({
             parentChildrenToRenderInlineForListItem: {
                 dependencyType: "parentStateVariable",
@@ -148,88 +148,75 @@ export function returnPassThroughListItemChildStateVariableDefinitions() {
         },
     };
 
-    Object.assign(
-        stateVariableDefinitions,
-        returnPassThroughListItemAlignmentStateVariableDefinitions(),
-    );
+    stateVariableDefinitions.listItemInlineAlignment = {
+        forRenderer: true,
+        stateVariablesDeterminingDependencies: [
+            "childrenToRenderInlineForListItem",
+        ],
+        returnDependencies: ({
+            stateValues,
+        }: {
+            stateValues: Record<string, any>;
+        }) => {
+            const dependencies: Record<string, any> = {
+                parentChildrenToRenderInlineForListItem: {
+                    dependencyType: "parentStateVariable",
+                    variableName: "childrenToRenderInlineForListItem",
+                },
+            };
 
-    return stateVariableDefinitions;
-}
-
-/**
- * Computes list-item inline alignment by forwarding alignment from the selected child.
- */
-function returnPassThroughListItemAlignmentStateVariableDefinitions() {
-    return {
-        listItemInlineAlignment: {
-            forRenderer: true,
-            stateVariablesDeterminingDependencies: [
-                "childrenToRenderInlineForListItem",
-            ],
-            returnDependencies: ({
-                stateValues,
-            }: {
-                stateValues: Record<string, any>;
-            }) => {
-                const dependencies: Record<string, any> = {
-                    parentChildrenToRenderInlineForListItem: {
-                        dependencyType: "parentStateVariable",
-                        variableName: "childrenToRenderInlineForListItem",
-                    },
+            const child = stateValues.childrenToRenderInlineForListItem?.[0];
+            if (child && typeof child === "object") {
+                dependencies[`childListItemInlineAlignment`] = {
+                    dependencyType: "stateVariable",
+                    componentIdx: child.componentIdx,
+                    variableName: "listItemInlineAlignment",
+                    variablesOptional: true,
                 };
+            }
 
-                const child =
-                    stateValues.childrenToRenderInlineForListItem?.[0];
-                if (child && typeof child === "object") {
-                    dependencies[`childListItemInlineAlignment`] = {
-                        dependencyType: "stateVariable",
-                        componentIdx: child.componentIdx,
-                        variableName: "listItemInlineAlignment",
-                        variablesOptional: true,
-                    };
-                }
-
-                return dependencies;
-            },
-            definition({
+            return dependencies;
+        },
+        definition({
+            dependencyValues,
+            componentIdx,
+        }: {
+            dependencyValues: Record<string, any>;
+            componentIdx: number;
+        }) {
+            const shouldRenderInline = returnShouldRenderInline({
                 dependencyValues,
                 componentIdx,
-            }: {
-                dependencyValues: Record<string, any>;
-                componentIdx: number;
-            }) {
-                const shouldRenderInline = returnShouldRenderInline({
-                    dependencyValues,
-                    componentIdx,
-                });
+            });
 
-                if (!shouldRenderInline) {
-                    return {
-                        setValue: { listItemInlineAlignment: "none" },
-                    };
-                }
+            if (!shouldRenderInline) {
+                return {
+                    setValue: { listItemInlineAlignment: "none" },
+                };
+            }
 
-                const childAlignment =
-                    dependencyValues[`childListItemInlineAlignment`];
-                if (
-                    childAlignment === "baseline" ||
-                    childAlignment === "flex-start"
-                ) {
-                    return {
-                        setValue: {
-                            listItemInlineAlignment: childAlignment,
-                        },
-                    };
-                }
-
+            const childAlignment =
+                dependencyValues[`childListItemInlineAlignment`];
+            if (
+                childAlignment === "baseline" ||
+                childAlignment === "flex-start"
+            ) {
                 return {
                     setValue: {
-                        listItemInlineAlignment: "none",
+                        listItemInlineAlignment: childAlignment,
                     },
                 };
-            },
+            }
+
+            return {
+                setValue: {
+                    listItemInlineAlignment: "none",
+                },
+            };
         },
     };
+
+    return stateVariableDefinitions;
 }
 
 /**

--- a/packages/doenetml/src/Viewer/renderers/GraphFrame.tsx
+++ b/packages/doenetml/src/Viewer/renderers/GraphFrame.tsx
@@ -6,8 +6,9 @@ import { DescriptionAsDetails, DescriptionPopover } from "./utils/Description";
 /**
  * Shared frame for graph-style renderers.
  *
- * suppressTopMargin removes only the outer top margin so list-item numbering can
- * align with the top of a block graph while preserving bottom spacing.
+ * suppressTopMargin removes the graph's top vertical offset so list-item
+ * numbering can align with the top edge of the graph while preserving
+ * bottom spacing.
  */
 export default function GraphFrame({
     id,
@@ -48,7 +49,7 @@ export default function GraphFrame({
         contentStyle.border = "none";
     }
     contentStyle.marginBottom = "12px";
-    contentStyle.marginTop = "12px";
+    contentStyle.marginTop = suppressTopMargin ? "0px" : "12px";
     contentStyle.backgroundColor = "var(--canvas)";
     contentStyle.color = "var(--canvasText)";
 
@@ -83,13 +84,7 @@ export default function GraphFrame({
         typeof children === "function" ? children(contentStyle) : children;
 
     return (
-        <div
-            style={
-                suppressTopMargin ? { ...outerStyle, marginTop: 0 } : outerStyle
-            }
-            ref={containerRef}
-            id={`${id}-container`}
-        >
+        <div style={outerStyle} ref={containerRef} id={`${id}-container`}>
             <div style={innerStyle}>
                 <div
                     id={`${id}-description`}

--- a/packages/doenetml/src/Viewer/renderers/GraphFrame.tsx
+++ b/packages/doenetml/src/Viewer/renderers/GraphFrame.tsx
@@ -10,6 +10,7 @@ export default function GraphFrame({
     containerRef,
     descriptionChild,
     hasInteractiveControls,
+    suppressTopMargin = false,
     children,
 }) {
     const contentStyle: React.CSSProperties = {
@@ -76,7 +77,11 @@ export default function GraphFrame({
         typeof children === "function" ? children(contentStyle) : children;
 
     return (
-        <div style={outerStyle} ref={containerRef} id={`${id}-container`}>
+        <div
+            style={suppressTopMargin ? { ...outerStyle, marginTop: 0 } : outerStyle}
+            ref={containerRef}
+            id={`${id}-container`}
+        >
             <div style={innerStyle}>
                 <div
                     id={`${id}-description`}

--- a/packages/doenetml/src/Viewer/renderers/GraphFrame.tsx
+++ b/packages/doenetml/src/Viewer/renderers/GraphFrame.tsx
@@ -3,6 +3,12 @@ import React from "react";
 import { sizeToCSS } from "./utils/css";
 import { DescriptionAsDetails, DescriptionPopover } from "./utils/Description";
 
+/**
+ * Shared frame for graph-style renderers.
+ *
+ * suppressTopMargin removes only the outer top margin so list-item numbering can
+ * align with the top of a block graph while preserving bottom spacing.
+ */
 export default function GraphFrame({
     id,
     SVs,
@@ -78,7 +84,9 @@ export default function GraphFrame({
 
     return (
         <div
-            style={suppressTopMargin ? { ...outerStyle, marginTop: 0 } : outerStyle}
+            style={
+                suppressTopMargin ? { ...outerStyle, marginTop: 0 } : outerStyle
+            }
             ref={containerRef}
             id={`${id}-container`}
         >

--- a/packages/doenetml/src/Viewer/renderers/blockQuote.tsx
+++ b/packages/doenetml/src/Viewer/renderers/blockQuote.tsx
@@ -30,6 +30,8 @@ export default React.memo(function Container(props: UseDoenetRendererProps) {
         <blockquote
             id={id}
             ref={ref}
+            // Only suppress top margin so list-item numbering top-aligns; keep
+            // native blockquote side/bottom spacing from stylesheet defaults.
             style={SVs.renderInlineForListItem ? { marginTop: 0 } : undefined}
         >
             {children}

--- a/packages/doenetml/src/Viewer/renderers/blockQuote.tsx
+++ b/packages/doenetml/src/Viewer/renderers/blockQuote.tsx
@@ -27,7 +27,11 @@ export default React.memo(function Container(props: UseDoenetRendererProps) {
     }
 
     return (
-        <blockquote id={id} ref={ref}>
+        <blockquote
+            id={id}
+            ref={ref}
+            style={SVs.renderInlineForListItem ? { marginTop: 0 } : undefined}
+        >
             {children}
         </blockquote>
     );

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -584,7 +584,10 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
             <fieldset
                 id={inputKey}
                 style={{
-                    margin: "16px 0",
+                    margin:
+                        SVs.renderInlineForListItem && !SVs.inline
+                            ? "0 0 16px 0"
+                            : "16px 0",
                     padding: 0,
                     border: "none",
                     minInlineSize: 0,

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -11,6 +11,7 @@ import {
 } from "./utils/checkWork";
 import { DescriptionPopover } from "./utils/Description";
 import { addValidationStateToShortDescription } from "./utils/description";
+import { getBlockMarginWithOptionalTopSuppression } from "./utils/nonInlineMediaLayout";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
 
 // type guard
@@ -584,10 +585,12 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
             <fieldset
                 id={inputKey}
                 style={{
-                    margin:
-                        SVs.renderInlineForListItem && !SVs.inline
-                            ? "0 0 16px 0"
-                            : "16px 0",
+                    margin: getBlockMarginWithOptionalTopSuppression({
+                        suppressTopMargin:
+                            SVs.renderInlineForListItem && !SVs.inline,
+                        top: 16,
+                        bottom: 16,
+                    }),
                     padding: 0,
                     border: "none",
                     minInlineSize: 0,

--- a/packages/doenetml/src/Viewer/renderers/containerBlock.tsx
+++ b/packages/doenetml/src/Viewer/renderers/containerBlock.tsx
@@ -57,7 +57,11 @@ export default React.memo(function Container(props: UseDoenetRendererProps) {
     }
 
     return (
-        <div id={id} ref={ref}>
+        <div
+            id={id}
+            ref={ref}
+            style={SVs.renderInlineForListItem ? { marginTop: 0 } : undefined}
+        >
             {children}
             {checkWorkComponent}
         </div>

--- a/packages/doenetml/src/Viewer/renderers/containerBlock.tsx
+++ b/packages/doenetml/src/Viewer/renderers/containerBlock.tsx
@@ -60,6 +60,8 @@ export default React.memo(function Container(props: UseDoenetRendererProps) {
         <div
             id={id}
             ref={ref}
+            // Suppress only top margin for list-item alignment while preserving
+            // any existing bottom/other spacing styles on container blocks.
             style={SVs.renderInlineForListItem ? { marginTop: 0 } : undefined}
         >
             {children}

--- a/packages/doenetml/src/Viewer/renderers/graph.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graph.tsx
@@ -178,6 +178,7 @@ export default React.memo(function Graph(props) {
             containerRef={containerRef}
             descriptionChild={descriptionChild}
             hasInteractiveControls={shouldRenderControls}
+            suppressTopMargin={SVs.renderInlineForListItem}
         >
             {(surfaceStyle) => {
                 const graphContent = isPrefigureRenderer ? (

--- a/packages/doenetml/src/Viewer/renderers/image.tsx
+++ b/packages/doenetml/src/Viewer/renderers/image.tsx
@@ -601,7 +601,11 @@ export default React.memo(function Image(props) {
     }
 
     return (
-        <div style={outerStyle} ref={ref} id={`${id}-container`}>
+        <div
+            style={SVs.renderInlineForListItem ? { ...outerStyle, marginTop: 0 } : outerStyle}
+            ref={ref}
+            id={`${id}-container`}
+        >
             <div style={innerStyle}>
                 {SVs.displayMode === "inline" ? (
                     urlOrSource ? (

--- a/packages/doenetml/src/Viewer/renderers/image.tsx
+++ b/packages/doenetml/src/Viewer/renderers/image.tsx
@@ -602,7 +602,11 @@ export default React.memo(function Image(props) {
 
     return (
         <div
-            style={SVs.renderInlineForListItem ? { ...outerStyle, marginTop: 0 } : outerStyle}
+            style={
+                SVs.renderInlineForListItem
+                    ? { ...outerStyle, marginTop: 0 }
+                    : outerStyle
+            }
             ref={ref}
             id={`${id}-container`}
         >

--- a/packages/doenetml/src/Viewer/renderers/p.tsx
+++ b/packages/doenetml/src/Viewer/renderers/p.tsx
@@ -54,7 +54,12 @@ export default React.memo(function P(props: UseDoenetRendererProps) {
     }
 
     return (
-        <div id={id} ref={ref} className="para">
+        <div
+            id={id}
+            ref={ref}
+            className="para"
+            style={SVs.renderInlineForListItem ? { marginTop: 0 } : undefined}
+        >
             {children}
             {checkWorkComponent}
         </div>

--- a/packages/doenetml/src/Viewer/renderers/p.tsx
+++ b/packages/doenetml/src/Viewer/renderers/p.tsx
@@ -58,6 +58,8 @@ export default React.memo(function P(props: UseDoenetRendererProps) {
             id={id}
             ref={ref}
             className="para"
+            // Keep paragraph spacing contract intact and only collapse the top
+            // margin when this paragraph is first in a list-item container.
             style={SVs.renderInlineForListItem ? { marginTop: 0 } : undefined}
         >
             {children}

--- a/packages/doenetml/src/Viewer/renderers/pre.tsx
+++ b/packages/doenetml/src/Viewer/renderers/pre.tsx
@@ -4,6 +4,7 @@ import useDoenetRenderer, {
 } from "../useDoenetRenderer";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 import { addCommasForCompositeRanges } from "./utils/composites";
+import { getBlockMarginWithOptionalTopSuppression } from "./utils/nonInlineMediaLayout";
 
 export default React.memo(function Pre(props: UseDoenetRendererProps) {
     let { id, SVs, children, actions, callAction } = useDoenetRenderer(props);
@@ -45,11 +46,11 @@ export default React.memo(function Pre(props: UseDoenetRendererProps) {
     return (
         <pre
             id={id}
-            style={
-                SVs.renderInlineForListItem
-                    ? { margin: "0 0 12px 0" }
-                    : { margin: "12px 0" }
-            }
+            style={{
+                margin: getBlockMarginWithOptionalTopSuppression({
+                    suppressTopMargin: SVs.renderInlineForListItem,
+                }),
+            }}
             ref={ref}
         >
             {children}

--- a/packages/doenetml/src/Viewer/renderers/pre.tsx
+++ b/packages/doenetml/src/Viewer/renderers/pre.tsx
@@ -43,7 +43,15 @@ export default React.memo(function Pre(props: UseDoenetRendererProps) {
     }
 
     return (
-        <pre id={id} style={{ margin: "12px 0" }} ref={ref}>
+        <pre
+            id={id}
+            style={
+                SVs.renderInlineForListItem
+                    ? { margin: "0 0 12px 0" }
+                    : { margin: "12px 0" }
+            }
+            ref={ref}
+        >
             {children}
         </pre>
     );

--- a/packages/doenetml/src/Viewer/renderers/section.tsx
+++ b/packages/doenetml/src/Viewer/renderers/section.tsx
@@ -407,13 +407,14 @@ export default React.memo(function Section(props) {
     }
 
     let childrenForContentWrapper = children;
-    if (
+    const needsContentWrapper =
         SVs.isListItem &&
         !SVs.collapsible &&
         !SVs.boxed &&
         !heading &&
-        hasAdjustedFirstChildForListItem
-    ) {
+        hasAdjustedFirstChildForListItem;
+
+    if (needsContentWrapper) {
         let startInd = 0;
         while (
             startInd < children.length &&
@@ -424,13 +425,6 @@ export default React.memo(function Section(props) {
         }
         childrenForContentWrapper = children.slice(startInd);
     }
-
-    const needsContentWrapperForUntitledListItem =
-        SVs.isListItem &&
-        !SVs.collapsible &&
-        !SVs.boxed &&
-        !heading &&
-        hasAdjustedFirstChildForListItem;
 
     let content = (
         <>
@@ -451,7 +445,7 @@ export default React.memo(function Section(props) {
             ) : (
                 heading
             )}
-            {needsContentWrapperForUntitledListItem ? (
+            {needsContentWrapper ? (
                 <div id={`${id}-content-wrapper`}>
                     {childrenForContentWrapper}
                     {checkWorkComponent}

--- a/packages/doenetml/src/Viewer/renderers/section.tsx
+++ b/packages/doenetml/src/Viewer/renderers/section.tsx
@@ -43,6 +43,11 @@ export default React.memo(function Section(props) {
     // Declare heading variable early (assigned later in the component)
     let heading = null;
 
+    const hasAdjustedFirstChildForListItem =
+        SVs.firstVisibleChildAdjustedForListItem;
+    const shouldBaselineAlignFirstChild =
+        SVs.firstChildListItemAlignment === "baseline";
+
     // Helper function to generate CSS for section number ::before pseudo-element
     // Used for list-item sections to display hanging section numbers
     const getSectionNumberStyles = (hasHeading: boolean) => {
@@ -151,6 +156,7 @@ export default React.memo(function Section(props) {
         const cssRules = [];
         const escapedId = cesc(id);
         const escapedHeadingWrapperId = cesc(`${id}-heading-wrapper`);
+        const escapedContentWrapperId = cesc(`${id}-content-wrapper`);
 
         // For non-boxed sections with heading wrapper
         if (!SVs.collapsible && !SVs.boxed && hasTitle) {
@@ -180,6 +186,28 @@ export default React.memo(function Section(props) {
                     vertical-align: baseline;
                 }
             `);
+
+            if (hasAdjustedFirstChildForListItem) {
+                cssRules.push(`
+                    #${escapedId} {
+                        display: flex;
+                        align-items: ${
+                            shouldBaselineAlignFirstChild
+                                ? "baseline"
+                                : "flex-start"
+                        };
+                    }
+
+                    #${escapedContentWrapperId} {
+                        flex: 1 1 auto;
+                        min-width: 0;
+                    }
+
+                    #${escapedContentWrapperId} > :first-child {
+                        margin-block-start: 0;
+                    }
+                `);
+            }
         }
 
         // For collapsible boxed sections
@@ -227,6 +255,8 @@ export default React.memo(function Section(props) {
         SVs.collapsible,
         SVs.boxed,
         hasTitle,
+        hasAdjustedFirstChildForListItem,
+        shouldBaselineAlignFirstChild,
         id,
     ]);
 
@@ -376,6 +406,32 @@ export default React.memo(function Section(props) {
         });
     }
 
+    let childrenForContentWrapper = children;
+    if (
+        SVs.isListItem &&
+        !SVs.collapsible &&
+        !SVs.boxed &&
+        !heading &&
+        hasAdjustedFirstChildForListItem
+    ) {
+        let startInd = 0;
+        while (
+            startInd < children.length &&
+            typeof children[startInd] === "string" &&
+            children[startInd].trim() === ""
+        ) {
+            startInd++;
+        }
+        childrenForContentWrapper = children.slice(startInd);
+    }
+
+    const needsContentWrapperForUntitledListItem =
+        SVs.isListItem &&
+        !SVs.collapsible &&
+        !SVs.boxed &&
+        !heading &&
+        hasAdjustedFirstChildForListItem;
+
     let content = (
         <>
             {/* For non-boxed list items with a heading, wrap the heading in a flex container
@@ -395,8 +451,17 @@ export default React.memo(function Section(props) {
             ) : (
                 heading
             )}
-            {children}
-            {checkWorkComponent}
+            {needsContentWrapperForUntitledListItem ? (
+                <div id={`${id}-content-wrapper`}>
+                    {childrenForContentWrapper}
+                    {checkWorkComponent}
+                </div>
+            ) : (
+                <>
+                    {children}
+                    {checkWorkComponent}
+                </>
+            )}
         </>
     );
 

--- a/packages/doenetml/src/Viewer/renderers/sideBySide.tsx
+++ b/packages/doenetml/src/Viewer/renderers/sideBySide.tsx
@@ -10,6 +10,8 @@ function isRenderablePanelChild(child: unknown): child is React.ReactElement {
     if (!child) {
         return false;
     }
+    // Renderer output can include whitespace text nodes; panel layout should
+    // only count actual panel elements.
     if (typeof child === "string") {
         return false;
     }

--- a/packages/doenetml/src/Viewer/renderers/sideBySide.tsx
+++ b/packages/doenetml/src/Viewer/renderers/sideBySide.tsx
@@ -6,12 +6,14 @@ import useDoenetRenderer, {
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 import { getBlockMarginWithOptionalTopSuppression } from "./utils/nonInlineMediaLayout";
 
+function isWhitespaceTextChild(child: unknown): child is string {
+    return typeof child === "string" && child.trim() === "";
+}
+
 function isRenderablePanelChild(child: unknown): child is React.ReactElement {
     if (!child) {
         return false;
     }
-    // Renderer output can include whitespace text nodes; panel layout should
-    // only count actual panel elements.
     if (typeof child === "string") {
         return false;
     }
@@ -36,11 +38,30 @@ export default React.memo(function sideBySide(props: UseDoenetRendererProps) {
             ? null
             : SVs.listItemInlineAlignment;
 
-    const panelChildren = children.filter(isRenderablePanelChild);
-    const numColumns = SVs.numPanels ?? panelChildren.length;
+    // Preserve panel-slot indices from worker order. Null placeholders can appear
+    // while lazy-loaded children are resolving; they should still consume a slot.
+    let panelSlotCount = 0;
+    for (const child of children) {
+        if (!isWhitespaceTextChild(child)) {
+            panelSlotCount += 1;
+        }
+    }
+    const numColumns = SVs.numPanels ?? panelSlotCount;
 
-    for (let [i, child] of panelChildren.entries()) {
-        let width = SVs.widths[i];
+    let panelIndex = 0;
+    for (const child of children) {
+        if (isWhitespaceTextChild(child)) {
+            continue;
+        }
+
+        const currentPanelIndex = panelIndex;
+        panelIndex += 1;
+
+        if (!isRenderablePanelChild(child)) {
+            continue;
+        }
+
+        let width = SVs.widths[currentPanelIndex];
         // console.log(">>>marginLeft",marginLeft)
         // console.log(">>>width",width)
         // console.log(">>>marginRight",marginRight)
@@ -49,10 +70,10 @@ export default React.memo(function sideBySide(props: UseDoenetRendererProps) {
         let thisMarginLeft = marginLeft;
         let thisMarginRight = marginRight;
 
-        if (i > 0) {
+        if (currentPanelIndex > 0) {
             thisMarginLeft += SVs.gapWidth / 2;
         }
-        if (i < numColumns - 1) {
+        if (currentPanelIndex < numColumns - 1) {
             thisMarginRight += SVs.gapWidth / 2;
         }
 

--- a/packages/doenetml/src/Viewer/renderers/sideBySide.tsx
+++ b/packages/doenetml/src/Viewer/renderers/sideBySide.tsx
@@ -4,6 +4,17 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
+import { getBlockMarginWithOptionalTopSuppression } from "./utils/nonInlineMediaLayout";
+
+function isRenderablePanelChild(child: unknown): child is React.ReactElement {
+    if (!child) {
+        return false;
+    }
+    if (typeof child === "string") {
+        return false;
+    }
+    return typeof child === "object" && "key" in child;
+}
 
 export default React.memo(function sideBySide(props: UseDoenetRendererProps) {
     let { id, SVs, children, actions, callAction } = useDoenetRenderer(props);
@@ -23,25 +34,10 @@ export default React.memo(function sideBySide(props: UseDoenetRendererProps) {
             ? null
             : SVs.listItemInlineAlignment;
 
-    const numColumns = SVs.numPanels ?? children.length;
-    let panelIndex = 0;
+    const panelChildren = children.filter(isRenderablePanelChild);
+    const numColumns = SVs.numPanels ?? panelChildren.length;
 
-    for (let child of children) {
-        if (!child) {
-            continue;
-        }
-
-        if (typeof child === "string" && child.trim() === "") {
-            continue;
-        }
-
-        if (typeof child !== "object" || !("key" in child)) {
-            continue;
-        }
-
-        const i = panelIndex;
-        panelIndex += 1;
-
+    for (let [i, child] of panelChildren.entries()) {
         let width = SVs.widths[i];
         // console.log(">>>marginLeft",marginLeft)
         // console.log(">>>width",width)
@@ -85,7 +81,9 @@ export default React.memo(function sideBySide(props: UseDoenetRendererProps) {
                     alignItems: listItemInlineAlignment,
                 }),
                 maxWidth: "850px",
-                margin: listItemInlineAlignment ? "0 0 12px 0" : "12px 0",
+                margin: getBlockMarginWithOptionalTopSuppression({
+                    suppressTopMargin: Boolean(listItemInlineAlignment),
+                }),
             }}
             ref={ref}
         >

--- a/packages/doenetml/src/Viewer/renderers/sideBySide.tsx
+++ b/packages/doenetml/src/Viewer/renderers/sideBySide.tsx
@@ -18,18 +18,30 @@ export default React.memo(function sideBySide(props: UseDoenetRendererProps) {
     let styledChildren = [];
     const marginLeft = SVs.margins[0];
     const marginRight = SVs.margins[1];
+    const listItemInlineAlignment =
+        SVs.listItemInlineAlignment === "none"
+            ? null
+            : SVs.listItemInlineAlignment;
 
-    const numColumns = children.length;
+    const numColumns = SVs.numPanels ?? children.length;
+    let panelIndex = 0;
 
-    for (let [i, child] of children.entries()) {
+    for (let child of children) {
         if (!child) {
             continue;
         }
-        if (typeof child !== "object" || !("key" in child)) {
-            // We are not a React element, so we do no modification (e.g., we might be a string)
-            styledChildren.push(child);
+
+        if (typeof child === "string" && child.trim() === "") {
             continue;
         }
+
+        if (typeof child !== "object" || !("key" in child)) {
+            continue;
+        }
+
+        const i = panelIndex;
+        panelIndex += 1;
+
         let width = SVs.widths[i];
         // console.log(">>>marginLeft",marginLeft)
         // console.log(">>>width",width)
@@ -49,6 +61,10 @@ export default React.memo(function sideBySide(props: UseDoenetRendererProps) {
         styledChildren.push(
             <span
                 style={{
+                    ...(listItemInlineAlignment && {
+                        display: "flex",
+                        alignItems: "flex-start",
+                    }),
                     marginLeft: `${thisMarginLeft}%`,
                     marginRight: `${thisMarginRight}%`,
                     width: `${width}%`,
@@ -63,7 +79,14 @@ export default React.memo(function sideBySide(props: UseDoenetRendererProps) {
     return (
         <div
             id={id}
-            style={{ display: "flex", maxWidth: "850px", margin: "12px 0" }}
+            style={{
+                display: "flex",
+                ...(listItemInlineAlignment && {
+                    alignItems: listItemInlineAlignment,
+                }),
+                maxWidth: "850px",
+                margin: listItemInlineAlignment ? "0 0 12px 0" : "12px 0",
+            }}
             ref={ref}
         >
             {styledChildren}

--- a/packages/doenetml/src/Viewer/renderers/spreadsheet.tsx
+++ b/packages/doenetml/src/Viewer/renderers/spreadsheet.tsx
@@ -7,6 +7,7 @@ import "handsontable/dist/handsontable.full.css";
 import { sizeToCSS } from "./utils/css";
 import { registerAllModules } from "handsontable/registry";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
+import { getBlockMarginWithOptionalTopSuppression } from "./utils/nonInlineMediaLayout";
 
 registerAllModules();
 
@@ -24,7 +25,11 @@ export default React.memo(function SpreadsheetRenderer(props) {
     return (
         <div
             id={id}
-            style={{ margin: SVs.renderInlineForListItem ? "0 0 12px 0" : "12px 0" }}
+            style={{
+                margin: getBlockMarginWithOptionalTopSuppression({
+                    suppressTopMargin: SVs.renderInlineForListItem,
+                }),
+            }}
             ref={ref}
         >
             <HotTable

--- a/packages/doenetml/src/Viewer/renderers/spreadsheet.tsx
+++ b/packages/doenetml/src/Viewer/renderers/spreadsheet.tsx
@@ -22,7 +22,11 @@ export default React.memo(function SpreadsheetRenderer(props) {
     }
 
     return (
-        <div id={id} style={{ margin: "12px 0" }} ref={ref}>
+        <div
+            id={id}
+            style={{ margin: SVs.renderInlineForListItem ? "0 0 12px 0" : "12px 0" }}
+            ref={ref}
+        >
             <HotTable
                 // style={{ borderRadius:"var(--mainBorderRadius)", border:"var(--mainBorder)" }}
                 licenseKey="non-commercial-and-evaluation"

--- a/packages/doenetml/src/Viewer/renderers/tabular.tsx
+++ b/packages/doenetml/src/Viewer/renderers/tabular.tsx
@@ -3,6 +3,7 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 import { sizeToCSS } from "./utils/css";
+import { getBlockMarginWithOptionalTopSuppression } from "./utils/nonInlineMediaLayout";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 
 export default React.memo(function Tabular(props: UseDoenetRendererProps) {
@@ -42,7 +43,11 @@ export default React.memo(function Tabular(props: UseDoenetRendererProps) {
 
     return (
         <div
-            style={{ margin: SVs.renderInlineForListItem ? "0 0 12px 0" : "12px 0" }}
+            style={{
+                margin: getBlockMarginWithOptionalTopSuppression({
+                    suppressTopMargin: SVs.renderInlineForListItem,
+                }),
+            }}
             ref={ref}
         >
             <table id={id} style={tableStyle}>

--- a/packages/doenetml/src/Viewer/renderers/tabular.tsx
+++ b/packages/doenetml/src/Viewer/renderers/tabular.tsx
@@ -35,8 +35,16 @@ export default React.memo(function Tabular(props: UseDoenetRendererProps) {
         }
     }
 
+    // Known limitation: when tabular is the first child of a list-item section,
+    // the table box/cell padding can leave a slight horizontal/vertical offset.
+    // We intentionally leave that visual quirk unchanged for now to avoid adding
+    // table-specific list-item layout rules without a stronger product need.
+
     return (
-        <div style={{ margin: "12px 0" }} ref={ref}>
+        <div
+            style={{ margin: SVs.renderInlineForListItem ? "0 0 12px 0" : "12px 0" }}
+            ref={ref}
+        >
             <table id={id} style={tableStyle}>
                 <tbody>{children}</tbody>
             </table>

--- a/packages/doenetml/src/Viewer/renderers/utils/nonInlineMediaLayout.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/nonInlineMediaLayout.ts
@@ -27,3 +27,15 @@ export function getNonInlineMediaLayoutStyles({
         },
     };
 }
+
+export function getBlockMarginWithOptionalTopSuppression({
+    suppressTopMargin,
+    top = 12,
+    bottom = 12,
+}: {
+    suppressTopMargin: boolean;
+    top?: number;
+    bottom?: number;
+}) {
+    return suppressTopMargin ? `0 0 ${bottom}px 0` : `${top}px 0 ${bottom}px 0`;
+}

--- a/packages/doenetml/src/Viewer/renderers/utils/nonInlineMediaLayout.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/nonInlineMediaLayout.ts
@@ -28,6 +28,11 @@ export function getNonInlineMediaLayoutStyles({
     };
 }
 
+/**
+ * Returns a block margin shorthand while optionally collapsing only the top margin.
+ *
+ * This is used by block renderers that own their full vertical spacing contract.
+ */
 export function getBlockMarginWithOptionalTopSuppression({
     suppressTopMargin,
     top = 12,

--- a/packages/doenetml/src/Viewer/renderers/video.tsx
+++ b/packages/doenetml/src/Viewer/renderers/video.tsx
@@ -531,7 +531,7 @@ export default React.memo(function Video(props) {
     return (
         <div
             tabIndex="0"
-            style={outerStyle}
+            style={SVs.renderInlineForListItem ? { ...outerStyle, marginTop: 0 } : outerStyle}
             id={`${id}-container`}
             ref={ref}
             className="video"

--- a/packages/doenetml/src/Viewer/renderers/video.tsx
+++ b/packages/doenetml/src/Viewer/renderers/video.tsx
@@ -531,7 +531,11 @@ export default React.memo(function Video(props) {
     return (
         <div
             tabIndex="0"
-            style={SVs.renderInlineForListItem ? { ...outerStyle, marginTop: 0 } : outerStyle}
+            style={
+                SVs.renderInlineForListItem
+                    ? { ...outerStyle, marginTop: 0 }
+                    : outerStyle
+            }
             id={`${id}-container`}
             ref={ref}
             className="video"

--- a/packages/test-cypress/cypress/e2e/tagSpecific/problem.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/problem.cy.js
@@ -1,4 +1,5 @@
 import { cesc } from "@doenet/utils";
+import { verifySideBySideColumnTopAlignment } from "./utils/listItemAlignment";
 
 describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
     beforeEach(() => {
@@ -1092,10 +1093,6 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
             expect(before.getPropertyValue("position")).to.not.equal(
                 "absolute",
             );
-            expect(before.getPropertyValue("display")).to.equal("inline-block");
-            expect(before.getPropertyValue("vertical-align")).to.equal(
-                "baseline",
-            );
         });
     }
 
@@ -1142,6 +1139,66 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
         );
     }
 
+    /**
+     * Verifies untitled, unboxed list items use the flex-row layout that keeps
+     * the section number and first child on the same line, even when first child
+     * is a block-level renderer.
+     */
+    function verifyUntitledUnboxedListItemUsesFlexLayout(
+        itemId,
+        expectedNumber,
+    ) {
+        const escapedItemId = cesc(itemId);
+        const escapedContentWrapperId = cesc(`${itemId}-content-wrapper`);
+
+        cy.get(`#${escapedItemId}`).then(($el) => {
+            const win = $el[0].ownerDocument.defaultView;
+            const style = win.getComputedStyle($el[0]);
+            expect(style.getPropertyValue("display")).to.equal("flex");
+
+            const before = win.getComputedStyle($el[0], "::before");
+            expect(before.getPropertyValue("content")).to.equal(
+                `"${expectedNumber}."`,
+            );
+            expect(before.getPropertyValue("position")).to.not.equal(
+                "absolute",
+            );
+        });
+
+        cy.get(`#${escapedContentWrapperId}`).then(($el) => {
+            const win = $el[0].ownerDocument.defaultView;
+            const style = win.getComputedStyle($el[0]);
+            expect(style.getPropertyValue("flex-grow")).to.equal("1");
+            expect(style.getPropertyValue("min-width")).to.equal("0px");
+        });
+    }
+
+    function verifySectionNumberRendered(itemId, expectedNumber) {
+        const escapedItemId = cesc(itemId);
+        const escapedHeadingWrapperId = cesc(`${itemId}-heading-wrapper`);
+
+        cy.get(`#${escapedItemId}`).then(($el) => {
+            const win = $el[0].ownerDocument.defaultView;
+            const rootBefore = win.getComputedStyle($el[0], "::before");
+            const rootContent = rootBefore.getPropertyValue("content");
+
+            if (rootContent === `"${expectedNumber}."`) {
+                expect(rootContent).to.equal(`"${expectedNumber}."`);
+                return;
+            }
+
+            cy.get(`#${escapedHeadingWrapperId}`).then(($headingEl) => {
+                const headingBefore = win.getComputedStyle(
+                    $headingEl[0],
+                    "::before",
+                );
+                expect(headingBefore.getPropertyValue("content")).to.equal(
+                    `"${expectedNumber}."`,
+                );
+            });
+        });
+    }
+
     it("tasks with dotted ids still render section numbers", () => {
         cy.window().then(async (win) => {
             win.postMessage(
@@ -1163,29 +1220,10 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        cy.get(`#${cesc("s1.t1")}`).then(($el) => {
-            const win = $el[0].ownerDocument.defaultView;
-            const before = win.getComputedStyle($el[0], "::before");
-            expect(before.getPropertyValue("content")).to.equal('"1."');
-        });
-
-        cy.get(`#${cesc("s1.t2")}`).then(($el) => {
-            const win = $el[0].ownerDocument.defaultView;
-            const before = win.getComputedStyle($el[0], "::before");
-            expect(before.getPropertyValue("content")).to.equal('"2."');
-        });
-
-        cy.get(`#${cesc("s2.t1")}`).then(($el) => {
-            const win = $el[0].ownerDocument.defaultView;
-            const before = win.getComputedStyle($el[0], "::before");
-            expect(before.getPropertyValue("content")).to.equal('"1."');
-        });
-
-        cy.get(`#${cesc("s2.t2")}`).then(($el) => {
-            const win = $el[0].ownerDocument.defaultView;
-            const before = win.getComputedStyle($el[0], "::before");
-            expect(before.getPropertyValue("content")).to.equal('"2."');
-        });
+        verifySectionNumberRendered("s1.t1", 1);
+        verifySectionNumberRendered("s1.t2", 2);
+        verifySectionNumberRendered("s2.t1", 1);
+        verifySectionNumberRendered("s2.t2", 2);
     });
 
     it("boxed tasks with dotted ids still render section numbers", () => {
@@ -1269,6 +1307,8 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
                 <title>boxed task with title</title>
                 boxed content
             </task>
+            <task name="task6"><choiceInput inline><label>Pick one</label><choice>a</choice></choiceInput></task>
+            <task name="task7"><answer inline><label>Pick one</label><choice>a</choice></answer></task>
             <conclusion name="conclusion">Finished</conclusion>
         </problem>
     `,
@@ -1282,6 +1322,114 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
         verifyNonBoxedListItemUsesInlineBefore("task3", 3);
         verifyBoxedListItemNumberInHeadingBox("task4", 4);
         verifyBoxedListItemNumberInHeadingBox("task5", 5);
+        verifyNonBoxedListItemUsesInlineBefore("task6", 6);
+        verifyNonBoxedListItemUsesInlineBefore("task7", 7);
+    });
+
+    it("untitled unboxed list items align numbering with block first children", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+        <problem name="problem">
+            <task name="task1"><p>Paragraph first child</p></task>
+            <task name="task2"><sideBySide name="sbs"><p name="left">Left</p><pre name="mid">Middle</pre><p name="right">Right</p></sideBySide></task>
+            <task name="task3"><blockQuote name="quote"><p name="quotedP">Quoted</p></blockQuote></task>
+            <task name="task4"><div name="divBlock"><p name="divP">Div content</p></div></task>
+            <task name="task5"><pre name="directPre">x+y</pre></task>
+
+            <task name="task6"><title>Has title</title><p>Title case</p></task>
+            <task name="task7" boxed><p>Boxed case</p></task>
+            <task name="task8"><sideBySide name="sbsMixed"><blockQuote name="q8"><p>Blockquote</p></blockQuote><pre name="pre8">Pre</pre><div name="div8"><p>Div</p></div><stack name="stack8"><div><p>Div</p></div><p>Stacked</p></stack></sideBySide></task>
+            <task name="task9"><choiceInput name="ci"><label>Pick one</label><choice>Choice 1</choice><choice>Choice 2</choice><choice>Choice 3</choice></choiceInput></task>
+            <task name="task10"><answer name="ans"><label>Pick one</label><choice>Choice 1</choice><choice>Choice 2</choice><choice>Choice 3</choice></answer></task>
+        </problem>
+    `,
+                },
+                "*",
+            );
+        });
+
+        verifyUntitledUnboxedListItemUsesFlexLayout("task1", 1);
+        verifyUntitledUnboxedListItemUsesFlexLayout("task2", 2);
+        verifyUntitledUnboxedListItemUsesFlexLayout("task3", 3);
+        verifyUntitledUnboxedListItemUsesFlexLayout("task4", 4);
+        verifyUntitledUnboxedListItemUsesFlexLayout("task5", 5);
+        verifyUntitledUnboxedListItemUsesFlexLayout("task8", 8);
+        verifyUntitledUnboxedListItemUsesFlexLayout("task9", 9);
+        verifyUntitledUnboxedListItemUsesFlexLayout("task10", 10);
+        verifySideBySideColumnTopAlignment({
+            sideBySideId: "sbs",
+            expectedAlignment: "baseline",
+        });
+        verifySideBySideColumnTopAlignment({
+            sideBySideId: "sbsMixed",
+            expectedAlignment: "flex-start",
+        });
+
+        cy.get(`#${cesc("directPre")}`).should("have.css", "margin-top", "0px");
+        cy.get(`#${cesc("q8")}`).should("have.css", "margin-top", "0px");
+        cy.get(`#${cesc("pre8")}`).should("have.css", "margin-top", "0px");
+        cy.get(`#${cesc("div8")}`).should("have.css", "margin-top", "0px");
+        cy.get(`#${cesc("stack8")}`).should("have.css", "margin-top", "0px");
+        cy.get(`#${cesc("ci")}`).should("have.css", "margin-top", "0px");
+        cy.get(`#${cesc("ans")} fieldset`).should(
+            "have.css",
+            "margin-top",
+            "0px",
+        );
+
+        cy.get(`#${cesc("task6")}`).then(($el) => {
+            const win = $el[0].ownerDocument.defaultView;
+            const style = win.getComputedStyle($el[0]);
+            expect(style.getPropertyValue("display")).to.not.equal("flex");
+        });
+
+        verifyBoxedListItemNumberInHeadingBox("task7", 7);
+    });
+
+    it("answer list-item alignment only triggers flex-start for block choiceInput child", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <problem name="problem">
+        <task name="task1"><answer name="a1"><mathInput name="mi1"/><award>x</award></answer></task>
+        <task name="task2"><answer name="a2"><choiceInput inline name="ci2"><label>Pick one</label><choice>a</choice></choiceInput></answer></task>
+        <task name="task3"><answer name="a3"><choiceInput name="ci3"><label>Pick one</label><choice>Choice 1</choice><choice>Choice 2</choice></choiceInput></answer></task>
+    </problem>
+`,
+                },
+                "*",
+            );
+        });
+
+        // task1: answer with mathInput — section uses baseline alignment, not flex-start
+        cy.get(`#${cesc("task1")}`).then(($el) => {
+            const win = $el[0].ownerDocument.defaultView;
+            const style = win.getComputedStyle($el[0]);
+            expect(style.getPropertyValue("display")).to.equal("flex");
+            expect(style.getPropertyValue("align-items")).to.equal("baseline");
+        });
+
+        // task2: answer with inline choiceInput — section uses baseline alignment, not flex-start
+        cy.get(`#${cesc("task2")}`).then(($el) => {
+            const win = $el[0].ownerDocument.defaultView;
+            const style = win.getComputedStyle($el[0]);
+            expect(style.getPropertyValue("display")).to.equal("flex");
+            expect(style.getPropertyValue("align-items")).to.equal("baseline");
+        });
+
+        // task3: answer with block choiceInput — section uses flex-start, choiceInput margin is suppressed
+        cy.get(`#${cesc("task3")}`).then(($el) => {
+            const win = $el[0].ownerDocument.defaultView;
+            const style = win.getComputedStyle($el[0]);
+            expect(style.getPropertyValue("display")).to.equal("flex");
+            expect(style.getPropertyValue("align-items")).to.equal(
+                "flex-start",
+            );
+        });
+        cy.get(`#${cesc("ci3")}`).should("have.css", "margin-top", "0px");
     });
 
     it("problems render children as list", () => {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/problem.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/problem.cy.js
@@ -1093,6 +1093,9 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
             expect(before.getPropertyValue("position")).to.not.equal(
                 "absolute",
             );
+            // Do not assert display/vertical-align details here.
+            // Those are implementation choices that can vary between heading
+            // and non-heading list-item paths while preserving numbering behavior.
         });
     }
 

--- a/packages/test-cypress/cypress/e2e/tagSpecific/problem.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/problem.cy.js
@@ -1176,29 +1176,15 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
         });
     }
 
-    function verifySectionNumberRendered(itemId, expectedNumber) {
+    function verifySectionNumberRenderedOnRoot(itemId, expectedNumber) {
         const escapedItemId = cesc(itemId);
-        const escapedHeadingWrapperId = cesc(`${itemId}-heading-wrapper`);
 
         cy.get(`#${escapedItemId}`).then(($el) => {
             const win = $el[0].ownerDocument.defaultView;
             const rootBefore = win.getComputedStyle($el[0], "::before");
-            const rootContent = rootBefore.getPropertyValue("content");
-
-            if (rootContent === `"${expectedNumber}."`) {
-                expect(rootContent).to.equal(`"${expectedNumber}."`);
-                return;
-            }
-
-            cy.get(`#${escapedHeadingWrapperId}`).then(($headingEl) => {
-                const headingBefore = win.getComputedStyle(
-                    $headingEl[0],
-                    "::before",
-                );
-                expect(headingBefore.getPropertyValue("content")).to.equal(
-                    `"${expectedNumber}."`,
-                );
-            });
+            expect(rootBefore.getPropertyValue("content")).to.equal(
+                `"${expectedNumber}."`,
+            );
         });
     }
 
@@ -1223,10 +1209,10 @@ describe("Problem Tag Tests", { tags: ["@group5"] }, function () {
             );
         });
 
-        verifySectionNumberRendered("s1.t1", 1);
-        verifySectionNumberRendered("s1.t2", 2);
-        verifySectionNumberRendered("s2.t1", 1);
-        verifySectionNumberRendered("s2.t2", 2);
+        verifySectionNumberRenderedOnRoot("s1.t1", 1);
+        verifySectionNumberRenderedOnRoot("s1.t2", 2);
+        verifySectionNumberRenderedOnRoot("s2.t1", 1);
+        verifySectionNumberRenderedOnRoot("s2.t2", 2);
     });
 
     it("boxed tasks with dotted ids still render section numbers", () => {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/utils/listItemAlignment.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/utils/listItemAlignment.js
@@ -1,0 +1,49 @@
+import { cesc } from "@doenet/utils";
+
+/**
+ * Verifies that sideBySide panel wrappers stay top-aligned and do not drift
+ * vertically relative to each other in list-item layout mode when using
+ * flex-start alignment.
+ *
+ * @param {Object} options
+ * @param {string} options.sideBySideId Doenet component id for the sideBySide.
+ * @param {"baseline"|"flex-start"} [options.expectedAlignment="flex-start"]
+ * Expected list-item alignment for panel wrappers.
+ * @param {number} [options.maxVerticalDriftPx=2.5] Maximum allowed top-edge drift in px.
+ */
+export function verifySideBySideColumnTopAlignment({
+    sideBySideId,
+    expectedAlignment = "flex-start",
+    maxVerticalDriftPx = 2.5,
+}) {
+    const escapedSideBySideId = cesc(sideBySideId);
+
+    cy.get(`#${escapedSideBySideId}`).then(($el) => {
+        const win = $el[0].ownerDocument.defaultView;
+        const style = win.getComputedStyle($el[0]);
+        expect(style.getPropertyValue("display")).to.equal("flex");
+        expect(style.getPropertyValue("align-items")).to.equal(
+            expectedAlignment,
+        );
+    });
+
+    cy.get(`#${escapedSideBySideId} > span`).each(($el) => {
+        const win = $el[0].ownerDocument.defaultView;
+        const style = win.getComputedStyle($el[0]);
+        expect(style.getPropertyValue("display")).to.equal("flex");
+        expect(style.getPropertyValue("align-items")).to.equal("flex-start");
+    });
+
+    if (expectedAlignment === "flex-start") {
+        cy.get(`#${escapedSideBySideId} > span`).then(($spans) => {
+            const tops = [...$spans].map(
+                (el) => el.getBoundingClientRect().top,
+            );
+            const minTop = Math.min(...tops);
+            const maxTop = Math.max(...tops);
+
+            // Allow small browser/font variance while preventing staircase drift.
+            expect(maxTop - minTop).to.be.lessThan(maxVerticalDriftPx);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add list-item alignment state-variable helpers for block and pass-through components
- propagate first-child alignment through section/task rendering so numbering top-aligns with block-first content
- update renderers (including sideBySide and answer/choiceInput paths) to suppress top margin where needed
- expand Cypress coverage for untitled unboxed list-item layout and alignment behavior
- add a changeset for the affected published packages

Fixes #981