### PR TITLE
refactor(worker-javascript): CompositeExpander → module functions

### DIFF
--- a/CORE_REFACTOR_DEFERRED.md
+++ b/CORE_REFACTOR_DEFERRED.md
@@ -96,7 +96,6 @@ Phase 3 lifted further `TODO`s verbatim from `Core.js` into the new modules:
 - `StateVariableDefinitionFactory.ts:1355, 1451` — duplicate `// TODO: how do we make it do this just once?` on the array-entry definition setup.
 - `ComponentBuilder.ts:170, 238` — duplicate `// TODO: should we check for child results earlier so we don't have to check them ...` on the post-creation child-result re-derivation.
 - `CompositeExpander.ts:373` — `// TODO: are there any scenarios where this will lead to an infinite loop?` on the `createSerializedReplacements` retry loop.
-- `CompositeExpander.ts:688` — `// XXX: what is the replacement for targetComponentIdx?` on the shadow-mediating composite branch.
 
 Phase 4 lifted further `TODO`s verbatim into the five new modules — line numbers are approximate and subject to drift; `grep -n "TODO\|XXX\|kludge" path/to/file` is the canonical lookup:
 

--- a/packages/debug-hooks/src/externalPathResolution.ts
+++ b/packages/debug-hooks/src/externalPathResolution.ts
@@ -5,7 +5,10 @@ import type {
     PublicDoenetMLCore,
 } from "lib-doenetml-worker";
 
-import { PublicDoenetMLCore as PublicDoenetMLCoreJavascript } from "@doenet/doenetml-worker-javascript";
+import {
+    PublicDoenetMLCore as PublicDoenetMLCoreJavascript,
+    expandCompositeComponent,
+} from "@doenet/doenetml-worker-javascript";
 
 /**
  * Attempt to resolve `name` immediately by parsing `name` to a path
@@ -110,7 +113,10 @@ export async function resolvePathImmediatelyToNodeIdx(
             // then we force expand it by forcibly resolving `readyToExpandWhenResolved`
             // before calling `expandCompositeComponent`.
             await refComponent.stateValues.readyToExpandWhenResolved;
-            await jsCore.core.expandCompositeComponent(refComponent);
+            await expandCompositeComponent({
+                core: jsCore.core,
+                component: refComponent,
+            });
 
             // try resolving again
             resolution = rustCore.resolve_path({ path }, origin, false);

--- a/packages/debug-hooks/vite.config.ts
+++ b/packages/debug-hooks/vite.config.ts
@@ -14,5 +14,11 @@ export default defineConfig({
             },
             formats: ["es"],
         },
+        rollupOptions: {
+            // `@doenet/doenetml-worker-javascript` is also pulled in by `doenetml-worker`;
+            // bundling a second copy here would duplicate component classes (e.g. `Section`
+            // becomes `Section$1`) and break runtime lookups by class name.
+            external: ["@doenet/doenetml-worker-javascript"],
+        },
     },
 });

--- a/packages/doenetml-worker-javascript/src/ChildMatcher.ts
+++ b/packages/doenetml-worker-javascript/src/ChildMatcher.ts
@@ -1,5 +1,9 @@
 import type Core from "./Core";
 import { assignDoenetMLRange } from "@doenet/utils";
+import {
+    expandCompositeOfDefiningChildren,
+    replaceCompositeChildren,
+} from "./CompositeExpander";
 
 /**
  * Resolves a parent's defining children into matched, adapted, ordered
@@ -66,12 +70,13 @@ export async function deriveChildResultsFromDefiningChildren({
         // apply child logic and substitute adapters to modify activeChildren
 
         // attempt to expand composites before modifying active children
-        let result = await core.expandCompositeOfDefiningChildren(
+        let result = await expandCompositeOfDefiningChildren({
+            core,
             parent,
-            parent.definingChildren,
+            children: parent.definingChildren,
             expandComposites,
             forceExpandComposites,
-        );
+        });
         parent.unexpandedCompositesReady = result.unexpandedCompositesReady;
         parent.unexpandedCompositesNotReady =
             result.unexpandedCompositesNotReady;
@@ -118,7 +123,7 @@ export async function deriveChildResultsFromDefiningChildren({
 
         // if any of activeChildren are expanded compositeComponents
         // replace with new components given by the composite component
-        await core.replaceCompositeChildren(parent);
+        await replaceCompositeChildren({ core, parent });
 
         const childGroupResults = await matchChildrenToChildGroups({
             core,

--- a/packages/doenetml-worker-javascript/src/ComponentBuilder.ts
+++ b/packages/doenetml-worker-javascript/src/ComponentBuilder.ts
@@ -4,6 +4,10 @@ import {
     addChildrenAndRecurseToShadows,
     registerComponent,
 } from "./ComponentLifecycle";
+import {
+    componentAndRenderedDescendants,
+    expandAllComposites,
+} from "./CompositeExpander";
 import { addComponentsToResolver } from "./ResolverAdapter";
 import { convertToErrorComponent } from "./utils/dast/errors";
 import { gatherVariantComponents } from "./utils/variants";
@@ -186,8 +190,10 @@ export class ComponentBuilder {
             await this.core.replacementChangesFromCompositesToUpdate();
 
             await this.core.updateRendererInstructions({
-                componentNamesToUpdate:
-                    await this.core.componentAndRenderedDescendants(parent),
+                componentNamesToUpdate: await componentAndRenderedDescendants({
+                    core: this.core,
+                    component: parent,
+                }),
             });
 
             // updating renderer instructions could trigger more composite updates
@@ -910,8 +916,15 @@ export class ComponentBuilder {
      * mutating the tree.
      */
     async _expandAllCompositesBothPasses() {
-        await this.core.expandAllComposites(this.core.document);
-        await this.core.expandAllComposites(this.core.document, true);
+        await expandAllComposites({
+            core: this.core,
+            component: this.core.document,
+        });
+        await expandAllComposites({
+            core: this.core,
+            component: this.core.document,
+            force: true,
+        });
     }
 
     /**

--- a/packages/doenetml-worker-javascript/src/CompositeExpander.ts
+++ b/packages/doenetml-worker-javascript/src/CompositeExpander.ts
@@ -83,7 +83,6 @@ export async function expandAllComposites({
             }
 
             if (foundReady) {
-                let parent = core._components[parentIdx];
                 await deriveChildResultsFromDefiningChildren({
                     core,
                     parent,
@@ -177,7 +176,7 @@ export async function componentAndRenderedDescendants({
             await deriveChildResultsFromDefiningChildren({
                 core,
                 parent: component,
-                expandComposites: true, //forceExpandComposites: true,
+                expandComposites: true,
             });
         }
         for (let child of component.activeChildren) {
@@ -240,7 +239,7 @@ export async function expandCompositeOfDefiningChildren({
                                 componentIdx: child.componentIdx,
                                 type: "stateVariable",
                                 stateVariable: "readyToExpandWhenResolved",
-                                expandComposites, //: forceExpandComposites,
+                                expandComposites,
                                 force: forceExpandComposites,
                             },
                         );
@@ -409,10 +408,7 @@ export async function expandCompositeComponent({
             component,
         });
 
-        // expand `core._components` to length `newNComponents` so that the component indices will not be reused
-        if (newNComponents > core._components.length) {
-            core._components[newNComponents - 1] = undefined;
-        }
+        reserveComponentIndices(core, newNComponents);
 
         await createAndSetReplacements({
             core,
@@ -487,8 +483,7 @@ async function expandShadowingComposite({
         num: component.replacementsWorkspace.replacementsCreated,
     };
 
-    let nComponents = core._components.length;
-    let newNComponents = nComponents;
+    let newNComponents = core._components.length;
 
     // We address one complication from shadowing a component with copied in children.
     // In this case, the name resolver will already have the component indices of the serialized children of `component`.
@@ -692,10 +687,7 @@ async function expandShadowingComposite({
         component,
     });
 
-    // expand `core._components` to length `newNComponents` so that the component indices will not be reused
-    if (newNComponents > core._components.length) {
-        core._components[newNComponents - 1] = undefined;
-    }
+    reserveComponentIndices(core, newNComponents);
 
     await createAndSetReplacements({
         core,
@@ -737,6 +729,17 @@ function _finishExpanding({
         );
     }
     core.updateInfo.compositesBeingExpanded.splice(targetInd, 1);
+}
+
+/**
+ * Pad `core._components` out to `newNComponents` slots so the indices
+ * already handed out by `createSerializedReplacements` (and reflected in
+ * the resolver) cannot be reused by a subsequent expansion.
+ */
+function reserveComponentIndices(core: Core, newNComponents: number) {
+    if (newNComponents > core._components.length) {
+        core._components[newNComponents - 1] = undefined;
+    }
 }
 
 /**
@@ -799,7 +802,6 @@ export async function createAndSetReplacements({
         component.replacements = replacementResult.components;
     } catch (e: any) {
         console.error(e);
-        // throw e;
         component.replacements = await core.setErrorReplacements({
             composite: component,
             message: e.message,

--- a/packages/doenetml-worker-javascript/src/CompositeExpander.ts
+++ b/packages/doenetml-worker-javascript/src/CompositeExpander.ts
@@ -30,1278 +30,1295 @@ import {
  * active or inactive when their visibility changes.
  *
  * Mutually recursive with `ComponentBuilder` (creating components
- * triggers expansion; expansion creates components). Cross-calls go
- * through Core's delegators.
+ * triggers expansion; expansion creates components).
  *
- * Holds a back-reference to Core to read `_components`,
- * `componentInfoObjects`, `parameterStack`, `dependencies`, `flags`,
- * `updateInfo`, `rootNames`, to invoke `matchPublicStateVariables`, and
- * to invoke the other extracted managers.
+ * Stateless — each function takes a back-reference to Core to read
+ * `_components`, `componentInfoObjects`, `parameterStack`, `dependencies`,
+ * `flags`, `updateInfo`, `rootNames`, to invoke `matchPublicStateVariables`,
+ * and to invoke the other extracted managers.
  */
