### PR TITLE
refactor(worker-javascript): type Phase 4 destructure parameters + JSDoc (Phase 5g)

### DIFF
--- a/CORE_REFACTOR_DEFERRED.md
+++ b/CORE_REFACTOR_DEFERRED.md
@@ -251,31 +251,31 @@ The Phase 4 extraction (`StateVariableEvaluator`, `StalenessPropagator`, `Essent
 - `_recordSourceDetails(instruction, sourceInformation)` extracted; both call sites (read-only branch and main loop) now invoke it.
 - Cumulative-merge pattern between the essential-values and newStateVariableValues branches relocated into `EssentialValueWriter._mergeIntoCumulative(stateId, varName, value)`. `UpdateExecutor` now hands off to `essentialValueWriter._mergeIntoCumulative(...)` from both branches; the `removeFunctionsMathExpressionClass` import that was only feeding those two sites is gone.
 
-### Phase 4: Type the destructure parameters and complete the strict-mode pass
+### Phase 4: Type the destructure parameters and complete the strict-mode pass — DONE
 
-The Phase 4 modules carry ~96 TypeScript warnings (down from ~188 after the inline cleanup pass on `Record<string, any>` bag locals, `Object.getOwnPropertyDescriptor(...)?.get` null-safety, `catch (e: any)`, and the three latent bugs TS caught — `&` typo, `Array.isArray()` no-arg, and `valuesChanged.arraySizeChanged` missing the `[varName]` index). The remaining warnings cluster:
+All five Phase 4 modules now report 0 errors under `tsc --noEmit`; package-level total dropped from 366 → 277. Public destructure parameters are typed using `ComponentInstance` (lifted to required `stateId` and `essentialState` since both are always present once `BaseComponent` / `ComponentBuilder` have run) and per-file local aliases for the loose-typed bags (`UpdateInstruction`, `PerformActionArgs`, `PerformUpdateArgs`, `NewStateVariableValues`, `ComponentChange`, `ComponentMap`, `SourceInformation`, `SourceOfUpdate`).
 
-- **TS7031 / TS7006 (~87 warnings)** — untyped destructured binding elements and untyped function parameters. Every public method on the five new managers (and most private ones) destructures `{ component, varName, ... }` without a parameter type. This is the same "established sibling-style pattern" that Phases 1-3 left in place; it's flagged as a follow-up rather than a regression. Adopting types for a single manager's surface (e.g., `StateVariableEvaluator`'s three public methods — `getStateVariableValue`, `getStateVariableDefinitionArguments`, `recordActualChangeInStateVariable`) is the highest-leverage starting point because callers are concentrated. The deferred `CoreBackref` interface (see top of this file) would also let `core: any` shed its `any`.
-- **TS7053 (~7 warnings)** — `sourceInformation[idx]` indexing in `UpdateExecutor` (lines 141, 143, 182, 184) and `arrayInstructionInProgress.desiredValue[arrayKey]` indexing in `EssentialValueWriter` (lines 765, 773, 804). Both root-cause to a destructure parameter that needs a type — once the wider pass above happens, these resolve as a side effect.
-- **TS2345 (4 warnings) — real signature drift across managers**:
-  - `CompositeReplacementUpdater.ts:213` — call to `deleteReplacementsFromShadowsThenComposite` is missing `componentsToDelete` from the destructure expectation.
-  - `EssentialValueWriter.ts:131` — `Argument of type 'any' is not assignable to parameter of type 'never'`; suggests an array typed as `never[]` getting pushed into.
-  - `StateVariableEvaluator.ts:91` — call to `getStateVariableDefinitionArguments` missing `excludeDependencyValues` from the destructure expectation.
-  - `UpdateExecutor.ts:39` — `performAction`'s recursive call to `performUpdate` passes only `{ updateInstructions, actionId, doNotSave }` while the destructure declares `diagnostics` and `event` as required. Either widen `performUpdate`'s destructure (mark them `?`) or pass them in the recursive call.
+Notable fixes folded in:
+- **Real shim bug in `Dependencies.d.ts`** — `checkForCircularDependency` was declared with `stateVariable: string`, but `Dependencies.js:566` accepts `varName`. The shim mismatch had been silently mis-rejecting the only TypeScript caller. Fixed.
+- **Empty `Set` initialisations** typed: `compositesNotReady` (`Set<number>`), `parentsOfDeleted` (`Set<ComponentIdx>`), `arrayVarNamesChanged` (`string[]`).
+- **TS2345 #1 (`UpdateExecutor.ts:39`)** — `PerformUpdateArgs` now declares `diagnostics`, `event`, and `actionId` optional (the recursive setTheme call only passes `updateInstructions`, `actionId`, `doNotSave`). The flag fields each got a JSDoc paragraph distinguishing `canSkipUpdatingRenderer` from `skipRendererUpdate`.
+- **TS2345 #2 (`EssentialValueWriter.ts:131`)** — fixed by typing the empty `Set` literal.
+- **TS2345 #3 (`StateVariableEvaluator.ts:91`)** — `getStateVariableDefinitionArguments` now marks `excludeDependencyValues` as `boolean | undefined` (defaulting to `false`) instead of declaring it required.
+- **TS2345 #4 (`CompositeReplacementUpdater.ts:213`)** — `deleteReplacementsFromShadowsThenComposite` now declares `componentsToDelete` as optional, matching the actual `if (componentsToDelete) { ... }` body.
 
-Each TS2345 hints at either a buggy call site or a destructure that should be marked optional. None have caused observable failures, so they're judgment calls — fix them when designing the real interfaces above.
+Where the strict cascade exposed nullable fields the codepath guarantees populated (e.g. `component.replacements` inside `adjustReplacementsToWithhold`, `component.shadows` inside `shadowedBy` walks, `component.parentIdx` inside `_components` lookups), non-null assertions (`!`) were used at the use site rather than tightening `ComponentInstance` further. The two newly-required fields were tightened deliberately because they are set unconditionally during construction.
 
-### Phase 4: JSDoc on public entry points
+### Phase 4: JSDoc on public entry points — DONE
 
-Each of the five new managers has a strong class-level docstring (`StateVariableEvaluator.ts:1-16` is the model — a one-paragraph contract describing role and back-reference fields). But the public methods themselves have no JSDoc, despite carrying rich option-bag semantics:
+JSDoc paragraphs added to every public entry point identified in the original list:
 
-- `UpdateExecutor.performUpdate` — has ~9 boolean flags (`overrideReadOnly`, `doNotSave`, `canSkipUpdatingRenderer`, `skipRendererUpdate`, …). The difference between `canSkipUpdatingRenderer` (skips both renderer paths) and `skipRendererUpdate` (skips only the late `updateAllChangedRenderers`) in particular is non-obvious and worth documenting.
-- `EssentialValueWriter.processNewStateVariableValues` and `requestComponentChanges` — the inverse-definition contract (what an instruction's `value` / `valueOfStateVariable` / `additionalDependencyValues` means and how the chain terminates) is the trickiest piece of the engine and lives only in code.
-- `StateVariableEvaluator.getStateVariableValue` — the most-called method on the class. A one-paragraph contract describing what it mutates on `component.state[*]` and when it triggers `markStateVariableAndUpstreamDependentsStale` would significantly help future maintainers.
-- `CompositeReplacementUpdater.updateCompositeReplacements` — the public entry point. The contract for `calculateReplacementChanges` (currently a free-floating comment block at the top of the function) should become a JSDoc on the helper or on the `do…while` retry loop.
-- `StalenessPropagator.processMarkStale` — the freshness-predicate contract (the meaning of `fresh`/`partiallyFresh` returns and how the array-entry remap bridges array-level and entry-level freshness) is alluded to in the class header but belongs on the method itself.
-
-This is a documentation-only PR; can be done independently of the duplication or typing work above.
+- `UpdateExecutor.performUpdate` — full contract for the `updateInstructions` dispatch loop, the post-loop renderer/persistence side effects, and an inline distinction between the four boolean flags (notably `canSkipUpdatingRenderer` vs `skipRendererUpdate`).
+- `EssentialValueWriter.processNewStateVariableValues` — bulk-apply contract, missing-component bookkeeping, and the role of the `newComponent` flag.
+- `EssentialValueWriter.requestComponentChanges` — inverse-definition chain contract: how `instruction` is recursively expanded, where `newStateVariableValues` and `workspace` accumulate, and how the chain terminates.
+- `StateVariableEvaluator.getStateVariableValue` — what gets mutated on `component.state[*]`, the `reprocessAfterEvaluate` kludge, and the relationship to `markStateVariableAndUpstreamDependentsStale`.
+- `CompositeReplacementUpdater.updateCompositeReplacements` — the four-step pipeline (calculate / delete / create / thread) and the shadow short-circuit.
+- `StalenessPropagator.markStateVariableAndUpstreamDependentsStale` — the entry-point contract for the staleness pass.
+- `StalenessPropagator.processMarkStale` — the `fresh` / `partiallyFresh` freshness verdict shape and the array-level/entry-level bridging via `_remapArrayEntryFreshness`.
 
 ### Phase 4: Pre-existing console-error-and-throw blocks — DONE
 

--- a/CORE_REFACTOR_DEFERRED.md
+++ b/CORE_REFACTOR_DEFERRED.md
@@ -267,15 +267,24 @@ Where the strict cascade exposed nullable fields the codepath guarantees populat
 
 ### Phase 4: JSDoc on public entry points — DONE
 
-JSDoc paragraphs added to every public entry point identified in the original list:
+JSDoc paragraphs added to every public entry point identified in the original list, plus the surrounding methods on the same classes for symmetry:
 
 - `UpdateExecutor.performUpdate` — full contract for the `updateInstructions` dispatch loop, the post-loop renderer/persistence side effects, and an inline distinction between the four boolean flags (notably `canSkipUpdatingRenderer` vs `skipRendererUpdate`).
+- `UpdateExecutor.performAction` — special-case branches (`setTheme` re-entry, post-deletion `recordVisibilityChange`) and the main action-dispatch path with optional case-insensitive matching.
+- `EssentialValueWriter.executeUpdateStateVariables` — public bulk-write entry point: write → flush composites → expand → flush again.
 - `EssentialValueWriter.processNewStateVariableValues` — bulk-apply contract, missing-component bookkeeping, and the role of the `newComponent` flag.
 - `EssentialValueWriter.requestComponentChanges` — inverse-definition chain contract: how `instruction` is recursively expanded, where `newStateVariableValues` and `workspace` accumulate, and how the chain terminates.
 - `StateVariableEvaluator.getStateVariableValue` — what gets mutated on `component.state[*]`, the `reprocessAfterEvaluate` kludge, and the relationship to `markStateVariableAndUpstreamDependentsStale`.
+- `StateVariableEvaluator.recordActualChangeInStateVariable` — the three side effects (mark-stale, force-recalculation, record-actual-change) and how they relate to the `additionalStateVariablesDefined` group.
 - `CompositeReplacementUpdater.updateCompositeReplacements` — the four-step pipeline (calculate / delete / create / thread) and the shadow short-circuit.
 - `StalenessPropagator.markStateVariableAndUpstreamDependentsStale` — the entry-point contract for the staleness pass.
+- `StalenessPropagator.lookUpCurrentFreshness` — the read-only freshness probe used to capture "previously effectively fresh" before the new mark-stale pass runs.
 - `StalenessPropagator.processMarkStale` — the `fresh` / `partiallyFresh` freshness verdict shape and the array-level/entry-level bridging via `_remapArrayEntryFreshness`.
+- `StalenessPropagator.markUpstreamDependentsStale` — one-step upstream walk, per-edge bookkeeping, and the `_processStaleVisit` re-entry that terminates at any cached-stale frontier.
+
+### Phase 4: Loose `(repl: any)` callbacks in `CompositeReplacementUpdater` — deferred
+
+Several arrow-callback parameters in `CompositeReplacementUpdater` carry an explicit `(repl: any)` annotation (lines around the `component.replacements!.map(...)` calls and the `(x: unknown) => !x` filter in `EssentialValueWriter`). They survive only because `ComponentInstance.replacements` is loosely typed as `any[]` (with a `!` non-null assertion at each use site). Once `replacements` is tightened to `(ComponentInstance | string)[]` (and `dep.downstreamPrimitives` to a concrete shape), these annotations should drop. Tracking here so the cleanup happens together with the wider `ComponentInstance` typing pass.
 
 ### Phase 4: Pre-existing console-error-and-throw blocks — DONE
 

--- a/packages/doenetml-worker-javascript/src/CompositeReplacementUpdater.ts
+++ b/packages/doenetml-worker-javascript/src/CompositeReplacementUpdater.ts
@@ -70,9 +70,12 @@ export class CompositeReplacementUpdater {
      * Returns `{ success, deletedComponents, addedComponents,
      * parentsOfDeleted }`. `parentsOfDeleted` carries every parent whose
      * defining-children list was touched, so the caller knows what to
-     * re-render. The `do…while` retry loop inside is bounded by the
-     * `nPasses` counter elsewhere in the file (100 passes max) to break
-     * any pathological recursion.
+     * re-render. The `do…while` retry loop inside reruns
+     * `calculateReplacementChanges` when `core._components.length` shifted
+     * during the call (a sign that another expansion happened mid-resolve
+     * and could collide with our assigned indices); it terminates as soon
+     * as the length is stable across one pass. There is currently no
+     * explicit upper bound — see the `TODO` at the loop's tail.
      *
      * Skips entirely when this composite is itself a shadow — its
      * replacements will be (re)created when the shadowed composite is

--- a/packages/doenetml-worker-javascript/src/CompositeReplacementUpdater.ts
+++ b/packages/doenetml-worker-javascript/src/CompositeReplacementUpdater.ts
@@ -1213,7 +1213,7 @@ export class CompositeReplacementUpdater {
         deleteResults: any;
         composite: any;
         numberDeleted: number;
-        parentsOfDeleted: Set<number>;
+        parentsOfDeleted: Set<ComponentIdx>;
         deletedComponents: Record<string, any>;
         componentChanges: any[];
         topLevel?: boolean;
@@ -1223,7 +1223,7 @@ export class CompositeReplacementUpdater {
             parentsOfDeleted.add(parent.componentIdx);
             const componentsAffected =
                 await this.core.componentAndRenderedDescendants(parent);
-            componentsAffected.forEach((cIdx: number) =>
+            componentsAffected.forEach((cIdx: ComponentIdx) =>
                 this.core.updateInfo.componentsToUpdateRenderers.add(cIdx),
             );
         }
@@ -1284,7 +1284,7 @@ function* iterateExpandableShadows(component: any) {
  */
 function findExpandableShadowByCompositeIdx(
     component: any,
-    compositeIdx: number,
+    compositeIdx: ComponentIdx,
 ): any | undefined {
     for (const shadow of iterateExpandableShadows(component)) {
         if (shadow.shadows.compositeIdx === compositeIdx) {
@@ -1294,8 +1294,8 @@ function findExpandableShadowByCompositeIdx(
     return undefined;
 }
 
-function calculateAllComponentsShadowing(component: any): number[] {
-    const allShadowing: number[] = [];
+function calculateAllComponentsShadowing(component: any): ComponentIdx[] {
+    const allShadowing: ComponentIdx[] = [];
     for (const shadow of iterateExpandableShadows(component)) {
         allShadowing.push(shadow.componentIdx);
         allShadowing.push(...calculateAllComponentsShadowing(shadow));

--- a/packages/doenetml-worker-javascript/src/CompositeReplacementUpdater.ts
+++ b/packages/doenetml-worker-javascript/src/CompositeReplacementUpdater.ts
@@ -1,4 +1,6 @@
 import type Core from "./Core";
+import type { ComponentInstance } from "./types/componentInstance";
+import type { ComponentIdx } from "@doenet/utils";
 import { postProcessCopy } from "./utils/copy";
 import { preprocessAttributesObject } from "./utils/attributes";
 import { convertUnresolvedAttributesForComponentType } from "./utils/dast/convertNormalizedDast";
@@ -6,6 +8,24 @@ import {
     createComponentIndicesFromSerializedChildren,
     createNewComponentIndices,
 } from "./utils/componentIndices";
+
+/**
+ * Loose-typed bag describing one entry in the `componentChanges` array
+ * threaded through the update pipeline. Each call site builds these
+ * inline; a stricter discriminated union waits for the broader inverse-
+ * definition typing pass.
+ */
+type ComponentChange = Record<string, any>;
+
+/**
+ * Keyed by component-index string; each entry is the component instance
+ * that was added or deleted during this update. Loose-typed because the
+ * bookkeeping survives across Core, the dependency engine, and the
+ * persistence layer with different field expectations.
+ */
+type ComponentMap = Record<string, any>;
+
+type SourceOfUpdate = Record<string, any>;
 
 /**
  * Recomputes a composite component's replacements after its inputs
@@ -29,16 +49,49 @@ export class CompositeReplacementUpdater {
         this.core = core;
     }
 
+    /**
+     * Public entry point: recompute a composite's replacements after its
+     * inputs change.
+     *
+     * Walks the diff between old and new replacement lists by:
+     *   1. Asking the composite's `calculateReplacementChanges` for an
+     *      ordered list of structural changes (added/deleted/withheld
+     *      replacement spans).
+     *   2. Deleting obsolete replacements via
+     *      `deleteReplacementsFromShadowsThenComposite`, which recurses
+     *      into shadowing composites first so the shadow tree shrinks
+     *      from leaves inward.
+     *   3. Creating new replacements via `componentBuilder` /
+     *      `compositeExpander`, calling `createShadowedReplacements` for
+     *      every shadow so the shadow tree grows in lockstep.
+     *   4. Threading every change through `componentChanges` so callers
+     *      can inspect what moved.
+     *
+     * Returns `{ success, deletedComponents, addedComponents,
+     * parentsOfDeleted }`. `parentsOfDeleted` carries every parent whose
+     * defining-children list was touched, so the caller knows what to
+     * re-render. The `do…while` retry loop inside is bounded by the
+     * `nPasses` counter elsewhere in the file (100 passes max) to break
+     * any pathological recursion.
+     *
+     * Skips entirely when this composite is itself a shadow — its
+     * replacements will be (re)created when the shadowed composite is
+     * processed.
+     */
     async updateCompositeReplacements({
         component,
         componentChanges,
         sourceOfUpdate,
+    }: {
+        component: ComponentInstance;
+        componentChanges: ComponentChange[];
+        sourceOfUpdate: SourceOfUpdate;
     }) {
         // console.log("updateCompositeReplacements " + component.componentIdx);
 
         let deletedComponents: Record<string, any> = {};
         let addedComponents: Record<string, any> = {};
-        let parentsOfDeleted = new Set();
+        let parentsOfDeleted = new Set<ComponentIdx>();
 
         if (
             component.shadows &&
@@ -205,8 +258,9 @@ export class CompositeReplacementUpdater {
                 );
 
                 // determine which replacements are blank strings before deleting replacements
-                const blankStringReplacements = component.replacements.map(
-                    (repl) => typeof repl === "string" && repl.trim() === "",
+                const blankStringReplacements = component.replacements!.map(
+                    (repl: any) =>
+                        typeof repl === "string" && repl.trim() === "",
                 );
 
                 if (numberToDelete > 0 && change.changeTopLevelReplacements) {
@@ -385,7 +439,7 @@ export class CompositeReplacementUpdater {
                             await this.core.componentAndRenderedDescendants(
                                 parent,
                             );
-                        componentsAffected.forEach((cIdx) =>
+                        componentsAffected.forEach((cIdx: ComponentIdx) =>
                             this.core.updateInfo.componentsToUpdateRenderers.add(
                                 cIdx,
                             ),
@@ -419,7 +473,7 @@ export class CompositeReplacementUpdater {
                             await this.core.componentAndRenderedDescendants(
                                 parent,
                             );
-                        componentsAffected.forEach((cIdx) =>
+                        componentsAffected.forEach((cIdx: ComponentIdx) =>
                             this.core.updateInfo.componentsToUpdateRenderers.add(
                                 cIdx,
                             ),
@@ -504,7 +558,13 @@ export class CompositeReplacementUpdater {
         return results;
     }
 
-    async setErrorReplacements({ composite, message }) {
+    async setErrorReplacements({
+        composite,
+        message,
+    }: {
+        composite: ComponentInstance;
+        message: string;
+    }) {
         // display error for replacements and set composite to error state
 
         this.core.addDiagnostic({
@@ -549,6 +609,16 @@ export class CompositeReplacementUpdater {
         deletedComponents,
         addedComponents,
         processNewChildren = true,
+    }: {
+        change: ComponentChange;
+        composite: ComponentInstance;
+        componentsToDelete?: ComponentInstance[];
+        componentChanges: ComponentChange[];
+        sourceOfUpdate: SourceOfUpdate;
+        parentsOfDeleted: Set<ComponentIdx>;
+        deletedComponents: ComponentMap;
+        addedComponents: ComponentMap;
+        processNewChildren?: boolean;
     }) {
         if (!composite.isExpanded) {
             return;
@@ -596,7 +666,7 @@ export class CompositeReplacementUpdater {
             }
 
             // delete from replacements
-            let replacementsToDelete = composite.replacements.splice(
+            let replacementsToDelete = composite.replacements!.splice(
                 firstIndex,
                 numberToDelete,
             );
@@ -616,7 +686,7 @@ export class CompositeReplacementUpdater {
             if (processNewChildren) {
                 // since skipped, process children now but without expanding composites
                 await this.core.processNewDefiningChildren({
-                    parent: this.core._components[composite.parentIdx],
+                    parent: this.core._components[composite.parentIdx!],
                     expandComposites: false,
                 });
             }
@@ -641,15 +711,15 @@ export class CompositeReplacementUpdater {
             // branch deletes deeper components whose parents are already
             // covered by the `parentsOfDeleted` walk inside
             // `_recordDeleteResults`, so it doesn't need this fan-out.
-            let parent = this.core._components[composite.parentIdx];
+            let parent = this.core._components[composite.parentIdx!];
             let componentsAffected =
                 await this.core.componentAndRenderedDescendants(parent);
-            componentsAffected.forEach((cIdx) =>
+            componentsAffected.forEach((cIdx: ComponentIdx) =>
                 this.core.updateInfo.componentsToUpdateRenderers.add(cIdx),
             );
         } else {
             // if not change top level replacements
-            let numberToDelete = componentsToDelete.length;
+            let numberToDelete = componentsToDelete!.length;
             // TODO: check if components are appropriate dependency of composite
             let deleteResults = await this.core.deleteComponents({
                 components: componentsToDelete,
@@ -674,15 +744,15 @@ export class CompositeReplacementUpdater {
         }
     }
 
-    async processChildChangesAndRecurseToShadows(component) {
-        let parent = this.core._components[component.parentIdx];
+    async processChildChangesAndRecurseToShadows(component: ComponentInstance) {
+        let parent = this.core._components[component.parentIdx!];
         await this.core.processNewDefiningChildren({
             parent,
             expandComposites: false,
         });
         let componentsAffected =
             await this.core.componentAndRenderedDescendants(parent);
-        componentsAffected.forEach((cIdx) =>
+        componentsAffected.forEach((cIdx: ComponentIdx) =>
             this.core.updateInfo.componentsToUpdateRenderers.add(cIdx),
         );
 
@@ -706,6 +776,19 @@ export class CompositeReplacementUpdater {
         updateOldReplacementsStart,
         updateOldReplacementsEnd,
         blankStringReplacements,
+    }: {
+        replacementsToShadow: any[];
+        componentToShadow: ComponentInstance;
+        parentToShadow: ComponentInstance;
+        currentShadowedBy: Record<string, any[]>;
+        componentChanges: ComponentChange[];
+        sourceOfUpdate: SourceOfUpdate;
+        parentsOfDeleted: Set<ComponentIdx>;
+        deletedComponents: ComponentMap;
+        addedComponents: ComponentMap;
+        updateOldReplacementsStart: number;
+        updateOldReplacementsEnd: number;
+        blankStringReplacements: boolean[];
     }) {
         let newShadowedBy = calculateAllComponentsShadowing(componentToShadow);
 
@@ -962,6 +1045,11 @@ export class CompositeReplacementUpdater {
         change,
         componentChanges,
         adjustResolver = false,
+    }: {
+        component: ComponentInstance;
+        change: ComponentChange;
+        componentChanges: ComponentChange[];
+        adjustResolver?: boolean;
     }) {
         let replacementsToWithhold = change.replacementsToWithhold;
 
@@ -975,12 +1063,12 @@ export class CompositeReplacementUpdater {
         if (changeInReplacementsToWithhold < 0) {
             // Note: don't subtract one of this last ind, as slice doesn't include last ind
             let lastIndToStopWithholding =
-                component.replacements.length - replacementsToWithhold;
+                component.replacements!.length - replacementsToWithhold;
             let firstIndToStopWithholding =
-                component.replacements.length -
+                component.replacements!.length -
                 replacementsToWithhold +
                 changeInReplacementsToWithhold;
-            let newReplacements = component.replacements.slice(
+            let newReplacements = component.replacements!.slice(
                 firstIndToStopWithholding,
                 lastIndToStopWithholding,
             );
@@ -996,16 +1084,16 @@ export class CompositeReplacementUpdater {
             componentChanges.push(newChange);
         } else if (changeInReplacementsToWithhold > 0) {
             let firstIndToStartWithholding =
-                component.replacements.length - replacementsToWithhold;
+                component.replacements!.length - replacementsToWithhold;
             let lastIndToStartWithholding =
                 firstIndToStartWithholding + changeInReplacementsToWithhold;
-            let withheldReplacements = component.replacements.slice(
+            let withheldReplacements = component.replacements!.slice(
                 firstIndToStartWithholding,
                 lastIndToStartWithholding,
             );
             let withheldNamesByParent: Record<string, any[]> = {};
             for (let comp of withheldReplacements) {
-                let par = comp.parentIdx;
+                let par = comp.parentIdx!;
                 if (withheldNamesByParent[par] === undefined) {
                     withheldNamesByParent[par] = [];
                 }
@@ -1024,8 +1112,8 @@ export class CompositeReplacementUpdater {
         }
 
         if (adjustResolver) {
-            const blankStringReplacements = component.replacements.map(
-                (repl) => typeof repl === "string" && repl.trim() === "",
+            const blankStringReplacements = component.replacements!.map(
+                (repl: any) => typeof repl === "string" && repl.trim() === "",
             );
 
             const { indexResolution } =
@@ -1033,7 +1121,7 @@ export class CompositeReplacementUpdater {
                     component,
                     updateOldReplacementsStart: 0,
                     updateOldReplacementsEnd:
-                        component.replacements.length -
+                        component.replacements!.length -
                         (component.replacementsToWithhold ?? 0),
                     blankStringReplacements,
                 });
@@ -1051,13 +1139,13 @@ export class CompositeReplacementUpdater {
 
                 if (indexParentComposite) {
                     if (this.core.replaceIndexResolutionsInResolver) {
-                        const newContentForIndex = component.replacements
-                            .slice(
+                        const newContentForIndex = component
+                            .replacements!.slice(
                                 0,
-                                component.replacements.length -
+                                component.replacements!.length -
                                     change.replacementsToWithhold,
                             )
-                            .map((repl) => {
+                            .map((repl: any) => {
                                 if (typeof repl === "string") {
                                     return repl;
                                 } else {

--- a/packages/doenetml-worker-javascript/src/Dependencies.d.ts
+++ b/packages/doenetml-worker-javascript/src/Dependencies.d.ts
@@ -89,7 +89,7 @@ export declare class DependencyHandler {
 
     checkForCircularDependency(args: {
         componentIdx: ComponentIdx;
-        stateVariable: string;
+        varName: string;
         previouslyVisited?: any[];
     }): void;
 

--- a/packages/doenetml-worker-javascript/src/EssentialValueWriter.ts
+++ b/packages/doenetml-worker-javascript/src/EssentialValueWriter.ts
@@ -1,5 +1,6 @@
 import type Core from "./Core";
 import type { ComponentInstance } from "./types/componentInstance";
+import type { ComponentIdx } from "@doenet/utils";
 import me from "math-expressions";
 import {
     preprocessMathInverseDefinition,
@@ -49,6 +50,27 @@ export class EssentialValueWriter {
         this.core = core;
     }
 
+    /**
+     * Public bulk-write entry point. Applies `newStateVariableValues` to the
+     * live component tree, then flushes any composite-replacement work the
+     * writes triggered:
+     *   1. `processNewStateVariableValues` writes the values and records
+     *      the changes back to upstream dependencies.
+     *   2. `replacementChangesFromCompositesToUpdate` recomputes the
+     *      replacements of every composite added to
+     *      `updateInfo.compositesToUpdateReplacements` during step 1.
+     *   3. If any composite produced new replacements, `expandAllComposites`
+     *      runs (twice — once normally, once with the force flag) to
+     *      catch composites that became expandable as a side effect, and
+     *      any deferred state variables in
+     *      `updateInfo.stateVariablesToEvaluate` are evaluated.
+     *   4. A second `replacementChangesFromCompositesToUpdate` pass picks
+     *      up composites scheduled by step 3.
+     *
+     * Note: this stops after one expand/flush cycle. If step 3 schedules
+     * further composites, they will be picked up on the next call from
+     * `UpdateExecutor.performUpdate` rather than looping here.
+     */
     async executeUpdateStateVariables(
         newStateVariableValues: NewStateVariableValues,
     ) {
@@ -96,7 +118,7 @@ export class EssentialValueWriter {
         ];
         this.core.updateInfo.compositesToUpdateReplacements.clear();
 
-        let compositesNotReady = new Set<number>();
+        let compositesNotReady = new Set<ComponentIdx>();
 
         let nPasses = 0;
 
@@ -852,30 +874,9 @@ export class EssentialValueWriter {
                                     // need to convert multidimensional array (newInstruction.desiredValue)
                                     // to an object with multidimesional arrayKeys
                                     // where each array key is a concatenation of the array indices, joined by commas
-
-                                    function convert_md_array(
-                                        array: any,
-                                        n_dim: number,
-                                    ): Record<string, any> {
-                                        if (n_dim === 1) {
-                                            return Object.assign({}, array);
-                                        }
-                                        let new_obj: Record<string, any> = {};
-                                        for (let ind in array) {
-                                            let sub_obj = convert_md_array(
-                                                array[ind],
-                                                n_dim - 1,
-                                            );
-                                            for (let key in sub_obj) {
-                                                new_obj[`${ind},${key}`] =
-                                                    sub_obj[key];
-                                            }
-                                        }
-                                        return new_obj;
-                                    }
                                     Object.assign(
                                         arrayInstructionInProgress.desiredValue,
-                                        convert_md_array(
+                                        convertMultidimensionalArrayToKeyedObject(
                                             newInstruction.desiredValue,
                                             depStateVarObj.numDimensions,
                                         ),
@@ -1378,7 +1379,7 @@ export class EssentialValueWriter {
         definingInd: number;
         newValue: any;
         newStateVariableValues: NewStateVariableValues;
-        markToIgnoreForParent: number | undefined;
+        markToIgnoreForParent?: ComponentIdx;
     }) {
         if (!newStateVariableValues[parent.componentIdx]) {
             newStateVariableValues[parent.componentIdx] = {};
@@ -1484,4 +1485,31 @@ export class EssentialValueWriter {
             newStateVariableValues,
         });
     }
+}
+
+/**
+ * Flatten a multidimensional `array` of depth `nDim` into an object whose
+ * keys are comma-joined indices (e.g. `"0,1"` for `array[0][1]`) and whose
+ * values are the leaf entries. Used by `requestComponentChanges` to feed
+ * a multidimensional desired-value into the array-keyed
+ * `arrayInstructionInProgress.desiredValue` shape.
+ */
+function convertMultidimensionalArrayToKeyedObject(
+    array: any,
+    nDim: number,
+): Record<string, any> {
+    if (nDim === 1) {
+        return Object.assign({}, array);
+    }
+    let newObj: Record<string, any> = {};
+    for (let ind in array) {
+        let subObj = convertMultidimensionalArrayToKeyedObject(
+            array[ind],
+            nDim - 1,
+        );
+        for (let key in subObj) {
+            newObj[`${ind},${key}`] = subObj[key];
+        }
+    }
+    return newObj;
 }

--- a/packages/doenetml-worker-javascript/src/EssentialValueWriter.ts
+++ b/packages/doenetml-worker-javascript/src/EssentialValueWriter.ts
@@ -1,9 +1,18 @@
 import type Core from "./Core";
+import type { ComponentInstance } from "./types/componentInstance";
 import me from "math-expressions";
 import {
     preprocessMathInverseDefinition,
     removeFunctionsMathExpressionClass,
 } from "./utils/math";
+
+/**
+ * Loose-typed bag of `componentIdx → varName → newValue` entries that the
+ * inverse-definition pipeline accumulates and the essential-write engine
+ * applies. Keys are component-index strings (the form `for...in` yields);
+ * indices are coerced to `Number` only at lookup time.
+ */
+type NewStateVariableValues = Record<string, Record<string, any>>;
 
 /**
  * Applies authored / interactive state-variable changes to the live
@@ -40,7 +49,9 @@ export class EssentialValueWriter {
         this.core = core;
     }
 
-    async executeUpdateStateVariables(newStateVariableValues) {
+    async executeUpdateStateVariables(
+        newStateVariableValues: NewStateVariableValues,
+    ) {
         await this.processNewStateVariableValues(newStateVariableValues);
 
         // calculate any replacement changes on composites touched
@@ -85,7 +96,7 @@ export class EssentialValueWriter {
         ];
         this.core.updateInfo.compositesToUpdateReplacements.clear();
 
-        let compositesNotReady = new Set([]);
+        let compositesNotReady = new Set<number>();
 
         let nPasses = 0;
 
@@ -165,8 +176,29 @@ export class EssentialValueWriter {
         return { updatedComposites };
     }
 
+    /**
+     * Apply a bulk batch of `componentIdx → varName → newValue` updates to
+     * the live component tree. Used at boot to re-apply persisted /
+     * restored state and after `executeUpdate` instructions to flush
+     * intermediate inverse-definition results.
+     *
+     * For each component:
+     *   - Skips and stashes onto `updateInfo.stateVariableUpdatesForMissingComponents`
+     *     when the component does not exist yet (it will be re-applied
+     *     once the component is created via `checkForDependenciesOnNewComponent`).
+     *   - For each variable, calls `processNewStateVariableValueForVariable`,
+     *     which dispatches into the array / scalar / essential / primitive-child
+     *     branches and may recurse into shadowing variables.
+     *   - Records actual changes back to upstream dependencies so the rest
+     *     of the staleness machinery sees the write.
+     *
+     * The optional `newComponent` flag is set when the bulk apply is
+     * happening as part of a fresh component initialization, which
+     * suppresses some warnings that would otherwise fire for
+     * not-yet-resolved variables.
+     */
     async processNewStateVariableValues(
-        newStateVariableValues,
+        newStateVariableValues: NewStateVariableValues,
         newComponent = false,
     ) {
         // console.log("process new state variable values");
@@ -310,7 +342,7 @@ export class EssentialValueWriter {
                             continue;
                         }
 
-                        let set = (x) => x;
+                        let set = (x: any) => x;
                         if (compStateObj.set) {
                             set = compStateObj.set;
                         }
@@ -369,11 +401,39 @@ export class EssentialValueWriter {
         return { nFailures, foundIgnore };
     }
 
+    /**
+     * Walk one update instruction's inverse-definition chain, threading
+     * desired values through dependencies until each lands on an essential
+     * or inverse-set target. The instruction object describes a single
+     * variable change; the function recursively expands it via the
+     * variable's `inverseDefinition` (or `arrayInverseDefinition` for
+     * arrays), calling itself on each downstream "set" instruction the
+     * inverse returns.
+     *
+     * Result accumulators:
+     *   - `newStateVariableValues[componentIdx][varName]` collects the
+     *     final values to write — flushed by the caller via
+     *     `executeUpdateStateVariables` / `processNewStateVariableValues`.
+     *   - `workspace[componentIdx]` holds per-component scratch state
+     *     shared across recursive calls so each variable is processed once.
+     *
+     * Termination: a chain ends at an essential variable, an inverse
+     * definition returning `success: false`, or an instruction whose
+     * `value` already matches the current value (per `_isUnchanged` checks
+     * inside the inverse definitions). The `initialChange` flag is true
+     * only for the top-level call so child recursions can suppress some
+     * provenance bookkeeping.
+     */
     async requestComponentChanges({
         instruction,
         initialChange = true,
         workspace,
         newStateVariableValues,
+    }: {
+        instruction: Record<string, any>;
+        initialChange?: boolean;
+        workspace: Record<string, any>;
+        newStateVariableValues: NewStateVariableValues;
     }) {
         // console.log(`request component changes`);
         // console.log(instruction);
@@ -1070,7 +1130,7 @@ export class EssentialValueWriter {
                         let downstreamInd =
                             dep.downstreamPrimitives
                                 .slice(0, childInd + 1)
-                                .filter((x) => !x).length - 1;
+                                .filter((x: unknown) => !x).length - 1;
 
                         let cIdx =
                             dep.downstreamComponentIndices[downstreamInd];
@@ -1258,6 +1318,12 @@ export class EssentialValueWriter {
         value,
         newStateVariableValues,
         recurseToShadows = true,
+    }: {
+        component: ComponentInstance;
+        varName: string;
+        value: any;
+        newStateVariableValues: NewStateVariableValues;
+        recurseToShadows?: boolean;
     }) {
         if (!newStateVariableValues[component.componentIdx]) {
             newStateVariableValues[component.componentIdx] = {};
@@ -1286,7 +1352,7 @@ export class EssentialValueWriter {
                 // Don't include shadows due to propVariable
                 // unless it is a plain copy marked as returning the same type
                 if (
-                    shadow.shadows.propVariable === undefined ||
+                    shadow.shadows!.propVariable === undefined ||
                     (shadow.doenetAttributes.fromImplicitProp &&
                         component.constructor.implicitPropReturnsSameType)
                 ) {
@@ -1307,6 +1373,12 @@ export class EssentialValueWriter {
         newValue,
         newStateVariableValues,
         markToIgnoreForParent,
+    }: {
+        parent: ComponentInstance;
+        definingInd: number;
+        newValue: any;
+        newStateVariableValues: NewStateVariableValues;
+        markToIgnoreForParent: number | undefined;
     }) {
         if (!newStateVariableValues[parent.componentIdx]) {
             newStateVariableValues[parent.componentIdx] = {};
@@ -1323,7 +1395,7 @@ export class EssentialValueWriter {
 
         if (parent.shadowedBy) {
             for (let shadow of parent.shadowedBy) {
-                if (shadow.shadows.propVariable === undefined) {
+                if (shadow.shadows!.propVariable === undefined) {
                     this.calculatePrimitiveChildChanges({
                         parent: shadow,
                         definingInd,

--- a/packages/doenetml-worker-javascript/src/StalenessPropagator.ts
+++ b/packages/doenetml-worker-javascript/src/StalenessPropagator.ts
@@ -206,6 +206,17 @@ export class StalenessPropagator {
         });
     }
 
+    /**
+     * Read-only freshness probe: invoke the variable's `getCurrentFreshness`
+     * predicate (if defined) and return the same `{ fresh, partiallyFresh,
+     * ... }` verdict shape that `processMarkStale` uses, with
+     * array-state-variable readings remapped onto their array-entry mirrors
+     * via `_remapArrayEntryFreshness`. Returns `undefined` when the
+     * variable has no predicate. Does not mutate state.
+     *
+     * Called from `_processStaleVisit` to decide whether a variable was
+     * "previously effectively fresh" before the new mark-stale pass runs.
+     */
     async lookUpCurrentFreshness({
         component,
         varName,
@@ -329,6 +340,26 @@ export class StalenessPropagator {
         return result;
     }
 
+    /**
+     * Walk one step upward from `component`/`varName` and queue stale-marking
+     * on every upstream dependent that consumes it. For each upstream
+     * dependency:
+     *   - Skip if `onlyToSetInInverseDefinition` (write-only edge).
+     *   - Run the dependency's optional `markStale` side effect.
+     *   - Find the position of `componentIdx` in
+     *     `downstreamComponentIndices` and record `valuesChanged` for that
+     *     slot (with our `freshnessInfo` if available) so the upstream
+     *     definition sees a concrete change.
+     *   - If the upstream variable is in its component's
+     *     `rendererVariablesByComponentType` set, queue the upstream
+     *     component for a renderer update.
+     *   - Dispatch `_processStaleVisit` against the upstream component, which
+     *     re-enters this function for its upstream dependents.
+     *
+     * `_processStaleVisit` already short-circuits when a variable is
+     * already stale (has a getter in place), so this walk terminates at
+     * any cached-stale frontier.
+     */
     async markUpstreamDependentsStale({
         component,
         varName,
@@ -336,13 +367,6 @@ export class StalenessPropagator {
         component: ComponentInstance;
         varName: string;
     }) {
-        // Recursively mark every upstream dependency of component/varName as stale
-        // If a state variable is already stale (has a getter in place)
-        // then don't recurse
-        // Before marking a stateVariable as stale, run markStale function, if it exists
-        // Record additional information about the staleness from result of markStale,
-        // and recurse only if markStale indicates variable is actually stale
-
         let componentIdx = component.componentIdx;
 
         // console.log(`marking upstream of ${varName} of ${componentIdx} as stale`);

--- a/packages/doenetml-worker-javascript/src/StalenessPropagator.ts
+++ b/packages/doenetml-worker-javascript/src/StalenessPropagator.ts
@@ -1,4 +1,5 @@
 import type Core from "./Core";
+import type { ComponentInstance } from "./types/componentInstance";
 /**
  * Walks the dependency graph to invalidate state-variable values and
  * propagate freshness changes:
@@ -33,6 +34,10 @@ export class StalenessPropagator {
         stateVariable,
         component,
         initializeOnly = false,
+    }: {
+        stateVariable: string;
+        component: ComponentInstance;
+        initializeOnly?: boolean;
     }) {
         if (!component.arrayEntryPrefixes) {
             throw Error(
@@ -131,12 +136,12 @@ export class StalenessPropagator {
         );
     }
 
-    async markDescendantsToUpdateRenderers(component) {
+    async markDescendantsToUpdateRenderers(component: ComponentInstance) {
         if (component.constructor.renderChildren) {
             let indicesToRender =
                 await this.core.returnActiveChildrenIndicesToRender(component);
             for (let ind of indicesToRender) {
-                let child = component.activeChildren[ind];
+                let child = component.activeChildren![ind];
                 this.core.updateInfo.componentsToUpdateRenderers.add(
                     child.componentIdx,
                 );
@@ -145,7 +150,34 @@ export class StalenessPropagator {
         }
     }
 
-    async markStateVariableAndUpstreamDependentsStale({ component, varName }) {
+    /**
+     * Public entry point used after a value has materially changed: invalidate
+     * `varName` and every state variable downstream of it.
+     *
+     *  - Adds `component.componentIdx` to `componentsToUpdateRenderers` if
+     *    `varName` is in the component's renderer-variable set.
+     *  - Builds the `allStateVariablesAffectedObj` covering `varName` and
+     *    every entry in its `additionalStateVariablesDefined` group, then
+     *    dispatches into `_processStaleVisit`, which:
+     *      - Calls each variable's `markStale` predicate, classifying the
+     *        result as `fresh` (no recursion), `partiallyFresh` (mark and
+     *        recurse), or fully stale (replace `value` with the lazy getter
+     *        and recurse). For array state variables, the array-entry remap
+     *        bridges array-level freshness to the per-entry mirrors via
+     *        `_remapArrayEntryFreshness`.
+     *      - When the variable is fully stale, saves `_previousValue`,
+     *        reinstalls the lazy getter via `_replaceWithStaleGetter`, and
+     *        calls `markUpstreamDependentsStale` to walk the upstream graph.
+     *      - Triggers `actionTriggerScheduler.queueTriggeredActions` and the
+     *        auto-submit detector for each visited variable.
+     */
+    async markStateVariableAndUpstreamDependentsStale({
+        component,
+        varName,
+    }: {
+        component: ComponentInstance;
+        varName: string;
+    }) {
         // console.log(`mark state variable ${varName} of ${component.componentIdx} and updeps stale`)
 
         if (
@@ -178,6 +210,10 @@ export class StalenessPropagator {
         component,
         varName,
         allStateVariablesAffectedObj,
+    }: {
+        component: ComponentInstance;
+        varName: string;
+        allStateVariablesAffectedObj: Record<string, any>;
     }) {
         let stateVarObj = component.state[varName];
 
@@ -206,25 +242,32 @@ export class StalenessPropagator {
         return result;
     }
 
+    /**
+     * Run the variable's `markStale` predicate (if any) and merge the result
+     * back into `allStateVariablesAffectedObj`.
+     *
+     * Returns a freshness verdict:
+     *   - `{ fresh: { [varName]: true, ... } }`: predicate considers the value
+     *     completely fresh; the caller should not recurse into upstream deps.
+     *   - `{ partiallyFresh: { [varName]: true, ... } }`: predicate sees a
+     *     partial change; the caller should recurse but also mark the variable
+     *     so a later mark-stale invocation can revisit it.
+     *   - other attributes set by `markStale` are passed through to the caller.
+     *
+     * For array state variables the predicate is invoked with `arrayKeys` and
+     * `arraySize`; the caller bridges array-level vs entry-level freshness
+     * via `_remapArrayEntryFreshness`. May mutate `freshnessInfo` on the
+     * affected variables; does not record changes or queue renderer updates.
+     */
     async processMarkStale({
         component,
         varName,
         allStateVariablesAffectedObj,
+    }: {
+        component: ComponentInstance;
+        varName: string;
+        allStateVariablesAffectedObj: Record<string, any>;
     }) {
-        // if the stateVariable varName (or its array state variable)
-        // has a markStale function, then run that function,
-        // giving it arguments with information about what changed
-
-        // markStale may change the freshnessInfo for varName (or its array state variable)
-        // and will return an object with attributes
-        // - fresh: if the variable is to be considered completely fresh,
-        //   indicating the mark stale process should not recurse
-        // - partiallyFresh: if the variable is partially fresh,
-        //   indicating the mark stale process should recurse,
-        //   but the variable should be marked to allow later mark stale
-        //   processes that involve the variable to process the variable again
-        // - other attributes that not processed in this function but returned
-
         let stateVarObj = component.state[varName];
 
         if (!stateVarObj.markStale || !stateVarObj.initiallyResolved) {
@@ -286,7 +329,13 @@ export class StalenessPropagator {
         return result;
     }
 
-    async markUpstreamDependentsStale({ component, varName }) {
+    async markUpstreamDependentsStale({
+        component,
+        varName,
+    }: {
+        component: ComponentInstance;
+        varName: string;
+    }) {
         // Recursively mark every upstream dependency of component/varName as stale
         // If a state variable is already stale (has a getter in place)
         // then don't recurse

--- a/packages/doenetml-worker-javascript/src/StateVariableEvaluator.ts
+++ b/packages/doenetml-worker-javascript/src/StateVariableEvaluator.ts
@@ -1,4 +1,6 @@
 import type Core from "./Core";
+import type { ComponentInstance } from "./types/componentInstance";
+import type { ComponentIdx } from "@doenet/utils";
 /**
  * Resolves a state variable's value: walks the dependency graph to gather
  * fresh inputs, invokes the variable's `definition` function (or
@@ -22,7 +24,36 @@ export class StateVariableEvaluator {
         this.core = core;
     }
 
-    async getStateVariableValue({ component, stateVariable }) {
+    /**
+     * Resolve `component.state[stateVariable]` to a fresh value, returning the
+     * awaited `value` (or array values for array state variables).
+     *
+     * Behaviour highlights for callers that need to reason about side effects:
+     *  - Lazily resolves any unresolved state variables in the
+     *    `additionalStateVariablesDefined` group via
+     *    `dependencies.resolveItem`; throws if resolution fails.
+     *  - Records a `dependencies.recordActualChangeInUpstreamDependencies`
+     *    entry for every variable whose value materially changed (per
+     *    `_isUnchanged`), and for the matching array entries when an array
+     *    state variable's keys, size, or contents changed.
+     *  - Forces a re-evaluation of `expressionWithCodes`-style state via
+     *    `component.reprocessAfterEvaluate` (see the kludge note below) when
+     *    that flag is set on the component.
+     *  - Mutates `component.state[varName].value`,
+     *    `_previousValue`, `freshnessInfo`, `arrayValues`, and clears
+     *    `forceRecalculation` and `justUpdatedForNewComponent` on the
+     *    affected variables. Does not mark anything stale itself —
+     *    downstream invalidation is the responsibility of
+     *    `markStateVariableAndUpstreamDependentsStale`, called by callers
+     *    that record a change.
+     */
+    async getStateVariableValue({
+        component,
+        stateVariable,
+    }: {
+        component: ComponentInstance;
+        stateVariable: string;
+    }) {
         // console.log(`getting value of state variable ${stateVariable} of ${component.componentIdx}`)
 
         let stateVarObj = component.state[stateVariable];
@@ -782,7 +813,7 @@ export class StateVariableEvaluator {
             });
 
             if (component.state[varName].isArray) {
-                let arrayVarNamesChanged = [];
+                let arrayVarNamesChanged: string[] = [];
                 if (
                     valuesChanged[varName] === true ||
                     valuesChanged[varName].allArrayKeysChanged ||
@@ -832,8 +863,13 @@ export class StateVariableEvaluator {
     async getStateVariableDefinitionArguments({
         component,
         stateVariable,
-        excludeDependencyValues,
+        excludeDependencyValues = false,
         consumeChanges = true,
+    }: {
+        component: ComponentInstance;
+        stateVariable: string;
+        excludeDependencyValues?: boolean;
+        consumeChanges?: boolean;
     }) {
         // console.log(`get state variable dependencies of ${component.componentIdx}, ${stateVariable}`)
 
@@ -908,7 +944,13 @@ export class StateVariableEvaluator {
         return args;
     }
 
-    async recordActualChangeInStateVariable({ componentIdx, varName }) {
+    async recordActualChangeInStateVariable({
+        componentIdx,
+        varName,
+    }: {
+        componentIdx: ComponentIdx;
+        varName: string;
+    }) {
         let component = this.core._components[componentIdx];
 
         // mark stale always includes additional state variables defined

--- a/packages/doenetml-worker-javascript/src/StateVariableEvaluator.ts
+++ b/packages/doenetml-worker-javascript/src/StateVariableEvaluator.ts
@@ -944,6 +944,20 @@ export class StateVariableEvaluator {
         return args;
     }
 
+    /**
+     * Record that `componentIdx`/`varName` has actually changed (called
+     * after the bulk-write path has updated values in `comp.essentialState`
+     * and friends). Three side effects, in order:
+     *   1. `markStateVariableAndUpstreamDependentsStale` — invalidate
+     *      `varName` and propagate up the dependency graph. The mark-stale
+     *      pass already covers `additionalStateVariablesDefined`.
+     *   2. Set `forceRecalculation = true` on `varName` and every entry in
+     *      its `additionalStateVariablesDefined` group, so the next
+     *      `getStateVariableValue` call ignores the "no changes detected"
+     *      fast-path and re-runs the definition.
+     *   3. `recordActualChangeInUpstreamDependencies` for each variable in
+     *      the group, so dependents see a concrete change flag.
+     */
     async recordActualChangeInStateVariable({
         componentIdx,
         varName,

--- a/packages/doenetml-worker-javascript/src/UpdateExecutor.ts
+++ b/packages/doenetml-worker-javascript/src/UpdateExecutor.ts
@@ -264,9 +264,9 @@ export class UpdateExecutor {
                 }
 
                 await this.core.updateRendererInstructions({
-                    componentNamesToUpdate: updateInstructions.map(
-                        (x: UpdateInstruction) => x.componentIdx,
-                    ),
+                    componentNamesToUpdate: updateInstructions
+                        .map((x: UpdateInstruction) => x.componentIdx)
+                        .filter((idx): idx is ComponentIdx => idx != undefined),
                     sourceOfUpdate: { sourceInformation },
                     actionId,
                 });
@@ -287,9 +287,7 @@ export class UpdateExecutor {
         let recordComponentSubmissions: any[] = [];
 
         for (let instruction of updateInstructions) {
-            if (instruction.componentIdx != undefined) {
-                this._recordSourceDetails(instruction, sourceInformation);
-            }
+            this._recordSourceDetails(instruction, sourceInformation);
 
             if (instruction.updateType === "updateValue") {
                 await this.core.requestComponentChanges({
@@ -478,15 +476,21 @@ export class UpdateExecutor {
 
     /**
      * Merge `instruction.sourceDetails` into the per-component bag inside
-     * `sourceInformation`. No-op when `sourceDetails` is absent. Used to
-     * forward upstream-action provenance ("which input triggered this
-     * change?") through the update pipeline.
+     * `sourceInformation`. No-op when `sourceDetails` is absent or when the
+     * instruction has no `componentIdx` (e.g. `recordItemSubmission`
+     * entries from `Answer.js`/`Pretzel.js`, which would otherwise create
+     * a `sourceInformation["undefined"]` sentinel bucket). Used to forward
+     * upstream-action provenance ("which input triggered this change?")
+     * through the update pipeline.
      */
     _recordSourceDetails(
         instruction: any,
         sourceInformation: Record<string, any>,
     ) {
-        if (!instruction.sourceDetails) {
+        if (
+            instruction.componentIdx == undefined ||
+            !instruction.sourceDetails
+        ) {
             return;
         }
 

--- a/packages/doenetml-worker-javascript/src/UpdateExecutor.ts
+++ b/packages/doenetml-worker-javascript/src/UpdateExecutor.ts
@@ -1,6 +1,79 @@
 import type Core from "./Core";
+import type { ComponentIdx } from "@doenet/utils";
 import { createNewComponentIndices } from "./utils/componentIndices";
 import { reportTimerError, TimerLabels } from "./utils/timerErrors";
+
+/**
+ * Source-side metadata about *how* an update originated. Indexed by
+ * `componentIdx` (string-coerced because this object also carries
+ * non-numeric keys like `actionId` from upstream callers); each entry is
+ * a free-form bag of provenance attributes that flows through to renderers.
+ */
+type SourceInformation = Record<string, any>;
+
+/**
+ * One entry in `performUpdate`'s `updateInstructions` array. The shape
+ * varies by `updateType`; this discriminated union is loose because the
+ * historical call sites mix authored, interactive, and chained
+ * instructions on the same array.
+ */
+type UpdateInstruction = {
+    updateType: string;
+    componentIdx?: ComponentIdx;
+    stateVariable?: string;
+    value?: any;
+    serializedComponents?: any;
+    parentIdx?: ComponentIdx;
+    componentIndices?: ComponentIdx[];
+    componentNumber?: number;
+    sourceDetails?: Record<string, any>;
+    [k: string]: any;
+};
+
+type RecordEvent = Record<string, any>;
+type Diagnostic = Record<string, any>;
+
+type PerformActionArgs = {
+    componentIdx?: ComponentIdx;
+    actionName: string;
+    args?: Record<string, any>;
+    event?: RecordEvent;
+    caseInsensitiveMatch?: boolean;
+};
+
+type PerformUpdateArgs = {
+    updateInstructions: UpdateInstruction[];
+    diagnostics?: Diagnostic[];
+    actionId?: string;
+    event?: RecordEvent;
+    /**
+     * When true, perform the update even if `core.flags.readOnly` is set.
+     * Used by Core's own internal flows (e.g. theme set) where the caller
+     * has decided the read-only flag does not apply.
+     */
+    overrideReadOnly?: boolean;
+    /**
+     * Skip the debounced state-persistence side effect. The update still
+     * mutates state and updates renderers; only the call to
+     * `statePersistence.scheduleSave` is suppressed. Used for theme
+     * changes and other non-interactions.
+     */
+    doNotSave?: boolean;
+    /**
+     * Skip *both* renderer-update paths (the read-only mirror and the
+     * post-update fan-out). Used when the caller will re-issue updates
+     * imminently and renderer churn would be wasted.
+     */
+    canSkipUpdatingRenderer?: boolean;
+    /**
+     * Skip only the late `updateAllChangedRenderers` call at the end of
+     * `performUpdate`, while still letting the early read-only path and
+     * the components-to-update bookkeeping run. Submission-recording
+     * updates override this and always fan out.
+     */
+    skipRendererUpdate?: boolean;
+    sourceInformation?: SourceInformation;
+};
 
 /**
  * The orchestrators dequeued by `ProcessQueue`:
@@ -30,7 +103,7 @@ export class UpdateExecutor {
         args,
         event,
         caseInsensitiveMatch,
-    }) {
+    }: PerformActionArgs) {
         if (actionName === "setTheme" && componentIdx === undefined) {
             // For now, co-opting the action mechanism to let the viewer set the theme (dark mode) on document.
             // Don't have an actual action on document as don't want the ability for others to call it.
@@ -41,17 +114,17 @@ export class UpdateExecutor {
                         updateType: "updateValue",
                         componentIdx: this.core.documentIdx,
                         stateVariable: "theme",
-                        value: args.theme,
+                        value: args!.theme,
                     },
                 ],
-                actionId: args.actionId,
+                actionId: args!.actionId,
                 doNotSave: true, // this isn't an interaction, so don't save doc state
             });
 
-            return { actionId: args.actionId };
+            return { actionId: args!.actionId };
         }
 
-        let component = this.core._components[componentIdx];
+        let component = this.core._components[componentIdx!];
         if (component && component.actions) {
             let action = component.actions[actionName];
             if (!action && caseInsensitiveMatch) {
@@ -107,6 +180,40 @@ export class UpdateExecutor {
         return {};
     }
 
+    /**
+     * Drive a batch of update instructions through the inverse-definition
+     * pipeline, then surface the results to renderers and persistence.
+     *
+     * The instruction array is processed in order. Each instruction
+     * dispatches by `updateType`:
+     *   - `updateValue`: hand off to `requestComponentChanges`, accumulating
+     *     `newStateVariableValues` for the post-loop flush.
+     *   - `addComponents` / `deleteComponents`: structural changes that
+     *     synchronously call `Core.addComponents` / `Core.deleteComponents`.
+     *   - `executeUpdate`: flush the currently-accumulated
+     *     `newStateVariableValues` immediately so subsequent inverse
+     *     definitions can read the updated values.
+     *   - `recordItemSubmission`: queue the instruction for the
+     *     post-loop submission-event recording (and triggers an
+     *     immediate save).
+     *   - `setComponentNeedingUpdateValue` /
+     *     `unsetComponentNeedingUpdateValue`: flag bookkeeping for
+     *     downstream answer-submission detection.
+     *
+     * After the loop, `executeUpdateStateVariables` runs once more on
+     * any leftover `newStateVariableValues`, then
+     * `processStateVariableTriggers` and `updateAllChangedRenderers` run
+     * conditionally based on the `skipRendererUpdate` /
+     * `canSkipUpdatingRenderer` flags. Essential values saved during
+     * definitions are merged into the cumulative changes log so they
+     * persist on the next save.
+     *
+     * Persistence side effects:
+     *   - Submission updates fire `saveState(true, true)` immediately
+     *     (fire-and-forget; failures are logged but do not block).
+     *   - Otherwise `statePersistence.scheduleSave(1000)` debounces a
+     *     save unless `doNotSave` is set.
+     */
     async performUpdate({
         updateInstructions,
         diagnostics,
@@ -117,7 +224,7 @@ export class UpdateExecutor {
         canSkipUpdatingRenderer = false,
         skipRendererUpdate = false,
         sourceInformation = {},
-    }) {
+    }: PerformUpdateArgs) {
         if (diagnostics) {
             for (let diagnostic of diagnostics) {
                 this.core.addDiagnostic(diagnostic);
@@ -132,7 +239,7 @@ export class UpdateExecutor {
 
                 await this.core.updateRendererInstructions({
                     componentNamesToUpdate: updateInstructions.map(
-                        (x) => x.componentIdx,
+                        (x: UpdateInstruction) => x.componentIdx,
                     ),
                     sourceOfUpdate: { sourceInformation },
                     actionId,
@@ -177,9 +284,9 @@ export class UpdateExecutor {
                     parentIdx: instruction.parentIdx,
                 });
             } else if (instruction.updateType === "deleteComponents") {
-                if (instruction.componentIndices.length > 0) {
+                if (instruction.componentIndices!.length > 0) {
                     let componentsToDelete = [];
-                    for (let componentIdx of instruction.componentIndices) {
+                    for (let componentIdx of instruction.componentIndices!) {
                         let component = this.core._components[componentIdx];
                         if (component) {
                             componentsToDelete.push(component);
@@ -214,7 +321,7 @@ export class UpdateExecutor {
                 instruction.updateType === "setComponentNeedingUpdateValue"
             ) {
                 this.core.cumulativeStateVariableChanges.__componentNeedingUpdateValue =
-                    this.core._components[instruction.componentIdx].stateId;
+                    this.core._components[instruction.componentIdx!]!.stateId;
             } else if (
                 instruction.updateType === "unsetComponentNeedingUpdateValue"
             ) {

--- a/packages/doenetml-worker-javascript/src/UpdateExecutor.ts
+++ b/packages/doenetml-worker-javascript/src/UpdateExecutor.ts
@@ -5,17 +5,20 @@ import { reportTimerError, TimerLabels } from "./utils/timerErrors";
 
 /**
  * Source-side metadata about *how* an update originated. Indexed by
- * `componentIdx` (string-coerced because this object also carries
- * non-numeric keys like `actionId` from upstream callers); each entry is
- * a free-form bag of provenance attributes that flows through to renderers.
+ * `componentIdx` (string-coerced because that's what `for...in` yields);
+ * each entry is a free-form bag of provenance attributes that flows
+ * through to renderers via `sourceOfUpdate`.
  */
 type SourceInformation = Record<string, any>;
 
 /**
  * One entry in `performUpdate`'s `updateInstructions` array. The shape
- * varies by `updateType`; this discriminated union is loose because the
+ * varies by `updateType`; the explicit fields below are documentation
+ * for the most common keys, while the `[k: string]: any` index signature
+ * is what TypeScript actually checks against — necessary because the
  * historical call sites mix authored, interactive, and chained
- * instructions on the same array.
+ * instructions on the same array. A discriminated union per `updateType`
+ * is deferred (see `CORE_REFACTOR_DEFERRED.md`).
  */
 type UpdateInstruction = {
     updateType: string;
@@ -97,6 +100,29 @@ export class UpdateExecutor {
         this.core = core;
     }
 
+    /**
+     * Run a component-defined action method (e.g. `submitAnswer`,
+     * `revealSection`).
+     *
+     * Special-case branches handled before the main dispatch:
+     *   - `actionName === "setTheme"` with no `componentIdx`: re-enters via
+     *     `performUpdate` to set `document.theme`. The action mechanism is
+     *     co-opted here because the document doesn't expose a real action
+     *     surface, but theme is a UI-only state variable that the viewer
+     *     needs to be able to set. `doNotSave` is always passed since theme
+     *     is not user content.
+     *   - Component missing + `actionName === "recordVisibilityChange"`
+     *     with `args.isVisible === false`: a "component became hidden"
+     *     event for a component that has already been deleted. Recorded
+     *     directly via `requestRecordEvent` because there is no live
+     *     component to dispatch through.
+     *
+     * Main path: look up `component.actions[actionName]` (with optional
+     * case-insensitive fallback when `caseInsensitiveMatch` is set), record
+     * the `event` if provided, and `await` the action. Returns
+     * `{ actionId }` on success. If the component exists but the action
+     * does not, a warning diagnostic is added and `{}` is returned.
+     */
     async performAction({
         componentIdx,
         actionName,
@@ -451,8 +477,8 @@ export class UpdateExecutor {
     }
 
     /**
-     * Stash `instruction.sourceDetails` onto the per-component bag inside
-     * `sourceInformation`, creating the bag if it doesn't exist. Used to
+     * Merge `instruction.sourceDetails` into the per-component bag inside
+     * `sourceInformation`. No-op when `sourceDetails` is absent. Used to
      * forward upstream-action provenance ("which input triggered this
      * change?") through the update pipeline.
      */
@@ -460,6 +486,10 @@ export class UpdateExecutor {
         instruction: any,
         sourceInformation: Record<string, any>,
     ) {
+        if (!instruction.sourceDetails) {
+            return;
+        }
+
         let componentSourceInformation =
             sourceInformation[instruction.componentIdx];
         if (!componentSourceInformation) {
@@ -468,11 +498,6 @@ export class UpdateExecutor {
             ] = {};
         }
 
-        if (instruction.sourceDetails) {
-            Object.assign(
-                componentSourceInformation,
-                instruction.sourceDetails,
-            );
-        }
+        Object.assign(componentSourceInformation, instruction.sourceDetails);
     }
 }

--- a/packages/doenetml-worker-javascript/src/types/componentInstance.ts
+++ b/packages/doenetml-worker-javascript/src/types/componentInstance.ts
@@ -33,7 +33,10 @@ export interface ComponentInstance {
      * the adapted index instead. */
     componentOrAdaptedIdx?: ComponentIdx;
     rendererType?: string;
-    stateId?: string;
+    /** Set to `serializedComponent.stateId ?? componentIdx.toString()` in
+     * `ComponentBuilder.createComponentClass`. Always present once the
+     * component is in `Core._components`. */
+    stateId: string;
 
     // ─── Tree pointers ────────────────────────────────────────────────────
     parent: ComponentInstance | null;
@@ -64,7 +67,9 @@ export interface ComponentInstance {
     // ─── State ────────────────────────────────────────────────────────────
     state: ComponentStateBag;
     stateValues: ComponentStateValues;
-    essentialState?: Record<string, any>;
+    /** Initialized to `{}` in `BaseComponent` and populated as essential
+     * values are set; always present on a constructed component. */
+    essentialState: Record<string, any>;
     unresolvedState?: Record<string, any>;
     unresolvedDependencies?: Record<string, any>;
     stateVarAliases?: Record<string, string>;


### PR DESCRIPTION
## Summary

Phase 5g of the Core refactor: type the public destructure parameters across the five Phase 4 modules (`StateVariableEvaluator`, `StalenessPropagator`, `EssentialValueWriter`, `CompositeReplacementUpdater`, `UpdateExecutor`) and add JSDoc on every public entry point. Worker-package `tsc --noEmit` count drops 366 → 277; all five Phase 4 files now report 0 errors.

## What changed

- Public destructure parameters typed using `ComponentInstance` and per-file local aliases (`UpdateInstruction`, `PerformActionArgs`, `PerformUpdateArgs`, `NewStateVariableValues`, `ComponentChange`, `ComponentMap`, `SourceInformation`, `SourceOfUpdate`).
- `ComponentInstance.stateId` and `essentialState` tightened from optional to required (both are unconditionally initialised in `ComponentBuilder` / `BaseComponent`). Cascade contained — non-null assertions used at the use site for the strict-mode-exposed nullable fields the codepaths guarantee populated.
- `ComponentIdx` used consistently across the touched helpers (`compositesNotReady`, `parentsOfDeleted`, `_recordDeleteResults`, `findExpandableShadowByCompositeIdx`, `calculateAllComponentsShadowing`, `markToIgnoreForParent`).
- JSDoc paragraphs added to every public entry point flagged in `CORE_REFACTOR_DEFERRED.md`, plus the surrounding methods on the same classes for symmetry:
  - `UpdateExecutor.performUpdate` (with explicit per-flag contracts; `canSkipUpdatingRenderer` vs `skipRendererUpdate` in particular) and `performAction`.
  - `EssentialValueWriter.executeUpdateStateVariables`, `processNewStateVariableValues`, and `requestComponentChanges`.
  - `StateVariableEvaluator.getStateVariableValue` and `recordActualChangeInStateVariable`.
  - `CompositeReplacementUpdater.updateCompositeReplacements`.
  - `StalenessPropagator.markStateVariableAndUpstreamDependentsStale`, `lookUpCurrentFreshness`, `processMarkStale`, and `markUpstreamDependentsStale`.
- `convert_md_array` hoisted out of the inverse-definition loop into a module-private `convertMultidimensionalArrayToKeyedObject` helper with JSDoc.

## Real fixes folded in

- **`Dependencies.d.ts` shim bug**: `checkForCircularDependency` was declared with `stateVariable: string`, but `Dependencies.js:566` accepts `varName`. The shim mismatch had been silently mis-rejecting the only TS caller.
- **`performUpdate` read-only branch leaked `undefined` `componentIdx` to `updateRendererInstructions`** (caught by Copilot review): `recordItemSubmission` instructions (`Answer.js:2510`, `Pretzel.js:576`) carry `componentNumber` / `submittedComponent` instead of `componentIdx`. The main loop already guarded `_recordSourceDetails` with an `instruction.componentIdx != undefined` check; the read-only short-circuit branch did not, so `componentNamesToUpdate` could include `undefined` entries (and `sourceInformation["undefined"]` was one line away from being created if a future caller set `sourceDetails`). Pushed the guard into `_recordSourceDetails` itself and added a `.filter(...)` on the read-only branch's `componentNamesToUpdate` map.
- **Empty literals inferring to `Set<never>` / `never[]`**: `compositesNotReady` (`Set<ComponentIdx>`), `parentsOfDeleted` (`Set<ComponentIdx>`), `arrayVarNamesChanged` (`string[]`) — all blocking subsequent `add` / `push` calls (TS2345).
- **Four real signature-drift TS2345s noted in the deferred doc** all resolved by marking optional what the call sites had been omitting:
  - `getStateVariableDefinitionArguments.excludeDependencyValues`
  - `performUpdate.diagnostics` / `event` / `actionId`
  - `deleteReplacementsFromShadowsThenComposite.componentsToDelete`

## Test plan

- [x] `tsc --noEmit`: 366 → 277 worker-package errors; all five Phase 4 files at 0.
- [x] `vitest run src/test/utils/calcStartEndIdx.test.ts`: 9/9 passing.
- [x] `vitest run src/test/copying/extend_references.test.ts`: 49/49 passing (6 pre-existing skips).
- [x] CI: full vitest + Cypress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)