### PR TITLE
refactor(worker-javascript): extract calcStartEndIdx helper from ResolverAdapter

### DIFF
--- a/CORE_REFACTOR_DEFERRED.md
+++ b/CORE_REFACTOR_DEFERRED.md
@@ -58,11 +58,9 @@ export const TimerLabels = {
 
 Skip if the next phase introduces a broader logging/instrumentation layer that supersedes this helper.
 
-### Refactor `calcStartEndIdx` out of `determineParentAndIndexResolutionForResolver`
+### Refactor `calcStartEndIdx` out of `determineParentAndIndexResolutionForResolver` — DONE
 
-`ResolverAdapter.determineParentAndIndexResolutionForResolver` contains a nested `async function calcStartEndIdx(replacements)` that mutates three variables from the outer scope (`start_idx`, `end_idx`, and reads `update_start`, `update_end`, `copyComponent`) as side effects. The function is recursive and returns a value, but callers discard the return and rely entirely on the side-effect mutations. This was carried over verbatim from Core.js.
-
-A cleaner shape: make `calcStartEndIdx` a standalone helper (or a private method on `ResolverAdapter`) that returns `{ start_idx, end_idx }` directly, eliminating the closure mutation. This untangles the logic and makes the function independently testable.
+Extracted from the nested closure in `ResolverAdapter.determineParentAndIndexResolutionForResolver` into a standalone module-level helper in `utils/resolver.ts`. The new `calcStartEndIdx({ replacements, copyComponentIdx, updateStart, updateEnd })` returns `{ flattenedReplacements, startIdx, endIdx }` directly — no closure mutation, no discarded return value. Behaviour is preserved verbatim, including the parent-overrides-child semantics that the original closure relied on. Unit tests cover the nine behavioural branches in `src/test/utils/calcStartEndIdx.test.ts`.
 
 ### Pre-existing fire-and-forget calls still in `Core.js`
 

--- a/packages/doenetml-worker-javascript/src/CompositeExpander.ts
+++ b/packages/doenetml-worker-javascript/src/CompositeExpander.ts
@@ -26,7 +26,8 @@ import {
  *
  * Holds a back-reference to Core to read `_components`,
  * `componentInfoObjects`, `parameterStack`, `dependencies`, `flags`,
- * `updateInfo`, `rootNames`, and to invoke the other extracted managers.
+ * `updateInfo`, `rootNames`, to invoke `matchPublicStateVariables`, and
+ * to invoke the other extracted managers.
  */
 export class CompositeExpander {
     core: Core;
@@ -1185,11 +1186,12 @@ export class CompositeExpander {
     }
 
     /**
-     * Walk `replacements`, substituting each composite for its (already
-     * expanded) replacements. Returns the flattened list of non-composite
-     * replacements together with the composite indices encountered and the
-     * indices of any composites that were not yet expanded — split by
-     * whether `readyToExpandWhenResolved` had resolved.
+     * Walk `replacements`, substituting each expanded composite for its
+     * own replacements (recursively). Composites that are not yet expanded
+     * are kept in place and recorded in `unexpandedCompositesReady` or
+     * `unexpandedCompositesNotReady` based on whether
+     * `readyToExpandWhenResolved` has resolved, so the caller can decide
+     * to wait for or force their expansion.
      *
      * `recurseNonStandardComposites` widens the "what counts as a composite"
      * test to include non-standard composites. `includeWithheldReplacements`
@@ -1220,74 +1222,68 @@ export class CompositeExpander {
         let unexpandedCompositesNotReady: number[] = [];
 
         for (let replacement of replacements) {
-            if (
+            const isComposite =
                 this.core.componentInfoObjects.isCompositeComponent({
                     componentType: replacement.componentType,
                     includeNonStandard: recurseNonStandardComposites,
-                })
-            ) {
-                if (stopIfHaveProp) {
-                    const checkForPublic = this.core.matchPublicStateVariables({
-                        stateVariables: [stopIfHaveProp],
-                        componentClass: replacement.constructor,
-                    })[0];
+                });
 
-                    if (!checkForPublic.startsWith("__not_public_")) {
-                        // The composite has a public state variable that matches `stopIfHaveProp`.
-                        // Therefore, we don't recurse to its replacements but treat the composite itself as the replacement
-                        newReplacements.push(replacement);
-                        continue;
-                    }
-                }
-
-                compositesFound.push(replacement.componentIdx);
-
-                if (!replacement.isExpanded) {
-                    if (
-                        replacement.state.readyToExpandWhenResolved.isResolved
-                    ) {
-                        unexpandedCompositesReady.push(
-                            replacement.componentIdx,
-                        );
-                    } else {
-                        unexpandedCompositesNotReady.push(
-                            replacement.componentIdx,
-                        );
-                    }
-                }
-
-                if (replacement.isExpanded) {
-                    let replacementReplacements = replacement.replacements;
-                    if (
-                        !includeWithheldReplacements &&
-                        replacement.replacementsToWithhold > 0
-                    ) {
-                        replacementReplacements = replacementReplacements.slice(
-                            0,
-                            -replacement.replacementsToWithhold,
-                        );
-                    }
-                    let recursionResult =
-                        this.recursivelyReplaceCompositesWithReplacements({
-                            replacements: replacementReplacements,
-                            recurseNonStandardComposites,
-                            includeWithheldReplacements,
-                            stopIfHaveProp,
-                        });
-                    compositesFound.push(...recursionResult.compositesFound);
-                    newReplacements.push(...recursionResult.newReplacements);
-                    unexpandedCompositesReady.push(
-                        ...recursionResult.unexpandedCompositesReady,
-                    );
-                    unexpandedCompositesNotReady.push(
-                        ...recursionResult.unexpandedCompositesNotReady,
-                    );
-                } else {
-                    newReplacements.push(replacement);
-                }
-            } else {
+            if (!isComposite) {
                 newReplacements.push(replacement);
+                continue;
             }
+
+            if (stopIfHaveProp) {
+                const checkForPublic = this.core.matchPublicStateVariables({
+                    stateVariables: [stopIfHaveProp],
+                    componentClass: replacement.constructor,
+                })[0];
+
+                if (!checkForPublic.startsWith("__not_public_")) {
+                    // The composite has a public state variable that matches `stopIfHaveProp`.
+                    // Therefore, we don't recurse to its replacements but treat the composite itself as the replacement.
+                    newReplacements.push(replacement);
+                    continue;
+                }
+            }
+
+            compositesFound.push(replacement.componentIdx);
+
+            if (!replacement.isExpanded) {
+                if (replacement.state.readyToExpandWhenResolved.isResolved) {
+                    unexpandedCompositesReady.push(replacement.componentIdx);
+                } else {
+                    unexpandedCompositesNotReady.push(replacement.componentIdx);
+                }
+                newReplacements.push(replacement);
+                continue;
+            }
+
+            let replacementReplacements = replacement.replacements;
+            if (
+                !includeWithheldReplacements &&
+                replacement.replacementsToWithhold > 0
+            ) {
+                replacementReplacements = replacementReplacements.slice(
+                    0,
+                    -replacement.replacementsToWithhold,
+                );
+            }
+            const recursionResult =
+                this.recursivelyReplaceCompositesWithReplacements({
+                    replacements: replacementReplacements,
+                    recurseNonStandardComposites,
+                    includeWithheldReplacements,
+                    stopIfHaveProp,
+                });
+            compositesFound.push(...recursionResult.compositesFound);
+            newReplacements.push(...recursionResult.newReplacements);
+            unexpandedCompositesReady.push(
+                ...recursionResult.unexpandedCompositesReady,
+            );
+            unexpandedCompositesNotReady.push(
+                ...recursionResult.unexpandedCompositesNotReady,
+            );
         }
 
         return {

--- a/packages/doenetml-worker-javascript/src/ResolverAdapter.ts
+++ b/packages/doenetml-worker-javascript/src/ResolverAdapter.ts
@@ -3,6 +3,7 @@ import { assignDoenetMLRange } from "@doenet/utils";
 import { FlatFragment } from "@doenet/doenetml-worker";
 import {
     addNodesToFlatFragment,
+    calcStartEndIdx,
     getEffectiveComponentIdx,
 } from "./utils/resolver";
 
@@ -242,95 +243,18 @@ export class ResolverAdapter {
                 const indexParent = copyComponent.replacementOf;
 
                 // determine where the replacement will end up being spliced in
+                const { startIdx, endIdx } = await calcStartEndIdx({
+                    replacements: indexParent.replacements,
+                    copyComponentIdx: copyComponent.componentIdx,
+                    updateStart: update_start,
+                    updateEnd: update_end,
+                });
 
-                let start_idx: number | undefined;
-                let end_idx: number | undefined;
-
-                async function calcStartEndIdx(
-                    replacements: any[],
-                ): Promise<any[]> {
-                    let nonWithheldReplacements: any[] = [];
-                    for (const repl of replacements) {
-                        if (
-                            typeof repl === "string" ||
-                            !(await repl.stateValues
-                                .isInactiveCompositeReplacement)
-                        ) {
-                            nonWithheldReplacements.push(repl);
-                        }
-                    }
-
-                    const nonBlankStringReplacements =
-                        nonWithheldReplacements.filter(
-                            (x) => typeof x !== "string" || x.trim() !== "",
-                        );
-                    const replacementsWithoutExpandedCopies: any[] = [];
-
-                    let i = 0;
-
-                    for (const repl of nonBlankStringReplacements) {
-                        if (repl.componentType == "_copy") {
-                            if (!repl.isExpanded) {
-                                if (
-                                    repl.componentIdx ===
-                                    copyComponent.componentIdx
-                                ) {
-                                    start_idx = i;
-                                    end_idx = i + 1;
-                                }
-                                replacementsWithoutExpandedCopies.push(repl);
-                                i++;
-                            } else {
-                                let replReplacements = repl.replacements;
-                                if (repl.replacementsToWithhold) {
-                                    replReplacements = replReplacements.slice(
-                                        0,
-                                        replReplacements.length -
-                                            repl.replacementsToWithhold,
-                                    );
-                                }
-
-                                const newReplacements =
-                                    await calcStartEndIdx(replReplacements);
-                                const n = newReplacements.length;
-
-                                if (
-                                    repl.componentIdx ===
-                                    copyComponent.componentIdx
-                                ) {
-                                    if (
-                                        update_start !== undefined &&
-                                        update_end !== undefined
-                                    ) {
-                                        start_idx = i + update_start;
-                                        end_idx = i + update_end;
-                                    } else {
-                                        start_idx = i;
-                                        end_idx = i + n;
-                                    }
-                                }
-
-                                replacementsWithoutExpandedCopies.push(
-                                    ...newReplacements,
-                                );
-                                i += n;
-                            }
-                        } else {
-                            replacementsWithoutExpandedCopies.push(repl);
-                            i++;
-                        }
-                    }
-
-                    return replacementsWithoutExpandedCopies;
-                }
-
-                await calcStartEndIdx(indexParent.replacements);
-
-                if (start_idx !== undefined && end_idx !== undefined) {
+                if (startIdx !== undefined && endIdx !== undefined) {
                     indexResolution = {
                         ReplaceRange: {
                             parent: indexParent.componentIdx,
-                            range: { start: start_idx, end: end_idx },
+                            range: { start: startIdx, end: endIdx },
                         },
                     };
                 } else {

--- a/packages/doenetml-worker-javascript/src/StateVariableInitializer.ts
+++ b/packages/doenetml-worker-javascript/src/StateVariableInitializer.ts
@@ -22,8 +22,8 @@ import {
  *
  * Holds a back-reference to Core to read `_components`,
  * `componentInfoObjects`, and `stateVariableChangeTriggers`, and to invoke
- * `getStateVariableValue`, `checkIfArrayEntry`, `matchPublicStateVariables`,
- * `addDiagnostic`, and `createFromArrayEntry`.
+ * `getStateVariableValue`, `checkIfArrayEntry`, `addDiagnostic`, and
+ * `createFromArrayEntry`.
  */
 export class StateVariableInitializer {
     core: Core;

--- a/packages/doenetml-worker-javascript/src/test/utils/calcStartEndIdx.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/utils/calcStartEndIdx.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from "vitest";
+import { calcStartEndIdx } from "../../utils/resolver";
+
+// Lightweight stand-in for the runtime ComponentInstance shape that
+// `calcStartEndIdx` reads. Only the fields actually exercised are populated;
+// `as any` widens to the helper's `ComponentInstance` argument type without
+// pulling in the full surface.
+type ReplOpts = {
+    componentType?: string;
+    componentIdx: number;
+    isExpanded?: boolean;
+    replacements?: any[];
+    replacementsToWithhold?: number;
+    isInactiveCompositeReplacement?: boolean;
+};
+
+function repl(opts: ReplOpts): any {
+    return {
+        componentType: opts.componentType ?? "p",
+        componentIdx: opts.componentIdx,
+        isExpanded: opts.isExpanded ?? false,
+        replacements: opts.replacements,
+        replacementsToWithhold: opts.replacementsToWithhold,
+        stateValues: {
+            isInactiveCompositeReplacement:
+                opts.isInactiveCompositeReplacement ?? false,
+        },
+    };
+}
+
+function copy(opts: ReplOpts): any {
+    return repl({ ...opts, componentType: "_copy" });
+}
+
+describe("calcStartEndIdx utility", () => {
+    it("returns no match when copy is absent", async () => {
+        const result = await calcStartEndIdx({
+            replacements: [
+                repl({ componentIdx: 1 }),
+                repl({ componentIdx: 2 }),
+            ],
+            copyComponentIdx: 99,
+        });
+        expect(result.startIdx).toBeUndefined();
+        expect(result.endIdx).toBeUndefined();
+        expect(result.flattenedReplacements).toHaveLength(2);
+    });
+
+    it("locates an unexpanded copy at the top level", async () => {
+        const result = await calcStartEndIdx({
+            replacements: [
+                repl({ componentIdx: 1 }),
+                copy({ componentIdx: 42 }),
+                repl({ componentIdx: 3 }),
+            ],
+            copyComponentIdx: 42,
+        });
+        expect(result.startIdx).toBe(1);
+        expect(result.endIdx).toBe(2);
+        expect(result.flattenedReplacements).toHaveLength(3);
+    });
+
+    it("locates an expanded copy and substitutes its replacements", async () => {
+        const result = await calcStartEndIdx({
+            replacements: [
+                repl({ componentIdx: 1 }),
+                copy({
+                    componentIdx: 42,
+                    isExpanded: true,
+                    replacements: [
+                        repl({ componentIdx: 10 }),
+                        repl({ componentIdx: 11 }),
+                        repl({ componentIdx: 12 }),
+                    ],
+                }),
+                repl({ componentIdx: 3 }),
+            ],
+            copyComponentIdx: 42,
+        });
+        // expanded copy is replaced by its 3 replacements; match spans them
+        expect(result.startIdx).toBe(1);
+        expect(result.endIdx).toBe(4);
+        expect(
+            result.flattenedReplacements.map((r: any) => r.componentIdx),
+        ).toEqual([1, 10, 11, 12, 3]);
+    });
+
+    it("honours updateStart/updateEnd when matching at an expanded copy", async () => {
+        const result = await calcStartEndIdx({
+            replacements: [
+                copy({
+                    componentIdx: 42,
+                    isExpanded: true,
+                    replacements: [
+                        repl({ componentIdx: 10 }),
+                        repl({ componentIdx: 11 }),
+                        repl({ componentIdx: 12 }),
+                    ],
+                }),
+            ],
+            copyComponentIdx: 42,
+            updateStart: 1,
+            updateEnd: 2,
+        });
+        // updateStart/updateEnd override the expansion-spanning indices
+        expect(result.startIdx).toBe(1);
+        expect(result.endIdx).toBe(2);
+    });
+
+    it("respects replacementsToWithhold when expanding", async () => {
+        const result = await calcStartEndIdx({
+            replacements: [
+                copy({
+                    componentIdx: 42,
+                    isExpanded: true,
+                    replacements: [
+                        repl({ componentIdx: 10 }),
+                        repl({ componentIdx: 11 }),
+                        repl({ componentIdx: 12 }),
+                    ],
+                    replacementsToWithhold: 2,
+                }),
+            ],
+            copyComponentIdx: 42,
+        });
+        // only the first replacement of the expansion is included
+        expect(result.flattenedReplacements).toHaveLength(1);
+        expect(result.startIdx).toBe(0);
+        expect(result.endIdx).toBe(1);
+    });
+
+    it("skips inactive composite replacements", async () => {
+        const result = await calcStartEndIdx({
+            replacements: [
+                repl({
+                    componentIdx: 1,
+                    isInactiveCompositeReplacement: true,
+                }),
+                copy({ componentIdx: 42 }),
+            ],
+            copyComponentIdx: 42,
+        });
+        // inactive replacement is dropped; copy moves up to position 0
+        expect(result.flattenedReplacements).toHaveLength(1);
+        expect(result.startIdx).toBe(0);
+        expect(result.endIdx).toBe(1);
+    });
+
+    it("skips blank-string replacements but keeps non-blank strings", async () => {
+        const result = await calcStartEndIdx({
+            replacements: [
+                "   ",
+                repl({ componentIdx: 1 }),
+                "hello",
+                copy({ componentIdx: 42 }),
+            ],
+            copyComponentIdx: 42,
+        });
+        // blank string filtered, "hello" kept, copy at index 2
+        expect(result.flattenedReplacements).toEqual([
+            expect.objectContaining({ componentIdx: 1 }),
+            "hello",
+            expect.objectContaining({ componentIdx: 42 }),
+        ]);
+        expect(result.startIdx).toBe(2);
+        expect(result.endIdx).toBe(3);
+    });
+
+    it("finds a copy nested inside an expanded copy", async () => {
+        const result = await calcStartEndIdx({
+            replacements: [
+                repl({ componentIdx: 1 }),
+                copy({
+                    componentIdx: 7,
+                    isExpanded: true,
+                    replacements: [
+                        repl({ componentIdx: 20 }),
+                        copy({ componentIdx: 42 }),
+                        repl({ componentIdx: 22 }),
+                    ],
+                }),
+            ],
+            copyComponentIdx: 42,
+        });
+        // recursion's match is propagated; index is within the recursive
+        // (inner) flattened result, mirroring the legacy closure behaviour.
+        expect(result.startIdx).toBe(1);
+        expect(result.endIdx).toBe(2);
+    });
+
+    it("parent-level match overrides a recursive match (legacy semantics)", async () => {
+        // Both the outer copy (componentIdx 42) and an inner copy of the
+        // same componentIdx exist; the parent-level match must win.
+        const result = await calcStartEndIdx({
+            replacements: [
+                copy({
+                    componentIdx: 42,
+                    isExpanded: true,
+                    replacements: [
+                        repl({ componentIdx: 10 }),
+                        copy({ componentIdx: 42 }),
+                    ],
+                }),
+            ],
+            copyComponentIdx: 42,
+        });
+        // Parent-level (current iteration) match wins: spans the whole
+        // expanded slice [0, 2). The inner recursive match (which would
+        // have been startIdx 1) is overwritten.
+        expect(result.startIdx).toBe(0);
+        expect(result.endIdx).toBe(2);
+    });
+});

--- a/packages/doenetml-worker-javascript/src/utils/resolver.ts
+++ b/packages/doenetml-worker-javascript/src/utils/resolver.ts
@@ -2,6 +2,7 @@ import { FlatElement, FlatFragment } from "@doenet/doenetml-worker";
 import { SerializedComponent } from "./dast/types";
 import { unwrapSource } from "./dast/convertNormalizedDast";
 import { UnflattenedComponent } from "./dast/intermediateTypes";
+import type { ComponentInstance } from "../types/componentInstance";
 
 /**
  * Convert the `serializedComponents` into `FlatElements` and add them to `flatFragment` as children to `parentIdx`
@@ -268,4 +269,122 @@ function getEffectiveComponentName(
             return null;
         }
     }
+}
+
+/**
+ * Walk a tree of `replacements`, locating where the copy with index
+ * `copyComponentIdx` appears in the flattened (composite-expanded) list, and
+ * return the slice indices.
+ *
+ * Used by `ResolverAdapter.determineParentAndIndexResolutionForResolver` to
+ * translate a copy component's location back to a range in its
+ * `replacementOf`'s flattened replacements, for the resolver's `ReplaceRange`
+ * index resolution.
+ *
+ * Behaviour preserved verbatim from the original closure form in
+ * `ResolverAdapter`:
+ * - Withheld replacements (`stateValues.isInactiveCompositeReplacement`)
+ *   and blank-string replacements are skipped.
+ * - Expanded `_copy` replacements are substituted in place by their own
+ *   replacements (recursively); unexpanded copies remain.
+ * - When `copyComponentIdx` matches at the current level, `startIdx`/`endIdx`
+ *   are set to the position in the current level's flattened result. A match
+ *   at the current level overrides any match found in a recursive call (the
+ *   original code mutated outer-scope variables, so the last write — the
+ *   parent level — won).
+ * - When `updateStart`/`updateEnd` are provided and the match falls inside an
+ *   expanded copy, the indices are offset by `updateStart`/`updateEnd` instead
+ *   of spanning the whole expansion.
+ */
+export async function calcStartEndIdx({
+    replacements,
+    copyComponentIdx,
+    updateStart,
+    updateEnd,
+}: {
+    replacements: (ComponentInstance | string)[];
+    copyComponentIdx: number;
+    updateStart?: number;
+    updateEnd?: number;
+}): Promise<{
+    flattenedReplacements: (ComponentInstance | string)[];
+    startIdx?: number;
+    endIdx?: number;
+}> {
+    const nonWithheldReplacements: (ComponentInstance | string)[] = [];
+    for (const repl of replacements) {
+        if (
+            typeof repl === "string" ||
+            !(await repl.stateValues.isInactiveCompositeReplacement)
+        ) {
+            nonWithheldReplacements.push(repl);
+        }
+    }
+
+    const nonBlankStringReplacements = nonWithheldReplacements.filter(
+        (x) => typeof x !== "string" || x.trim() !== "",
+    );
+
+    const flattenedReplacements: (ComponentInstance | string)[] = [];
+    let startIdx: number | undefined;
+    let endIdx: number | undefined;
+    let i = 0;
+
+    for (const repl of nonBlankStringReplacements) {
+        if (typeof repl === "string" || repl.componentType !== "_copy") {
+            flattenedReplacements.push(repl);
+            i++;
+            continue;
+        }
+
+        if (!repl.isExpanded) {
+            if (repl.componentIdx === copyComponentIdx) {
+                startIdx = i;
+                endIdx = i + 1;
+            }
+            flattenedReplacements.push(repl);
+            i++;
+            continue;
+        }
+
+        let replReplacements = repl.replacements ?? [];
+        if (repl.replacementsToWithhold) {
+            replReplacements = replReplacements.slice(
+                0,
+                replReplacements.length - repl.replacementsToWithhold,
+            );
+        }
+
+        const recursionResult = await calcStartEndIdx({
+            replacements: replReplacements,
+            copyComponentIdx,
+            updateStart,
+            updateEnd,
+        });
+        const newReplacements = recursionResult.flattenedReplacements;
+        const n = newReplacements.length;
+
+        // The recursion may have produced a match. The current level's own
+        // match (below) overrides it — preserving the closure-mutation
+        // semantics of the original code.
+        if (recursionResult.startIdx !== undefined) {
+            startIdx = recursionResult.startIdx;
+            endIdx = recursionResult.endIdx;
+        }
+
+        if (repl.componentIdx === copyComponentIdx) {
+            if (updateStart !== undefined && updateEnd !== undefined) {
+                startIdx = i + updateStart;
+                endIdx = i + updateEnd;
+            } else {
+                startIdx = i;
+                endIdx = i + n;
+            }
+        }
+
+        flattenedReplacements.push(...newReplacements);
+        i += n;
+    }
+
+    return { flattenedReplacements, startIdx, endIdx };
 }

--- a/packages/doenetml-worker-javascript/src/utils/resolver.ts
+++ b/packages/doenetml-worker-javascript/src/utils/resolver.ts
@@ -281,12 +281,17 @@ function getEffectiveComponentName(
  * `replacementOf`'s flattened replacements, for the resolver's `ReplaceRange`
  * index resolution.
  *
+ * Async because `isInactiveCompositeReplacement` is a state-value getter that
+ * may resolve asynchronously.
+ *
  * Behaviour preserved verbatim from the original closure form in
  * `ResolverAdapter`:
  * - Withheld replacements (`stateValues.isInactiveCompositeReplacement`)
  *   and blank-string replacements are skipped.
  * - Expanded `_copy` replacements are substituted in place by their own
- *   replacements (recursively); unexpanded copies remain.
+ *   replacements (recursively); unexpanded copies remain. An expanded copy
+ *   missing `replacements` (shouldn't happen at runtime, but the type allows
+ *   it) is treated as having no replacements.
  * - When `copyComponentIdx` matches at the current level, `startIdx`/`endIdx`
  *   are set to the position in the current level's flattened result. A match
  *   at the current level overrides any match found in a recursive call (the
@@ -311,26 +316,23 @@ export async function calcStartEndIdx({
     startIdx?: number;
     endIdx?: number;
 }> {
-    const nonWithheldReplacements: (ComponentInstance | string)[] = [];
+    const activeReplacements: (ComponentInstance | string)[] = [];
     for (const repl of replacements) {
-        if (
-            typeof repl === "string" ||
-            !(await repl.stateValues.isInactiveCompositeReplacement)
-        ) {
-            nonWithheldReplacements.push(repl);
+        if (typeof repl === "string") {
+            if (repl.trim() !== "") {
+                activeReplacements.push(repl);
+            }
+        } else if (!(await repl.stateValues.isInactiveCompositeReplacement)) {
+            activeReplacements.push(repl);
         }
     }
-
-    const nonBlankStringReplacements = nonWithheldReplacements.filter(
-        (x) => typeof x !== "string" || x.trim() !== "",
-    );
 
     const flattenedReplacements: (ComponentInstance | string)[] = [];
     let startIdx: number | undefined;
     let endIdx: number | undefined;
     let i = 0;
 
-    for (const repl of nonBlankStringReplacements) {
+    for (const repl of activeReplacements) {
         if (typeof repl === "string" || repl.componentType !== "_copy") {
             flattenedReplacements.push(repl);
             i++;
@@ -361,8 +363,8 @@ export async function calcStartEndIdx({
             updateStart,
             updateEnd,
         });
-        const newReplacements = recursionResult.flattenedReplacements;
-        const n = newReplacements.length;
+        const recurFlattened = recursionResult.flattenedReplacements;
+        const n = recurFlattened.length;
 
         // The recursion may have produced a match. The current level's own
         // match (below) overrides it — preserving the closure-mutation
@@ -382,7 +384,7 @@ export async function calcStartEndIdx({
             }
         }
 
-        flattenedReplacements.push(...newReplacements);
+        flattenedReplacements.push(...recurFlattened);
         i += n;
     }
 


### PR DESCRIPTION
## Summary

Phase 5e follow-up to the [Core.js refactor](../blob/main/CORE_REFACTOR_DEFERRED.md). Extracts the closure-mutation `calcStartEndIdx` helper out of `ResolverAdapter.determineParentAndIndexResolutionForResolver` into a standalone module-level function in `utils/resolver.ts`, eliminating the side-effect-via-shared-locals pattern that was carried over verbatim from `Core.js`.

The helper now takes its inputs (`replacements`, `copyComponentIdx`, `updateStart`, `updateEnd`) explicitly and returns `{ flattenedReplacements, startIdx, endIdx }` — no closure mutation. Behaviour is preserved verbatim, including the parent-overrides-child match-precedence semantics that the original code derived from late-write-wins on the shared closure variables.

Includes a new `src/test/utils/calcStartEndIdx.test.ts` with nine cases covering each behavioural branch.

Also folds in the squashed-out PR-review cleanup commit from #1042 (commit c234f9e5c), which flattened the loop body of `recursivelyReplaceCompositesWithReplacements` using early `continue`s, refreshed the docstring, and synced the `CompositeExpander` / `StateVariableInitializer` class-header back-reference lists. That commit was lost when #1042 was squash-merged; cherry-picking it restores the actually-reviewed shape on top of main.

## Test plan
- [x] `pnpm tsc --noEmit` in `packages/doenetml-worker-javascript` — 454 errors, identical to main
- [x] `pnpm vitest run src/test/utils/calcStartEndIdx.test.ts` — 9/9 pass
- [x] `pnpm vitest run src/test/copying/extend_references.test.ts` — 49 pass / 6 skipped (regression check on the calling code path)
- [x] `pnpm vitest run "src/test/copying/unlinked copy.test.ts" "src/test/copying/external_references.test.ts" "src/test/tagSpecific/ref.test.ts"` — 49/49 pass
- [x] CI runs the full vitest + Cypress suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)