### PR TITLE
chore: add prettier auto-format hook for Claude Code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+    "hooks": {
+        "PostToolUse": [
+            {
+                "matcher": "Write|Edit|MultiEdit|NotebookEdit",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "jq -r '.tool_response.filePath // .tool_input.file_path' | { read -r f; case \"$f\" in \"$PWD\"/*) npx --no-install prettier --write --ignore-unknown \"$f\" ;; esac; } 2>/dev/null || true",
+                        "timeout": 30
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "jq -r '.tool_response.filePath // .tool_input.file_path' | { read -r f; case \"$f\" in \"$PWD\"/*) npx --no-install prettier --write --ignore-unknown \"$f\" ;; esac; } 2>/dev/null || true",
+                        "command": "jq -r '.tool_response.filePath // .tool_input.file_path' 2>/dev/null | { read -r f; [ -n \"$f\" ] && repo_root=$(realpath \"$PWD\") && target=$(realpath \"$f\") && case \"$target\" in \"$repo_root\"|\"$repo_root\"/*) npx --no-install prettier --write --ignore-unknown \"$target\" ;; esac; } 2>/dev/null || true",
                         "timeout": 30
                     }
                 ]


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with a `PostToolUse` hook that runs `prettier --write --ignore-unknown` on files after `Write`/`Edit`/`MultiEdit`/`NotebookEdit` operations.
- Enforces automatic formatting rather than relying on the agent to read and follow the "format with prettier before committing" instruction in `AGENTS.md` — which was missed in #1036.
- Hook respects `.prettierignore` (auto-discovered by prettier) and only formats files inside the project directory.

## Test plan
- [ ] After merging, contributors using Claude Code on this repo should open `/hooks` once (or restart Claude Code) so the new settings take effect.
- [ ] Verify by editing a `.ts`/`.js` file with formatting violations and confirming it gets auto-formatted on save.
- [ ] Confirm `.md` and other ignored paths are skipped (already covered by `.prettierignore`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)