-export class CompositeExpander {
+
+export async function expandAllComposites({
+    core,
+    component,
+    force = false,
+}: {
     core: Core;
+    component: any;
+    force?: boolean;
+}) {
+    let parentsWithCompositesNotReady = await expandCompositesOfDescendants({
+        core,
+        component,
+        forceExpandComposites: force,
+    });
 
-    constructor({ core }: { core: Core }) {
-        this.core = core;
-    }
+    let expandedAnother = true;
 
-    async expandAllComposites(component, force = false) {
-        let parentsWithCompositesNotReady =
-            await this.expandCompositesOfDescendants(component, force);
+    while (expandedAnother) {
+        expandedAnother = false;
 
-        let expandedAnother = true;
+        for (let parentIdx of parentsWithCompositesNotReady) {
+            let parent = core._components[parentIdx];
+            let foundReady = false;
+            for (let compositeIdx of parent.unexpandedCompositesNotReady) {
+                let composite = core._components[compositeIdx];
+                if (composite.state.readyToExpandWhenResolved.isResolved) {
+                    foundReady = true;
+                    break;
+                } else {
+                    let resolveResult = await core.dependencies.resolveItem({
+                        componentIdx: composite.componentIdx,
+                        type: "stateVariable",
+                        stateVariable: "readyToExpandWhenResolved",
+                        force,
+                        recurseUpstream: true,
+                    });
 
-        while (expandedAnother) {
-            expandedAnother = false;
-
-            for (let parentIdx of parentsWithCompositesNotReady) {
-                let parent = this.core._components[parentIdx];
-                let foundReady = false;
-                for (let compositeIdx of parent.unexpandedCompositesNotReady) {
-                    let composite = this.core._components[compositeIdx];
-                    if (composite.state.readyToExpandWhenResolved.isResolved) {
+                    if (resolveResult.success) {
                         foundReady = true;
                         break;
-                    } else {
-                        let resolveResult =
-                            await this.core.dependencies.resolveItem({
-                                componentIdx: composite.componentIdx,
-                                type: "stateVariable",
-                                stateVariable: "readyToExpandWhenResolved",
-                                force,
-                                recurseUpstream: true,
-                            });
-
-                        if (resolveResult.success) {
-                            foundReady = true;
-                            break;
-                        }
                     }
                 }
+            }
 
-                if (foundReady) {
-                    let parent = this.core._components[parentIdx];
-                    await deriveChildResultsFromDefiningChildren({
-                        core: this.core,
-                        parent,
-                        expandComposites: true,
-                        forceExpandComposites: force,
-                    });
-                    expandedAnother = true;
+            if (foundReady) {
+                let parent = core._components[parentIdx];
+                await deriveChildResultsFromDefiningChildren({
+                    core,
+                    parent,
+                    expandComposites: true,
+                    forceExpandComposites: force,
+                });
+                expandedAnother = true;
+            }
+        }
+    }
+}
+
+export async function expandCompositesOfDescendants({
+    core,
+    component,
+    forceExpandComposites = false,
+}: {
+    core: Core;
+    component: any;
+    forceExpandComposites?: boolean;
+}): Promise<any[]> {
+    // Attempt to expand the composites of all descendants, including
+    // attribute components.
+    let parentsWithCompositesNotReady: any[] = [];
+
+    if (!component.matchedCompositeChildren) {
+        await deriveChildResultsFromDefiningChildren({
+            core,
+            parent: component,
+            expandComposites: true,
+            forceExpandComposites,
+        });
+        if (component.unexpandedCompositesNotReady.length > 0) {
+            parentsWithCompositesNotReady.push(component.componentIdx);
+        } else {
+            await core.dependencies.resolveBlockersFromChangedActiveChildren(
+                component,
+                forceExpandComposites,
+            );
+        }
+    }
+
+    for (let attrName in component.attributes) {
+        let attrComp = component.attributes[attrName].component;
+        if (attrComp) {
+            let additionalParentsWithNotReady =
+                await expandCompositesOfDescendants({
+                    core,
+                    component: attrComp,
+                    forceExpandComposites,
+                });
+            parentsWithCompositesNotReady.push(
+                ...additionalParentsWithNotReady,
+            );
+        }
+    }
+
+    for (let childIdxStr in component.allChildren) {
+        let child = component.allChildren[childIdxStr].component;
+        if (typeof child !== "object") {
+            continue;
+        }
+
+        let additionalParentsWithNotReady = await expandCompositesOfDescendants(
+            {
+                core,
+                component: child,
+                forceExpandComposites,
+            },
+        );
+        parentsWithCompositesNotReady.push(...additionalParentsWithNotReady);
+    }
+
+    return parentsWithCompositesNotReady;
+}
+
+export async function componentAndRenderedDescendants({
+    core,
+    component,
+}: {
+    core: Core;
+    component: any;
+}): Promise<any[]> {
+    if (component?.componentIdx == undefined) {
+        return [];
+    }
+
+    let componentIndices = [component.componentIdx];
+    if (component.constructor.renderChildren) {
+        if (!component.matchedCompositeChildren) {
+            await deriveChildResultsFromDefiningChildren({
+                core,
+                parent: component,
+                expandComposites: true, //forceExpandComposites: true,
+            });
+        }
+        for (let child of component.activeChildren) {
+            componentIndices.push(
+                ...(await componentAndRenderedDescendants({
+                    core,
+                    component: child,
+                })),
+            );
+        }
+    }
+    return componentIndices;
+}
+
+export async function expandCompositeOfDefiningChildren({
+    core,
+    parent,
+    children,
+    expandComposites,
+    forceExpandComposites,
+}: {
+    core: Core;
+    parent: any;
+    children: any[];
+    expandComposites: boolean;
+    forceExpandComposites: boolean;
+}) {
+    // If a composite is not directly matched by any childGroup, replace
+    // the composite with its replacements, expanding it if not already
+    // expanded.
+    let unexpandedCompositesReady: number[] = [];
+    let unexpandedCompositesNotReady: number[] = [];
+
+    for (let childInd = 0; childInd < children.length; childInd++) {
+        let child = children[childInd];
+
+        if (
+            child instanceof
+            core.componentInfoObjects.allComponentClasses._composite
+        ) {
+            // if composite itself is in the child logic
+            // then don't replace it with its replacements
+            // but leave the composite as an activeChild
+            if (
+                findChildGroup({
+                    core,
+                    childType: child.componentType,
+                    parentClass: parent.constructor,
+                }).success
+            ) {
+                continue;
+            }
+
+            // expand composite if it isn't already
+            if (!child.isExpanded) {
+                if (!child.state.readyToExpandWhenResolved.isResolved) {
+                    if (expandComposites) {
+                        let resolveResult = await core.dependencies.resolveItem(
+                            {
+                                componentIdx: child.componentIdx,
+                                type: "stateVariable",
+                                stateVariable: "readyToExpandWhenResolved",
+                                expandComposites, //: forceExpandComposites,
+                                force: forceExpandComposites,
+                            },
+                        );
+
+                        if (!resolveResult.success) {
+                            unexpandedCompositesNotReady.push(
+                                child.componentIdx,
+                            );
+                            core.updateInfo.compositesToExpand.add(
+                                child.componentIdx,
+                            );
+                            continue;
+                        }
+                    } else {
+                        unexpandedCompositesNotReady.push(child.componentIdx);
+                        core.updateInfo.compositesToExpand.add(
+                            child.componentIdx,
+                        );
+                        continue;
+                    }
+                } else if (!expandComposites) {
+                    unexpandedCompositesReady.push(child.componentIdx);
+                    core.updateInfo.compositesToExpand.add(child.componentIdx);
+                    continue;
                 }
+
+                // will either succeed or throw error since is ready to expand
+                await expandCompositeComponent({ core, component: child });
+            }
+
+            // recurse on replacements
+            let result = await expandCompositeOfDefiningChildren({
+                core,
+                parent,
+                children: child.replacements,
+                expandComposites,
+                forceExpandComposites,
+            });
+
+            unexpandedCompositesReady.push(...result.unexpandedCompositesReady);
+            unexpandedCompositesNotReady.push(
+                ...result.unexpandedCompositesNotReady,
+            );
+        }
+    }
+
+    return { unexpandedCompositesReady, unexpandedCompositesNotReady };
+}
+
+export async function expandCompositeComponent({
+    core,
+    component,
+}: {
+    core: Core;
+    component: any;
+}) {
+    if (!("readyToExpandWhenResolved" in component.state)) {
+        throw Error(
+            `Could not find state variable readyToExpandWhenResolved of composite ${component.componentIdx}`,
+        );
+    }
+
+    if (!component.state.readyToExpandWhenResolved.isResolved) {
+        core.updateInfo.compositesToExpand.add(component.componentIdx);
+        return { success: false };
+    }
+
+    core.updateInfo.compositesToExpand.delete(component.componentIdx);
+
+    core.updateInfo.compositesBeingExpanded.push(component.componentIdx);
+
+    if (component.parent) {
+        for (const list of [
+            component.parent.unexpandedCompositesReady,
+            component.parent.unexpandedCompositesNotReady,
+        ]) {
+            if (!list) {
+                continue;
+            }
+            const ind = list.indexOf(component.componentIdx);
+            if (ind !== -1) {
+                list.splice(ind, 1);
             }
         }
     }
 
-    async expandCompositesOfDescendants(
-        component,
-        forceExpandComposites = false,
+    if (
+        component.shadows &&
+        !component.shadows.propVariable &&
+        !component.constructor.doNotExpandAsShadowed
     ) {
-        // Attempt to expand the composites of all descendants, including
-        // attribute components.
-        let parentsWithCompositesNotReady = [];
+        return await expandShadowingComposite({ core, component });
+    }
 
-        if (!component.matchedCompositeChildren) {
-            await deriveChildResultsFromDefiningChildren({
-                core: this.core,
-                parent: component,
-                expandComposites: true,
-                forceExpandComposites,
-            });
-            if (component.unexpandedCompositesNotReady.length > 0) {
-                parentsWithCompositesNotReady.push(component.componentIdx);
-            } else {
-                await this.core.dependencies.resolveBlockersFromChangedActiveChildren(
-                    component,
-                    forceExpandComposites,
-                );
+    // Call the static function createSerializedReplacements from the composite component
+    // which returns an object containing a key "replacements" with value an array
+    // of serialized components that will be turned into real components.
+    // The replacement components will be used to replace
+    // the composite itself as children for the composite's parent
+    let initialNComponents;
+    let result;
+    const originalWorkspace = { ...component.replacementsWorkspace };
+
+    do {
+        initialNComponents = core._components.length;
+        component.replacementsWorkspace = { ...originalWorkspace };
+        result = await component.constructor.createSerializedReplacements({
+            component: core._components[component.componentIdx], // to create proxy
+            components: core._components,
+            nComponents: core._components.length,
+            workspace: component.replacementsWorkspace,
+            componentInfoObjects: core.componentInfoObjects,
+            allDoenetMLs: core.allDoenetMLs,
+            flags: core.flags,
+            resolveItem: core.dependencies.resolveItem.bind(core.dependencies),
+            publicCaseInsensitiveAliasSubstitutions:
+                core.publicCaseInsensitiveAliasSubstitutions.bind(core),
+        });
+
+        // If `core._components` changed in length while `createSerializedReplacements` was executing,
+        // it means that some other action (like calling another `createSerializedReplacements`)
+        // occurred while resolving state variables.
+        // Since this would lead to collisions in assigned component indices, we rerun `createSerializedReplacements`.
+        // TODO: are there any scenarios where this will lead to an infinite loop?
+    } while (core._components.length !== initialNComponents);
+
+    const newNComponents = result.nComponents;
+
+    if (
+        !(
+            Number.isInteger(newNComponents) &&
+            newNComponents >= core._components.length
+        )
+    ) {
+        throw Error(
+            `Invalid nComponents returned by createSerializedReplacements for ${component.componentType}: `,
+            newNComponents,
+        );
+    }
+
+    let position = core._components[component.componentIdx].position;
+    let sourceDoc = core._components[component.componentIdx].sourceDoc;
+    let overwriteDoenetMLRange = component.componentType === "_copy";
+
+    gatherDiagnosticsAndAssignDoenetMLRange({
+        core,
+        components: result.replacements,
+        diagnostics: result.diagnostics,
+        position,
+        sourceDoc,
+        overwriteDoenetMLRange,
+    });
+
+    if (component.constructor.stateVariableToEvaluateAfterReplacements) {
+        await component.stateValues[
+            component.constructor.stateVariableToEvaluateAfterReplacements
+        ];
+    }
+
+    if (result.replacements) {
+        let serializedReplacements = result.replacements;
+
+        await addReplacementsToResolver({
+            core,
+            serializedReplacements,
+            component,
+        });
+
+        // expand `core._components` to length `newNComponents` so that the component indices will not be reused
+        if (newNComponents > core._components.length) {
+            core._components[newNComponents - 1] = undefined;
+        }
+
+        await createAndSetReplacements({
+            core,
+            component,
+            serializedReplacements,
+        });
+    } else {
+        throw Error(
+            `Invalid createSerializedReplacements of ${component.componentIdx}`,
+        );
+    }
+
+    _finishExpanding({ core, componentIdx: component.componentIdx });
+
+    return { success: true, compositesExpanded: [component.componentIdx] };
+}
+
+async function expandShadowingComposite({
+    core,
+    component,
+}: {
+    core: Core;
+    component: any;
+}) {
+    if (
+        core.updateInfo.compositesBeingExpanded.includes(
+            component.shadows.componentIdx,
+        )
+    ) {
+        // found a circular dependency,
+        // as we are in the middle of expanding a composite
+        // that we are now trying to shadow
+        let compositeInvolved =
+            core._components[component.shadows.componentIdx];
+        // find non-shadow for error message, as that would be a component from document
+        while (compositeInvolved.shadows) {
+            compositeInvolved =
+                core._components[compositeInvolved.shadows.componentIdx];
+        }
+        throw Error(
+            `Circular dependency involving ${compositeInvolved.componentIdx}.`,
+        );
+    }
+
+    let shadowedComposite = core._components[component.shadows.componentIdx];
+    let compositesExpanded = [];
+
+    if (!shadowedComposite.isExpanded) {
+        let result = await expandCompositeComponent({
+            core,
+            component: shadowedComposite,
+        });
+
+        if (!result.success) {
+            throw Error(
+                `expand result of ${component.componentIdx} was not a success even though ready to expand.`,
+            );
+        }
+        compositesExpanded.push(...result.compositesExpanded);
+    }
+
+    // we'll copy the replacements of the shadowed composite
+    // and make those be the replacements of the shadowing composite
+    let serializedReplacements: any[] = [];
+
+    if (component.replacementsWorkspace.replacementsCreated === undefined) {
+        component.replacementsWorkspace.replacementsCreated = 0;
+    }
+
+    const stateIdInfo = {
+        prefix: `${component.stateId}|`,
+        num: component.replacementsWorkspace.replacementsCreated,
+    };
+
+    let nComponents = core._components.length;
+    let newNComponents = nComponents;
+
+    // We address one complication from shadowing a component with copied in children.
+    // In this case, the name resolver will already have the component indices of the serialized children of `component`.
+    // The corresponding replacements of `component` should have those component indices.
+    // However, those replacements already exist in the replacements of `shadowedComposite` which we are copying.
+    // As a workaround, we create a map from the indices of the children of `shadowedComposite`
+    // to the indices of the children of `component` and override the component indices created on the new replacements.
+    const idxMapOverride: Record<string, number> = {};
+    const copyInChildren =
+        shadowedComposite.attributes.copyInChildren?.primitive.value;
+    if (copyInChildren) {
+        const componentChildren = JSON.parse(
+            JSON.stringify(component.serializedChildren),
+        );
+        const shadowedChildren = JSON.parse(
+            JSON.stringify(shadowedComposite.serializedChildren),
+        );
+
+        // We are reusing this code that maps indices from serialized components to get the map
+        // from indices of `shadowedChildren` to indices of `componentChildren`.
+        const res = createComponentIndicesFromSerializedChildren(
+            shadowedChildren,
+            componentChildren,
+            newNComponents,
+        );
+
+        for (const idx in res.idxMap) {
+            // the above code might also have created new indices, which we ignore
+            if (res.idxMap[idx] < newNComponents) {
+                idxMapOverride[idx] = res.idxMap[idx];
             }
+        }
+    }
+
+    for (let [idx, repl] of shadowedComposite.replacements.entries()) {
+        if (typeof repl === "object") {
+            const serializedComponent = await repl.serialize();
+
+            if (component.constructor.useSerializedChildrenComponentIndices) {
+                const res = createComponentIndicesFromSerializedChildren(
+                    [serializedComponent],
+                    [component.serializedChildren[idx]],
+                    newNComponents,
+                    stateIdInfo,
+                );
+                newNComponents = res.nComponents;
+
+                serializedReplacements.push(...res.components);
+            } else {
+                const res = createNewComponentIndices(
+                    [serializedComponent],
+                    newNComponents,
+                    stateIdInfo,
+                    idxMapOverride,
+                );
+                newNComponents = res.nComponents;
+
+                serializedReplacements.push(...res.components);
+            }
+        } else {
+            serializedReplacements.push(repl);
+        }
+    }
+
+    if (component.constructor.addExtraSerializedChildrenWhenShadowing) {
+        let rendered = true;
+        if ("rendered" in component.state) {
+            rendered = await component.state.rendered.value;
+        }
+
+        if (rendered) {
+            // add any serialized children that are beyond the replacements we already have
+            serializedReplacements.push(
+                ...deepClone(
+                    component.serializedChildren.slice(
+                        serializedReplacements.length,
+                    ),
+                ),
+            );
+        }
+    }
+
+    adjustForCreateComponentIdxName({
+        serializedReplacements,
+        composite: component,
+    });
+
+    // Have three composites involved:
+    // 1. the shadowing composite (component, the one we're trying to expand)
+    // 2. the shadowed composite
+    // 3. the composite mediating the shadowing
+    //    (of which shadowing composite is the replacement)
+
+    let nameOfCompositeMediatingTheShadow = component.shadows.compositeIdx;
+    let compositeMediatingTheShadow =
+        core._components[nameOfCompositeMediatingTheShadow];
+    serializedReplacements = postProcessCopy({
+        serializedComponents: serializedReplacements,
+        componentIdx: nameOfCompositeMediatingTheShadow,
+    });
+
+    // If shadowed composite mediates the shadow of compositeMediatingTheShadow,
+    // then we have a circular reference.
+    let foundCircular = false;
+    let shadowedByShadowed = shadowedComposite.mediatesShadows
+        ?.filter((v: any) => v.propVariable === undefined)
+        .map((v: any) => v.shadowed);
+
+    while (shadowedByShadowed?.length > 0) {
+        if (shadowedByShadowed.includes(nameOfCompositeMediatingTheShadow)) {
+            foundCircular = true;
+            let message = "Circular dependency detected";
+            if (component.attributes.createComponentOfType?.primitive) {
+                message += ` involving \`<${component.attributes.createComponentOfType.primitive.value}>\` component`;
+            }
+            message += ".";
+            serializedReplacements = [
+                {
+                    type: "serialized",
+                    componentType: "_error",
+                    componentIdx: newNComponents++,
+                    attributes: {},
+                    doenetAttributes: {},
+                    children: [],
+                    state: { message },
+                    position: compositeMediatingTheShadow.position,
+                    sourceDoc: compositeMediatingTheShadow.sourceDoc,
+                },
+            ];
+            core.addDiagnostic({
+                type: "error",
+                message,
+                position: compositeMediatingTheShadow.position,
+                sourceDoc: compositeMediatingTheShadow.sourceDoc,
+            });
+
+            break;
+        }
+
+        // recurse to check if one the shadowed components mediates
+        // the shadow of compositeMediatingTheShadow
+        shadowedByShadowed = shadowedByShadowed.reduce(
+            (acc: any[], cIdx: number) => {
+                let comp = core._components[cIdx];
+                if (comp?.mediatesShadows) {
+                    return [
+                        ...acc,
+                        ...comp.mediatesShadows
+                            .filter((v: any) => v.propVariable === undefined)
+                            .map((v: any) => v.shadowed),
+                    ];
+                } else {
+                    return acc;
+                }
+            },
+            [],
+        );
+    }
+
+    if (!foundCircular) {
+        // `replacementsCreated` is already initialized to 0 ~200 lines
+        // earlier in this same function and is never re-set to undefined
+        // between the two sites. The duplicate guard that used to live
+        // here was dead. Removed per CORE_REFACTOR_DEFERRED.md
+        // §"Drop dead `replacementsCreated` guard".
+
+        let verificationResult = await verifyReplacementsMatchSpecifiedType({
+            component,
+            replacements: serializedReplacements,
+            componentInfoObjects: core.componentInfoObjects,
+            compositeAttributesObj: preprocessAttributesObject(
+                component.constructor.createAttributesObject(),
+            ),
+            components: core._components,
+            nComponents: newNComponents,
+            stateIdInfo,
+            publicCaseInsensitiveAliasSubstitutions:
+                core.publicCaseInsensitiveAliasSubstitutions.bind(core),
+        });
+
+        for (const diagnostic of verificationResult.diagnostics) {
+            core.addDiagnostic(diagnostic);
+        }
+
+        newNComponents = verificationResult.nComponents;
+
+        serializedReplacements = verificationResult.replacements;
+
+        addAttributesToSingleReplacement(
+            serializedReplacements,
+            component,
+            core.componentInfoObjects,
+        );
+    }
+
+    component.replacementsWorkspace.replacementsCreated = stateIdInfo.num;
+
+    await addReplacementsToResolver({
+        core,
+        serializedReplacements,
+        component,
+    });
+
+    // expand `core._components` to length `newNComponents` so that the component indices will not be reused
+    if (newNComponents > core._components.length) {
+        core._components[newNComponents - 1] = undefined;
+    }
+
+    await createAndSetReplacements({
+        core,
+        component,
+        serializedReplacements,
+    });
+
+    if (shadowedComposite.replacementsToWithhold > 0) {
+        component.replacementsToWithhold =
+            shadowedComposite.replacementsToWithhold;
+    }
+
+    _finishExpanding({ core, componentIdx: component.componentIdx });
+
+    compositesExpanded.push(component.componentIdx);
+
+    return { success: true, compositesExpanded };
+}
+
+/**
+ * Pop `componentIdx` off `core.updateInfo.compositesBeingExpanded` to
+ * record that the composite has finished expanding. Throws if the
+ * composite was not on the in-progress list — that would indicate the
+ * push/pop pairing in `expandCompositeComponent` /
+ * `expandShadowingComposite` has drifted.
+ */
+function _finishExpanding({
+    core,
+    componentIdx,
+}: {
+    core: Core;
+    componentIdx: number;
+}) {
+    const targetInd =
+        core.updateInfo.compositesBeingExpanded.indexOf(componentIdx);
+    if (targetInd === -1) {
+        throw Error(
+            `Something is wrong as we lost track that we were expanding ${componentIdx}`,
+        );
+    }
+    core.updateInfo.compositesBeingExpanded.splice(targetInd, 1);
+}
+
+/**
+ * If `composite` has `createComponentIdx` specified,
+ * then its one replacement should have the componentIdx.
+ * Similarly, if it has `createComponentName` specified,
+ * then its one replacement should receive that name.
+ */
+export function adjustForCreateComponentIdxName({
+    serializedReplacements,
+    composite,
+}: {
+    serializedReplacements: any[];
+    composite: any;
+}) {
+    if (serializedReplacements.length === 1) {
+        if (
+            composite.attributes.createComponentIdx?.primitive.value !=
+            undefined
+        ) {
+            serializedReplacements[0].componentIdx =
+                composite.attributes.createComponentIdx.primitive.value;
+        }
+
+        if (
+            composite.attributes.createComponentName?.primitive.value !=
+            undefined
+        ) {
+            serializedReplacements[0].attributes.name = {
+                type: "primitive",
+                name: "name",
+                primitive: {
+                    type: "string",
+                    value: composite.attributes.createComponentName.primitive
+                        .value,
+                },
+            };
+        }
+    }
+}
+
+export async function createAndSetReplacements({
+    core,
+    component,
+    serializedReplacements,
+}: {
+    core: Core;
+    component: any;
+    serializedReplacements: any[];
+}) {
+    core.parameterStack.push(component.sharedParameters, false);
+
+    try {
+        let replacementResult = await core.createIsolatedComponents({
+            serializedComponents: serializedReplacements,
+            ancestors: component.ancestors,
+            shadow: true,
+            componentsReplacementOf: component,
+        });
+        component.replacements = replacementResult.components;
+    } catch (e: any) {
+        console.error(e);
+        // throw e;
+        component.replacements = await core.setErrorReplacements({
+            composite: component,
+            message: e.message,
+        });
+    }
+    core.parameterStack.pop();
+
+    await core.dependencies.addBlockersFromChangedReplacements(component);
+
+    component.isExpanded = true;
+}
+
+export async function replaceCompositeChildren({
+    core,
+    parent,
+}: {
+    core: Core;
+    parent: any;
+}) {
+    // If a composite is not directly matched by any childGroup, replace
+    // the composite with its replacements, expanding it if not already
+    // expanded.
+    delete parent.placeholderActiveChildrenIndices;
+    delete parent.placeholderActiveChildrenIndicesByComposite;
+    delete parent.compositeReplacementActiveRange;
+
+    let undisplayableErrorChildren;
+
+    let nPlaceholdersAdded = 0;
+
+    for (
+        let childInd = 0;
+        childInd < parent.activeChildren.length;
+        childInd++
+    ) {
+        let child = parent.activeChildren[childInd];
+
+        if (
+            child instanceof
+            core.componentInfoObjects.allComponentClasses._composite
+        ) {
+            // if composite itself is in the child logic
+            // then don't replace it with its replacements
+            // but leave the composite as an activeChild
+            if (
+                findChildGroup({
+                    core,
+                    childType: child.componentType,
+                    parentClass: parent.constructor,
+                }).success
+            ) {
+                continue;
+            }
+
+            let replaceWithPlaceholders = false;
+
+            // if an unexpanded composite has a createComponentOfType specified
+            // replace with placeholders
+            // otherwise, leave composite as an activeChild
+            if (!child.isExpanded) {
+                if (child.attributes.createComponentOfType?.primitive) {
+                    replaceWithPlaceholders = true;
+                } else {
+                    continue;
+                }
+            }
+
+            let replacements;
+
+            if (replaceWithPlaceholders) {
+                let numComponents;
+
+                if (child.attributes.numComponents) {
+                    numComponents =
+                        child.attributes.numComponents.primitive.value;
+                } else {
+                    numComponents = 1;
+                }
+
+                let componentType =
+                    core.componentInfoObjects.componentTypeLowerCaseMapping[
+                        child.attributes.createComponentOfType.primitive.value.toLowerCase()
+                    ];
+                replacements = [];
+
+                for (let i = 0; i < numComponents; i++) {
+                    replacements.push({
+                        componentType,
+                        fromComposite: child.componentIdx,
+                        placeholderInd: nPlaceholdersAdded,
+                    });
+                    nPlaceholdersAdded++;
+                }
+
+                parent.hasPlaceholderActiveChildren = true;
+                let placeholdInds = [...Array(numComponents).keys()].map(
+                    (x) => x + childInd,
+                );
+
+                if (!parent.placeholderActiveChildrenIndices) {
+                    parent.placeholderActiveChildrenIndices = [];
+                }
+                parent.placeholderActiveChildrenIndices.push(...placeholdInds);
+
+                if (!parent.placeholderActiveChildrenIndicesByComposite) {
+                    parent.placeholderActiveChildrenIndicesByComposite = {};
+                }
+                parent.placeholderActiveChildrenIndicesByComposite[
+                    child.componentIdx
+                ] = placeholdInds;
+            } else {
+                // don't use any replacements that are marked as being withheld
+                await markWithheldReplacementsInactive({
+                    core,
+                    composite: child,
+                });
+
+                replacements = child.replacements;
+                if (child.replacementsToWithhold > 0) {
+                    replacements = replacements.slice(
+                        0,
+                        -child.replacementsToWithhold,
+                    );
+                }
+
+                // don't include blank string replacements if parent excludes blank children
+                if (
+                    !parent.constructor.includeBlankStringChildren ||
+                    parent.constructor.removeBlankStringChildrenPostSugar
+                ) {
+                    replacements = replacements.filter(
+                        (x: any) => typeof x !== "string" || /\S/.test(x),
+                    );
+                }
+            }
+
+            if (!parent.compositeReplacementActiveRange) {
+                parent.compositeReplacementActiveRange = [];
+            }
+
+            // Record whether or not each component can be considered an element of a list.
+            // If this composite or a containing composite has asList set,
+            // then it may be turned into a list if all the components can be list elements.
+
+            // All inline components and any components with canBeInList set
+            // are considered potential components for a list.
+            let replacementsCanBeInList = replacements.map((repl: any) =>
+                Boolean(
+                    typeof repl !== "object" ||
+                    (core.componentInfoObjects.isInheritedComponentType({
+                        inheritedComponentType: repl.componentType,
+                        baseComponentType: "_inline",
+                    }) &&
+                        repl.constructor.canBeInList !== false) ||
+                    repl.constructor.canBeInList,
+                ),
+            );
+
+            for (let otherCompositeObject of parent.compositeReplacementActiveRange) {
+                if (otherCompositeObject.lastInd >= childInd) {
+                    otherCompositeObject.lastInd += replacements.length - 1;
+                    otherCompositeObject.potentialListComponents.splice(
+                        childInd,
+                        1,
+                        ...replacementsCanBeInList,
+                    );
+                }
+            }
+
+            if (
+                replacements.some(
+                    (repl: any) => repl.componentType === "_error",
+                ) &&
+                !parent.constructor.canDisplayChildErrors
+            ) {
+                // The composite returned an error but this parent cannot display child errors,
+                // so remove it from the replacements
+                // (to avoid a confusing warning about an invalid _error child)
+                // and store it in undisplayableErrorChildren.
+                // We will add these error children to an ancestor that can display them, below.
+
+                if (!undisplayableErrorChildren) {
+                    undisplayableErrorChildren = [];
+                }
+                let errorReplacements = replacements.filter(
+                    (repl: any) => repl.componentType === "_error",
+                );
+                replacements = replacements.filter(
+                    (repl: any) => repl.componentType !== "_error",
+                );
+                undisplayableErrorChildren.push(...errorReplacements);
+            }
+
+            // compositeReplacementActiveRange will be used
+            // - in renderers to determined if they should add commas
+            // - in child dependencies, where they will be translated for matched children
+            //   and used in some components to determine if those children can be formed into a list
+            if (child.isExpanded) {
+                parent.compositeReplacementActiveRange.push({
+                    compositeIdx: child.componentIdx,
+                    compositeName:
+                        core.rootNames?.[child.componentIdx] ??
+                        "_id_" + child.componentIdx.toString(),
+                    extendIdx: await child.stateValues.extendIdx,
+                    unresolvedPath: await child.stateValues.unresolvedPath,
+                    firstInd: childInd,
+                    lastInd: childInd + replacements.length - 1,
+                    asList: await child.stateValues.asList,
+                    potentialListComponents: replacementsCanBeInList,
+                });
+            }
+
+            parent.activeChildren.splice(childInd, 1, ...replacements);
+
+            // Update allChildren object with info on composite and its replacemnts
+            let allChildrenObj = parent.allChildren[child.componentIdx];
+            delete allChildrenObj.activeChildrenIndex;
+            for (let ind2 = 0; ind2 < replacements.length; ind2++) {
+                let replacement = replacements[ind2];
+                if (replacement.componentIdx != undefined) {
+                    // ignore placeholder, string, and primitive number active children
+                    parent.allChildren[replacement.componentIdx] = {
+                        activeChildrenIndex: childInd + ind2,
+                        component: replacement,
+                    };
+                }
+            }
+
+            // find index of child in allChildrenOrdered
+            // and place replacements immediately afterward
+            let ind2 = parent.allChildrenOrdered.indexOf(child.componentIdx);
+            parent.allChildrenOrdered.splice(
+                ind2 + 1,
+                0,
+                ...replacements
+                    .filter((x: any) => typeof x === "object")
+                    .map((x: any) =>
+                        x.componentIdx ? x.componentIdx : x.placeholderInd,
+                    ),
+            );
+
+            if (replacements.length !== 1) {
+                // if replaced composite with anything other than one replacement
+                // shift activeChildrenIndices of later children
+                let nShift = replacements.length - 1;
+                for (
+                    let ind2 = childInd + replacements.length;
+                    ind2 < parent.activeChildren.length;
+                    ind2++
+                ) {
+                    let child2 = parent.activeChildren[ind2];
+                    if (child2.componentIdx != undefined) {
+                        parent.allChildren[
+                            child2.componentIdx
+                        ].activeChildrenIndex += nShift;
+                    }
+                }
+            }
+
+            // rewind one index, in case any of the new activeChildren are composites
+            childInd--;
+        }
+    }
+
+    if (undisplayableErrorChildren) {
+        await addUndisplayableErrorChildrenToAncestor({
+            core,
+            parent,
+            undisplayableErrorChildren,
+        });
+    }
+}
+
+async function addUndisplayableErrorChildrenToAncestor({
+    core,
+    parent,
+    undisplayableErrorChildren,
+}: {
+    core: Core;
+    parent: any;
+    undisplayableErrorChildren: any[];
+}) {
+    // If parent had an error added by a composite, but it can't display errors,
+    // then look for an ancestor that can display errors
+    // (which will exist since document can display errors).
+    // Add the errors to the defining children of that ancestor.
+    let ancestorToDisplayErrors = parent;
+    let definingChildIndToAddError;
+    while (!ancestorToDisplayErrors.constructor.canDisplayChildErrors) {
+        let nextAncestor = core._components[ancestorToDisplayErrors.parentIdx];
+
+        definingChildIndToAddError = nextAncestor.definingChildren.indexOf(
+            ancestorToDisplayErrors,
+        );
+
+        ancestorToDisplayErrors = nextAncestor;
+    }
+
+    // if child wasn't a defining child, put the error as the first child
+    if (definingChildIndToAddError === -1) {
+        definingChildIndToAddError = 0;
+    }
+
+    ancestorToDisplayErrors.definingChildren.splice(
+        definingChildIndToAddError,
+        0,
+        ...undisplayableErrorChildren,
+    );
+
+    await processNewDefiningChildren({
+        core,
+        parent: ancestorToDisplayErrors,
+        expandComposites: false,
+    });
+}
+
+async function markWithheldReplacementsInactive({
+    core,
+    composite,
+}: {
+    core: Core;
+    composite: any;
+}) {
+    let numActive = composite.replacements.length;
+
+    if (await composite.stateValues.isInactiveCompositeReplacement) {
+        numActive = 0;
+    } else if (composite.replacementsToWithhold > 0) {
+        numActive -= composite.replacementsToWithhold;
+    }
+
+    for (let repl of composite.replacements.slice(0, numActive)) {
+        await changeInactiveComponentAndDescendants({
+            core,
+            component: repl,
+            inactive: false,
+        });
+    }
+
+    for (let repl of composite.replacements.slice(numActive)) {
+        await changeInactiveComponentAndDescendants({
+            core,
+            component: repl,
+            inactive: true,
+        });
+    }
+
+    // composite is newly active
+    // if updates to replacements were postponed
+    // add them back to the queue
+    if (!(await composite.stateValues.isInactiveCompositeReplacement)) {
+        let cIdx = composite.componentIdx;
+        if (core.updateInfo.inactiveCompositesToUpdateReplacements.has(cIdx)) {
+            core.updateInfo.inactiveCompositesToUpdateReplacements.delete(cIdx);
+            core.updateInfo.compositesToUpdateReplacements.add(cIdx);
+        }
+    }
+}
+
+export async function changeInactiveComponentAndDescendants({
+    core,
+    component,
+    inactive,
+}: {
+    core: Core;
+    component: any;
+    inactive: boolean;
+}) {
+    if (typeof component !== "object") {
+        return;
+    }
+
+    if (
+        (await component.stateValues.isInactiveCompositeReplacement) !==
+        inactive
+    ) {
+        component.state.isInactiveCompositeReplacement.value = inactive;
+        await core.markUpstreamDependentsStale({
+            component,
+            varName: "isInactiveCompositeReplacement",
+        });
+        core.dependencies.recordActualChangeInUpstreamDependencies({
+            component,
+            varName: "isInactiveCompositeReplacement",
+        });
+        for (const childIdxStr in component.allChildren) {
+            await changeInactiveComponentAndDescendants({
+                core,
+                component: core._components[childIdxStr],
+                inactive,
+            });
         }
 
         for (let attrName in component.attributes) {
             let attrComp = component.attributes[attrName].component;
             if (attrComp) {
-                let additionalParentsWithNotReady =
-                    await this.expandCompositesOfDescendants(
-                        attrComp,
-                        forceExpandComposites,
-                    );
-                parentsWithCompositesNotReady.push(
-                    ...additionalParentsWithNotReady,
-                );
-            }
-        }
-
-        for (let childIdxStr in component.allChildren) {
-            let child = component.allChildren[childIdxStr].component;
-            if (typeof child !== "object") {
-                continue;
-            }
-
-            let additionalParentsWithNotReady =
-                await this.expandCompositesOfDescendants(
-                    child,
-                    forceExpandComposites,
-                );
-            parentsWithCompositesNotReady.push(
-                ...additionalParentsWithNotReady,
-            );
-        }
-
-        return parentsWithCompositesNotReady;
-    }
-
-    async componentAndRenderedDescendants(component) {
-        if (component?.componentIdx == undefined) {
-            return [];
-        }
-
-        let componentIndices = [component.componentIdx];
-        if (component.constructor.renderChildren) {
-            if (!component.matchedCompositeChildren) {
-                await deriveChildResultsFromDefiningChildren({
-                    core: this.core,
-                    parent: component,
-                    expandComposites: true, //forceExpandComposites: true,
-                });
-            }
-            for (let child of component.activeChildren) {
-                componentIndices.push(
-                    ...(await this.componentAndRenderedDescendants(child)),
-                );
-            }
-        }
-        return componentIndices;
-    }
-
-    async expandCompositeOfDefiningChildren(
-        parent,
-        children,
-        expandComposites,
-        forceExpandComposites,
-    ) {
-        // If a composite is not directly matched by any childGroup, replace
-        // the composite with its replacements, expanding it if not already
-        // expanded.
-        let unexpandedCompositesReady = [];
-        let unexpandedCompositesNotReady = [];
-
-        for (let childInd = 0; childInd < children.length; childInd++) {
-            let child = children[childInd];
-
-            if (
-                child instanceof
-                this.core.componentInfoObjects.allComponentClasses._composite
-            ) {
-                // if composite itself is in the child logic
-                // then don't replace it with its replacements
-                // but leave the composite as an activeChild
-                if (
-                    findChildGroup({
-                        core: this.core,
-                        childType: child.componentType,
-                        parentClass: parent.constructor,
-                    }).success
-                ) {
-                    continue;
-                }
-
-                // expand composite if it isn't already
-                if (!child.isExpanded) {
-                    if (!child.state.readyToExpandWhenResolved.isResolved) {
-                        if (expandComposites) {
-                            let resolveResult =
-                                await this.core.dependencies.resolveItem({
-                                    componentIdx: child.componentIdx,
-                                    type: "stateVariable",
-                                    stateVariable: "readyToExpandWhenResolved",
-                                    expandComposites, //: forceExpandComposites,
-                                    force: forceExpandComposites,
-                                });
-
-                            if (!resolveResult.success) {
-                                unexpandedCompositesNotReady.push(
-                                    child.componentIdx,
-                                );
-                                this.core.updateInfo.compositesToExpand.add(
-                                    child.componentIdx,
-                                );
-                                continue;
-                            }
-                        } else {
-                            unexpandedCompositesNotReady.push(
-                                child.componentIdx,
-                            );
-                            this.core.updateInfo.compositesToExpand.add(
-                                child.componentIdx,
-                            );
-                            continue;
-                        }
-                    } else if (!expandComposites) {
-                        unexpandedCompositesReady.push(child.componentIdx);
-                        this.core.updateInfo.compositesToExpand.add(
-                            child.componentIdx,
-                        );
-                        continue;
-                    }
-
-                    // will either succeed or throw error since is ready to expand
-                    await this.expandCompositeComponent(child);
-                }
-
-                // recurse on replacements
-                let result = await this.expandCompositeOfDefiningChildren(
-                    parent,
-                    child.replacements,
-                    expandComposites,
-                    forceExpandComposites,
-                );
-
-                unexpandedCompositesReady.push(
-                    ...result.unexpandedCompositesReady,
-                );
-                unexpandedCompositesNotReady.push(
-                    ...result.unexpandedCompositesNotReady,
-                );
-            }
-        }
-
-        return { unexpandedCompositesReady, unexpandedCompositesNotReady };
-    }
-
-    async expandCompositeComponent(component) {
-        if (!("readyToExpandWhenResolved" in component.state)) {
-            throw Error(
-                `Could not find state variable readyToExpandWhenResolved of composite ${component.componentIdx}`,
-            );
-        }
-
-        if (!component.state.readyToExpandWhenResolved.isResolved) {
-            this.core.updateInfo.compositesToExpand.add(component.componentIdx);
-            return { success: false };
-        }
-
-        this.core.updateInfo.compositesToExpand.delete(component.componentIdx);
-
-        this.core.updateInfo.compositesBeingExpanded.push(
-            component.componentIdx,
-        );
-
-        if (component.parent) {
-            for (const list of [
-                component.parent.unexpandedCompositesReady,
-                component.parent.unexpandedCompositesNotReady,
-            ]) {
-                if (!list) {
-                    continue;
-                }
-                const ind = list.indexOf(component.componentIdx);
-                if (ind !== -1) {
-                    list.splice(ind, 1);
-                }
-            }
-        }
-
-        if (
-            component.shadows &&
-            !component.shadows.propVariable &&
-            !component.constructor.doNotExpandAsShadowed
-            //&&
-            // this.core.componentInfoObjects.isCompositeComponent({
-            //   componentType: component.componentType,
-            //   includeNonStandard: false,
-            // })
-        ) {
-            return await this.expandShadowingComposite(component);
-        }
-
-        // Call the static function createSerializedReplacements from the composite component
-        // which returns an object containing a key "replacements" with value an array
-        // of serialized components that will be turned into real components.
-        // The replacement components will be used to replace
-        // the composite itself as children for the composite's parent
-        // Arguments
-        // component: the composite component
-        // components: all components in the document
-        // workspace: an initially empty object that a composite can use to store information that will then
-        //   be provided when updating composite replacements via calculateReplacementChanges
-        // componentInfoObjects
-        // flags
-        // resolveItem: a function that the composite can use to resolve any state variables
-        // publicCaseInsensitiveAliasSubstitutions: a function that can be used to find a case insensitive match
-        //   to a public state variable, substituting aliases if necessary
-        let initialNComponents;
-        let result;
-        const originalWorkspace = { ...component.replacementsWorkspace };
-
-        do {
-            initialNComponents = this.core._components.length;
-            component.replacementsWorkspace = { ...originalWorkspace };
-            result = await component.constructor.createSerializedReplacements({
-                component: this.core._components[component.componentIdx], // to create proxy
-                components: this.core._components,
-                nComponents: this.core._components.length,
-                workspace: component.replacementsWorkspace,
-                componentInfoObjects: this.core.componentInfoObjects,
-                allDoenetMLs: this.core.allDoenetMLs,
-                flags: this.core.flags,
-                resolveItem: this.core.dependencies.resolveItem.bind(
-                    this.core.dependencies,
-                ),
-                publicCaseInsensitiveAliasSubstitutions:
-                    this.core.publicCaseInsensitiveAliasSubstitutions.bind(
-                        this.core,
-                    ),
-            });
-
-            // If `this.core._components` changed in length while `createSerializedReplacements` was executing,
-            // it means that some other action (like calling another `createSerializedReplacements`)
-            // occurred while resolving state variables.
-            // Since this would lead to collisions in assigned component indices, we rerun `createSerializedReplacements`.
-            // TODO: are there any scenarios where this will lead to an infinite loop?
-        } while (this.core._components.length !== initialNComponents);
-
-        const newNComponents = result.nComponents;
-
-        if (
-            !(
-                Number.isInteger(newNComponents) &&
-                newNComponents >= this.core._components.length
-            )
-        ) {
-            throw Error(
-                `Invalid nComponents returned by createSerializedReplacements for ${component.componentType}: `,
-                newNComponents,
-            );
-        }
-
-        let position = this.core._components[component.componentIdx].position;
-        let sourceDoc = this.core._components[component.componentIdx].sourceDoc;
-        let overwriteDoenetMLRange = component.componentType === "_copy";
-
-        gatherDiagnosticsAndAssignDoenetMLRange({
-            core: this.core,
-            components: result.replacements,
-            diagnostics: result.diagnostics,
-            position,
-            sourceDoc,
-            overwriteDoenetMLRange,
-        });
-
-        if (component.constructor.stateVariableToEvaluateAfterReplacements) {
-            await component.stateValues[
-                component.constructor.stateVariableToEvaluateAfterReplacements
-            ];
-        }
-
-        if (result.replacements) {
-            let serializedReplacements = result.replacements;
-
-            await addReplacementsToResolver({
-                core: this.core,
-                serializedReplacements,
-                component,
-            });
-
-            // expand `this.core._components` to length `newNComponents` so that the component indices will not be reused
-            if (newNComponents > this.core._components.length) {
-                this.core._components[newNComponents - 1] = undefined;
-            }
-
-            await this.createAndSetReplacements({
-                component,
-                serializedReplacements,
-            });
-        } else {
-            throw Error(
-                `Invalid createSerializedReplacements of ${component.componentIdx}`,
-            );
-        }
-
-        this._finishExpanding(component.componentIdx);
-
-        return { success: true, compositesExpanded: [component.componentIdx] };
-    }
-
-    async expandShadowingComposite(component) {
-        if (
-            this.core.updateInfo.compositesBeingExpanded.includes(
-                component.shadows.componentIdx,
-            )
-        ) {
-            // found a circular dependency,
-            // as we are in the middle of expanding a composite
-            // that we are now trying to shadow
-            let compositeInvolved =
-                this.core._components[component.shadows.componentIdx];
-            // find non-shadow for error message, as that would be a component from document
-            while (compositeInvolved.shadows) {
-                compositeInvolved =
-                    this.core._components[
-                        compositeInvolved.shadows.componentIdx
-                    ];
-            }
-            throw Error(
-                `Circular dependency involving ${compositeInvolved.componentIdx}.`,
-            );
-        }
-
-        let shadowedComposite =
-            this.core._components[component.shadows.componentIdx];
-        let compositesExpanded = [];
-
-        if (!shadowedComposite.isExpanded) {
-            let result = await this.expandCompositeComponent(shadowedComposite);
-
-            if (!result.success) {
-                throw Error(
-                    `expand result of ${component.componentIdx} was not a success even though ready to expand.`,
-                );
-            }
-            compositesExpanded.push(...result.compositesExpanded);
-        }
-
-        // we'll copy the replacements of the shadowed composite
-        // and make those be the replacements of the shadowing composite
-        let serializedReplacements = [];
-
-        if (component.replacementsWorkspace.replacementsCreated === undefined) {
-            component.replacementsWorkspace.replacementsCreated = 0;
-        }
-
-        const stateIdInfo = {
-            prefix: `${component.stateId}|`,
-            num: component.replacementsWorkspace.replacementsCreated,
-        };
-
-        let nComponents = this.core._components.length;
-        let newNComponents = nComponents;
-
-        // We address one complication from shadowing a component with copied in children.
-        // In this case, the name resolver will already have the component indices of the serialized children of `component`.
-        // The corresponding replacements of `component` should have those component indices.
-        // However, those replacements already exist in the replacements of `shadowedComposite` which we are copying.
-        // As a workaround, we create a map from the indices of the children of `shadowedComposite`
-        // to the indices of the children of `component` and override the component indices created on the new replacements.
-        const idxMapOverride = {};
-        const copyInChildren =
-            shadowedComposite.attributes.copyInChildren?.primitive.value;
-        if (copyInChildren) {
-            const componentChildren = JSON.parse(
-                JSON.stringify(component.serializedChildren),
-            );
-            const shadowedChildren = JSON.parse(
-                JSON.stringify(shadowedComposite.serializedChildren),
-            );
-
-            // We are reusing this code that maps indices from serialized components to get the map
-            // from indices of `shadowedChildren` to indices of `componentChildren`.
-            const res = createComponentIndicesFromSerializedChildren(
-                shadowedChildren,
-                componentChildren,
-                newNComponents,
-            );
-
-            for (const idx in res.idxMap) {
-                // the above code might also have created new indices, which we ignore
-                if (res.idxMap[idx] < newNComponents) {
-                    idxMapOverride[idx] = res.idxMap[idx];
-                }
-            }
-        }
-
-        for (let [idx, repl] of shadowedComposite.replacements.entries()) {
-            if (typeof repl === "object") {
-                const serializedComponent = await repl.serialize();
-
-                if (
-                    component.constructor.useSerializedChildrenComponentIndices
-                ) {
-                    const res = createComponentIndicesFromSerializedChildren(
-                        [serializedComponent],
-                        [component.serializedChildren[idx]],
-                        newNComponents,
-                        stateIdInfo,
-                    );
-                    newNComponents = res.nComponents;
-
-                    serializedReplacements.push(...res.components);
-                } else {
-                    const res = createNewComponentIndices(
-                        [serializedComponent],
-                        newNComponents,
-                        stateIdInfo,
-                        idxMapOverride,
-                    );
-                    newNComponents = res.nComponents;
-
-                    serializedReplacements.push(...res.components);
-                }
-            } else {
-                serializedReplacements.push(repl);
-            }
-        }
-
-        if (component.constructor.addExtraSerializedChildrenWhenShadowing) {
-            let rendered = true;
-            if ("rendered" in component.state) {
-                rendered = await component.state.rendered.value;
-            }
-
-            if (rendered) {
-                // add any serialized children that are beyond the replacements we already have
-                serializedReplacements.push(
-                    ...deepClone(
-                        component.serializedChildren.slice(
-                            serializedReplacements.length,
-                        ),
-                    ),
-                );
-            }
-        }
-
-        this.adjustForCreateComponentIdxName(serializedReplacements, component);
-
-        // Have three composites involved:
-        // 1. the shadowing composite (component, the one we're trying to expand)
-        // 2. the shadowed composite
-        // 3. the composite mediating the shadowing
-        //    (of which shadowing composite is the replacement)
-
-        let nameOfCompositeMediatingTheShadow = component.shadows.compositeIdx;
-        let compositeMediatingTheShadow =
-            this.core._components[nameOfCompositeMediatingTheShadow];
-        serializedReplacements = postProcessCopy({
-            serializedComponents: serializedReplacements,
-            componentIdx: nameOfCompositeMediatingTheShadow,
-        });
-
-        // If shadowed composite mediates the shadow of compositeMediatingTheShadow,
-        // then we have a circular reference.
-        // mediatesShadows is an array of objects with keys shadows and shadowed,
-        // that the shadow mediated by the component.
-        // We check if shadowedComposite mediates the shadow of compositeMediatingTheShadow,
-        // or, recursively, if one of those shadowed components
-        // mediates the shadow of compositeMediatingTheShadow
-
-        let foundCircular = false;
-        let shadowedByShadowed = shadowedComposite.mediatesShadows
-            ?.filter((v) => v.propVariable === undefined)
-            .map((v) => v.shadowed);
-
-        while (shadowedByShadowed?.length > 0) {
-            if (
-                shadowedByShadowed.includes(nameOfCompositeMediatingTheShadow)
-            ) {
-                foundCircular = true;
-                let message = "Circular dependency detected";
-                if (component.attributes.createComponentOfType?.primitive) {
-                    message += ` involving \`<${component.attributes.createComponentOfType.primitive.value}>\` component`;
-                }
-                message += ".";
-                serializedReplacements = [
-                    {
-                        type: "serialized",
-                        componentType: "_error",
-                        componentIdx: newNComponents++,
-                        attributes: {},
-                        doenetAttributes: {},
-                        children: [],
-                        state: { message },
-                        position: compositeMediatingTheShadow.position,
-                        sourceDoc: compositeMediatingTheShadow.sourceDoc,
-                    },
-                ];
-                this.core.addDiagnostic({
-                    type: "error",
-                    message,
-                    position: compositeMediatingTheShadow.position,
-                    sourceDoc: compositeMediatingTheShadow.sourceDoc,
-                });
-
-                break;
-            }
-
-            // recurse to check if one the shadowed components mediates
-            // the shadow of compositeMediatingTheShadow
-            shadowedByShadowed = shadowedByShadowed.reduce((acc, cIdx) => {
-                let comp = this.core._components[cIdx];
-                if (comp?.mediatesShadows) {
-                    return [
-                        ...acc,
-                        ...comp.mediatesShadows
-                            .filter((v) => v.propVariable === undefined)
-                            .map((v) => v.shadowed),
-                    ];
-                } else {
-                    return acc;
-                }
-            }, []);
-        }
-
-        // XXX: what is the replacement for targetComponentIdx?
-        // let target =
-        //     this.core._components[
-        //         compositeMediatingTheShadow.doenetAttributes.targetComponentIdx
-        //     ];
-
-        // if (
-        //     target?.componentIdx === shadowedComposite.componentIdx &&
-        //     compositeMediatingTheShadow.attributes.copyInChildren?.primitive
-        //         .value
-        // ) {
-        //     let newReplacements = deepClone(
-        //         compositeMediatingTheShadow.serializedChildren,
-        //     );
-        //     let componentClass =
-        //         this.core.componentInfoObjects.allComponentClasses[
-        //             component.componentType
-        //         ];
-
-        //     if (!componentClass.includeBlankStringChildren) {
-        //         newReplacements = newReplacements.filter(
-        //             (x) => typeof x !== "string" || x.trim() !== "",
-        //         );
-        //     }
-
-        //     serializedReplacements.push(...newReplacements);
-        // }
-
-        if (!foundCircular) {
-            // `replacementsCreated` is already initialized to 0 ~200 lines
-            // earlier in this same function (`if (component.replacementsWorkspace
-            // .replacementsCreated === undefined) { ... = 0 }`) and is never
-            // re-set to undefined between the two sites, so the duplicate
-            // guard that used to live here is dead. Removed per
-            // CORE_REFACTOR_DEFERRED.md §"Drop dead `replacementsCreated`
-            // guard".
-
-            let verificationResult = await verifyReplacementsMatchSpecifiedType(
-                {
-                    component,
-                    replacements: serializedReplacements,
-                    componentInfoObjects: this.core.componentInfoObjects,
-                    compositeAttributesObj: preprocessAttributesObject(
-                        component.constructor.createAttributesObject(),
-                    ),
-                    components: this.core._components,
-                    nComponents: newNComponents,
-                    stateIdInfo,
-                    publicCaseInsensitiveAliasSubstitutions:
-                        this.core.publicCaseInsensitiveAliasSubstitutions.bind(
-                            this.core,
-                        ),
-                },
-            );
-
-            for (const diagnostic of verificationResult.diagnostics) {
-                this.core.addDiagnostic(diagnostic);
-            }
-
-            newNComponents = verificationResult.nComponents;
-
-            serializedReplacements = verificationResult.replacements;
-
-            addAttributesToSingleReplacement(
-                serializedReplacements,
-                component,
-                this.core.componentInfoObjects,
-            );
-        }
-
-        component.replacementsWorkspace.replacementsCreated = stateIdInfo.num;
-
-        await addReplacementsToResolver({
-            core: this.core,
-            serializedReplacements,
-            component,
-        });
-
-        // expand `this.core._components` to length `newNComponents` so that the component indices will not be reused
-        if (newNComponents > this.core._components.length) {
-            this.core._components[newNComponents - 1] = undefined;
-        }
-
-        await this.createAndSetReplacements({
-            component,
-            serializedReplacements,
-        });
-
-        if (shadowedComposite.replacementsToWithhold > 0) {
-            component.replacementsToWithhold =
-                shadowedComposite.replacementsToWithhold;
-        }
-
-        this._finishExpanding(component.componentIdx);
-
-        compositesExpanded.push(component.componentIdx);
-
-        return { success: true, compositesExpanded };
-    }
-
-    /**
-     * Pop `componentIdx` off `core.updateInfo.compositesBeingExpanded` to
-     * record that the composite has finished expanding. Throws if the
-     * composite was not on the in-progress list — that would indicate the
-     * push/pop pairing in `expandCompositeComponent` /
-     * `expandShadowingComposite` has drifted.
-     */
-    _finishExpanding(componentIdx: number) {
-        const targetInd =
-            this.core.updateInfo.compositesBeingExpanded.indexOf(componentIdx);
-        if (targetInd === -1) {
-            throw Error(
-                `Something is wrong as we lost track that we were expanding ${componentIdx}`,
-            );
-        }
-        this.core.updateInfo.compositesBeingExpanded.splice(targetInd, 1);
-    }
-
-    /**
-     * If `composite` has `createComponentIdx` specified,
-     * then its one replacement should have the componentIdx.
-     * Similarly, if it has `createComponentName` specified,
-     * then its one replacement should receive that name.
-     */
-    adjustForCreateComponentIdxName(serializedReplacements, composite) {
-        if (serializedReplacements.length === 1) {
-            if (
-                composite.attributes.createComponentIdx?.primitive.value !=
-                undefined
-            ) {
-                serializedReplacements[0].componentIdx =
-                    composite.attributes.createComponentIdx.primitive.value;
-            }
-
-            if (
-                composite.attributes.createComponentName?.primitive.value !=
-                undefined
-            ) {
-                serializedReplacements[0].attributes.name = {
-                    type: "primitive",
-                    name: "name",
-                    primitive: {
-                        type: "string",
-                        value: composite.attributes.createComponentName
-                            .primitive.value,
-                    },
-                };
-            }
-        }
-    }
-
-    async createAndSetReplacements({ component, serializedReplacements }) {
-        this.core.parameterStack.push(component.sharedParameters, false);
-
-        try {
-            let replacementResult = await this.core.createIsolatedComponents({
-                serializedComponents: serializedReplacements,
-                ancestors: component.ancestors,
-                shadow: true,
-                componentsReplacementOf: component,
-            });
-            component.replacements = replacementResult.components;
-        } catch (e) {
-            console.error(e);
-            // throw e;
-            component.replacements = await this.core.setErrorReplacements({
-                composite: component,
-                message: e.message,
-            });
-        }
-        this.core.parameterStack.pop();
-
-        await this.core.dependencies.addBlockersFromChangedReplacements(
-            component,
-        );
-
-        component.isExpanded = true;
-    }
-
-    async replaceCompositeChildren(parent) {
-        // If a composite is not directly matched by any childGroup, replace
-        // the composite with its replacements, expanding it if not already
-        // expanded.
-        delete parent.placeholderActiveChildrenIndices;
-        delete parent.placeholderActiveChildrenIndicesByComposite;
-        delete parent.compositeReplacementActiveRange;
-
-        let undisplayableErrorChildren;
-
-        let nPlaceholdersAdded = 0;
-
-        for (
-            let childInd = 0;
-            childInd < parent.activeChildren.length;
-            childInd++
-        ) {
-            let child = parent.activeChildren[childInd];
-
-            if (
-                child instanceof
-                this.core.componentInfoObjects.allComponentClasses._composite
-            ) {
-                // if composite itself is in the child logic
-                // then don't replace it with its replacements
-                // but leave the composite as an activeChild
-                if (
-                    findChildGroup({
-                        core: this.core,
-                        childType: child.componentType,
-                        parentClass: parent.constructor,
-                    }).success
-                ) {
-                    continue;
-                }
-
-                let replaceWithPlaceholders = false;
-
-                // if an unexpanded composite has a createComponentOfType specified
-                // replace with placeholders
-                // otherwise, leave composite as an activeChild
-                if (!child.isExpanded) {
-                    if (child.attributes.createComponentOfType?.primitive) {
-                        replaceWithPlaceholders = true;
-                    } else {
-                        continue;
-                    }
-                }
-
-                let replacements;
-
-                if (replaceWithPlaceholders) {
-                    let numComponents;
-
-                    if (child.attributes.numComponents) {
-                        numComponents =
-                            child.attributes.numComponents.primitive.value;
-                    } else {
-                        numComponents = 1;
-                    }
-
-                    let componentType =
-                        this.core.componentInfoObjects
-                            .componentTypeLowerCaseMapping[
-                            child.attributes.createComponentOfType.primitive.value.toLowerCase()
-                        ];
-                    replacements = [];
-
-                    for (let i = 0; i < numComponents; i++) {
-                        replacements.push({
-                            componentType,
-                            fromComposite: child.componentIdx,
-                            placeholderInd: nPlaceholdersAdded,
-                        });
-                        nPlaceholdersAdded++;
-                    }
-
-                    parent.hasPlaceholderActiveChildren = true;
-                    let placeholdInds = [...Array(numComponents).keys()].map(
-                        (x) => x + childInd,
-                    );
-
-                    if (!parent.placeholderActiveChildrenIndices) {
-                        parent.placeholderActiveChildrenIndices = [];
-                    }
-                    parent.placeholderActiveChildrenIndices.push(
-                        ...placeholdInds,
-                    );
-
-                    if (!parent.placeholderActiveChildrenIndicesByComposite) {
-                        parent.placeholderActiveChildrenIndicesByComposite = {};
-                    }
-                    parent.placeholderActiveChildrenIndicesByComposite[
-                        child.componentIdx
-                    ] = placeholdInds;
-                } else {
-                    // don't use any replacements that are marked as being withheld
-                    await this.markWithheldReplacementsInactive(child);
-
-                    replacements = child.replacements;
-                    if (child.replacementsToWithhold > 0) {
-                        replacements = replacements.slice(
-                            0,
-                            -child.replacementsToWithhold,
-                        );
-                    }
-
-                    // don't include blank string replacements if parent excludes blank children
-                    if (
-                        !parent.constructor.includeBlankStringChildren ||
-                        parent.constructor.removeBlankStringChildrenPostSugar
-                    ) {
-                        replacements = replacements.filter(
-                            (x) => typeof x !== "string" || /\S/.test(x),
-                        );
-                    }
-                }
-
-                if (!parent.compositeReplacementActiveRange) {
-                    parent.compositeReplacementActiveRange = [];
-                }
-
-                // Record whether or not each component can be considered an element of a list.
-                // If this composite or a containing composite has asList set,
-                // then it may be turned into a list if all the components can be list elements.
-
-                // All inline components and any components with canBeInList set
-                // are considered potential components for a list.
-                let replacementsCanBeInList = replacements.map((repl) =>
-                    Boolean(
-                        typeof repl !== "object" ||
-                        (this.core.componentInfoObjects.isInheritedComponentType(
-                            {
-                                inheritedComponentType: repl.componentType,
-                                baseComponentType: "_inline",
-                            },
-                        ) &&
-                            repl.constructor.canBeInList !== false) ||
-                        repl.constructor.canBeInList,
-                    ),
-                );
-
-                for (let otherCompositeObject of parent.compositeReplacementActiveRange) {
-                    if (otherCompositeObject.lastInd >= childInd) {
-                        otherCompositeObject.lastInd += replacements.length - 1;
-                        otherCompositeObject.potentialListComponents.splice(
-                            childInd,
-                            1,
-                            ...replacementsCanBeInList,
-                        );
-                    }
-                }
-
-                if (
-                    replacements.some(
-                        (repl) => repl.componentType === "_error",
-                    ) &&
-                    !parent.constructor.canDisplayChildErrors
-                ) {
-                    // The composite returned an error but this parent cannot display child errors,
-                    // so remove it from the replacements
-                    // (to avoid a confusing warning about an invalid _error child)
-                    // and store it in undisplayableErrorChildren.
-                    // We will add these error children to an ancestor that can display them, below.
-
-                    if (!undisplayableErrorChildren) {
-                        undisplayableErrorChildren = [];
-                    }
-                    let errorReplacements = replacements.filter(
-                        (repl) => repl.componentType === "_error",
-                    );
-                    replacements = replacements.filter(
-                        (repl) => repl.componentType !== "_error",
-                    );
-                    undisplayableErrorChildren.push(...errorReplacements);
-                }
-
-                // compositeReplacementActiveRange will be used
-                // - in renderers to determined if they should add commas
-                // - in child dependencies, where they will be translated for matched children
-                //   and used in some components to determine if those children can be formed into a list
-                if (child.isExpanded) {
-                    parent.compositeReplacementActiveRange.push({
-                        compositeIdx: child.componentIdx,
-                        compositeName:
-                            this.core.rootNames?.[child.componentIdx] ??
-                            "_id_" + child.componentIdx.toString(),
-                        extendIdx: await child.stateValues.extendIdx,
-                        unresolvedPath: await child.stateValues.unresolvedPath,
-                        firstInd: childInd,
-                        lastInd: childInd + replacements.length - 1,
-                        asList: await child.stateValues.asList,
-                        potentialListComponents: replacementsCanBeInList,
-                    });
-                }
-
-                parent.activeChildren.splice(childInd, 1, ...replacements);
-
-                // Update allChildren object with info on composite and its replacemnts
-                let allChildrenObj = parent.allChildren[child.componentIdx];
-                delete allChildrenObj.activeChildrenIndex;
-                for (let ind2 = 0; ind2 < replacements.length; ind2++) {
-                    let replacement = replacements[ind2];
-                    if (replacement.componentIdx != undefined) {
-                        // ignore placeholder, string, and primitive number active children
-                        parent.allChildren[replacement.componentIdx] = {
-                            activeChildrenIndex: childInd + ind2,
-                            component: replacement,
-                        };
-                    }
-                }
-
-                // find index of child in allChildrenOrdered
-                // and place replacements immediately afterward
-                let ind2 = parent.allChildrenOrdered.indexOf(
-                    child.componentIdx,
-                );
-                parent.allChildrenOrdered.splice(
-                    ind2 + 1,
-                    0,
-                    ...replacements
-                        .filter((x) => typeof x === "object")
-                        .map((x) =>
-                            x.componentIdx ? x.componentIdx : x.placeholderInd,
-                        ),
-                );
-
-                if (replacements.length !== 1) {
-                    // if replaced composite with anything other than one replacement
-                    // shift activeChildrenIndices of later children
-                    let nShift = replacements.length - 1;
-                    for (
-                        let ind2 = childInd + replacements.length;
-                        ind2 < parent.activeChildren.length;
-                        ind2++
-                    ) {
-                        let child2 = parent.activeChildren[ind2];
-                        if (child2.componentIdx != undefined) {
-                            parent.allChildren[
-                                child2.componentIdx
-                            ].activeChildrenIndex += nShift;
-                        }
-                    }
-                }
-
-                // rewind one index, in case any of the new activeChildren are composites
-                childInd--;
-            }
-        }
-
-        if (undisplayableErrorChildren) {
-            await this.addUndisplayableErrorChildrenToAncestor(
-                parent,
-                undisplayableErrorChildren,
-            );
-        }
-    }
-
-    async addUndisplayableErrorChildrenToAncestor(
-        parent,
-        undisplayableErrorChildren,
-    ) {
-        // If parent had an error added by a composite, but it can't display errors,
-        // then look for an ancestor that can display errors
-        // (which will exist since document can display errors).
-        // Add the errors to the defining children of that ancestor.
-        // Note: this breaks the rules of DoenetML and
-        // it is possible that these errors will accumulate in the ancestor
-        // if this code is repeated. But, the DoenetML is broken anyway with errors,
-        // and the purpose is just to make sure that the error is prominently displayed.
-
-        let ancestorToDisplayErrors = parent;
-        let definingChildIndToAddError;
-        while (!ancestorToDisplayErrors.constructor.canDisplayChildErrors) {
-            let nextAncestor =
-                this.core._components[ancestorToDisplayErrors.parentIdx];
-
-            definingChildIndToAddError = nextAncestor.definingChildren.indexOf(
-                ancestorToDisplayErrors,
-            );
-
-            ancestorToDisplayErrors = nextAncestor;
-        }
-
-        // if child wasn't a defining child, put the error as the first child
-        if (definingChildIndToAddError === -1) {
-            definingChildIndToAddError = 0;
-        }
-
-        ancestorToDisplayErrors.definingChildren.splice(
-            definingChildIndToAddError,
-            0,
-            ...undisplayableErrorChildren,
-        );
-
-        await processNewDefiningChildren({
-            core: this.core,
-            parent: ancestorToDisplayErrors,
-            expandComposites: false,
-        });
-    }
-
-    async markWithheldReplacementsInactive(composite) {
-        let numActive = composite.replacements.length;
-
-        if (await composite.stateValues.isInactiveCompositeReplacement) {
-            numActive = 0;
-        } else if (composite.replacementsToWithhold > 0) {
-            numActive -= composite.replacementsToWithhold;
-        }
-
-        for (let repl of composite.replacements.slice(0, numActive)) {
-            await this.changeInactiveComponentAndDescendants(repl, false);
-        }
-
-        for (let repl of composite.replacements.slice(numActive)) {
-            await this.changeInactiveComponentAndDescendants(repl, true);
-        }
-
-        // composite is newly active
-        // if updates to replacements were postponed
-        // add them back to the queue
-        if (!(await composite.stateValues.isInactiveCompositeReplacement)) {
-            let cIdx = composite.componentIdx;
-            if (
-                this.core.updateInfo.inactiveCompositesToUpdateReplacements.has(
-                    cIdx,
-                )
-            ) {
-                this.core.updateInfo.inactiveCompositesToUpdateReplacements.delete(
-                    cIdx,
-                );
-                this.core.updateInfo.compositesToUpdateReplacements.add(cIdx);
-            }
-        }
-    }
-
-    async changeInactiveComponentAndDescendants(component, inactive) {
-        if (typeof component !== "object") {
-            return;
-        }
-
-        if (
-            (await component.stateValues.isInactiveCompositeReplacement) !==
-            inactive
-        ) {
-            component.state.isInactiveCompositeReplacement.value = inactive;
-            await this.core.markUpstreamDependentsStale({
-                component,
-                varName: "isInactiveCompositeReplacement",
-            });
-            this.core.dependencies.recordActualChangeInUpstreamDependencies({
-                component,
-                varName: "isInactiveCompositeReplacement",
-            });
-            for (const childIdxStr in component.allChildren) {
-                await this.changeInactiveComponentAndDescendants(
-                    this.core._components[childIdxStr],
+                await changeInactiveComponentAndDescendants({
+                    core,
+                    component: core._components[attrComp.componentIdx],
                     inactive,
-                );
-            }
-
-            for (let attrName in component.attributes) {
-                let attrComp = component.attributes[attrName].component;
-                if (attrComp) {
-                    await this.changeInactiveComponentAndDescendants(
-                        this.core._components[attrComp.componentIdx],
-                        inactive,
-                    );
-                }
-            }
-
-            if (component.replacements) {
-                await this.markWithheldReplacementsInactive(component);
+                });
             }
         }
+
+        if (component.replacements) {
+            await markWithheldReplacementsInactive({
+                core,
+                composite: component,
+            });
+        }
     }
+}
 
-    /**
-     * Walk `replacements`, substituting each expanded composite for its
-     * own replacements (recursively). Composites that are not yet expanded
-     * are kept in place and recorded in `unexpandedCompositesReady` or
-     * `unexpandedCompositesNotReady` based on whether
-     * `readyToExpandWhenResolved` has resolved, so the caller can decide
-     * to wait for or force their expansion.
-     *
-     * `recurseNonStandardComposites` widens the "what counts as a composite"
-     * test to include non-standard composites. `includeWithheldReplacements`
-     * keeps replacements past `replacementsToWithhold`. `stopIfHaveProp`,
-     * if set, names a state variable: a composite that publicly exposes
-     * that variable is treated as the replacement itself rather than
-     * recursed into.
-     */
-    recursivelyReplaceCompositesWithReplacements({
-        replacements,
-        recurseNonStandardComposites = false,
-        includeWithheldReplacements = false,
-        stopIfHaveProp,
-    }: {
-        replacements: any[];
-        recurseNonStandardComposites?: boolean;
-        includeWithheldReplacements?: boolean;
-        stopIfHaveProp?: string;
-    }): {
-        compositesFound: number[];
-        newReplacements: any[];
-        unexpandedCompositesReady: number[];
-        unexpandedCompositesNotReady: number[];
-    } {
-        let compositesFound: number[] = [];
-        let newReplacements: any[] = [];
-        let unexpandedCompositesReady: number[] = [];
-        let unexpandedCompositesNotReady: number[] = [];
+/**
+ * Walk `replacements`, substituting each expanded composite for its
+ * own replacements (recursively). Composites that are not yet expanded
+ * are kept in place and recorded in `unexpandedCompositesReady` or
+ * `unexpandedCompositesNotReady` based on whether
+ * `readyToExpandWhenResolved` has resolved, so the caller can decide
+ * to wait for or force their expansion.
+ *
+ * `recurseNonStandardComposites` widens the "what counts as a composite"
+ * test to include non-standard composites. `includeWithheldReplacements`
+ * keeps replacements past `replacementsToWithhold`. `stopIfHaveProp`,
+ * if set, names a state variable: a composite that publicly exposes
+ * that variable is treated as the replacement itself rather than
+ * recursed into.
+ */
+export function recursivelyReplaceCompositesWithReplacements({
+    core,
+    replacements,
+    recurseNonStandardComposites = false,
+    includeWithheldReplacements = false,
+    stopIfHaveProp,
+}: {
+    core: Core;
+    replacements: any[];
+    recurseNonStandardComposites?: boolean;
+    includeWithheldReplacements?: boolean;
+    stopIfHaveProp?: string;
+}): {
+    compositesFound: number[];
+    newReplacements: any[];
+    unexpandedCompositesReady: number[];
+    unexpandedCompositesNotReady: number[];
+} {
+    let compositesFound: number[] = [];
+    let newReplacements: any[] = [];
+    let unexpandedCompositesReady: number[] = [];
+    let unexpandedCompositesNotReady: number[] = [];
 
-        for (let replacement of replacements) {
-            const isComposite =
-                this.core.componentInfoObjects.isCompositeComponent({
-                    componentType: replacement.componentType,
-                    includeNonStandard: recurseNonStandardComposites,
-                });
+    for (let replacement of replacements) {
+        const isComposite = core.componentInfoObjects.isCompositeComponent({
+            componentType: replacement.componentType,
+            includeNonStandard: recurseNonStandardComposites,
+        });
 
-            if (!isComposite) {
+        if (!isComposite) {
+            newReplacements.push(replacement);
+            continue;
+        }
+
+        if (stopIfHaveProp) {
+            const checkForPublic = core.matchPublicStateVariables({
+                stateVariables: [stopIfHaveProp],
+                componentClass: replacement.constructor,
+            })[0];
+
+            if (!checkForPublic.startsWith("__not_public_")) {
+                // The composite has a public state variable that matches `stopIfHaveProp`.
+                // Therefore, we don't recurse to its replacements but treat the composite itself as the replacement.
                 newReplacements.push(replacement);
                 continue;
             }
-
-            if (stopIfHaveProp) {
-                const checkForPublic = this.core.matchPublicStateVariables({
-                    stateVariables: [stopIfHaveProp],
-                    componentClass: replacement.constructor,
-                })[0];
-
-                if (!checkForPublic.startsWith("__not_public_")) {
-                    // The composite has a public state variable that matches `stopIfHaveProp`.
-                    // Therefore, we don't recurse to its replacements but treat the composite itself as the replacement.
-                    newReplacements.push(replacement);
-                    continue;
-                }
-            }
-
-            compositesFound.push(replacement.componentIdx);
-
-            if (!replacement.isExpanded) {
-                if (replacement.state.readyToExpandWhenResolved.isResolved) {
-                    unexpandedCompositesReady.push(replacement.componentIdx);
-                } else {
-                    unexpandedCompositesNotReady.push(replacement.componentIdx);
-                }
-                newReplacements.push(replacement);
-                continue;
-            }
-
-            let replacementReplacements = replacement.replacements;
-            if (
-                !includeWithheldReplacements &&
-                replacement.replacementsToWithhold > 0
-            ) {
-                replacementReplacements = replacementReplacements.slice(
-                    0,
-                    -replacement.replacementsToWithhold,
-                );
-            }
-            const recursionResult =
-                this.recursivelyReplaceCompositesWithReplacements({
-                    replacements: replacementReplacements,
-                    recurseNonStandardComposites,
-                    includeWithheldReplacements,
-                    stopIfHaveProp,
-                });
-            compositesFound.push(...recursionResult.compositesFound);
-            newReplacements.push(...recursionResult.newReplacements);
-            unexpandedCompositesReady.push(
-                ...recursionResult.unexpandedCompositesReady,
-            );
-            unexpandedCompositesNotReady.push(
-                ...recursionResult.unexpandedCompositesNotReady,
-            );
         }
 
-        return {
-            compositesFound,
-            newReplacements,
-            unexpandedCompositesReady,
-            unexpandedCompositesNotReady,
-        };
+        compositesFound.push(replacement.componentIdx);
+
+        if (!replacement.isExpanded) {
+            if (replacement.state.readyToExpandWhenResolved.isResolved) {
+                unexpandedCompositesReady.push(replacement.componentIdx);
+            } else {
+                unexpandedCompositesNotReady.push(replacement.componentIdx);
+            }
+            newReplacements.push(replacement);
+            continue;
+        }
+
+        let replacementReplacements = replacement.replacements;
+        if (
+            !includeWithheldReplacements &&
+            replacement.replacementsToWithhold > 0
+        ) {
+            replacementReplacements = replacementReplacements.slice(
+                0,
+                -replacement.replacementsToWithhold,
+            );
+        }
+        const recursionResult = recursivelyReplaceCompositesWithReplacements({
+            core,
+            replacements: replacementReplacements,
+            recurseNonStandardComposites,
+            includeWithheldReplacements,
+            stopIfHaveProp,
+        });
+        compositesFound.push(...recursionResult.compositesFound);
+        newReplacements.push(...recursionResult.newReplacements);
+        unexpandedCompositesReady.push(
+            ...recursionResult.unexpandedCompositesReady,
+        );
+        unexpandedCompositesNotReady.push(
+            ...recursionResult.unexpandedCompositesNotReady,
+        );
     }
+
+    return {
+        compositesFound,
+        newReplacements,
+        unexpandedCompositesReady,
+        unexpandedCompositesNotReady,
+    };
 }

--- a/packages/doenetml-worker-javascript/src/CompositeReplacementUpdater.ts
+++ b/packages/doenetml-worker-javascript/src/CompositeReplacementUpdater.ts
@@ -5,6 +5,11 @@ import {
     processNewDefiningChildren,
     spliceChildren,
 } from "./ComponentLifecycle";
+import {
+    adjustForCreateComponentIdxName,
+    componentAndRenderedDescendants,
+    expandCompositeComponent,
+} from "./CompositeExpander";
 import { deleteComponents } from "./DeletionEngine";
 import {
     addReplacementsToResolver,
@@ -396,7 +401,10 @@ export class CompositeReplacementUpdater {
                         newReplacementsByComposite[compositeIdx].newComponents;
 
                     if (!composite.isExpanded) {
-                        await this.core.expandCompositeComponent(composite);
+                        await expandCompositeComponent({
+                            core: this.core,
+                            component: composite,
+                        });
 
                         const newChange = {
                             changeType: "addedReplacements",
@@ -453,9 +461,10 @@ export class CompositeReplacementUpdater {
                         });
 
                         const componentsAffected =
-                            await this.core.componentAndRenderedDescendants(
-                                parent,
-                            );
+                            await componentAndRenderedDescendants({
+                                core: this.core,
+                                component: parent,
+                            });
                         componentsAffected.forEach((cIdx: ComponentIdx) =>
                             this.core.updateInfo.componentsToUpdateRenderers.add(
                                 cIdx,
@@ -491,9 +500,10 @@ export class CompositeReplacementUpdater {
                         }
 
                         const componentsAffected =
-                            await this.core.componentAndRenderedDescendants(
-                                parent,
-                            );
+                            await componentAndRenderedDescendants({
+                                core: this.core,
+                                component: parent,
+                            });
                         componentsAffected.forEach((cIdx: ComponentIdx) =>
                             this.core.updateInfo.componentsToUpdateRenderers.add(
                                 cIdx,
@@ -733,8 +743,10 @@ export class CompositeReplacementUpdater {
             // covered by the `parentsOfDeleted` walk inside
             // `_recordDeleteResults`, so it doesn't need this fan-out.
             let parent = this.core._components[composite.parentIdx!];
-            let componentsAffected =
-                await this.core.componentAndRenderedDescendants(parent);
+            let componentsAffected = await componentAndRenderedDescendants({
+                core: this.core,
+                component: parent,
+            });
             componentsAffected.forEach((cIdx: ComponentIdx) =>
                 this.core.updateInfo.componentsToUpdateRenderers.add(cIdx),
             );
@@ -771,8 +783,10 @@ export class CompositeReplacementUpdater {
             parent,
             expandComposites: false,
         });
-        let componentsAffected =
-            await this.core.componentAndRenderedDescendants(parent);
+        let componentsAffected = await componentAndRenderedDescendants({
+            core: this.core,
+            component: parent,
+        });
         componentsAffected.forEach((cIdx: ComponentIdx) =>
             this.core.updateInfo.componentsToUpdateRenderers.add(cIdx),
         );
@@ -906,10 +920,10 @@ export class CompositeReplacementUpdater {
                 shadowingComponent.replacementsWorkspace.replacementsCreated =
                     stateIdInfo.num;
 
-                this.core.adjustForCreateComponentIdxName(
-                    newSerializedReplacements,
-                    shadowingComponent,
-                );
+                adjustForCreateComponentIdxName({
+                    serializedReplacements: newSerializedReplacements,
+                    composite: shadowingComponent,
+                });
 
                 await addReplacementsToResolver({
                     core: this.core,
@@ -1244,8 +1258,10 @@ export class CompositeReplacementUpdater {
     }) {
         for (const parent of deleteResults.parentsOfDeleted) {
             parentsOfDeleted.add(parent.componentIdx);
-            const componentsAffected =
-                await this.core.componentAndRenderedDescendants(parent);
+            const componentsAffected = await componentAndRenderedDescendants({
+                core: this.core,
+                component: parent,
+            });
             componentsAffected.forEach((cIdx: ComponentIdx) =>
                 this.core.updateInfo.componentsToUpdateRenderers.add(cIdx),
             );

--- a/packages/doenetml-worker-javascript/src/Core.ts
+++ b/packages/doenetml-worker-javascript/src/Core.ts
@@ -19,7 +19,6 @@ import { DependencyHandler } from "./Dependencies";
 import { ActionTriggerScheduler } from "./ActionTriggerScheduler";
 import { AutoSubmitManager } from "./AutoSubmitManager";
 import { ComponentBuilder } from "./ComponentBuilder";
-import { CompositeExpander } from "./CompositeExpander";
 import { CompositeReplacementUpdater } from "./CompositeReplacementUpdater";
 import { DiagnosticsManager } from "./DiagnosticsManager";
 import { EssentialValueWriter } from "./EssentialValueWriter";
@@ -109,10 +108,10 @@ export interface CoreInfo {
  * VisibilityTracker, StatePersistence, AutoSubmitManager,
  * RendererInstructionBuilder, ProcessQueue, ActionTriggerScheduler,
  * StateVariableDefinitionFactory, StateVariableInitializer, ComponentBuilder,
- * CompositeExpander, StateVariableEvaluator, StalenessPropagator,
- * EssentialValueWriter, CompositeReplacementUpdater, UpdateExecutor, and the
- * `nameResolver` namespace); others (NavigationHandler, ResolverAdapter,
- * ComponentLifecycle, ChildMatcher, DeletionEngine) are plain module-level
+ * StateVariableEvaluator, StalenessPropagator, EssentialValueWriter,
+ * CompositeReplacementUpdater, UpdateExecutor, and the `nameResolver`
+ * namespace); others (NavigationHandler, ResolverAdapter, ComponentLifecycle,
+ * ChildMatcher, DeletionEngine, CompositeExpander) are plain module-level
  * functions imported directly by callers. Each delegating block still held on
  * Core is grouped near its original location and tagged with a
  * `// → managerName` marker; see the corresponding module for details.
@@ -204,7 +203,6 @@ export default class Core {
     stalenessPropagator: StalenessPropagator;
     essentialValueWriter: EssentialValueWriter;
     componentBuilder: ComponentBuilder;
-    compositeExpander: CompositeExpander;
     compositeReplacementUpdater: CompositeReplacementUpdater;
     updateExecutor: UpdateExecutor;
     statePersistence: StatePersistence;
@@ -375,7 +373,6 @@ export default class Core {
         this.stalenessPropagator = new StalenessPropagator({ core: this });
         this.essentialValueWriter = new EssentialValueWriter({ core: this });
         this.componentBuilder = new ComponentBuilder({ core: this });
-        this.compositeExpander = new CompositeExpander({ core: this });
         this.compositeReplacementUpdater = new CompositeReplacementUpdater({
             core: this,
         });
@@ -744,78 +741,6 @@ export default class Core {
 
     async checkForActionChaining(args: any): Promise<any> {
         return this.actionTriggerScheduler.checkForActionChaining(args);
-    }
-
-    // → compositeExpander
-    async expandAllComposites(
-        component: any,
-        force: boolean = false,
-    ): Promise<any> {
-        return this.compositeExpander.expandAllComposites(component, force);
-    }
-
-    async expandCompositesOfDescendants(
-        component: any,
-        force: boolean = false,
-    ): Promise<any> {
-        return this.compositeExpander.expandCompositesOfDescendants(
-            component,
-            force,
-        );
-    }
-
-    async componentAndRenderedDescendants(
-        component: ComponentInstance,
-    ): Promise<any> {
-        return this.compositeExpander.componentAndRenderedDescendants(
-            component,
-        );
-    }
-
-    async expandCompositeOfDefiningChildren(
-        parent: any,
-        children: any,
-        expandComposites: any,
-        forceExpandComposites: any,
-    ): Promise<any> {
-        return this.compositeExpander.expandCompositeOfDefiningChildren(
-            parent,
-            children,
-            expandComposites,
-            forceExpandComposites,
-        );
-    }
-
-    async expandCompositeComponent(component: ComponentInstance): Promise<any> {
-        return this.compositeExpander.expandCompositeComponent(component);
-    }
-
-    adjustForCreateComponentIdxName(
-        serializedReplacements: any,
-        composite: any,
-    ): any {
-        return this.compositeExpander.adjustForCreateComponentIdxName(
-            serializedReplacements,
-            composite,
-        );
-    }
-
-    async createAndSetReplacements(args: any): Promise<any> {
-        return this.compositeExpander.createAndSetReplacements(args);
-    }
-
-    async replaceCompositeChildren(parent: any): Promise<any> {
-        return this.compositeExpander.replaceCompositeChildren(parent);
-    }
-
-    async changeInactiveComponentAndDescendants(
-        component: any,
-        inactive: any,
-    ): Promise<any> {
-        return this.compositeExpander.changeInactiveComponentAndDescendants(
-            component,
-            inactive,
-        );
     }
 
     async createStateVariableDefinitions(args: any): Promise<any> {

--- a/packages/doenetml-worker-javascript/src/CoreWorker.ts
+++ b/packages/doenetml-worker-javascript/src/CoreWorker.ts
@@ -3,6 +3,7 @@ import { handleNavigatingToComponent } from "./NavigationHandler";
 import { removeFunctionsMathExpressionClass } from "./utils/math";
 import { createComponentInfoObjects } from "./utils/componentInfoObjects";
 export { createComponentInfoObjects } from "./utils/componentInfoObjects";
+export { expandCompositeComponent } from "./CompositeExpander";
 import { returnAllPossibleVariants } from "./utils/returnAllPossibleVariants";
 import {
     FlatFragment,

--- a/packages/doenetml-worker-javascript/src/Dependencies.js
+++ b/packages/doenetml-worker-javascript/src/Dependencies.js
@@ -1,5 +1,9 @@
 import { deriveChildResultsFromDefiningChildren } from "./ChildMatcher";
 import {
+    expandCompositeComponent,
+    recursivelyReplaceCompositesWithReplacements,
+} from "./CompositeExpander";
+import {
     ancestorsIncludingComposites,
     gatherDescendants,
 } from "./utils/descendants";
@@ -2074,9 +2078,10 @@ export class DependencyHandler {
                         return { success: false };
                     }
 
-                    await this.core.expandCompositeComponent(
-                        this._components[componentIdxNewlyResolved],
-                    );
+                    await expandCompositeComponent({
+                        core: this.core,
+                        component: this._components[componentIdxNewlyResolved],
+                    });
                 }
             } else {
                 throw Error(
@@ -6900,17 +6905,13 @@ class ReplacementDependency extends Dependency {
         }
 
         if (this.recursive) {
-            let result =
-                this.dependencyHandler.core.compositeExpander.recursivelyReplaceCompositesWithReplacements(
-                    {
-                        replacements,
-                        recurseNonStandardComposites:
-                            this.recurseNonStandardComposites,
-                        includeWithheldReplacements:
-                            this.includeWithheldReplacements,
-                        stopIfHaveProp: this.stopIfHaveProp,
-                    },
-                );
+            let result = recursivelyReplaceCompositesWithReplacements({
+                core: this.dependencyHandler.core,
+                replacements,
+                recurseNonStandardComposites: this.recurseNonStandardComposites,
+                includeWithheldReplacements: this.includeWithheldReplacements,
+                stopIfHaveProp: this.stopIfHaveProp,
+            });
 
             if (
                 result.unexpandedCompositesNotReady.length > 0 ||

--- a/packages/doenetml-worker-javascript/src/EssentialValueWriter.ts
+++ b/packages/doenetml-worker-javascript/src/EssentialValueWriter.ts
@@ -3,6 +3,7 @@ import type { ComponentInstance } from "./types/componentInstance";
 import type { ComponentIdx } from "@doenet/utils";
 import me from "math-expressions";
 import { processNewDefiningChildren } from "./ComponentLifecycle";
+import { expandAllComposites } from "./CompositeExpander";
 import {
     preprocessMathInverseDefinition,
     removeFunctionsMathExpressionClass,
@@ -84,8 +85,15 @@ export class EssentialValueWriter {
         if (replacementResult.updatedComposites) {
             // make sure the new composite replacements didn't
             // create other composites that have to be expanded
-            await this.core.expandAllComposites(this.core.document);
-            await this.core.expandAllComposites(this.core.document, true);
+            await expandAllComposites({
+                core: this.core,
+                component: this.core.document,
+            });
+            await expandAllComposites({
+                core: this.core,
+                component: this.core.document,
+                force: true,
+            });
 
             if (this.core.updateInfo.stateVariablesToEvaluate) {
                 let stateVariablesToEvaluate =


### PR DESCRIPTION
## Summary

Convert `CompositeExpander` from a class to module-level functions, the second piece of the Phase 5c stateless-manager pass.

- Each method becomes an exported (or module-private) function whose first parameter is `core: Core`.
- Cross-module callers — `ChildMatcher`, `ComponentBuilder`, `CompositeReplacementUpdater`, `EssentialValueWriter`, `Dependencies.js` — import the functions directly.
- Internal helpers (`_finishExpanding`, `expandShadowingComposite`, `addUndisplayableErrorChildrenToAncestor`, `markWithheldReplacementsInactive`) are module-private; the rest are exported.
- The `compositeExpander` field, instantiation, and 8 delegate-only wrappers in `Core.ts` are removed.
- `expandCompositeComponent` is re-exported from the worker-js public surface (`CoreWorker.ts`) so `@doenet/debug-hooks` can call it directly; `debug-hooks/externalPathResolution.ts` updated to use the new named-args shape.

### Follow-up cleanups in this PR

- Stripped stale `//forceExpandComposites: true,` / `//: forceExpandComposites,` / `// throw e;` comment fragments.
- Collapsed dead `nComponents` declaration and a redundant `parent` shadowing.
- Extracted `reserveComponentIndices(core, newNComponents)` helper for the two component-slot reservation sites in `expandCompositeComponent` / `expandShadowingComposite`.
- Removed the now-resolved `targetComponentIdx` deferred entry from `CORE_REFACTOR_DEFERRED.md` (its comment block was deleted in this branch).

## Notes on the typecheck delta

Baseline drops from 277 → 238. Declaring `core: Core` on each function (previously `core: any` via `this.core`) and giving the previously-untyped destructure parameters explicit `any` shed 39 implicit-any errors. One TS2345 message text shifts from `replacements: any` → `replacements: any[]` — same underlying mismatch with `verifyReplacementsMatchSpecifiedType`'s declared signature, just rendered with a slightly tighter type.

## Test plan

- [x] `pnpm typecheck` — 238 (down from 277, no new errors).
- [x] Targeted vitest: external_references, calcStartEndIdx, sectioning, group, stickygroup — 54 passing.
- [x] `debug-hooks` typecheck against the rebuilt worker-js dist — clean.
- [x] Full vitest + Cypress in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)