### PR TITLE
refactor(worker-javascript): ComponentBuilder → module functions

### DIFF
--- a/packages/doenetml-worker-javascript/src/ChildMatcher.ts
+++ b/packages/doenetml-worker-javascript/src/ChildMatcher.ts
@@ -1,5 +1,6 @@
 import type Core from "./Core";
 import { assignDoenetMLRange } from "@doenet/utils";
+import { createIsolatedComponents } from "./ComponentBuilder";
 import {
     expandCompositeOfDefiningChildren,
     replaceCompositeChildren,
@@ -506,7 +507,8 @@ export async function substituteAdapter({
                 originalChild.position,
                 originalChild.sourceDoc,
             );
-            let newChildrenResult = await core.createIsolatedComponents({
+            let newChildrenResult = await createIsolatedComponents({
+                core,
                 serializedComponents: [newSerializedChild],
                 shadow: true,
                 ancestors: originalChild.ancestors,

--- a/packages/doenetml-worker-javascript/src/ComponentBuilder.ts
+++ b/packages/doenetml-worker-javascript/src/ComponentBuilder.ts
@@ -23,395 +23,392 @@ import { extractCreateComponentIdxMapping } from "./utils/componentIndices";
  * state-variable definitions.
  *
  * The expansion of composite components into their replacements is the
- * responsibility of `CompositeExpander` (mutual recursion is expected;
- * cross-calls go through Core's delegators).
+ * responsibility of `CompositeExpander` (mutual recursion is expected).
  *
- * Holds a back-reference to Core to read the hot fields
- * (`_components`, `componentInfoObjects`, `parameterStack`, `dependencies`,
- * `updateInfo`, `numerics`, `flags`, `coreFunctions`, `document`,
- * `componentIdxByStateId`, `nTimesAddedComponents`, `rootNames`,
- * `createComponentIdxMapping`, `errorComponentsToAdd`, `initialAddPhase`)
- * and to dispatch through the other extracted managers.
+ * Stateless — each function takes a back-reference to Core to read the
+ * hot fields (`_components`, `componentInfoObjects`, `parameterStack`,
+ * `dependencies`, `updateInfo`, `numerics`, `flags`, `coreFunctions`,
+ * `document`, `componentIdxByStateId`, `nTimesAddedComponents`,
+ * `rootNames`, `createComponentIdxMapping`, `errorComponentsToAdd`,
+ * `initialAddPhase`) and to dispatch through the other extracted managers.
  */
-export class ComponentBuilder {
-    core: Core;
 
-    constructor({ core }: { core: Core }) {
-        this.core = core;
+export async function addComponents({
+    core,
+    serializedComponents,
+    parentIdx,
+    indexOfDefiningChildren,
+    initialAdd = false,
+}: {
+    core: Core;
+    serializedComponents: any;
+    parentIdx?: any;
+    indexOfDefiningChildren?: any;
+    initialAdd?: boolean;
+}) {
+    core.initialAddPhase = initialAdd;
+
+    if (!Array.isArray(serializedComponents)) {
+        serializedComponents = [serializedComponents];
     }
 
-    async addComponents({
-        serializedComponents,
-        parentIdx,
-        indexOfDefiningChildren,
-        initialAdd = false,
-    }) {
-        this.core.initialAddPhase = initialAdd;
+    let parent;
+    let ancestors: any[] = [];
 
-        if (!Array.isArray(serializedComponents)) {
-            serializedComponents = [serializedComponents];
-        }
-
-        let parent;
-        let ancestors = [];
-
-        if (!initialAdd) {
-            parent = this.core._components[parentIdx];
-            if (!parent) {
-                this.core.addDiagnostic({
-                    type: "warning",
-                    message: `Cannot add children to parent ${parentIdx} as ${parentIdx} does not exist`,
-                });
-                return [];
-            }
-
-            ancestors = [
-                {
-                    componentIdx: parentIdx,
-                    componentClass: parent.constructor,
-                },
-                ...parent.ancestors,
-            ];
-
-            this.core.parameterStack.push(parent.sharedParameters, false);
-
-            this.core.nTimesAddedComponents =
-                (this.core.nTimesAddedComponents ?? 0) + 1;
-
-            addComponentsToResolver({
-                core: this.core,
-                components: serializedComponents,
-                parentIdx,
+    if (!initialAdd) {
+        parent = core._components[parentIdx];
+        if (!parent) {
+            core.addDiagnostic({
+                type: "warning",
+                message: `Cannot add children to parent ${parentIdx} as ${parentIdx} does not exist`,
             });
+            return [];
         }
-        let createResult = await this.createIsolatedComponents({
-            serializedComponents,
-            ancestors,
+
+        ancestors = [
+            {
+                componentIdx: parentIdx,
+                componentClass: parent.constructor,
+            },
+            ...parent.ancestors,
+        ];
+
+        core.parameterStack.push(parent.sharedParameters, false);
+
+        core.nTimesAddedComponents = (core.nTimesAddedComponents ?? 0) + 1;
+
+        addComponentsToResolver({
+            core,
+            components: serializedComponents,
+            parentIdx,
         });
-        if (!initialAdd) {
-            this.core.parameterStack.pop();
+    }
+    let createResult = await createIsolatedComponents({
+        core,
+        serializedComponents,
+        ancestors,
+    });
+    if (!initialAdd) {
+        core.parameterStack.pop();
+    }
+
+    const newComponents = createResult.components;
+
+    let deletedComponents: Record<string, any> = {};
+    let addedComponents: Record<string, any> = {};
+    newComponents.forEach((x: any) => (addedComponents[x.componentIdx] = x));
+
+    if (initialAdd) {
+        if (newComponents.length !== 1) {
+            throw Error(
+                "Initial components need to be an array of just one component.",
+            );
+        }
+        core.document = newComponents[0];
+
+        await _expandAllCompositesBothPasses(core);
+        await _drainStateVariablesToEvaluate(core);
+
+        await addQueuedErrorComponentsFromStateVariables({ core });
+
+        await core.replacementChangesFromCompositesToUpdate();
+
+        let results = await core.initializeRenderedComponentInstruction(
+            core.document,
+        );
+
+        if (core.errorComponentsToAdd.length > 0) {
+            await addQueuedErrorComponentsFromStateVariables({ core });
+
+            // Adding queued _error components can touch composites and alter
+            // what needs to be rendered from the document root.
+            await core.replacementChangesFromCompositesToUpdate();
+
+            results = await core.initializeRenderedComponentInstruction(
+                core.document,
+            );
         }
 
-        const newComponents = createResult.components;
+        core.documentRendererInstructions = results.componentToRender;
 
-        let deletedComponents = {};
-        let addedComponents = {};
-        newComponents.forEach((x) => (addedComponents[x.componentIdx] = x));
+        let updateInstructions = [
+            {
+                instructionType: "updateRendererStates",
+                rendererStatesToUpdate: results.rendererStatesToUpdate,
+            },
+        ];
 
-        if (initialAdd) {
-            if (newComponents.length !== 1) {
-                throw Error(
-                    "Initial components need to be an array of just one component.",
-                );
-            }
-            this.core.document = newComponents[0];
+        core.callUpdateRenderers({ updateInstructions }, true);
 
-            await this._expandAllCompositesBothPasses();
-            await this._drainStateVariablesToEvaluate();
-
-            await this.addQueuedErrorComponentsFromStateVariables();
-
-            await this.core.replacementChangesFromCompositesToUpdate();
-
-            let results =
-                await this.core.initializeRenderedComponentInstruction(
-                    this.core.document,
-                );
-
-            if (this.core.errorComponentsToAdd.length > 0) {
-                await this.addQueuedErrorComponentsFromStateVariables();
-
-                // Adding queued _error components can touch composites and alter
-                // what needs to be rendered from the document root.
-                await this.core.replacementChangesFromCompositesToUpdate();
-
-                results =
-                    await this.core.initializeRenderedComponentInstruction(
-                        this.core.document,
-                    );
-            }
-
-            this.core.documentRendererInstructions = results.componentToRender;
-
+        // if have some states to force update
+        // then post these updates without setting init to true
+        if (results.rendererStatesToForceUpdate.length > 0) {
             let updateInstructions = [
                 {
                     instructionType: "updateRendererStates",
-                    rendererStatesToUpdate: results.rendererStatesToUpdate,
+                    rendererStatesToUpdate: results.rendererStatesToForceUpdate,
                 },
             ];
-
-            this.core.callUpdateRenderers({ updateInstructions }, true);
-
-            // if have some states to force update
-            // then post these updates without setting init to true
-            if (results.rendererStatesToForceUpdate.length > 0) {
-                let updateInstructions = [
-                    {
-                        instructionType: "updateRendererStates",
-                        rendererStatesToUpdate:
-                            results.rendererStatesToForceUpdate,
-                    },
-                ];
-                this.core.callUpdateRenderers({ updateInstructions });
-            }
-
-            // initializing renderer instructions could trigger more composite updates
-            // (presumably from deriving child results)
-            // if so, make replacement changes and update renderer instructions again
-            // TODO: should we check for child results earlier so we don't have to check them
-            // when updating renderer instructions?
-            await this._drainCompositesToUpdateReplacements();
-
-            await this.core.processStateVariableTriggers(true);
-        } else {
-            if (parent === undefined) {
-                throw Error("Must specify parent when adding components.");
-            }
-            if (indexOfDefiningChildren === undefined) {
-                indexOfDefiningChildren = parent.definingChildren.length;
-            }
-
-            let addResults = await addChildrenAndRecurseToShadows({
-                core: this.core,
-                parent,
-                indexOfDefiningChildren: indexOfDefiningChildren,
-                newChildren: newComponents,
-            });
-            if (!addResults.success) {
-                throw Error(
-                    "Couldn't satisfy child logic result.  Need informative error message",
-                );
-            }
-            Object.assign(addedComponents, addResults.addedComponents);
-            Object.assign(deletedComponents, addResults.deletedComponents);
-
-            await this._expandAllCompositesBothPasses();
-            await this._drainStateVariablesToEvaluate();
-            await this.core.replacementChangesFromCompositesToUpdate();
-
-            await this.core.updateRendererInstructions({
-                componentNamesToUpdate: await componentAndRenderedDescendants({
-                    core: this.core,
-                    component: parent,
-                }),
-            });
-
-            // updating renderer instructions could trigger more composite updates
-            // (presumably from deriving child results)
-            // if so, make replacement changes and update renderer instructions again
-            // TODO: should we check for child results earlier so we don't have to check them
-            // when updating renderer instructions?
-            await this._drainCompositesToUpdateReplacements();
-
-            await this.core.processStateVariableTriggers(true);
+            core.callUpdateRenderers({ updateInstructions });
         }
 
-        this.core.initialAddPhase = false;
-        return newComponents;
+        // initializing renderer instructions could trigger more composite updates
+        // (presumably from deriving child results)
+        // if so, make replacement changes and update renderer instructions again
+        // TODO: should we check for child results earlier so we don't have to check them
+        // when updating renderer instructions?
+        await _drainCompositesToUpdateReplacements(core);
+
+        await core.processStateVariableTriggers(true);
+    } else {
+        if (parent === undefined) {
+            throw Error("Must specify parent when adding components.");
+        }
+        if (indexOfDefiningChildren === undefined) {
+            indexOfDefiningChildren = parent.definingChildren.length;
+        }
+
+        let addResults = await addChildrenAndRecurseToShadows({
+            core,
+            parent,
+            indexOfDefiningChildren: indexOfDefiningChildren,
+            newChildren: newComponents,
+        });
+        if (!addResults.success) {
+            throw Error(
+                "Couldn't satisfy child logic result.  Need informative error message",
+            );
+        }
+        Object.assign(addedComponents, addResults.addedComponents);
+        Object.assign(deletedComponents, addResults.deletedComponents);
+
+        await _expandAllCompositesBothPasses(core);
+        await _drainStateVariablesToEvaluate(core);
+        await core.replacementChangesFromCompositesToUpdate();
+
+        await core.updateRendererInstructions({
+            componentNamesToUpdate: await componentAndRenderedDescendants({
+                core,
+                component: parent,
+            }),
+        });
+
+        // updating renderer instructions could trigger more composite updates
+        // (presumably from deriving child results)
+        // if so, make replacement changes and update renderer instructions again
+        // TODO: should we check for child results earlier so we don't have to check them
+        // when updating renderer instructions?
+        await _drainCompositesToUpdateReplacements(core);
+
+        await core.processStateVariableTriggers(true);
     }
 
-    async createIsolatedComponents({
-        serializedComponents,
-        ancestors,
-        shadow = false,
-        componentsReplacementOf,
-    }) {
-        const newComponents = [];
+    core.initialAddPhase = false;
+    return newComponents;
+}
 
-        let lastErrorMessage = "";
+export async function createIsolatedComponents({
+    core,
+    serializedComponents,
+    ancestors,
+    shadow = false,
+    componentsReplacementOf,
+}: {
+    core: Core;
+    serializedComponents: any;
+    ancestors: any;
+    shadow?: boolean;
+    componentsReplacementOf?: any;
+}) {
+    const newComponents: any[] = [];
 
-        const res = extractCreateComponentIdxMapping(serializedComponents);
-        Object.assign(
-            this.core.createComponentIdxMapping,
-            res.createComponentIdxMapping,
-        );
+    let lastErrorMessage = "";
 
-        for (let serializedComponent of serializedComponents) {
-            if (typeof serializedComponent !== "object") {
-                newComponents.push(serializedComponent);
-                continue;
-            }
+    const res = extractCreateComponentIdxMapping(serializedComponents);
+    Object.assign(
+        core.createComponentIdxMapping,
+        res.createComponentIdxMapping,
+    );
 
-            let componentClass =
-                this.core.componentInfoObjects.allComponentClasses[
+    for (let serializedComponent of serializedComponents) {
+        if (typeof serializedComponent !== "object") {
+            newComponents.push(serializedComponent);
+            continue;
+        }
+
+        let componentClass =
+            core.componentInfoObjects.allComponentClasses[
+                serializedComponent.componentType
+            ];
+        if (componentClass === undefined) {
+            // Note: This error shouldn't get reached from author-typed code,
+            // as it should get caught by the correctComponentTypeCapitalization function.
+            // However, it could get called from Javascript if developers
+            // create a serialized component that doesn't exist.
+            const message = `Invalid component type: \`<${serializedComponent.componentType}>\`.`;
+
+            core.diagnosticsManager.markPending();
+
+            const convertResult = convertToErrorComponent(
+                serializedComponent,
+                message,
+            );
+            serializedComponent = convertResult.component;
+
+            lastErrorMessage = message;
+
+            componentClass =
+                core.componentInfoObjects.allComponentClasses[
                     serializedComponent.componentType
                 ];
-            if (componentClass === undefined) {
-                // Note: This error shouldn't get reached from author-typed code,
-                // as it should get caught by the correctComponentTypeCapitalization function.
-                // However, it could get called from Javascript if developers
-                // create a serialized component that doesn't exist.
-                const message = `Invalid component type: \`<${serializedComponent.componentType}>\`.`;
-
-                this.core.diagnosticsManager.markPending();
-
-                const convertResult = convertToErrorComponent(
-                    serializedComponent,
-                    message,
-                );
-                serializedComponent = convertResult.component;
-
-                lastErrorMessage = message;
-
-                componentClass =
-                    this.core.componentInfoObjects.allComponentClasses[
-                        serializedComponent.componentType
-                    ];
-            }
-
-            if (!serializedComponent.doenetAttributes) {
-                serializedComponent.doenetAttributes = {};
-            }
-
-            let componentIdx = serializedComponent.componentIdx;
-            if (componentIdx === undefined) {
-                throw Error(
-                    "Found a serialized component without a componentIdx",
-                    serializedComponent,
-                );
-            }
-
-            const createResult = await this.createChildrenThenComponent({
-                serializedComponent,
-                componentIdx,
-                ancestors,
-                componentClass,
-                shadow,
-                componentsReplacementOf,
-            });
-
-            const newComponent = createResult.newComponent;
-            newComponents.push(newComponent);
-
-            if (createResult.lastErrorMessage) {
-                lastErrorMessage = createResult.lastErrorMessage;
-            }
         }
 
-        let results = {
-            components: newComponents,
-            lastErrorMessage,
-        };
-
-        return results;
-    }
-
-    async createChildrenThenComponent({
-        serializedComponent,
-        componentIdx,
-        ancestors,
-        componentClass,
-        shadow = false,
-        componentsReplacementOf,
-    }) {
-        let lastErrorMessage = "";
-        let lastErrorMessageFromAttribute = "";
-
-        if (!(Number.isInteger(componentIdx) && componentIdx >= 0)) {
-            throw Error(`Found an invalid componentIdx: ${componentIdx}`);
+        if (!serializedComponent.doenetAttributes) {
+            serializedComponent.doenetAttributes = {};
         }
 
-        if (this.core._components[componentIdx] !== undefined) {
-            console.log(
-                this.core._components[componentIdx],
+        let componentIdx = serializedComponent.componentIdx;
+        if (componentIdx === undefined) {
+            throw Error(
+                "Found a serialized component without a componentIdx",
                 serializedComponent,
             );
-            throw Error(`Found a duplicate componentIdx: ${componentIdx}`);
         }
 
-        const serializedChildren = serializedComponent.children;
-        let definingChildren = [];
-        const childrenToRemainSerialized = [];
+        const createResult = await createChildrenThenComponent({
+            core,
+            serializedComponent,
+            componentIdx,
+            ancestors,
+            componentClass,
+            shadow,
+            componentsReplacementOf,
+        });
 
-        const ancestorsForChildren = [
-            { componentIdx, componentClass },
-            ...ancestors,
-        ];
+        const newComponent = createResult.newComponent;
+        newComponents.push(newComponent);
 
-        const parentSharedParameters = this.core.parameterStack.parameters;
-        this.core.parameterStack.push();
-        const sharedParameters = this.core.parameterStack.parameters;
+        if (createResult.lastErrorMessage) {
+            lastErrorMessage = createResult.lastErrorMessage;
+        }
+    }
 
-        if (
-            componentClass.descendantCompositesMustHaveAReplacement &&
-            !shadow
-        ) {
-            sharedParameters.compositesMustHaveAReplacement = true;
-            sharedParameters.compositesDefaultReplacementType =
-                componentClass.descendantCompositesDefaultReplacementType;
-        } else if (
-            componentClass.descendantCompositesMustHaveAReplacement === false ||
-            shadow
-        ) {
-            sharedParameters.compositesMustHaveAReplacement = false;
+    let results = {
+        components: newComponents,
+        lastErrorMessage,
+    };
+
+    return results;
+}
+
+export async function createChildrenThenComponent({
+    core,
+    serializedComponent,
+    componentIdx,
+    ancestors,
+    componentClass,
+    shadow = false,
+    componentsReplacementOf,
+}: {
+    core: Core;
+    serializedComponent: any;
+    componentIdx: any;
+    ancestors: any;
+    componentClass: any;
+    shadow?: boolean;
+    componentsReplacementOf?: any;
+}) {
+    let lastErrorMessage = "";
+    let lastErrorMessageFromAttribute = "";
+
+    if (!(Number.isInteger(componentIdx) && componentIdx >= 0)) {
+        throw Error(`Found an invalid componentIdx: ${componentIdx}`);
+    }
+
+    if (core._components[componentIdx] !== undefined) {
+        console.log(core._components[componentIdx], serializedComponent);
+        throw Error(`Found a duplicate componentIdx: ${componentIdx}`);
+    }
+
+    const serializedChildren = serializedComponent.children;
+    let definingChildren: any[] = [];
+    const childrenToRemainSerialized: any[] = [];
+
+    const ancestorsForChildren = [
+        { componentIdx, componentClass },
+        ...ancestors,
+    ];
+
+    const parentSharedParameters = core.parameterStack.parameters;
+    core.parameterStack.push();
+    const sharedParameters = core.parameterStack.parameters;
+
+    if (componentClass.descendantCompositesMustHaveAReplacement && !shadow) {
+        sharedParameters.compositesMustHaveAReplacement = true;
+        sharedParameters.compositesDefaultReplacementType =
+            componentClass.descendantCompositesDefaultReplacementType;
+    } else if (
+        componentClass.descendantCompositesMustHaveAReplacement === false ||
+        shadow
+    ) {
+        sharedParameters.compositesMustHaveAReplacement = false;
+    }
+
+    if (serializedChildren !== undefined) {
+        if (componentClass.preprocessSerializedChildren) {
+            componentClass.preprocessSerializedChildren({
+                serializedChildren,
+                attributes: serializedComponent.attributes,
+                componentIdx,
+            });
         }
 
-        if (serializedChildren !== undefined) {
-            if (componentClass.preprocessSerializedChildren) {
-                componentClass.preprocessSerializedChildren({
-                    serializedChildren,
-                    attributes: serializedComponent.attributes,
-                    componentIdx,
-                });
+        if (componentClass.setUpVariant) {
+            const descendantVariantComponents = gatherVariantComponents({
+                serializedComponents: serializedChildren,
+                componentInfoObjects: core.componentInfoObjects,
+            });
+
+            componentClass.setUpVariant({
+                serializedComponent,
+                sharedParameters,
+                descendantVariantComponents,
+            });
+        }
+
+        if (componentClass.keepChildrenSerialized) {
+            const childrenAddressed = new Set<number>([]);
+
+            const keepSerializedInds = componentClass.keepChildrenSerialized({
+                serializedComponent,
+                componentInfoObjects: core.componentInfoObjects,
+            });
+
+            for (const ind of keepSerializedInds) {
+                if (childrenAddressed.has(Number(ind))) {
+                    throw Error(
+                        "Invalid instructions to keep children serialized from " +
+                            componentClass.componentType +
+                            ": child repeated",
+                    );
+                }
+                childrenAddressed.add(Number(ind));
+                childrenToRemainSerialized.push(serializedChildren[ind]);
             }
 
-            if (componentClass.setUpVariant) {
-                const descendantVariantComponents = gatherVariantComponents({
-                    serializedComponents: serializedChildren,
-                    componentInfoObjects: this.core.componentInfoObjects,
-                });
-
-                componentClass.setUpVariant({
-                    serializedComponent,
-                    sharedParameters,
-                    descendantVariantComponents,
-                });
+            const childrenToCreate: any[] = [];
+            for (const [ind, child] of serializedChildren.entries() as Iterable<
+                [number, any]
+            >) {
+                if (!childrenAddressed.has(ind)) {
+                    childrenToCreate.push(child);
+                }
             }
 
-            if (componentClass.keepChildrenSerialized) {
-                const childrenAddressed = new Set([]);
-
-                const keepSerializedInds =
-                    componentClass.keepChildrenSerialized({
-                        serializedComponent,
-                        componentInfoObjects: this.core.componentInfoObjects,
-                    });
-
-                for (const ind of keepSerializedInds) {
-                    if (childrenAddressed.has(Number(ind))) {
-                        throw Error(
-                            "Invalid instructions to keep children serialized from " +
-                                componentClass.componentType +
-                                ": child repeated",
-                        );
-                    }
-                    childrenAddressed.add(Number(ind));
-                    childrenToRemainSerialized.push(serializedChildren[ind]);
-                }
-
-                const childrenToCreate = [];
-                for (const [ind, child] of serializedChildren.entries()) {
-                    if (!childrenAddressed.has(ind)) {
-                        childrenToCreate.push(child);
-                    }
-                }
-
-                if (childrenToCreate.length > 0) {
-                    const childrenResult = await this.createIsolatedComponents({
-                        serializedComponents: childrenToCreate,
-                        ancestors: ancestorsForChildren,
-                        shadow,
-                        componentsReplacementOf,
-                    });
-
-                    definingChildren = childrenResult.components;
-                    if (childrenResult.lastErrorMessage) {
-                        lastErrorMessage = childrenResult.lastErrorMessage;
-                    }
-                }
-            } else {
-                const childrenResult = await this.createIsolatedComponents({
-                    serializedComponents: serializedChildren,
+            if (childrenToCreate.length > 0) {
+                const childrenResult = await createIsolatedComponents({
+                    core,
+                    serializedComponents: childrenToCreate,
                     ancestors: ancestorsForChildren,
                     shadow,
                     componentsReplacementOf,
@@ -422,55 +419,41 @@ export class ComponentBuilder {
                     lastErrorMessage = childrenResult.lastErrorMessage;
                 }
             }
+        } else {
+            const childrenResult = await createIsolatedComponents({
+                core,
+                serializedComponents: serializedChildren,
+                ancestors: ancestorsForChildren,
+                shadow,
+                componentsReplacementOf,
+            });
+
+            definingChildren = childrenResult.components;
+            if (childrenResult.lastErrorMessage) {
+                lastErrorMessage = childrenResult.lastErrorMessage;
+            }
         }
+    }
 
-        let attributes = {};
+    let attributes: Record<string, any> = {};
 
-        if (serializedComponent.attributes) {
-            for (const attrName in serializedComponent.attributes) {
-                const attribute = serializedComponent.attributes[attrName];
+    if (serializedComponent.attributes) {
+        for (const attrName in serializedComponent.attributes) {
+            const attribute = serializedComponent.attributes[attrName];
 
-                if (attribute.component) {
-                    if (attrName === componentClass.addAttributeToResolver) {
-                        addComponentsToResolver({
-                            core: this.core,
-                            components: [attribute.component],
-                            parentIdx: serializedComponent.componentIdx,
-                        });
-                    }
+            if (attribute.component) {
+                if (attrName === componentClass.addAttributeToResolver) {
+                    addComponentsToResolver({
+                        core,
+                        components: [attribute.component],
+                        parentIdx: serializedComponent.componentIdx,
+                    });
+                }
 
-                    try {
-                        const attrResult = await this.createIsolatedComponents({
-                            serializedComponents: [attribute.component],
-                            ancestors: ancestorsForChildren,
-                            shadow,
-                            componentsReplacementOf,
-                        });
-
-                        if (attrResult.lastErrorMessage) {
-                            lastErrorMessage = attrResult.lastErrorMessage;
-                            lastErrorMessageFromAttribute =
-                                attrResult.lastErrorMessage;
-                        }
-
-                        attributes[attrName] = {
-                            component: attrResult.components[0],
-                        };
-                    } catch (e) {
-                        console.error(e);
-                        if (e.message.includes("Circular dependency")) {
-                            throw Error(
-                                this.core.dependencies.getCircularDependencyMessage(
-                                    [serializedComponent],
-                                ),
-                            );
-                        } else {
-                            throw e;
-                        }
-                    }
-                } else if (attribute.references) {
-                    const attrResult = await this.createIsolatedComponents({
-                        serializedComponents: attribute.references,
+                try {
+                    const attrResult = await createIsolatedComponents({
+                        core,
+                        serializedComponents: [attribute.component],
                         ancestors: ancestorsForChildren,
                         shadow,
                         componentsReplacementOf,
@@ -483,495 +466,517 @@ export class ComponentBuilder {
                     }
 
                     attributes[attrName] = {
-                        references: attrResult.components,
-                        stringChildren: attribute.stringChildren,
+                        component: attrResult.components[0],
                     };
-                } else {
-                    attributes[attrName] =
-                        serializedComponent.attributes[attrName];
+                } catch (e: any) {
+                    console.error(e);
+                    if (e.message.includes("Circular dependency")) {
+                        throw Error(
+                            core.dependencies.getCircularDependencyMessage([
+                                serializedComponent,
+                            ]),
+                        );
+                    } else {
+                        throw e;
+                    }
                 }
+            } else if (attribute.references) {
+                const attrResult = await createIsolatedComponents({
+                    core,
+                    serializedComponents: attribute.references,
+                    ancestors: ancestorsForChildren,
+                    shadow,
+                    componentsReplacementOf,
+                });
+
+                if (attrResult.lastErrorMessage) {
+                    lastErrorMessage = attrResult.lastErrorMessage;
+                    lastErrorMessageFromAttribute = attrResult.lastErrorMessage;
+                }
+
+                attributes[attrName] = {
+                    references: attrResult.components,
+                    stringChildren: attribute.stringChildren,
+                };
+            } else {
+                attributes[attrName] = serializedComponent.attributes[attrName];
             }
         }
+    }
 
-        let refResolution = null;
-        if (serializedComponent.extending) {
-            refResolution = unwrapSource(serializedComponent.extending);
+    let refResolution: any = null;
+    if (serializedComponent.extending) {
+        refResolution = unwrapSource(serializedComponent.extending);
 
-            const nodeIdx = refResolution.nodeIdx;
+        const nodeIdx = refResolution.nodeIdx;
 
-            const originalPath = [];
-            for (const pathPart of refResolution.originalPath) {
-                const index = [];
-                for (const indexPiece of pathPart.index) {
-                    const valueResult = await this.createIsolatedComponents({
-                        serializedComponents: indexPiece.value,
-                        ancestors: ancestorsForChildren,
-                        shadow,
-                        componentsReplacementOf,
-                    });
-                    if (valueResult.lastErrorMessage) {
-                        lastErrorMessage = valueResult.lastErrorMessage;
-                    }
-                    const value = valueResult.components;
-                    index.push({
-                        value,
-                        position: indexPiece.position,
-                        sourceDoc: indexPiece.sourceDoc,
-                    });
+        const originalPath: any[] = [];
+        for (const pathPart of refResolution.originalPath) {
+            const index: any[] = [];
+            for (const indexPiece of pathPart.index) {
+                const valueResult = await createIsolatedComponents({
+                    core,
+                    serializedComponents: indexPiece.value,
+                    ancestors: ancestorsForChildren,
+                    shadow,
+                    componentsReplacementOf,
+                });
+                if (valueResult.lastErrorMessage) {
+                    lastErrorMessage = valueResult.lastErrorMessage;
                 }
-                originalPath.push({
-                    name: pathPart.name,
-                    index,
-                    position: pathPart.position,
-                    sourceDoc: pathPart.sourceDoc,
+                const value = valueResult.components;
+                index.push({
+                    value,
+                    position: indexPiece.position,
+                    sourceDoc: indexPiece.sourceDoc,
                 });
             }
-            refResolution = {
-                nodeIdx,
-                unresolvedPath: refResolution.unresolvedPath,
-                originalPath,
-                nodesInResolvedPath: refResolution.nodesInResolvedPath,
-            };
-        }
-
-        if (serializedComponent.componentType === "_error") {
-            lastErrorMessage = serializedComponent.state.message;
-
-            this.core.addDiagnostic({
-                type: "error",
-                message: serializedComponent.state.message,
-                position: serializedComponent.position,
-                sourceDoc: serializedComponent.sourceDoc,
+            originalPath.push({
+                name: pathPart.name,
+                index,
+                position: pathPart.position,
+                sourceDoc: pathPart.sourceDoc,
             });
-        } else if (
-            lastErrorMessageFromAttribute ||
-            (lastErrorMessage && !componentClass.canDisplayChildErrors)
-        ) {
-            // We have to deal with two special cases where errors wouldn't be displayed:
-            // 1. there is an error message from an attribute, or
-            // 2. this component cannot display errors from children
-            // In these cases, we turn this component into an error component
-            // to ensure the error message is displayed.
-
-            const convertResult = convertToErrorComponent(
-                serializedComponent,
-                lastErrorMessageFromAttribute || lastErrorMessage,
-            );
-            serializedComponent = convertResult.component;
-
-            attributes = {};
-            componentClass =
-                this.core.componentInfoObjects.allComponentClasses[
-                    serializedComponent.componentType
-                ];
         }
+        refResolution = {
+            nodeIdx,
+            unresolvedPath: refResolution.unresolvedPath,
+            originalPath,
+            nodesInResolvedPath: refResolution.nodesInResolvedPath,
+        };
+    }
 
-        const prescribedDependencies = {};
+    if (serializedComponent.componentType === "_error") {
+        lastErrorMessage = serializedComponent.state.message;
 
-        if (serializedComponent.downstreamDependencies) {
-            for (const idxStr in serializedComponent.downstreamDependencies) {
-                const idx = Number(idxStr);
-                if (idx === componentIdx) {
-                    throw Error(
-                        this.core.dependencies.getCircularDependencyMessage([
-                            serializedComponent,
-                        ]),
-                    );
-                }
-                if (this.core._components[idx]) {
-                    prescribedDependencies[idx] =
-                        serializedComponent.downstreamDependencies[idx];
-                } else {
-                    throw Error(
-                        this.core.dependencies.getCircularDependencyMessage([
-                            serializedComponent,
-                        ]),
-                    );
-                }
-            }
-        }
+        core.addDiagnostic({
+            type: "error",
+            message: serializedComponent.state.message,
+            position: serializedComponent.position,
+            sourceDoc: serializedComponent.sourceDoc,
+        });
+    } else if (
+        lastErrorMessageFromAttribute ||
+        (lastErrorMessage && !componentClass.canDisplayChildErrors)
+    ) {
+        // We have to deal with two special cases where errors wouldn't be displayed:
+        // 1. there is an error message from an attribute, or
+        // 2. this component cannot display errors from children
+        // In these cases, we turn this component into an error component
+        // to ensure the error message is displayed.
 
-        const stateVariableDefinitions =
-            await this.core.createStateVariableDefinitions({
-                componentClass,
-                prescribedDependencies,
-                componentIdx,
-            });
-
-        // In case a component with the same idx was deleted before, clear it
-        // from the deleted-tracking maps so the new component isn't shadowed
-        // by the prior tombstone.
-        delete this.core.updateInfo.deletedComponents[componentIdx];
-        delete this.core.updateInfo.deletedStateVariables[componentIdx];
-
-        const stateId = serializedComponent.stateId ?? componentIdx.toString();
-        this.core.componentIdxByStateId[stateId] = componentIdx;
-
-        const newComponent = new componentClass({
-            componentIdx,
-            stateId,
-            rootName:
-                this.core.rootNames?.[componentIdx] ??
-                "_id_" + componentIdx.toString(),
-            ancestors,
-            definingChildren,
-            stateVariableDefinitions,
-            serializedChildren: childrenToRemainSerialized,
+        const convertResult = convertToErrorComponent(
             serializedComponent,
-            attributes,
-            componentInfoObjects: this.core.componentInfoObjects,
-            coreFunctions: this.core.coreFunctions,
-            flags: this.core.flags,
-            shadow,
-            numerics: this.core.numerics,
-            sharedParameters,
-            parentSharedParameters,
-            refResolution,
-        });
+            lastErrorMessageFromAttribute || lastErrorMessage,
+        );
+        serializedComponent = convertResult.component;
 
-        registerComponent({ core: this.core, component: newComponent });
+        attributes = {};
+        componentClass =
+            core.componentInfoObjects.allComponentClasses[
+                serializedComponent.componentType
+            ];
+    }
 
-        if (componentsReplacementOf) {
-            newComponent.replacementOf = componentsReplacementOf;
-        }
+    const prescribedDependencies: Record<string, any> = {};
 
-        if (serializedComponent.adaptedFrom) {
-            // record adapter relationship
-            newComponent.adaptedFrom =
-                this.core._components[serializedComponent.adaptedFrom];
-            newComponent.adaptedFrom.adapterUsed = newComponent;
-        }
-
-        for (const idxStr in prescribedDependencies) {
+    if (serializedComponent.downstreamDependencies) {
+        for (const idxStr in serializedComponent.downstreamDependencies) {
             const idx = Number(idxStr);
-            const depArray = prescribedDependencies[idx];
-            for (const dep of depArray) {
-                if (dep.dependencyType === "referenceShadow") {
-                    const shadowInfo = {
-                        componentIdx: idx,
-                    };
-                    Object.assign(shadowInfo, dep);
-                    delete shadowInfo.dependencyType;
-                    newComponent.shadows = shadowInfo;
-
-                    if (dep.firstLevelReplacement) {
-                        newComponent.firstLevelReplacement = true;
-                    }
-
-                    const shadowedComponent = this.core._components[idx];
-                    if (!shadowedComponent.shadowedBy) {
-                        shadowedComponent.shadowedBy = [];
-                    }
-                    shadowedComponent.shadowedBy.push(newComponent);
-
-                    const mediatingShadowComposite =
-                        this.core._components[shadowInfo.compositeIdx];
-                    if (!mediatingShadowComposite.mediatesShadows) {
-                        mediatingShadowComposite.mediatesShadows = [];
-                    }
-                    mediatingShadowComposite.mediatesShadows.push({
-                        shadowing: newComponent.componentIdx,
-                        shadowed: idx,
-                        propVariable: dep.propVariable,
-                    });
-
-                    if (dep.isPrimaryShadow) {
-                        shadowedComponent.primaryShadow =
-                            newComponent.componentIdx;
-
-                        if (
-                            this.core.dependencies.updateTriggers
-                                .primaryShadowDependencies[idx]
-                        ) {
-                            for (const dep of this.core.dependencies
-                                .updateTriggers.primaryShadowDependencies[
-                                idx
-                            ]) {
-                                await dep.recalculateDownstreamComponents();
-                            }
-                        }
-                    }
-
-                    break;
-                }
-            }
-        }
-
-        if (serializedComponent.unlinkedCopySource) {
-            newComponent.unlinkedCopySource =
-                serializedComponent.unlinkedCopySource;
-        }
-
-        await deriveChildResultsFromDefiningChildren({
-            core: this.core,
-            parent: newComponent,
-            expandComposites: false,
-        });
-
-        await this.core.initializeComponentStateVariables(newComponent);
-
-        await this.core.dependencies.setUpComponentDependencies(newComponent);
-
-        const variablesChanged =
-            await this.core.dependencies.checkForDependenciesOnNewComponent(
-                componentIdx,
-            );
-
-        for (const varDescription of variablesChanged) {
-            await this.core.markStateVariableAndUpstreamDependentsStale({
-                component: this.core._components[varDescription.componentIdx],
-                varName: varDescription.varName,
-            });
-        }
-
-        await this.checkForStateVariablesUpdatesForNewComponent(componentIdx);
-
-        await this.core.dependencies.resolveStateVariablesIfReady({
-            component: newComponent,
-        });
-
-        this.core.recordStateVariablesMustEvaluate(componentIdx);
-
-        await this.core.checkForActionChaining({ component: newComponent });
-
-        this.core.parameterStack.pop();
-
-        const results = { newComponent: newComponent, lastErrorMessage };
-
-        return results;
-    }
-
-    async checkForStateVariablesUpdatesForNewComponent(componentIdx) {
-        let comp = this.core._components[componentIdx];
-        const stateId = comp.stateId;
-        if (
-            stateId in
-            this.core.updateInfo.stateVariableUpdatesForMissingComponents
-        ) {
-            let result = await this.core.processNewStateVariableValues(
-                {
-                    [componentIdx]:
-                        this.core.updateInfo
-                            .stateVariableUpdatesForMissingComponents[stateId],
-                },
-                // This `true` indicates we have a new component
-                true,
-            );
-
-            // In order to make sure that a component takes on the same value
-            // that was saved to the database,
-            // it may be necessary for a component to treat the value received differently
-            // in the first pass of the definition.
-            // Hence, we run the definition of all variables with the extra flag
-            // justUpdatedForNewComponent = true
-            if (
-                comp.constructor.processWhenJustUpdatedForNewComponent ||
-                result.foundIgnore
-            ) {
-                for (let vName in this.core.updateInfo
-                    .stateVariableUpdatesForMissingComponents[stateId]) {
-                    if (comp.state[vName]) {
-                        this.core.updateInfo.stateVariablesToEvaluate.push({
-                            componentIdx,
-                            stateVariable: vName,
-                        });
-                        comp.state[vName].justUpdatedForNewComponent = true;
-                        if (result.foundIgnore) {
-                            // This is a kludge
-                            // The only case so far with ignored children is that Math ignores strings
-                            // (set in inverse definition of expressionWithCodes).
-                            // We need change its value a second time after evaluating
-                            // so that the next time the definition of expressionWithCodes is run,
-                            // the strings don't show any changes and we'll use the essential value
-                            // of expressionWithCodes
-                            comp.reprocessAfterEvaluate =
-                                this.core.updateInfo.stateVariableUpdatesForMissingComponents[
-                                    stateId
-                                ];
-                        }
-                    }
-                }
-            }
-
-            delete this.core.updateInfo
-                .stateVariableUpdatesForMissingComponents[stateId];
-        }
-    }
-
-    async addQueuedErrorComponentsFromStateVariables() {
-        if (!this.core.errorComponentsToAdd?.length) {
-            return;
-        }
-
-        const errorComponentsToAdd = this.core.errorComponentsToAdd;
-        this.core.errorComponentsToAdd = [];
-
-        const numberInsertedAfterSource = {};
-
-        for (let errorInfo of errorComponentsToAdd) {
-            let sourceComponent = this.core._components[errorInfo.componentIdx];
-            let parent;
-
-            while (sourceComponent?.parentIdx > 0) {
-                const candidateParent =
-                    this.core._components[sourceComponent.parentIdx];
-
-                if (!candidateParent) {
-                    break;
-                }
-
-                if (candidateParent.constructor.canDisplayChildErrors) {
-                    parent = candidateParent;
-                    break;
-                }
-
-                sourceComponent = candidateParent;
-            }
-
-            if (!parent) {
-                if (this.core.document?.constructor.canDisplayChildErrors) {
-                    parent = this.core.document;
-                }
-            }
-
-            if (!parent) {
-                continue;
-            }
-
-            let indexOfDefiningChildren = parent.definingChildren.length;
-
-            if (sourceComponent?.parentIdx === parent.componentIdx) {
-                const sourceInd = parent.definingChildren.findIndex(
-                    (child) =>
-                        typeof child === "object" &&
-                        child.componentIdx === sourceComponent.componentIdx,
-                );
-
-                if (sourceInd !== -1) {
-                    const numberAlreadyInserted =
-                        numberInsertedAfterSource[
-                            sourceComponent.componentIdx
-                        ] ?? 0;
-                    indexOfDefiningChildren =
-                        sourceInd + 1 + numberAlreadyInserted;
-                    numberInsertedAfterSource[sourceComponent.componentIdx] =
-                        numberAlreadyInserted + 1;
-                }
-            }
-
-            let serializedErrorComponents = [
-                {
-                    type: "serialized",
-                    componentType: "_error",
-                    componentIdx: this.core._components.length,
-                    state: { message: errorInfo.message },
-                    position: errorInfo.position,
-                    sourceDoc: errorInfo.sourceDoc,
-                    children: [],
-                    attributes: {},
-                    doenetAttributes: {},
-                },
-            ];
-
-            this.core._components[this.core._components.length] = undefined;
-
-            let ancestors = [
-                {
-                    componentIdx: parent.componentIdx,
-                    componentClass: parent.constructor,
-                },
-                ...parent.ancestors,
-            ];
-
-            this.core.parameterStack.push(parent.sharedParameters, false);
-            let createResult;
-            try {
-                createResult = await this.createIsolatedComponents({
-                    serializedComponents: serializedErrorComponents,
-                    ancestors,
-                });
-            } finally {
-                this.core.parameterStack.pop();
-            }
-
-            let addResults = await addChildrenAndRecurseToShadows({
-                core: this.core,
-                parent,
-                indexOfDefiningChildren,
-                newChildren: createResult.components,
-            });
-
-            if (!addResults.success) {
+            if (idx === componentIdx) {
                 throw Error(
-                    "Couldn't add error component from state variable evaluation.",
+                    core.dependencies.getCircularDependencyMessage([
+                        serializedComponent,
+                    ]),
+                );
+            }
+            if (core._components[idx]) {
+                prescribedDependencies[idx] =
+                    serializedComponent.downstreamDependencies[idx];
+            } else {
+                throw Error(
+                    core.dependencies.getCircularDependencyMessage([
+                        serializedComponent,
+                    ]),
                 );
             }
         }
     }
 
-    /**
-     * Two-pass `expandAllComposites` against the document: first the
-     * non-forced pass, then a forced pass to flush anything that was still
-     * pending. Both branches of `addComponents` need this sequence after
-     * mutating the tree.
-     */
-    async _expandAllCompositesBothPasses() {
-        await expandAllComposites({
-            core: this.core,
-            component: this.core.document,
-        });
-        await expandAllComposites({
-            core: this.core,
-            component: this.core.document,
-            force: true,
-        });
+    const stateVariableDefinitions = await core.createStateVariableDefinitions({
+        componentClass,
+        prescribedDependencies,
+        componentIdx,
+    });
+
+    // In case a component with the same idx was deleted before, clear it
+    // from the deleted-tracking maps so the new component isn't shadowed
+    // by the prior tombstone.
+    delete core.updateInfo.deletedComponents[componentIdx];
+    delete core.updateInfo.deletedStateVariables[componentIdx];
+
+    const stateId = serializedComponent.stateId ?? componentIdx.toString();
+    core.componentIdxByStateId[stateId] = componentIdx;
+
+    const newComponent = new componentClass({
+        componentIdx,
+        stateId,
+        rootName:
+            core.rootNames?.[componentIdx] ?? "_id_" + componentIdx.toString(),
+        ancestors,
+        definingChildren,
+        stateVariableDefinitions,
+        serializedChildren: childrenToRemainSerialized,
+        serializedComponent,
+        attributes,
+        componentInfoObjects: core.componentInfoObjects,
+        coreFunctions: core.coreFunctions,
+        flags: core.flags,
+        shadow,
+        numerics: core.numerics,
+        sharedParameters,
+        parentSharedParameters,
+        refResolution,
+    });
+
+    registerComponent({ core, component: newComponent });
+
+    if (componentsReplacementOf) {
+        newComponent.replacementOf = componentsReplacementOf;
     }
 
-    /**
-     * Drain `updateInfo.stateVariablesToEvaluate`, evaluating each queued
-     * `(componentIdx, stateVariable)` pair via `getStateVariableValue`. The
-     * queue is reset before evaluation so re-entrant pushes accumulate for
-     * the next drain.
-     */
-    async _drainStateVariablesToEvaluate() {
-        if (!this.core.updateInfo.stateVariablesToEvaluate) {
-            return;
-        }
-        const stateVariablesToEvaluate =
-            this.core.updateInfo.stateVariablesToEvaluate;
-        this.core.updateInfo.stateVariablesToEvaluate = [];
-        for (const {
-            componentIdx,
-            stateVariable,
-        } of stateVariablesToEvaluate) {
-            const comp = this.core._components[componentIdx];
-            if (comp && comp.state[stateVariable]) {
-                await this.core.getStateVariableValue({
-                    component: comp,
-                    stateVariable,
+    if (serializedComponent.adaptedFrom) {
+        // record adapter relationship
+        newComponent.adaptedFrom =
+            core._components[serializedComponent.adaptedFrom];
+        newComponent.adaptedFrom.adapterUsed = newComponent;
+    }
+
+    for (const idxStr in prescribedDependencies) {
+        const idx = Number(idxStr);
+        const depArray = prescribedDependencies[idx];
+        for (const dep of depArray) {
+            if (dep.dependencyType === "referenceShadow") {
+                const shadowInfo: Record<string, any> = {
+                    componentIdx: idx,
+                };
+                Object.assign(shadowInfo, dep);
+                delete shadowInfo.dependencyType;
+                newComponent.shadows = shadowInfo;
+
+                if (dep.firstLevelReplacement) {
+                    newComponent.firstLevelReplacement = true;
+                }
+
+                const shadowedComponent = core._components[idx];
+                if (!shadowedComponent.shadowedBy) {
+                    shadowedComponent.shadowedBy = [];
+                }
+                shadowedComponent.shadowedBy.push(newComponent);
+
+                const mediatingShadowComposite =
+                    core._components[shadowInfo.compositeIdx];
+                if (!mediatingShadowComposite.mediatesShadows) {
+                    mediatingShadowComposite.mediatesShadows = [];
+                }
+                mediatingShadowComposite.mediatesShadows.push({
+                    shadowing: newComponent.componentIdx,
+                    shadowed: idx,
+                    propVariable: dep.propVariable,
                 });
+
+                if (dep.isPrimaryShadow) {
+                    shadowedComponent.primaryShadow = newComponent.componentIdx;
+
+                    if (
+                        core.dependencies.updateTriggers
+                            .primaryShadowDependencies[idx]
+                    ) {
+                        for (const dep of core.dependencies.updateTriggers
+                            .primaryShadowDependencies[idx]) {
+                            await dep.recalculateDownstreamComponents();
+                        }
+                    }
+                }
+
+                break;
             }
         }
     }
 
-    /**
-     * If composites have queued replacement updates, flush them and
-     * forward the resulting `componentsToUpdateRenderers` to the renderer.
-     * No-op when the queue is empty.
-     */
-    async _drainCompositesToUpdateReplacements() {
-        if (this.core.updateInfo.compositesToUpdateReplacements.size === 0) {
-            return;
-        }
-        await this.core.replacementChangesFromCompositesToUpdate();
+    if (serializedComponent.unlinkedCopySource) {
+        newComponent.unlinkedCopySource =
+            serializedComponent.unlinkedCopySource;
+    }
 
-        const componentNamesToUpdate = [
-            ...this.core.updateInfo.componentsToUpdateRenderers,
-        ];
-        this.core.updateInfo.componentsToUpdateRenderers.clear();
+    await deriveChildResultsFromDefiningChildren({
+        core,
+        parent: newComponent,
+        expandComposites: false,
+    });
 
-        await this.core.updateRendererInstructions({
-            componentNamesToUpdate,
+    await core.initializeComponentStateVariables(newComponent);
+
+    await core.dependencies.setUpComponentDependencies(newComponent);
+
+    const variablesChanged =
+        await core.dependencies.checkForDependenciesOnNewComponent(
+            componentIdx,
+        );
+
+    for (const varDescription of variablesChanged) {
+        await core.markStateVariableAndUpstreamDependentsStale({
+            component: core._components[varDescription.componentIdx],
+            varName: varDescription.varName,
         });
     }
+
+    await checkForStateVariablesUpdatesForNewComponent({
+        core,
+        componentIdx,
+    });
+
+    await core.dependencies.resolveStateVariablesIfReady({
+        component: newComponent,
+    });
+
+    core.recordStateVariablesMustEvaluate(componentIdx);
+
+    await core.checkForActionChaining({ component: newComponent });
+
+    core.parameterStack.pop();
+
+    const results = { newComponent: newComponent, lastErrorMessage };
+
+    return results;
+}
+
+export async function checkForStateVariablesUpdatesForNewComponent({
+    core,
+    componentIdx,
+}: {
+    core: Core;
+    componentIdx: any;
+}) {
+    let comp = core._components[componentIdx];
+    const stateId = comp.stateId;
+    if (stateId in core.updateInfo.stateVariableUpdatesForMissingComponents) {
+        let result = await core.processNewStateVariableValues(
+            {
+                [componentIdx]:
+                    core.updateInfo.stateVariableUpdatesForMissingComponents[
+                        stateId
+                    ],
+            },
+            // This `true` indicates we have a new component
+            true,
+        );
+
+        // In order to make sure that a component takes on the same value
+        // that was saved to the database,
+        // it may be necessary for a component to treat the value received differently
+        // in the first pass of the definition.
+        // Hence, we run the definition of all variables with the extra flag
+        // justUpdatedForNewComponent = true
+        if (
+            comp.constructor.processWhenJustUpdatedForNewComponent ||
+            result.foundIgnore
+        ) {
+            for (let vName in core.updateInfo
+                .stateVariableUpdatesForMissingComponents[stateId]) {
+                if (comp.state[vName]) {
+                    core.updateInfo.stateVariablesToEvaluate.push({
+                        componentIdx,
+                        stateVariable: vName,
+                    });
+                    comp.state[vName].justUpdatedForNewComponent = true;
+                    if (result.foundIgnore) {
+                        // This is a kludge
+                        // The only case so far with ignored children is that Math ignores strings
+                        // (set in inverse definition of expressionWithCodes).
+                        // We need change its value a second time after evaluating
+                        // so that the next time the definition of expressionWithCodes is run,
+                        // the strings don't show any changes and we'll use the essential value
+                        // of expressionWithCodes
+                        comp.reprocessAfterEvaluate =
+                            core.updateInfo.stateVariableUpdatesForMissingComponents[
+                                stateId
+                            ];
+                    }
+                }
+            }
+        }
+
+        delete core.updateInfo.stateVariableUpdatesForMissingComponents[
+            stateId
+        ];
+    }
+}
+
+export async function addQueuedErrorComponentsFromStateVariables({
+    core,
+}: {
+    core: Core;
+}) {
+    if (!core.errorComponentsToAdd?.length) {
+        return;
+    }
+
+    const errorComponentsToAdd = core.errorComponentsToAdd;
+    core.errorComponentsToAdd = [];
+
+    const numberInsertedAfterSource: Record<string, number> = {};
+
+    for (let errorInfo of errorComponentsToAdd) {
+        let sourceComponent = core._components[errorInfo.componentIdx];
+        let parent;
+
+        while (sourceComponent?.parentIdx > 0) {
+            const candidateParent = core._components[sourceComponent.parentIdx];
+
+            if (!candidateParent) {
+                break;
+            }
+
+            if (candidateParent.constructor.canDisplayChildErrors) {
+                parent = candidateParent;
+                break;
+            }
+
+            sourceComponent = candidateParent;
+        }
+
+        if (!parent) {
+            if (core.document?.constructor.canDisplayChildErrors) {
+                parent = core.document;
+            }
+        }
+
+        if (!parent) {
+            continue;
+        }
+
+        let indexOfDefiningChildren = parent.definingChildren.length;
+
+        if (sourceComponent?.parentIdx === parent.componentIdx) {
+            const sourceInd = parent.definingChildren.findIndex(
+                (child: any) =>
+                    typeof child === "object" &&
+                    child.componentIdx === sourceComponent.componentIdx,
+            );
+
+            if (sourceInd !== -1) {
+                const numberAlreadyInserted =
+                    numberInsertedAfterSource[sourceComponent.componentIdx] ??
+                    0;
+                indexOfDefiningChildren = sourceInd + 1 + numberAlreadyInserted;
+                numberInsertedAfterSource[sourceComponent.componentIdx] =
+                    numberAlreadyInserted + 1;
+            }
+        }
+
+        let serializedErrorComponents = [
+            {
+                type: "serialized",
+                componentType: "_error",
+                componentIdx: core._components.length,
+                state: { message: errorInfo.message },
+                position: errorInfo.position,
+                sourceDoc: errorInfo.sourceDoc,
+                children: [],
+                attributes: {},
+                doenetAttributes: {},
+            },
+        ];
+
+        core._components[core._components.length] = undefined;
+
+        let ancestors = [
+            {
+                componentIdx: parent.componentIdx,
+                componentClass: parent.constructor,
+            },
+            ...parent.ancestors,
+        ];
+
+        core.parameterStack.push(parent.sharedParameters, false);
+        let createResult;
+        try {
+            createResult = await createIsolatedComponents({
+                core,
+                serializedComponents: serializedErrorComponents,
+                ancestors,
+            });
+        } finally {
+            core.parameterStack.pop();
+        }
+
+        let addResults = await addChildrenAndRecurseToShadows({
+            core,
+            parent,
+            indexOfDefiningChildren,
+            newChildren: createResult.components,
+        });
+
+        if (!addResults.success) {
+            throw Error(
+                "Couldn't add error component from state variable evaluation.",
+            );
+        }
+    }
+}
+
+/**
+ * Two-pass `expandAllComposites` against the document: first the
+ * non-forced pass, then a forced pass to flush anything that was still
+ * pending. Both branches of `addComponents` need this sequence after
+ * mutating the tree.
+ */
+async function _expandAllCompositesBothPasses(core: Core) {
+    await expandAllComposites({ core, component: core.document });
+    await expandAllComposites({ core, component: core.document, force: true });
+}
+
+/**
+ * Drain `updateInfo.stateVariablesToEvaluate`, evaluating each queued
+ * `(componentIdx, stateVariable)` pair via `getStateVariableValue`. The
+ * queue is reset before evaluation so re-entrant pushes accumulate for
+ * the next drain.
+ */
+async function _drainStateVariablesToEvaluate(core: Core) {
+    if (!core.updateInfo.stateVariablesToEvaluate) {
+        return;
+    }
+    const stateVariablesToEvaluate = core.updateInfo.stateVariablesToEvaluate;
+    core.updateInfo.stateVariablesToEvaluate = [];
+    for (const { componentIdx, stateVariable } of stateVariablesToEvaluate) {
+        const comp = core._components[componentIdx];
+        if (comp && comp.state[stateVariable]) {
+            await core.getStateVariableValue({
+                component: comp,
+                stateVariable,
+            });
+        }
+    }
+}
+
+/**
+ * If composites have queued replacement updates, flush them and
+ * forward the resulting `componentsToUpdateRenderers` to the renderer.
+ * No-op when the queue is empty.
+ */
+async function _drainCompositesToUpdateReplacements(core: Core) {
+    if (core.updateInfo.compositesToUpdateReplacements.size === 0) {
+        return;
+    }
+    await core.replacementChangesFromCompositesToUpdate();
+
+    const componentNamesToUpdate = [
+        ...core.updateInfo.componentsToUpdateRenderers,
+    ];
+    core.updateInfo.componentsToUpdateRenderers.clear();
+
+    await core.updateRendererInstructions({
+        componentNamesToUpdate,
+    });
 }

--- a/packages/doenetml-worker-javascript/src/ComponentBuilder.ts
+++ b/packages/doenetml-worker-javascript/src/ComponentBuilder.ts
@@ -1,4 +1,5 @@
 import type Core from "./Core";
+import type { ComponentIdx } from "@doenet/utils";
 import { deriveChildResultsFromDefiningChildren } from "./ChildMatcher";
 import {
     addChildrenAndRecurseToShadows,
@@ -33,6 +34,29 @@ import { extractCreateComponentIdxMapping } from "./utils/componentIndices";
  * `initialAddPhase`) and to dispatch through the other extracted managers.
  */
 
+/**
+ * Build a list of ancestor descriptors with `parent` prepended to its own
+ * `ancestors` chain — the canonical shape consumed by component
+ * constructors and by `createIsolatedComponents` recursion.
+ */
+function ancestorsForChild(parent: any): any[] {
+    return [
+        {
+            componentIdx: parent.componentIdx,
+            componentClass: parent.constructor,
+        },
+        ...parent.ancestors,
+    ];
+}
+
+/**
+ * Top-level entry point for materializing serialized DAST into live
+ * component instances. On `initialAdd` the resulting tree becomes
+ * `core.document` and is followed by the full initial-render pipeline
+ * (composite expansion, state-variable evaluation, queued error flush,
+ * renderer instructions). Otherwise the new components are spliced into
+ * `parent`'s defining children at `indexOfDefiningChildren`.
+ */
 export async function addComponents({
     core,
     serializedComponents,
@@ -42,8 +66,8 @@ export async function addComponents({
 }: {
     core: Core;
     serializedComponents: any;
-    parentIdx?: any;
-    indexOfDefiningChildren?: any;
+    parentIdx?: ComponentIdx;
+    indexOfDefiningChildren?: number;
     initialAdd?: boolean;
 }) {
     core.initialAddPhase = initialAdd;
@@ -56,7 +80,7 @@ export async function addComponents({
     let ancestors: any[] = [];
 
     if (!initialAdd) {
-        parent = core._components[parentIdx];
+        parent = core._components[parentIdx!];
         if (!parent) {
             core.addDiagnostic({
                 type: "warning",
@@ -65,13 +89,7 @@ export async function addComponents({
             return [];
         }
 
-        ancestors = [
-            {
-                componentIdx: parentIdx,
-                componentClass: parent.constructor,
-            },
-            ...parent.ancestors,
-        ];
+        ancestors = ancestorsForChild(parent);
 
         core.parameterStack.push(parent.sharedParameters, false);
 
@@ -80,7 +98,7 @@ export async function addComponents({
         addComponentsToResolver({
             core,
             components: serializedComponents,
-            parentIdx,
+            parentIdx: parentIdx!,
         });
     }
     let createResult = await createIsolatedComponents({
@@ -171,7 +189,7 @@ export async function addComponents({
         let addResults = await addChildrenAndRecurseToShadows({
             core,
             parent,
-            indexOfDefiningChildren: indexOfDefiningChildren,
+            indexOfDefiningChildren: indexOfDefiningChildren!,
             newChildren: newComponents,
         });
         if (!addResults.success) {
@@ -207,6 +225,14 @@ export async function addComponents({
     return newComponents;
 }
 
+/**
+ * Walks `serializedComponents` and produces matching live component
+ * instances without splicing them into any parent's defining-children
+ * list — used for replacements, attribute components, error components,
+ * and reference-resolution sub-trees that get attached by their caller.
+ * Mutually recursive with `createChildrenThenComponent` (children are
+ * built before their parent is constructed).
+ */
 export async function createIsolatedComponents({
     core,
     serializedComponents,
@@ -215,7 +241,7 @@ export async function createIsolatedComponents({
     componentsReplacementOf,
 }: {
     core: Core;
-    serializedComponents: any;
+    serializedComponents: any[];
     ancestors: any;
     shadow?: boolean;
     componentsReplacementOf?: any;
@@ -269,10 +295,8 @@ export async function createIsolatedComponents({
 
         let componentIdx = serializedComponent.componentIdx;
         if (componentIdx === undefined) {
-            throw Error(
-                "Found a serialized component without a componentIdx",
-                serializedComponent,
-            );
+            console.log(serializedComponent);
+            throw Error("Found a serialized component without a componentIdx");
         }
 
         const createResult = await createChildrenThenComponent({
@@ -301,6 +325,14 @@ export async function createIsolatedComponents({
     return results;
 }
 
+/**
+ * Materializes a single component: recursively creates its children
+ * (and attribute / reference-path sub-components) first, then constructs
+ * the component itself, registers it on Core, wires up shadow / adapter
+ * relationships, derives child results, initializes state-variable
+ * definitions and dependencies, and applies any state-variable updates
+ * that were queued for this `componentIdx` while it was missing.
+ */
 export async function createChildrenThenComponent({
     core,
     serializedComponent,
@@ -312,7 +344,7 @@ export async function createChildrenThenComponent({
 }: {
     core: Core;
     serializedComponent: any;
-    componentIdx: any;
+    componentIdx: ComponentIdx;
     ancestors: any;
     componentClass: any;
     shadow?: boolean;
@@ -751,12 +783,19 @@ export async function createChildrenThenComponent({
     return results;
 }
 
+/**
+ * Apply any state-variable updates that were queued against
+ * `componentIdx` while it was missing from `core._components` (e.g.
+ * persisted state restored before the component was constructed). Marks
+ * affected variables for re-evaluation when the component requires
+ * special handling on the first post-restoration pass.
+ */
 export async function checkForStateVariablesUpdatesForNewComponent({
     core,
     componentIdx,
 }: {
     core: Core;
-    componentIdx: any;
+    componentIdx: ComponentIdx;
 }) {
     let comp = core._components[componentIdx];
     const stateId = comp.stateId;
@@ -813,6 +852,14 @@ export async function checkForStateVariablesUpdatesForNewComponent({
     }
 }
 
+/**
+ * Drain `core.errorComponentsToAdd` (populated when state-variable
+ * definitions hit recoverable errors), creating an `_error` child under
+ * the nearest ancestor that can display child errors. Inserts the error
+ * component immediately after its triggering source within the parent's
+ * defining children when both share the same parent, so multiple errors
+ * from the same source preserve their relative order.
+ */
 export async function addQueuedErrorComponentsFromStateVariables({
     core,
 }: {
@@ -891,13 +938,7 @@ export async function addQueuedErrorComponentsFromStateVariables({
 
         core._components[core._components.length] = undefined;
 
-        let ancestors = [
-            {
-                componentIdx: parent.componentIdx,
-                componentClass: parent.constructor,
-            },
-            ...parent.ancestors,
-        ];
+        let ancestors = ancestorsForChild(parent);
 
         core.parameterStack.push(parent.sharedParameters, false);
         let createResult;

--- a/packages/doenetml-worker-javascript/src/ComponentLifecycle.ts
+++ b/packages/doenetml-worker-javascript/src/ComponentLifecycle.ts
@@ -1,5 +1,6 @@
 import type Core from "./Core";
 import { deriveChildResultsFromDefiningChildren } from "./ChildMatcher";
+import { createIsolatedComponents } from "./ComponentBuilder";
 import { postProcessCopy } from "./utils/copy";
 import { createNewComponentIndices } from "./utils/componentIndices";
 
@@ -213,7 +214,8 @@ export async function addChildrenAndRecurseToShadows({
                 false,
             );
 
-            let createResult = await core.createIsolatedComponents({
+            let createResult = await createIsolatedComponents({
+                core,
                 serializedComponents: shadowingSerializeChildren,
                 ancestors: shadowingParent.ancestors,
             });

--- a/packages/doenetml-worker-javascript/src/CompositeExpander.ts
+++ b/packages/doenetml-worker-javascript/src/CompositeExpander.ts
@@ -4,6 +4,7 @@ import {
     deriveChildResultsFromDefiningChildren,
     findChildGroup,
 } from "./ChildMatcher";
+import { createIsolatedComponents } from "./ComponentBuilder";
 import { processNewDefiningChildren } from "./ComponentLifecycle";
 import {
     addReplacementsToResolver,
@@ -793,7 +794,8 @@ export async function createAndSetReplacements({
     core.parameterStack.push(component.sharedParameters, false);
 
     try {
-        let replacementResult = await core.createIsolatedComponents({
+        let replacementResult = await createIsolatedComponents({
+            core,
             serializedComponents: serializedReplacements,
             ancestors: component.ancestors,
             shadow: true,

--- a/packages/doenetml-worker-javascript/src/CompositeReplacementUpdater.ts
+++ b/packages/doenetml-worker-javascript/src/CompositeReplacementUpdater.ts
@@ -1,6 +1,7 @@
 import type Core from "./Core";
 import type { ComponentInstance } from "./types/componentInstance";
 import type { ComponentIdx } from "@doenet/utils";
+import { createIsolatedComponents } from "./ComponentBuilder";
 import {
     processNewDefiningChildren,
     spliceChildren,
@@ -335,12 +336,12 @@ export class CompositeReplacementUpdater {
                 }
 
                 try {
-                    const createResult =
-                        await this.core.createIsolatedComponents({
-                            serializedComponents: serializedReplacements,
-                            ancestors: component.ancestors,
-                            componentsReplacementOf: component,
-                        });
+                    const createResult = await createIsolatedComponents({
+                        core: this.core,
+                        serializedComponents: serializedReplacements,
+                        ancestors: component.ancestors,
+                        componentsReplacementOf: component,
+                    });
 
                     newComponents = createResult.components;
                 } catch (e: any) {
@@ -621,7 +622,8 @@ export class CompositeReplacementUpdater {
 
         composite.isInErrorState = true;
 
-        let createResult = await this.core.createIsolatedComponents({
+        let createResult = await createIsolatedComponents({
+            core: this.core,
             serializedComponents: errorReplacements,
             ancestors: composite.ancestors,
             componentsReplacementOf: composite,
@@ -1000,13 +1002,12 @@ export class CompositeReplacementUpdater {
                 );
 
                 try {
-                    let createResult = await this.core.createIsolatedComponents(
-                        {
-                            serializedComponents: newSerializedReplacements,
-                            ancestors: shadowingComponent.ancestors,
-                            componentsReplacementOf: shadowingComponent,
-                        },
-                    );
+                    let createResult = await createIsolatedComponents({
+                        core: this.core,
+                        serializedComponents: newSerializedReplacements,
+                        ancestors: shadowingComponent.ancestors,
+                        componentsReplacementOf: shadowingComponent,
+                    });
                     newComponents = createResult.components;
                 } catch (e: any) {
                     console.error(e);

--- a/packages/doenetml-worker-javascript/src/CompositeReplacementUpdater.ts
+++ b/packages/doenetml-worker-javascript/src/CompositeReplacementUpdater.ts
@@ -54,9 +54,9 @@ type SourceOfUpdate = Record<string, any>;
  * Owns `updateInfo.compositesToUpdateReplacements` (read by the
  * post-update flush in `EssentialValueWriter` /
  * `RendererInstructionBuilder`). Holds a back-reference to Core for
- * the rest of the hot state and the other extracted managers
- * (notably `componentBuilder`, `compositeExpander`). Calls the module-level
- * `deleteComponents` from DeletionEngine directly.
+ * the rest of the hot state and the other extracted managers. Calls
+ * module-level functions from `ComponentBuilder`, `CompositeExpander`,
+ * and `DeletionEngine` directly.
  */
 export class CompositeReplacementUpdater {
     core: Core;
@@ -77,9 +77,10 @@ export class CompositeReplacementUpdater {
      *      `deleteReplacementsFromShadowsThenComposite`, which recurses
      *      into shadowing composites first so the shadow tree shrinks
      *      from leaves inward.
-     *   3. Creating new replacements via `componentBuilder` /
-     *      `compositeExpander`, calling `createShadowedReplacements` for
-     *      every shadow so the shadow tree grows in lockstep.
+     *   3. Creating new replacements via the `ComponentBuilder` and
+     *      `CompositeExpander` module functions, calling
+     *      `createShadowedReplacements` for every shadow so the shadow
+     *      tree grows in lockstep.
      *   4. Threading every change through `componentChanges` so callers
      *      can inspect what moved.
      *

--- a/packages/doenetml-worker-javascript/src/Core.ts
+++ b/packages/doenetml-worker-javascript/src/Core.ts
@@ -18,7 +18,7 @@ import type { ComponentInstance } from "./types/componentInstance";
 import { DependencyHandler } from "./Dependencies";
 import { ActionTriggerScheduler } from "./ActionTriggerScheduler";
 import { AutoSubmitManager } from "./AutoSubmitManager";
-import { ComponentBuilder } from "./ComponentBuilder";
+import { addComponents } from "./ComponentBuilder";
 import { CompositeReplacementUpdater } from "./CompositeReplacementUpdater";
 import { DiagnosticsManager } from "./DiagnosticsManager";
 import { EssentialValueWriter } from "./EssentialValueWriter";
@@ -107,14 +107,14 @@ export interface CoreInfo {
  * own modules. Some are class instances held on Core (DiagnosticsManager,
  * VisibilityTracker, StatePersistence, AutoSubmitManager,
  * RendererInstructionBuilder, ProcessQueue, ActionTriggerScheduler,
- * StateVariableDefinitionFactory, StateVariableInitializer, ComponentBuilder,
+ * StateVariableDefinitionFactory, StateVariableInitializer,
  * StateVariableEvaluator, StalenessPropagator, EssentialValueWriter,
  * CompositeReplacementUpdater, UpdateExecutor, and the `nameResolver`
  * namespace); others (NavigationHandler, ResolverAdapter, ComponentLifecycle,
- * ChildMatcher, DeletionEngine, CompositeExpander) are plain module-level
- * functions imported directly by callers. Each delegating block still held on
- * Core is grouped near its original location and tagged with a
- * `// → managerName` marker; see the corresponding module for details.
+ * ChildMatcher, DeletionEngine, CompositeExpander, ComponentBuilder) are
+ * plain module-level functions imported directly by callers. Each delegating
+ * block still held on Core is grouped near its original location and tagged
+ * with a `// → managerName` marker; see the corresponding module for details.
  */
 export default class Core {
     // ─── Identity / configuration ─────────────────────────────────────────
@@ -202,7 +202,6 @@ export default class Core {
     stateVariableEvaluator: StateVariableEvaluator;
     stalenessPropagator: StalenessPropagator;
     essentialValueWriter: EssentialValueWriter;
-    componentBuilder: ComponentBuilder;
     compositeReplacementUpdater: CompositeReplacementUpdater;
     updateExecutor: UpdateExecutor;
     statePersistence: StatePersistence;
@@ -372,7 +371,6 @@ export default class Core {
         });
         this.stalenessPropagator = new StalenessPropagator({ core: this });
         this.essentialValueWriter = new EssentialValueWriter({ core: this });
-        this.componentBuilder = new ComponentBuilder({ core: this });
         this.compositeReplacementUpdater = new CompositeReplacementUpdater({
             core: this,
         });
@@ -517,7 +515,8 @@ export default class Core {
         serializedComponents[0].variants.desiredVariant =
             this.parameterStack.parameters.variant;
 
-        await this.addComponents({
+        await addComponents({
+            core: this,
             serializedComponents,
             initialAdd: true,
         });
@@ -661,31 +660,6 @@ export default class Core {
         sourceDoc: number | undefined;
     } {
         return getSourceLocationForComponent(component, this._components);
-    }
-
-    // → componentBuilder
-    async addComponents(args: any): Promise<any> {
-        return this.componentBuilder.addComponents(args);
-    }
-
-    async createIsolatedComponents(args: any): Promise<any> {
-        return this.componentBuilder.createIsolatedComponents(args);
-    }
-
-    async createChildrenThenComponent(args: any): Promise<any> {
-        return this.componentBuilder.createChildrenThenComponent(args);
-    }
-
-    async checkForStateVariablesUpdatesForNewComponent(
-        componentIdx: ComponentIdx,
-    ): Promise<any> {
-        return this.componentBuilder.checkForStateVariablesUpdatesForNewComponent(
-            componentIdx,
-        );
-    }
-
-    async addQueuedErrorComponentsFromStateVariables(): Promise<any> {
-        return this.componentBuilder.addQueuedErrorComponentsFromStateVariables();
     }
 
     async updateRendererInstructions(args: any): Promise<any> {

--- a/packages/doenetml-worker-javascript/src/Dependencies.d.ts
+++ b/packages/doenetml-worker-javascript/src/Dependencies.d.ts
@@ -95,7 +95,7 @@ export declare class DependencyHandler {
 
     checkForDependenciesOnNewComponent(
         componentIdx: ComponentIdx,
-    ): Promise<{ varsChanged: Record<string, Record<string, boolean>> }>;
+    ): Promise<Array<{ componentIdx: ComponentIdx; varName: string }>>;
 
     getStateVariableDependencyValues(args: {
         component: any;

--- a/packages/doenetml-worker-javascript/src/UpdateExecutor.ts
+++ b/packages/doenetml-worker-javascript/src/UpdateExecutor.ts
@@ -1,5 +1,6 @@
 import type Core from "./Core";
 import type { ComponentIdx } from "@doenet/utils";
+import { addComponents } from "./ComponentBuilder";
 import { deleteComponents } from "./DeletionEngine";
 import { createNewComponentIndices } from "./utils/componentIndices";
 import { reportTimerError, TimerLabels } from "./utils/timerErrors";
@@ -304,7 +305,8 @@ export class UpdateExecutor {
                 if (res.nComponents > this.core._components.length) {
                     this.core._components[res.nComponents - 1] = undefined;
                 }
-                await this.core.addComponents({
+                await addComponents({
+                    core: this.core,
                     serializedComponents: res.components,
                     parentIdx: instruction.parentIdx,
                 });


### PR DESCRIPTION
## Summary

Convert `ComponentBuilder` from a class to module-level functions, the third piece of the Phase 5c stateless-manager pass.

- `addComponents`, `createIsolatedComponents`, `createChildrenThenComponent`, `checkForStateVariablesUpdatesForNewComponent`, and `addQueuedErrorComponentsFromStateVariables` become exported functions taking `{ core: Core, ... }` in their destructure.
- `_expandAllCompositesBothPasses`, `_drainStateVariablesToEvaluate`, and `_drainCompositesToUpdateReplacements` are module-private.
- Cross-module callers — `Core.generateDast`, `UpdateExecutor`, `CompositeExpander`, `ComponentLifecycle`, `ChildMatcher`, `CompositeReplacementUpdater` — import the functions directly.
- The `componentBuilder` field, instantiation, and 5 delegate-only wrappers in `Core.ts` are removed.

Stacked on #1051.

## Notes on the typecheck delta

Baseline drops 238 → 191. Same pattern as the prior conversions: typing the previously-untyped destructure params explicitly clears 47 implicit-any errors. No new errors; two pre-existing errors in ComponentBuilder (`TS2554` on the spurious 2-arg `Error()` call, `TS2488` on iterating `variablesChanged`) are unchanged in number, just shifted line numbers.

## Test plan

- [x] `pnpm typecheck` — 191 (down from 238, no new errors).
- [x] Targeted vitest: external_references, calcStartEndIdx, sectioning, group — 49 passing.
- [x] Full vitest + Cypress in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)