### PR TITLE
refactor(worker-javascript): StateVariableInitializer → module functions

### DIFF
--- a/CORE_REFACTOR_DEFERRED.md
+++ b/CORE_REFACTOR_DEFERRED.md
@@ -193,6 +193,24 @@ if (!numDimensionsInArrayKey > stateVarObj.numDimensions) {
 
 `!numDimensionsInArrayKey` is `false` for any positive integer, and `false > number` is always `false`, so the diagnostic is unreachable. Almost certainly intended `numDimensionsInArrayKey > stateVarObj.numDimensions`. Pre-dates the refactor (present in `Core.js` since the 2021 rename); flag for a separate fix once the intended check has been confirmed against test expectations.
 
+### Collapse the 1-D vs N-D branches of `StateVariableInitializer.initializeArrayStateVariable`
+
+`StateVariableInitializer.ts:449-797` (the `if (stateVarObj.numDimensions > 1) { ... } else { ... }` block) duplicates the per-array plumbing across both branches: `keyToIndex`, `setArrayValue`, `getArrayValue`, `getAllArrayKeys`, `arrayVarNameFromArrayKey`, `arrayVarNameFromPropIndex`, and `adjustArrayToNewArraySize`. The 1-D branch is essentially the N-D branch specialised to `numDimensions === 1`.
+
+A unified implementation that always uses the multi-index path would shed roughly 80 lines of duplication. The trade-off is that the 1-D path has a flatter, faster shape (`Number(key)` instead of `key.split(",").map(Number)`); benchmarking against the existing array-heavy components (`mathList`, `numberList`, `point`'s array entries) is the gating step before unifying. Carried over verbatim from `Core.js`; not introduced by the class→module conversion (PR `core-refactor-17`).
+
+### `getAllArrayKeys` default in `StateVariableInitializer.initializeArrayStateVariable`
+
+Five sites inside `initializeArrayStateVariable` (`returnDependencies`, `getCurrentFreshness`, `markStale`, `freshenOnNoChanges`, `definition`, `inverseDefinition`) all open with the same defaulting line:
+
+```ts
+if (args.arrayKeys === undefined) {
+    args.arrayKeys = stateVarObj.getAllArrayKeys(args.arraySize);
+}
+```
+
+Folding this into `getAllArrayKeys` itself (so callers can pass `undefined` and get the all-keys default back) would cut five 3-line repetitions to one. Pre-existing pattern carried over from `Core.js`; not introduced by the class→module conversion (PR `core-refactor-17`).
+
 ### Re-home `recursivelyReplaceCompositesWithReplacements` — DONE
 
 Moved from `StateVariableInitializer` to `CompositeExpander`. Dropped the unread

--- a/packages/doenetml-worker-javascript/src/ComponentBuilder.ts
+++ b/packages/doenetml-worker-javascript/src/ComponentBuilder.ts
@@ -10,6 +10,7 @@ import {
     expandAllComposites,
 } from "./CompositeExpander";
 import { addComponentsToResolver } from "./ResolverAdapter";
+import { initializeComponentStateVariables } from "./StateVariableInitializer";
 import { convertToErrorComponent } from "./utils/dast/errors";
 import { gatherVariantComponents } from "./utils/variants";
 import { unwrapSource } from "./utils/dast/convertNormalizedDast";
@@ -747,7 +748,7 @@ export async function createChildrenThenComponent({
         expandComposites: false,
     });
 
-    await core.initializeComponentStateVariables(newComponent);
+    await initializeComponentStateVariables({ core, component: newComponent });
 
     await core.dependencies.setUpComponentDependencies(newComponent);
 

--- a/packages/doenetml-worker-javascript/src/Core.ts
+++ b/packages/doenetml-worker-javascript/src/Core.ts
@@ -29,7 +29,6 @@ import { StalenessPropagator } from "./StalenessPropagator";
 import { StatePersistence } from "./StatePersistence";
 import { StateVariableDefinitionFactory } from "./StateVariableDefinitionFactory";
 import { StateVariableEvaluator } from "./StateVariableEvaluator";
-import { StateVariableInitializer } from "./StateVariableInitializer";
 import { UpdateExecutor } from "./UpdateExecutor";
 import { VisibilityTracker } from "./VisibilityTracker";
 import * as nameResolver from "./StateVariableNameResolver";
@@ -107,14 +106,15 @@ export interface CoreInfo {
  * own modules. Some are class instances held on Core (DiagnosticsManager,
  * VisibilityTracker, StatePersistence, AutoSubmitManager,
  * RendererInstructionBuilder, ProcessQueue, ActionTriggerScheduler,
- * StateVariableDefinitionFactory, StateVariableInitializer,
+ * StateVariableDefinitionFactory,
  * StateVariableEvaluator, StalenessPropagator, EssentialValueWriter,
  * CompositeReplacementUpdater, UpdateExecutor, and the `nameResolver`
  * namespace); others (NavigationHandler, ResolverAdapter, ComponentLifecycle,
- * ChildMatcher, DeletionEngine, CompositeExpander, ComponentBuilder) are
- * plain module-level functions imported directly by callers. Each delegating
- * block still held on Core is grouped near its original location and tagged
- * with a `// → managerName` marker; see the corresponding module for details.
+ * ChildMatcher, DeletionEngine, CompositeExpander, ComponentBuilder,
+ * StateVariableInitializer) are plain module-level functions imported
+ * directly by callers. Each delegating block still held on Core is grouped
+ * near its original location and tagged with a `// → managerName` marker;
+ * see the corresponding module for details.
  */
 export default class Core {
     // ─── Identity / configuration ─────────────────────────────────────────
@@ -198,7 +198,6 @@ export default class Core {
     processQueue: ProcessQueue;
     actionTriggerScheduler: ActionTriggerScheduler;
     stateVariableDefinitionFactory: StateVariableDefinitionFactory;
-    stateVariableInitializer: StateVariableInitializer;
     stateVariableEvaluator: StateVariableEvaluator;
     stalenessPropagator: StalenessPropagator;
     essentialValueWriter: EssentialValueWriter;
@@ -363,9 +362,6 @@ export default class Core {
             new StateVariableDefinitionFactory({
                 core: this,
             });
-        this.stateVariableInitializer = new StateVariableInitializer({
-            core: this,
-        });
         this.stateVariableEvaluator = new StateVariableEvaluator({
             core: this,
         });
@@ -741,37 +737,6 @@ export default class Core {
         return this.stateVariableDefinitionFactory.createReferenceShadowStateVariableDefinitions(
             args,
         );
-    }
-
-    // → stateVariableInitializer
-    async initializeComponentStateVariables(
-        component: ComponentInstance,
-    ): Promise<any> {
-        return this.stateVariableInitializer.initializeComponentStateVariables(
-            component,
-        );
-    }
-
-    async initializeStateVariable(args: any): Promise<any> {
-        return this.stateVariableInitializer.initializeStateVariable(args);
-    }
-
-    async initializeArrayEntryStateVariable(args: any): Promise<any> {
-        return this.stateVariableInitializer.initializeArrayEntryStateVariable(
-            args,
-        );
-    }
-
-    async initializeArrayStateVariable(args: any): Promise<any> {
-        return this.stateVariableInitializer.initializeArrayStateVariable(args);
-    }
-
-    async createArraySizeStateVariable(args: any): Promise<any> {
-        return this.stateVariableInitializer.createArraySizeStateVariable(args);
-    }
-
-    async arrayEntryNamesFromPropIndex(args: any): Promise<any> {
-        return this.stateVariableInitializer.arrayEntryNamesFromPropIndex(args);
     }
 
     // → stateVariableEvaluator

--- a/packages/doenetml-worker-javascript/src/Dependencies.js
+++ b/packages/doenetml-worker-javascript/src/Dependencies.js
@@ -3,6 +3,7 @@ import {
     expandCompositeComponent,
     recursivelyReplaceCompositesWithReplacements,
 } from "./CompositeExpander";
+import { arrayEntryNamesFromPropIndex } from "./StateVariableInitializer";
 import {
     ancestorsIncludingComposites,
     gatherDescendants,
@@ -2938,14 +2939,12 @@ class Dependency {
             }
 
             if (this.propIndex !== undefined) {
-                mappedVarNames =
-                    await this.dependencyHandler.core.arrayEntryNamesFromPropIndex(
-                        {
-                            stateVariables: mappedVarNames,
-                            component: downComponent,
-                            propIndex: this.propIndex,
-                        },
-                    );
+                mappedVarNames = await arrayEntryNamesFromPropIndex({
+                    core: this.dependencyHandler.core,
+                    stateVariables: mappedVarNames,
+                    component: downComponent,
+                    propIndex: this.propIndex,
+                });
             }
 
             // Note: mappedVarNames contains all original variables mapped with any aliases.

--- a/packages/doenetml-worker-javascript/src/StalenessPropagator.ts
+++ b/packages/doenetml-worker-javascript/src/StalenessPropagator.ts
@@ -1,6 +1,7 @@
 import type Core from "./Core";
 import type { ComponentInstance } from "./types/componentInstance";
 import { returnActiveChildrenIndicesToRender } from "./ChildMatcher";
+import { initializeStateVariable } from "./StateVariableInitializer";
 /**
  * Walks the dependency graph to invalidate state-variable values and
  * propagate freshness changes:
@@ -69,7 +70,8 @@ export class StalenessPropagator {
                 if (arrayKeys.length > 0) {
                     // found a reference to an arrayEntry that hasn't been created yet
                     // create this arrayEntry
-                    await this.core.initializeStateVariable({
+                    await initializeStateVariable({
+                        core: this.core,
                         component,
                         stateVariable,
                         arrayStateVariable: arrayVariableName,

--- a/packages/doenetml-worker-javascript/src/StateVariableInitializer.ts
+++ b/packages/doenetml-worker-javascript/src/StateVariableInitializer.ts
@@ -1,5 +1,6 @@
 import type Core from "./Core";
 import { deepClone, flattenDeep } from "@doenet/utils";
+import type { ComponentInstance } from "./types/componentInstance";
 import {
     returnDefaultArrayVarNameFromPropIndex,
     returnDefaultGetArrayKeysFromVarName,
@@ -20,10 +21,11 @@ import {
  * `getStateVariableValue` onto a separate manager, this capture must
  * become a lazy lookup so the binding source stays live.
  *
- * Stateless — each function takes a back-reference to Core to read
- * `_components`, `componentInfoObjects`, and
- * `stateVariableChangeTriggers`, and to invoke `getStateVariableValue`,
- * `checkIfArrayEntry`, `addDiagnostic`, and `createFromArrayEntry`.
+ * Stateless — exported functions take a back-reference to Core to read
+ * `stateVariableChangeTriggers` and to invoke `getStateVariableValue`,
+ * `checkIfArrayEntry`, `addDiagnostic`, and `createFromArrayEntry`. The
+ * private helper `initializeArrayEntryStateVariable` needs none of these
+ * and so does not take `core`.
  */
 
 export async function initializeComponentStateVariables({
@@ -31,7 +33,7 @@ export async function initializeComponentStateVariables({
     component,
 }: {
     core: Core;
-    component: any;
+    component: ComponentInstance;
 }) {
     for (let stateVariable in component.state) {
         if (component.state[stateVariable].isAlias) {
@@ -61,10 +63,10 @@ export async function initializeStateVariable({
     arrayEntryPrefix,
 }: {
     core: Core;
-    component: any;
-    stateVariable: any;
-    arrayStateVariable?: any;
-    arrayEntryPrefix?: any;
+    component: ComponentInstance;
+    stateVariable: string;
+    arrayStateVariable?: string;
+    arrayEntryPrefix?: string;
 }) {
     let getStateVar = core.getStateVariableValue;
     if (!component.state[stateVariable]) {
@@ -78,9 +80,11 @@ export async function initializeStateVariable({
     });
 
     if (arrayEntryPrefix !== undefined) {
+        // Callers always pair `arrayEntryPrefix` with `arrayStateVariable`;
+        // assert here so the inner helper can require both as `string`.
         await initializeArrayEntryStateVariable({
             stateVarObj,
-            arrayStateVariable,
+            arrayStateVariable: arrayStateVariable!,
             arrayEntryPrefix,
             component,
             stateVariable,
@@ -116,10 +120,10 @@ async function initializeArrayEntryStateVariable({
     stateVariable,
 }: {
     stateVarObj: any;
-    arrayStateVariable: any;
-    arrayEntryPrefix: any;
-    component: any;
-    stateVariable: any;
+    arrayStateVariable: string;
+    arrayEntryPrefix: string;
+    component: ComponentInstance;
+    stateVariable: string;
 }) {
     // This function used for initializing array entry variables
     // (not the original array variable)
@@ -384,8 +388,8 @@ async function initializeArrayStateVariable({
 }: {
     core: Core;
     stateVarObj: any;
-    component: any;
-    stateVariable: any;
+    component: ComponentInstance;
+    stateVariable: string;
 }) {
     // This function used for initializing original array variables
     // (not array entry variables)
@@ -1463,8 +1467,8 @@ async function createArraySizeStateVariable({
 }: {
     core: Core;
     stateVarObj: any;
-    component: any;
-    stateVariable: any;
+    component: ComponentInstance;
+    stateVariable: string;
 }) {
     let allStateVariablesAffected = [stateVariable];
     if (stateVarObj.additionalStateVariablesDefined) {
@@ -1556,9 +1560,9 @@ export async function arrayEntryNamesFromPropIndex({
     propIndex,
 }: {
     core: Core;
-    stateVariables: any;
-    component: any;
-    propIndex: any;
+    stateVariables: string[];
+    component: ComponentInstance;
+    propIndex: number[];
 }) {
     let newVarNames = [];
     for (let varName of stateVariables) {

--- a/packages/doenetml-worker-javascript/src/StateVariableInitializer.ts
+++ b/packages/doenetml-worker-javascript/src/StateVariableInitializer.ts
@@ -536,7 +536,7 @@ async function initializeArrayStateVariable({
                     if (desiredValue.length > currentSize) {
                         core.addDiagnostic({
                             type: "info",
-                            message: "ignoring array values of out bounds",
+                            message: "ignoring array values out of bounds",
                             position: component.position,
                             sourceDoc: component.sourceDoc,
                         });
@@ -562,12 +562,12 @@ async function initializeArrayStateVariable({
                             [number, any]
                         >) {
                             if (!arrayValuesPiece[ind]) {
-                                arrayValuesPiece = [];
+                                arrayValuesPiece[ind] = [];
                             }
                             let result = setArrayValuesPiece(
                                 val,
                                 arrayValuesPiece[ind],
-                                arraySizePiece[ind],
+                                arraySizePiece.slice(1),
                             );
                             nFailuresSub += result.nFailures;
                         }

--- a/packages/doenetml-worker-javascript/src/StateVariableInitializer.ts
+++ b/packages/doenetml-worker-javascript/src/StateVariableInitializer.ts
@@ -14,1030 +14,1062 @@ import {
  * array-key resolution.
  *
  * The per-state-variable getter captures `core.getStateVariableValue` once
- * inside `initializeStateVariable` (~line 59). This works today because
- * Core's constructor eagerly binds that method (`Core.js:148`), so the
- * captured reference stays valid for the lifetime of the manager. If a
- * future phase moves `getStateVariableValue` onto a separate manager, this
- * capture must become a lazy lookup so the binding source stays live.
+ * inside `initializeStateVariable`. This works today because Core's
+ * constructor eagerly binds that method, so the captured reference stays
+ * valid for the lifetime of the component. If a future phase moves
+ * `getStateVariableValue` onto a separate manager, this capture must
+ * become a lazy lookup so the binding source stays live.
  *
- * Holds a back-reference to Core to read `_components`,
- * `componentInfoObjects`, and `stateVariableChangeTriggers`, and to invoke
- * `getStateVariableValue`, `checkIfArrayEntry`, `addDiagnostic`, and
- * `createFromArrayEntry`.
+ * Stateless — each function takes a back-reference to Core to read
+ * `_components`, `componentInfoObjects`, and
+ * `stateVariableChangeTriggers`, and to invoke `getStateVariableValue`,
+ * `checkIfArrayEntry`, `addDiagnostic`, and `createFromArrayEntry`.
  */
-export class StateVariableInitializer {
+
+export async function initializeComponentStateVariables({
+    core,
+    component,
+}: {
     core: Core;
-
-    constructor({ core }: { core: Core }) {
-        this.core = core;
-    }
-
-    async initializeComponentStateVariables(component) {
-        for (let stateVariable in component.state) {
-            if (component.state[stateVariable].isAlias) {
-                if (!component.stateVarAliases) {
-                    component.stateVarAliases = {};
-                }
-                component.stateVarAliases[stateVariable] =
-                    component.state[stateVariable].targetVariableName;
-
-                // TODO: do we want to delete alias from state?
-                delete component.state[stateVariable];
-            } else {
-                await this.initializeStateVariable({
-                    component,
-                    stateVariable,
-                });
+    component: any;
+}) {
+    for (let stateVariable in component.state) {
+        if (component.state[stateVariable].isAlias) {
+            if (!component.stateVarAliases) {
+                component.stateVarAliases = {};
             }
+            component.stateVarAliases[stateVariable] =
+                component.state[stateVariable].targetVariableName;
+
+            // TODO: do we want to delete alias from state?
+            delete component.state[stateVariable];
+        } else {
+            await initializeStateVariable({
+                core,
+                component,
+                stateVariable,
+            });
         }
     }
+}
 
-    async initializeStateVariable({
-        component,
-        stateVariable,
-        arrayStateVariable,
-        arrayEntryPrefix,
-    }) {
-        let getStateVar = this.core.getStateVariableValue;
-        if (!component.state[stateVariable]) {
-            component.state[stateVariable] = {};
-        }
-        let stateVarObj = component.state[stateVariable];
-        stateVarObj.isResolved = false;
-        Object.defineProperty(stateVarObj, "value", {
-            get: () => getStateVar({ component, stateVariable }),
-            configurable: true,
+export async function initializeStateVariable({
+    core,
+    component,
+    stateVariable,
+    arrayStateVariable,
+    arrayEntryPrefix,
+}: {
+    core: Core;
+    component: any;
+    stateVariable: any;
+    arrayStateVariable?: any;
+    arrayEntryPrefix?: any;
+}) {
+    let getStateVar = core.getStateVariableValue;
+    if (!component.state[stateVariable]) {
+        component.state[stateVariable] = {};
+    }
+    let stateVarObj = component.state[stateVariable];
+    stateVarObj.isResolved = false;
+    Object.defineProperty(stateVarObj, "value", {
+        get: () => getStateVar({ component, stateVariable }),
+        configurable: true,
+    });
+
+    if (arrayEntryPrefix !== undefined) {
+        await initializeArrayEntryStateVariable({
+            stateVarObj,
+            arrayStateVariable,
+            arrayEntryPrefix,
+            component,
+            stateVariable,
         });
+    } else if (stateVarObj.isArray) {
+        await initializeArrayStateVariable({
+            core,
+            stateVarObj,
+            component,
+            stateVariable,
+        });
+    }
 
-        if (arrayEntryPrefix !== undefined) {
-            await this.initializeArrayEntryStateVariable({
-                stateVarObj,
-                arrayStateVariable,
-                arrayEntryPrefix,
-                component,
-                stateVariable,
-            });
-        } else if (stateVarObj.isArray) {
-            await this.initializeArrayStateVariable({
-                stateVarObj,
-                component,
-                stateVariable,
-            });
+    if (stateVarObj.triggerActionOnChange) {
+        let componentTriggers =
+            core.stateVariableChangeTriggers[component.componentIdx];
+        if (!componentTriggers) {
+            componentTriggers = core.stateVariableChangeTriggers[
+                component.componentIdx
+            ] = {};
         }
+        componentTriggers[stateVariable] = {
+            action: stateVarObj.triggerActionOnChange,
+        };
+    }
+}
 
-        if (stateVarObj.triggerActionOnChange) {
-            let componentTriggers =
-                this.core.stateVariableChangeTriggers[component.componentIdx];
-            if (!componentTriggers) {
-                componentTriggers = this.core.stateVariableChangeTriggers[
-                    component.componentIdx
-                ] = {};
+async function initializeArrayEntryStateVariable({
+    stateVarObj,
+    arrayStateVariable,
+    arrayEntryPrefix,
+    component,
+    stateVariable,
+}: {
+    stateVarObj: any;
+    arrayStateVariable: any;
+    arrayEntryPrefix: any;
+    component: any;
+    stateVariable: any;
+}) {
+    // This function used for initializing array entry variables
+    // (not the original array variable)
+    // It adds many attributes to state variables corresponding to
+    // array entries, including
+    // - arrayStateVariable: the name of the array for which this is an entry
+    // - arrayKeys: an array of the key(s) that constitute this entry
+    // - markStale: function from array state variable
+    // - freshnessInfo: object from array state variable
+    // - getValueFromArrayValues: function used to get this entry's value
+    // - isLocation: array entries are locations if the array state variable is
+    //   (See expanation of location in fixLocation state variable of BaseComponent.js)
+
+    stateVarObj.isArrayEntry = true;
+
+    stateVarObj.arrayStateVariable = arrayStateVariable;
+    let arrayStateVarObj = component.state[arrayStateVariable];
+    stateVarObj.definition = arrayStateVarObj.definition;
+    stateVarObj.inverseDefinition = arrayStateVarObj.inverseDefinition;
+    stateVarObj.markStale = arrayStateVarObj.markStale;
+    stateVarObj.freshnessInfo = arrayStateVarObj.freshnessInfo;
+    stateVarObj.getPreviousDependencyValuesForMarkStale =
+        arrayStateVarObj.getPreviousDependencyValuesForMarkStale;
+    stateVarObj.provideEssentialValuesInDefinition =
+        arrayStateVarObj.provideEssentialValuesInDefinition;
+    stateVarObj.providePreviousValuesInDefinition =
+        arrayStateVarObj.providePreviousValuesInDefinition;
+    stateVarObj.isLocation = arrayStateVarObj.isLocation;
+
+    stateVarObj.numDimensions =
+        arrayStateVarObj.returnEntryDimensions(arrayEntryPrefix);
+    stateVarObj.entryPrefix = arrayEntryPrefix;
+    stateVarObj.varEnding = stateVariable.slice(arrayEntryPrefix.length);
+
+    if (arrayStateVarObj.createWorkspace) {
+        stateVarObj.createWorkspace = true;
+        stateVarObj.workspace = arrayStateVarObj.workspace;
+    }
+
+    if (arrayStateVarObj.basedOnArrayKeyStateVariables) {
+        stateVarObj.basedOnArrayKeyStateVariables = true;
+    }
+
+    // if any of the additional state variables defined are arrays,
+    // (which should be all of them)
+    // transform to their array entry
+    if (arrayStateVarObj.additionalStateVariablesDefined) {
+        stateVarObj.additionalStateVariablesDefined = [];
+
+        let entryPrefixInd =
+            arrayStateVarObj.entryPrefixes.indexOf(arrayEntryPrefix);
+
+        for (let varName of arrayStateVarObj.additionalStateVariablesDefined) {
+            let sObj = component.state[varName];
+
+            if (sObj.isArray) {
+                // find the same array entry prefix in the other array state variable
+                let newArrayEntryPrefix = sObj.entryPrefixes[entryPrefixInd];
+                let arrayEntryVarName =
+                    newArrayEntryPrefix + stateVarObj.varEnding;
+
+                stateVarObj.additionalStateVariablesDefined.push(
+                    arrayEntryVarName,
+                );
+            } else {
+                stateVarObj.additionalStateVariablesDefined.push(varName);
             }
-            componentTriggers[stateVariable] = {
-                action: stateVarObj.triggerActionOnChange,
-            };
         }
     }
 
-    async initializeArrayEntryStateVariable({
-        stateVarObj,
-        arrayStateVariable,
-        arrayEntryPrefix,
-        component,
-        stateVariable,
-    }) {
-        // This function used for initializing array entry variables
-        // (not the original array variable)
-        // It adds many attributes to state variables corresponding to
-        // array entries, including
-        // - arrayStateVariable: the name of the array for which this is an entry
-        // - arrayKeys: an array of the key(s) that constitute this entry
-        // - markStale: function from array state variable
-        // - freshnessInfo: object from array state variable
-        // - getValueFromArrayValues: function used to get this entry's value
-        // - isLocation: array entries are locations if the array state variable is
-        //   (See expanation of location in fixLocation state variable of BaseComponent.js)
+    if (arrayStateVarObj.shadowingInstructions) {
+        stateVarObj.shadowingInstructions = {};
 
-        stateVarObj.isArrayEntry = true;
+        // See description of returnWrappingComponents in initializeArrayStateVariable, below.
+        stateVarObj.wrappingComponents =
+            arrayStateVarObj.shadowingInstructions.returnWrappingComponents(
+                arrayEntryPrefix,
+            );
 
-        stateVarObj.arrayStateVariable = arrayStateVariable;
-        let arrayStateVarObj = component.state[arrayStateVariable];
-        stateVarObj.definition = arrayStateVarObj.definition;
-        stateVarObj.inverseDefinition = arrayStateVarObj.inverseDefinition;
-        stateVarObj.markStale = arrayStateVarObj.markStale;
-        stateVarObj.freshnessInfo = arrayStateVarObj.freshnessInfo;
-        stateVarObj.getPreviousDependencyValuesForMarkStale =
-            arrayStateVarObj.getPreviousDependencyValuesForMarkStale;
-        stateVarObj.provideEssentialValuesInDefinition =
-            arrayStateVarObj.provideEssentialValuesInDefinition;
-        stateVarObj.providePreviousValuesInDefinition =
-            arrayStateVarObj.providePreviousValuesInDefinition;
-        stateVarObj.isLocation = arrayStateVarObj.isLocation;
-
-        stateVarObj.numDimensions =
-            arrayStateVarObj.returnEntryDimensions(arrayEntryPrefix);
-        stateVarObj.entryPrefix = arrayEntryPrefix;
-        stateVarObj.varEnding = stateVariable.slice(arrayEntryPrefix.length);
-
-        if (arrayStateVarObj.createWorkspace) {
-            stateVarObj.createWorkspace = true;
-            stateVarObj.workspace = arrayStateVarObj.workspace;
+        if (arrayStateVarObj.shadowingInstructions.attributesToShadow) {
+            stateVarObj.shadowingInstructions.attributesToShadow =
+                arrayStateVarObj.shadowingInstructions.attributesToShadow;
         }
 
-        if (arrayStateVarObj.basedOnArrayKeyStateVariables) {
-            stateVarObj.basedOnArrayKeyStateVariables = true;
-        }
-
-        // if any of the additional state variables defined are arrays,
-        // (which should be all of them)
-        // transform to their array entry
-        if (arrayStateVarObj.additionalStateVariablesDefined) {
-            stateVarObj.additionalStateVariablesDefined = [];
-
+        if (arrayStateVarObj.shadowingInstructions.createComponentOfType) {
             let entryPrefixInd =
                 arrayStateVarObj.entryPrefixes.indexOf(arrayEntryPrefix);
-
-            for (let varName of arrayStateVarObj.additionalStateVariablesDefined) {
-                let sObj = component.state[varName];
-
-                if (sObj.isArray) {
-                    // find the same array entry prefix in the other array state variable
-                    let newArrayEntryPrefix =
-                        sObj.entryPrefixes[entryPrefixInd];
-                    let arrayEntryVarName =
-                        newArrayEntryPrefix + stateVarObj.varEnding;
-
-                    stateVarObj.additionalStateVariablesDefined.push(
-                        arrayEntryVarName,
-                    );
-                } else {
-                    stateVarObj.additionalStateVariablesDefined.push(varName);
-                }
-            }
-        }
-
-        if (arrayStateVarObj.shadowingInstructions) {
-            stateVarObj.shadowingInstructions = {};
-
-            // See description of returnWrappingComponents in initializeArrayStateVariable, below.
-            stateVarObj.wrappingComponents =
-                arrayStateVarObj.shadowingInstructions.returnWrappingComponents(
-                    arrayEntryPrefix,
-                );
-
-            if (arrayStateVarObj.shadowingInstructions.attributesToShadow) {
-                stateVarObj.shadowingInstructions.attributesToShadow =
-                    arrayStateVarObj.shadowingInstructions.attributesToShadow;
-            }
-
-            if (arrayStateVarObj.shadowingInstructions.createComponentOfType) {
-                let entryPrefixInd =
-                    arrayStateVarObj.entryPrefixes.indexOf(arrayEntryPrefix);
-                if (
+            if (
+                arrayStateVarObj.shadowingInstructions.createComponentOfType[
+                    entryPrefixInd
+                ]
+            ) {
+                stateVarObj.shadowingInstructions.createComponentOfType = [
                     arrayStateVarObj.shadowingInstructions
-                        .createComponentOfType[entryPrefixInd]
-                ) {
-                    stateVarObj.shadowingInstructions.createComponentOfType = [
-                        arrayStateVarObj.shadowingInstructions
-                            .createComponentOfType[entryPrefixInd],
-                    ];
-                }
+                        .createComponentOfType[entryPrefixInd],
+                ];
             }
         }
+    }
 
-        // Each arrayEntry state variable will have a function getValueFromArrayValue
-        // that will be used to retrieve the actual value of the components
-        // specified by this entry from the whole array stored in arrayValues
-        // Note: getValueFromArrayValues assumes that arrayValues has been populated
-        if (arrayStateVarObj.getEntryValues) {
-            // the function getEntryValues must have been overwritten by the class
-            // so use this function instead
-            stateVarObj.getValueFromArrayValues = async function () {
-                return await arrayStateVarObj.getEntryValues({
-                    varName: stateVariable,
-                });
-            };
-        } else {
-            // getValueFromArrayValues returns an array of the values
-            // that correspond to the arrayKeys of this entry state variable
-            // (returning a scalar instead if it is just a single value)
-            // It uses the function getArrayValue, which gets the values
-            // from arrayValues of the corresponding array state variable
-            stateVarObj.getValueFromArrayValues = async function () {
-                let arrayKeys = await stateVarObj.arrayKeys;
-                if (arrayKeys.length === 0) {
-                    return;
-                }
-                let value = [];
-                for (let arrayKey of arrayKeys) {
-                    value.push(arrayStateVarObj.getArrayValue({ arrayKey }));
-                }
-                if (value.length === 1) {
-                    return value[0];
-                } else {
-                    return value;
-                }
-            };
-        }
-
-        stateVarObj.arraySizeStateVariable =
-            arrayStateVarObj.arraySizeStateVariable;
-
-        stateVarObj._arrayKeys = [];
-        stateVarObj._unflattenedArrayKeys = [];
-
-        Object.defineProperty(stateVarObj, "arrayKeys", {
-            get: function () {
-                return (async () => {
-                    // first evaluate arraySize so _arrayKeys is recalculated
-                    // in case arraySize change
-                    await arrayStateVarObj.arraySize;
-                    return stateVarObj._arrayKeys;
-                })();
-            },
-        });
-
-        Object.defineProperty(stateVarObj, "unflattenedArrayKeys", {
-            get: function () {
-                return (async () => {
-                    // first evaluate arraySize so _unflattenedArrayKeys is recalculated
-                    // in case arraySize change
-                    await arrayStateVarObj.arraySize;
-                    return stateVarObj._unflattenedArrayKeys;
-                })();
-            },
-        });
-
-        if (
-            component.state[stateVarObj.arraySizeStateVariable]
-                .initiallyResolved
-        ) {
-            let arraySize = await arrayStateVarObj.arraySize;
-            let arrayKeys = arrayStateVarObj.getArrayKeysFromVarName({
-                arrayEntryPrefix: stateVarObj.entryPrefix,
-                varEnding: stateVarObj.varEnding,
-                arraySize,
-                numDimensions: arrayStateVarObj.numDimensions,
+    // Each arrayEntry state variable will have a function getValueFromArrayValue
+    // that will be used to retrieve the actual value of the components
+    // specified by this entry from the whole array stored in arrayValues
+    // Note: getValueFromArrayValues assumes that arrayValues has been populated
+    if (arrayStateVarObj.getEntryValues) {
+        // the function getEntryValues must have been overwritten by the class
+        // so use this function instead
+        stateVarObj.getValueFromArrayValues = async function () {
+            return await arrayStateVarObj.getEntryValues({
+                varName: stateVariable,
             });
-
-            stateVarObj._unflattenedArrayKeys = arrayKeys;
-            stateVarObj._arrayKeys = flattenDeep(arrayKeys);
-
-            // for each arrayKey, add this entry name to the array's list variables
-            let varNamesIncluding = arrayStateVarObj.varNamesIncludingArrayKeys;
-            for (let arrayKey of stateVarObj._arrayKeys) {
-                if (!varNamesIncluding[arrayKey]) {
-                    varNamesIncluding[arrayKey] = [];
-                }
-                varNamesIncluding[arrayKey].push(stateVariable);
+        };
+    } else {
+        // getValueFromArrayValues returns an array of the values
+        // that correspond to the arrayKeys of this entry state variable
+        // (returning a scalar instead if it is just a single value)
+        // It uses the function getArrayValue, which gets the values
+        // from arrayValues of the corresponding array state variable
+        stateVarObj.getValueFromArrayValues = async function () {
+            let arrayKeys = await stateVarObj.arrayKeys;
+            if (arrayKeys.length === 0) {
+                return;
             }
-        }
-
-        arrayStateVarObj.arrayEntryNames.push(stateVariable);
-
-        Object.defineProperty(stateVarObj, "arraySize", {
-            get: () => arrayStateVarObj.arraySize,
-        });
-
-        // TODO: delete since arrayEntrySize isn't currently used?
-        Object.defineProperty(stateVarObj, "arrayEntrySize", {
-            get: function () {
-                return (async () => {
-                    // assume array is rectangular, so just look at first subarray of each dimension
-                    let unflattenedArrayKeys =
-                        await stateVarObj.unflattenedArrayKeys;
-                    let arrayEntrySize = [];
-                    let subArray = [unflattenedArrayKeys];
-                    for (let i = 0; i < stateVarObj.numDimensions; i++) {
-                        subArray = subArray[0];
-                        arrayEntrySize.push(subArray.length);
-                    }
-                    arrayEntrySize.reverse(); // so starts with inner dimension
-                    return arrayEntrySize;
-                })();
-            },
-        });
-
-        if (arrayStateVarObj.stateVariablesDeterminingDependencies) {
-            if (!stateVarObj.stateVariablesDeterminingDependencies) {
-                stateVarObj.stateVariablesDeterminingDependencies = [];
+            let value = [];
+            for (let arrayKey of arrayKeys) {
+                value.push(arrayStateVarObj.getArrayValue({ arrayKey }));
             }
-
-            for (let varName of arrayStateVarObj.stateVariablesDeterminingDependencies) {
-                if (
-                    !stateVarObj.stateVariablesDeterminingDependencies.includes(
-                        varName,
-                    )
-                ) {
-                    stateVarObj.stateVariablesDeterminingDependencies.push(
-                        varName,
-                    );
-                }
+            if (value.length === 1) {
+                return value[0];
+            } else {
+                return value;
             }
-        }
-
-        // add a returnDependencies function based on the array returnDependencies
-        let arrayReturnDependencies =
-            arrayStateVarObj.returnDependencies.bind(arrayStateVarObj);
-        stateVarObj.returnDependencies = async function (args) {
-            // add array size to argument of return dependencies
-            args.arraySize = await stateVarObj.arraySize;
-            args.arrayKeys = await stateVarObj.arrayKeys;
-            let dependencies = await arrayReturnDependencies(args);
-
-            // We keep track of how many names were defined when we calculate dependencies
-            // If this number changes, it should be treated as dependencies changing
-            // so that we recalculate the value of the arrayEntry variable
-            // TODO: we are communicating this to updateDependencies by adding
-            // an attribute to the arguments?  Is there a better way of doing it.
-            // Didn't want to add to the return value, as that would add complexity
-            // to how we normally define returnDependencies
-            // We could change returnDependencies to output an object.
-            // That would probably be cleaner.
-            let numNames = Object.keys(
-                arrayStateVarObj.dependencyNames.namesByKey,
-            ).length;
-            if (stateVarObj.numberNamesInPreviousReturnDep !== numNames) {
-                args.changedDependency = true;
-            }
-            stateVarObj.numberNamesInPreviousReturnDep = numNames;
-
-            return dependencies;
         };
     }
 
-    async initializeArrayStateVariable({
-        stateVarObj,
-        component,
-        stateVariable,
-    }) {
-        // This function used for initializing original array variables
-        // (not array entry variables)
+    stateVarObj.arraySizeStateVariable =
+        arrayStateVarObj.arraySizeStateVariable;
 
-        // Arrays values are stored in a (possibly-multidimensional) array
-        // called arrayValues.  However, so that core doesn't have to deal
-        // with special cases for multiple dimensions, array values are typically
-        // referenced with an arrayKey, which is a single string that corresponds
-        // to a single entry in the array.
-        // For one dimension, index is an integer and arrayKey is its string representation
-        // For multiple dimensions, index is an array of integers, e.g. [i,j,k]
-        // and arrayKey is its string representation, i.e., "i,j,k"
+    stateVarObj._arrayKeys = [];
+    stateVarObj._unflattenedArrayKeys = [];
 
-        // The function adds attributes to array state variables, including
-        // - arrayValues: the array of the current values of the array
-        //   (i.e., based on index rather than arrayKey)
-        //   arrayValues is used rather than value given that value is
-        //   sometimes deleted and replaced by a getter.  arrayValues is
-        //   never deleted, but entries are marked as stale using freshnessInfo
-        // - freshnessInfo: this object can be used to track information about the
-        //   freshness of the array entries or other array features, such as size.
-        //   freshnessInfo is prepopulated with
-        //     - a freshByKey object for tracking by key
-        //     - a freshArraySize for tracking array size
-        //   To take advantage of this object, a component can read and modify
-        //   freshnessInfo (as core will pass it in as an argument) in
-        //   - the state variable's definition function
-        //     (to short circuit calculation of something that is already fresh and/or
-        //     to indicate what is now fresh)
-        //   - the state variable's optional markStale function
-        //     (to indicate what is no longer fresh)
-        // - keyToIndex: maps arrayKey (single string) to (multi-)index
-        // - indexToKey: maps (multi-)index to arrayKey
-        // - setArrayValue: sets value in arrayValues corresponding to arrayKey
-        // - getArrayValue: gets value in arrayValues corresponding to arrayKey
-        // - getArrayKeysFromVarName: returns array of the arrayKeys that correspond
-        //   to a given variable name of an array entry
-        // - arrayVarNameFromArrayKey: returns the variable name of an array entry
-        //   that contains a given array key (if there are many, just return one)
-        //   This variable may not yet be created.
+    Object.defineProperty(stateVarObj, "arrayKeys", {
+        get: function () {
+            return (async () => {
+                // first evaluate arraySize so _arrayKeys is recalculated
+                // in case arraySize change
+                await arrayStateVarObj.arraySize;
+                return stateVarObj._arrayKeys;
+            })();
+        },
+    });
 
-        let core = this.core;
+    Object.defineProperty(stateVarObj, "unflattenedArrayKeys", {
+        get: function () {
+            return (async () => {
+                // first evaluate arraySize so _unflattenedArrayKeys is recalculated
+                // in case arraySize change
+                await arrayStateVarObj.arraySize;
+                return stateVarObj._unflattenedArrayKeys;
+            })();
+        },
+    });
 
-        stateVarObj.arrayValues = [];
+    if (component.state[stateVarObj.arraySizeStateVariable].initiallyResolved) {
+        let arraySize = await arrayStateVarObj.arraySize;
+        let arrayKeys = arrayStateVarObj.getArrayKeysFromVarName({
+            arrayEntryPrefix: stateVarObj.entryPrefix,
+            varEnding: stateVarObj.varEnding,
+            arraySize,
+            numDimensions: arrayStateVarObj.numDimensions,
+        });
 
-        if (stateVarObj.numDimensions === undefined) {
-            stateVarObj.numDimensions = 1;
+        stateVarObj._unflattenedArrayKeys = arrayKeys;
+        stateVarObj._arrayKeys = flattenDeep(arrayKeys);
+
+        // for each arrayKey, add this entry name to the array's list variables
+        let varNamesIncluding = arrayStateVarObj.varNamesIncludingArrayKeys;
+        for (let arrayKey of stateVarObj._arrayKeys) {
+            if (!varNamesIncluding[arrayKey]) {
+                varNamesIncluding[arrayKey] = [];
+            }
+            varNamesIncluding[arrayKey].push(stateVariable);
+        }
+    }
+
+    arrayStateVarObj.arrayEntryNames.push(stateVariable);
+
+    Object.defineProperty(stateVarObj, "arraySize", {
+        get: () => arrayStateVarObj.arraySize,
+    });
+
+    // TODO: delete since arrayEntrySize isn't currently used?
+    Object.defineProperty(stateVarObj, "arrayEntrySize", {
+        get: function () {
+            return (async () => {
+                // assume array is rectangular, so just look at first subarray of each dimension
+                let unflattenedArrayKeys =
+                    await stateVarObj.unflattenedArrayKeys;
+                let arrayEntrySize: number[] = [];
+                let subArray = [unflattenedArrayKeys];
+                for (let i = 0; i < stateVarObj.numDimensions; i++) {
+                    subArray = subArray[0];
+                    arrayEntrySize.push(subArray.length);
+                }
+                arrayEntrySize.reverse(); // so starts with inner dimension
+                return arrayEntrySize;
+            })();
+        },
+    });
+
+    if (arrayStateVarObj.stateVariablesDeterminingDependencies) {
+        if (!stateVarObj.stateVariablesDeterminingDependencies) {
+            stateVarObj.stateVariablesDeterminingDependencies = [];
         }
 
-        let entryPrefixes = stateVarObj.entryPrefixes;
-
-        if (!entryPrefixes) {
-            entryPrefixes = stateVarObj.entryPrefixes = [stateVariable];
+        for (let varName of arrayStateVarObj.stateVariablesDeterminingDependencies) {
+            if (
+                !stateVarObj.stateVariablesDeterminingDependencies.includes(
+                    varName,
+                )
+            ) {
+                stateVarObj.stateVariablesDeterminingDependencies.push(varName);
+            }
         }
+    }
 
-        if (!component.arrayEntryPrefixes) {
-            component.arrayEntryPrefixes = {};
-        }
-        for (let prefix of entryPrefixes) {
-            component.arrayEntryPrefixes[prefix] = stateVariable;
-        }
+    // add a returnDependencies function based on the array returnDependencies
+    let arrayReturnDependencies =
+        arrayStateVarObj.returnDependencies.bind(arrayStateVarObj);
+    stateVarObj.returnDependencies = async function (args: any) {
+        // add array size to argument of return dependencies
+        args.arraySize = await stateVarObj.arraySize;
+        args.arrayKeys = await stateVarObj.arrayKeys;
+        let dependencies = await arrayReturnDependencies(args);
 
-        if (stateVarObj.numDimensions > 1) {
-            // for multiple dimensions, have to convert from arrayKey
-            // to multi-index when getting or setting
-            // Note: we don't check that arrayKey has the appropriate number of dimensions
-            // If it has fewer dimensions than numDimensions, it will set the slice
-            // to the given value
-            // (useful, for example, to set entire rows)
-            // If it has more dimensinos than numDimensions, behavior isn't determined
-            // (it should throw an error, assuming the array entries aren't arrays)
-            stateVarObj.keyToIndex = (key) =>
-                key.split(",").map((x) => Number(x));
-            stateVarObj.setArrayValue = function ({
-                value,
-                arrayKey,
-                arraySize,
-                arrayValues = stateVarObj.arrayValues,
-            }) {
-                let index = stateVarObj.keyToIndex(arrayKey);
-                let numDimensionsInArrayKey = index.length;
-                // Pre-existing typo fixed per CORE_REFACTOR_DEFERRED.md
-                // §"Pre-existing unreachable diagnostic": the original
-                // `!numDimensionsInArrayKey > stateVarObj.numDimensions`
-                // evaluates to `false > number === false` for any positive
-                // integer, so the diagnostic was unreachable.
-                if (numDimensionsInArrayKey > stateVarObj.numDimensions) {
+        // We keep track of how many names were defined when we calculate dependencies
+        // If this number changes, it should be treated as dependencies changing
+        // so that we recalculate the value of the arrayEntry variable
+        // TODO: we are communicating this to updateDependencies by adding
+        // an attribute to the arguments?  Is there a better way of doing it.
+        // Didn't want to add to the return value, as that would add complexity
+        // to how we normally define returnDependencies
+        // We could change returnDependencies to output an object.
+        // That would probably be cleaner.
+        let numNames = Object.keys(
+            arrayStateVarObj.dependencyNames.namesByKey,
+        ).length;
+        if (stateVarObj.numberNamesInPreviousReturnDep !== numNames) {
+            args.changedDependency = true;
+        }
+        stateVarObj.numberNamesInPreviousReturnDep = numNames;
+
+        return dependencies;
+    };
+}
+
+async function initializeArrayStateVariable({
+    core,
+    stateVarObj,
+    component,
+    stateVariable,
+}: {
+    core: Core;
+    stateVarObj: any;
+    component: any;
+    stateVariable: any;
+}) {
+    // This function used for initializing original array variables
+    // (not array entry variables)
+
+    // Arrays values are stored in a (possibly-multidimensional) array
+    // called arrayValues.  However, so that core doesn't have to deal
+    // with special cases for multiple dimensions, array values are typically
+    // referenced with an arrayKey, which is a single string that corresponds
+    // to a single entry in the array.
+    // For one dimension, index is an integer and arrayKey is its string representation
+    // For multiple dimensions, index is an array of integers, e.g. [i,j,k]
+    // and arrayKey is its string representation, i.e., "i,j,k"
+
+    // The function adds attributes to array state variables, including
+    // - arrayValues: the array of the current values of the array
+    //   (i.e., based on index rather than arrayKey)
+    //   arrayValues is used rather than value given that value is
+    //   sometimes deleted and replaced by a getter.  arrayValues is
+    //   never deleted, but entries are marked as stale using freshnessInfo
+    // - freshnessInfo: this object can be used to track information about the
+    //   freshness of the array entries or other array features, such as size.
+    //   freshnessInfo is prepopulated with
+    //     - a freshByKey object for tracking by key
+    //     - a freshArraySize for tracking array size
+    //   To take advantage of this object, a component can read and modify
+    //   freshnessInfo (as core will pass it in as an argument) in
+    //   - the state variable's definition function
+    //     (to short circuit calculation of something that is already fresh and/or
+    //     to indicate what is now fresh)
+    //   - the state variable's optional markStale function
+    //     (to indicate what is no longer fresh)
+    // - keyToIndex: maps arrayKey (single string) to (multi-)index
+    // - indexToKey: maps (multi-)index to arrayKey
+    // - setArrayValue: sets value in arrayValues corresponding to arrayKey
+    // - getArrayValue: gets value in arrayValues corresponding to arrayKey
+    // - getArrayKeysFromVarName: returns array of the arrayKeys that correspond
+    //   to a given variable name of an array entry
+    // - arrayVarNameFromArrayKey: returns the variable name of an array entry
+    //   that contains a given array key (if there are many, just return one)
+    //   This variable may not yet be created.
+
+    stateVarObj.arrayValues = [];
+
+    if (stateVarObj.numDimensions === undefined) {
+        stateVarObj.numDimensions = 1;
+    }
+
+    let entryPrefixes = stateVarObj.entryPrefixes;
+
+    if (!entryPrefixes) {
+        entryPrefixes = stateVarObj.entryPrefixes = [stateVariable];
+    }
+
+    if (!component.arrayEntryPrefixes) {
+        component.arrayEntryPrefixes = {};
+    }
+    for (let prefix of entryPrefixes) {
+        component.arrayEntryPrefixes[prefix] = stateVariable;
+    }
+
+    if (stateVarObj.numDimensions > 1) {
+        // for multiple dimensions, have to convert from arrayKey
+        // to multi-index when getting or setting
+        // Note: we don't check that arrayKey has the appropriate number of dimensions
+        // If it has fewer dimensions than numDimensions, it will set the slice
+        // to the given value
+        // (useful, for example, to set entire rows)
+        // If it has more dimensinos than numDimensions, behavior isn't determined
+        // (it should throw an error, assuming the array entries aren't arrays)
+        stateVarObj.keyToIndex = (key: string) =>
+            key.split(",").map((x) => Number(x));
+        stateVarObj.setArrayValue = function ({
+            value,
+            arrayKey,
+            arraySize,
+            arrayValues = stateVarObj.arrayValues,
+        }: any) {
+            let index = stateVarObj.keyToIndex(arrayKey);
+            let numDimensionsInArrayKey = index.length;
+            // Pre-existing typo fixed per CORE_REFACTOR_DEFERRED.md
+            // §"Pre-existing unreachable diagnostic": the original
+            // `!numDimensionsInArrayKey > stateVarObj.numDimensions`
+            // evaluates to `false > number === false` for any positive
+            // integer, so the diagnostic was unreachable.
+            if (numDimensionsInArrayKey > stateVarObj.numDimensions) {
+                core.addDiagnostic({
+                    type: "info",
+                    message:
+                        "Cannot set array value.  Number of dimensions is too large.",
+                    position: component.position,
+                    sourceDoc: component.sourceDoc,
+                });
+                return { nFailures: 1 };
+            }
+            let arrayValuesDrillDown = arrayValues;
+            let arraySizeDrillDown = arraySize;
+            for (let indComponent of index.slice(0, index.length - 1)) {
+                if (indComponent >= 0 && indComponent < arraySizeDrillDown[0]) {
+                    if (!arrayValuesDrillDown[indComponent]) {
+                        arrayValuesDrillDown[indComponent] = [];
+                    }
+                    arrayValuesDrillDown = arrayValuesDrillDown[indComponent];
+                    arraySizeDrillDown = arraySizeDrillDown.slice(1);
+                } else {
                     core.addDiagnostic({
                         type: "info",
-                        message:
-                            "Cannot set array value.  Number of dimensions is too large.",
+                        message: "ignore setting array value out of bounds",
                         position: component.position,
                         sourceDoc: component.sourceDoc,
                     });
                     return { nFailures: 1 };
                 }
-                let arrayValuesDrillDown = arrayValues;
-                let arraySizeDrillDown = arraySize;
-                for (let indComponent of index.slice(0, index.length - 1)) {
-                    if (
-                        indComponent >= 0 &&
-                        indComponent < arraySizeDrillDown[0]
-                    ) {
-                        if (!arrayValuesDrillDown[indComponent]) {
-                            arrayValuesDrillDown[indComponent] = [];
-                        }
-                        arrayValuesDrillDown =
-                            arrayValuesDrillDown[indComponent];
-                        arraySizeDrillDown = arraySizeDrillDown.slice(1);
-                    } else {
+            }
+
+            let nFailures = 0;
+
+            if (numDimensionsInArrayKey < stateVarObj.numDimensions) {
+                // if dimensions from arrayKey is less than number of dimensions
+                // then attempt to get additional dimensions from
+                // array indices of value
+
+                let setArrayValuesPiece = function (
+                    desiredValue: any,
+                    arrayValuesPiece: any,
+                    arraySizePiece: any,
+                ): { nFailures: number } {
+                    // try to set value of entries of arrayValuePiece to entries of desiredValue
+                    // given that size of arrayValuesPieces is arraySizePiece
+
+                    if (!Array.isArray(desiredValue)) {
                         core.addDiagnostic({
                             type: "info",
-                            message: "ignore setting array value out of bounds",
+                            message:
+                                "ignoring array values with insufficient dimensions",
                             position: component.position,
                             sourceDoc: component.sourceDoc,
                         });
                         return { nFailures: 1 };
                     }
+
+                    let nFailuresSub = 0;
+
+                    let currentSize = arraySizePiece[0];
+                    if (desiredValue.length > currentSize) {
+                        core.addDiagnostic({
+                            type: "info",
+                            message: "ignoring array values of out bounds",
+                            position: component.position,
+                            sourceDoc: component.sourceDoc,
+                        });
+                        nFailuresSub += desiredValue.length - currentSize;
+                        desiredValue = desiredValue.slice(0, currentSize);
+                    }
+
+                    if (arraySizePiece.length === 1) {
+                        // down to last dimension
+                        for (let [
+                            ind,
+                            val,
+                        ] of desiredValue.entries() as Iterable<
+                            [number, any]
+                        >) {
+                            arrayValuesPiece[ind] = val;
+                        }
+                    } else {
+                        for (let [
+                            ind,
+                            val,
+                        ] of desiredValue.entries() as Iterable<
+                            [number, any]
+                        >) {
+                            if (!arrayValuesPiece[ind]) {
+                                arrayValuesPiece = [];
+                            }
+                            let result = setArrayValuesPiece(
+                                val,
+                                arrayValuesPiece[ind],
+                                arraySizePiece[ind],
+                            );
+                            nFailuresSub += result.nFailures;
+                        }
+                    }
+
+                    return { nFailures: nFailuresSub };
+                };
+
+                let result = setArrayValuesPiece(
+                    value,
+                    arrayValuesDrillDown,
+                    arraySizeDrillDown,
+                );
+                nFailures += result.nFailures;
+            } else {
+                arrayValuesDrillDown[index[index.length - 1]] = value;
+            }
+
+            return { nFailures };
+        };
+        stateVarObj.getArrayValue = function ({
+            arrayKey,
+            arrayValues = stateVarObj.arrayValues,
+        }: any) {
+            let index = stateVarObj.keyToIndex(arrayKey);
+            let aVals = arrayValues;
+            for (let indComponent of index.slice(0, index.length - 1)) {
+                aVals = aVals[indComponent];
+                if (!aVals) {
+                    return undefined;
+                }
+            }
+            return aVals[index[index.length - 1]];
+        };
+
+        if (!stateVarObj.getAllArrayKeys) {
+            stateVarObj.getAllArrayKeys = function (
+                arraySize: any,
+                flatten = true,
+                desiredSize?: any,
+            ) {
+                function prependToAllKeys(keys: any[], newStuff: any) {
+                    for (let [ind, key] of keys.entries() as Iterable<
+                        [number, any]
+                    >) {
+                        if (Array.isArray(key)) {
+                            prependToAllKeys(key, newStuff);
+                        } else {
+                            keys[ind] = newStuff + "," + key;
+                        }
+                    }
                 }
 
-                let nFailures = 0;
-
-                if (numDimensionsInArrayKey < stateVarObj.numDimensions) {
-                    // if dimensions from arrayKey is less than number of dimensions
-                    // then attempt to get additional dimensions from
-                    // array indices of value
-
-                    let setArrayValuesPiece = function (
-                        desiredValue,
-                        arrayValuesPiece,
-                        arraySizePiece,
-                    ) {
-                        // try to set value of entries of arrayValuePiece to entries of desiredValue
-                        // given that size of arrayValuesPieces is arraySizePiece
-
-                        if (!Array.isArray(desiredValue)) {
-                            core.addDiagnostic({
-                                type: "info",
-                                message:
-                                    "ignoring array values with insufficient dimensions",
-                                position: component.position,
-                                sourceDoc: component.sourceDoc,
-                            });
-                            return { nFailures: 1 };
-                        }
-
-                        let nFailuresSub = 0;
-
-                        let currentSize = arraySizePiece[0];
-                        if (desiredValue.length > currentSize) {
-                            core.addDiagnostic({
-                                type: "info",
-                                message: "ignoring array values of out bounds",
-                                position: component.position,
-                                sourceDoc: component.sourceDoc,
-                            });
-                            nFailuresSub += desiredValue.length - currentSize;
-                            desiredValue = desiredValue.slice(0, currentSize);
-                        }
-
-                        if (arraySizePiece.length === 1) {
-                            // down to last dimension
-                            for (let [ind, val] of desiredValue.entries()) {
-                                arrayValuesPiece[ind] = val;
-                            }
-                        } else {
-                            for (let [ind, val] of desiredValue.entries()) {
-                                if (!arrayValuesPiece[ind]) {
-                                    arrayValuesPiece = [];
-                                }
-                                let result = setArrayValuesPiece(
-                                    val,
-                                    arrayValuesPiece[ind],
-                                    arraySizePiece[ind],
+                function getAllArrayKeysSub(subArraySize: any): any[] {
+                    if (subArraySize.length === 1) {
+                        // array of numbers from 0 to subArraySize[0], cast to strings
+                        return Array.from(Array(subArraySize[0]), (_, i) =>
+                            String(i),
+                        );
+                    } else {
+                        let currentSize = subArraySize[0];
+                        let subSubKeys = getAllArrayKeysSub(
+                            subArraySize.slice(1),
+                        );
+                        let subKeys: any[] = [];
+                        for (let ind = 0; ind < currentSize; ind++) {
+                            if (flatten) {
+                                subKeys.push(
+                                    ...subSubKeys.map(
+                                        (x: any) => ind + "," + x,
+                                    ),
                                 );
-                                nFailuresSub += result.nFailures;
-                            }
-                        }
-
-                        return { nFailures: nFailuresSub };
-                    };
-
-                    let result = setArrayValuesPiece(
-                        value,
-                        arrayValuesDrillDown,
-                        arraySizeDrillDown,
-                    );
-                    nFailures += result.nFailures;
-                } else {
-                    arrayValuesDrillDown[index[index.length - 1]] = value;
-                }
-
-                return { nFailures };
-            };
-            stateVarObj.getArrayValue = function ({
-                arrayKey,
-                arrayValues = stateVarObj.arrayValues,
-            }) {
-                let index = stateVarObj.keyToIndex(arrayKey);
-                let aVals = arrayValues;
-                for (let indComponent of index.slice(0, index.length - 1)) {
-                    aVals = aVals[indComponent];
-                    if (!aVals) {
-                        return undefined;
-                    }
-                }
-                return aVals[index[index.length - 1]];
-            };
-
-            if (!stateVarObj.getAllArrayKeys) {
-                stateVarObj.getAllArrayKeys = function (
-                    arraySize,
-                    flatten = true,
-                    desiredSize,
-                ) {
-                    function prependToAllKeys(keys, newStuff) {
-                        for (let [ind, key] of keys.entries()) {
-                            if (Array.isArray(key)) {
-                                prependToAllKeys(key, newStuff);
                             } else {
-                                keys[ind] = newStuff + "," + key;
+                                let newSubSubKeys = deepClone(subSubKeys);
+                                prependToAllKeys(newSubSubKeys, ind);
+                                subKeys.push(newSubSubKeys);
                             }
                         }
-                    }
-
-                    function getAllArrayKeysSub(subArraySize) {
-                        if (subArraySize.length === 1) {
-                            // array of numbers from 0 to subArraySize[0], cast to strings
-                            return Array.from(Array(subArraySize[0]), (_, i) =>
-                                String(i),
-                            );
-                        } else {
-                            let currentSize = subArraySize[0];
-                            let subSubKeys = getAllArrayKeysSub(
-                                subArraySize.slice(1),
-                            );
-                            let subKeys = [];
-                            for (let ind = 0; ind < currentSize; ind++) {
-                                if (flatten) {
-                                    subKeys.push(
-                                        ...subSubKeys.map((x) => ind + "," + x),
-                                    );
-                                } else {
-                                    let newSubSubKeys = deepClone(subSubKeys);
-                                    prependToAllKeys(newSubSubKeys, ind);
-                                    subKeys.push(newSubSubKeys);
-                                }
-                            }
-                            return subKeys;
-                        }
-                    }
-
-                    if (desiredSize) {
-                        if (desiredSize.length === 0) {
-                            return [];
-                        } else {
-                            return getAllArrayKeysSub(desiredSize);
-                        }
-                    } else if (!arraySize || arraySize.length === 0) {
-                        return [];
-                    } else {
-                        return getAllArrayKeysSub(arraySize);
-                    }
-                };
-            }
-
-            if (!stateVarObj.arrayVarNameFromArrayKey) {
-                stateVarObj.arrayVarNameFromArrayKey = function (arrayKey) {
-                    return (
-                        entryPrefixes[0] +
-                        arrayKey
-                            .split(",")
-                            .map((x) => Number(x) + 1)
-                            .join("_")
-                    );
-                };
-            }
-
-            // arrayVarNameFromPropIndex is a function that calculates the name
-            // an array entry state variable that corresponds to the specified propIndex.
-            // It is a consequence of retrofitting the ability to index an array (e.g., $a.b[1])
-            // onto a system that was designed with just array entry variables (e..g, $a.b1).
-            // arrayVarNameFromPropIndex can be specified in the definition of the array state variable.
-            // Since numDimensions > 1 here, the default arrayVarNameFromPropIndex
-            // is to turn $a.b[1][2][3] to $a.p1_2_3,
-            // where "p" is the first entry prefix of the array "b".
-
-            // TODO: if we redesign arrays to be based on indices (or even slices),
-            // then arrayVarNameFromPropIndex will be obsolete.
-            if (!stateVarObj.arrayVarNameFromPropIndex) {
-                stateVarObj.arrayVarNameFromPropIndex =
-                    returnDefaultArrayVarNameFromPropIndex(
-                        stateVarObj.numDimensions,
-                        entryPrefixes[0],
-                    );
-            }
-
-            stateVarObj.adjustArrayToNewArraySize = async function () {
-                function resizeSubArray(subArray, subArraySize) {
-                    subArray.length = subArraySize[0];
-
-                    if (subArraySize.length > 1) {
-                        let subSubArraySize = subArraySize.slice(1);
-                        for (let [ind, subSubArray] of subArray.entries()) {
-                            if (!subSubArray) {
-                                // add in any empty entries
-                                subSubArray = subArray[ind] = [];
-                            }
-                            resizeSubArray(subSubArray, subSubArraySize);
-                        }
+                        return subKeys;
                     }
                 }
 
-                let arraySize = await stateVarObj.arraySize;
-                resizeSubArray(stateVarObj.arrayValues, arraySize);
-            };
-        } else {
-            // have just one dimension
-            stateVarObj.keyToIndex = (key) => Number(key);
-            stateVarObj.setArrayValue = function ({
-                value,
-                arrayKey,
-                arraySize,
-                arrayValues = stateVarObj.arrayValues,
-            }) {
-                let ind = stateVarObj.keyToIndex(arrayKey);
-                if (ind >= 0 && ind < arraySize[0]) {
-                    arrayValues[ind] = value;
-                    return { nFailures: 0 };
+                if (desiredSize) {
+                    if (desiredSize.length === 0) {
+                        return [];
+                    } else {
+                        return getAllArrayKeysSub(desiredSize);
+                    }
+                } else if (!arraySize || arraySize.length === 0) {
+                    return [];
                 } else {
-                    core.addDiagnostic({
-                        type: "info",
-                        message: `Ignoring setting array values out of bounds: ${arrayKey} of ${stateVariable}`,
-                        position: component.position,
-                        sourceDoc: component.sourceDoc,
-                    });
-                    return { nFailures: 1 };
+                    return getAllArrayKeysSub(arraySize);
                 }
             };
-            stateVarObj.getArrayValue = function ({
-                arrayKey,
-                arrayValues = stateVarObj.arrayValues,
-            }) {
-                return arrayValues[arrayKey];
-            };
+        }
 
-            if (!stateVarObj.getAllArrayKeys) {
-                stateVarObj.getAllArrayKeys = function (
-                    arraySize,
-                    flatten,
-                    desiredSize,
-                ) {
-                    if (desiredSize) {
-                        if (desiredSize.length === 0) {
-                            return [];
-                        } else {
-                            // array of numbers from 0 to desiredSize[0], cast to strings
-                            return Array.from(Array(desiredSize[0]), (_, i) =>
-                                String(i),
-                            );
+        if (!stateVarObj.arrayVarNameFromArrayKey) {
+            stateVarObj.arrayVarNameFromArrayKey = function (arrayKey: string) {
+                return (
+                    entryPrefixes[0] +
+                    arrayKey
+                        .split(",")
+                        .map((x) => Number(x) + 1)
+                        .join("_")
+                );
+            };
+        }
+
+        // arrayVarNameFromPropIndex is a function that calculates the name
+        // an array entry state variable that corresponds to the specified propIndex.
+        // It is a consequence of retrofitting the ability to index an array (e.g., $a.b[1])
+        // onto a system that was designed with just array entry variables (e..g, $a.b1).
+        // arrayVarNameFromPropIndex can be specified in the definition of the array state variable.
+        // Since numDimensions > 1 here, the default arrayVarNameFromPropIndex
+        // is to turn $a.b[1][2][3] to $a.p1_2_3,
+        // where "p" is the first entry prefix of the array "b".
+
+        // TODO: if we redesign arrays to be based on indices (or even slices),
+        // then arrayVarNameFromPropIndex will be obsolete.
+        if (!stateVarObj.arrayVarNameFromPropIndex) {
+            stateVarObj.arrayVarNameFromPropIndex =
+                returnDefaultArrayVarNameFromPropIndex(
+                    stateVarObj.numDimensions,
+                    entryPrefixes[0],
+                );
+        }
+
+        stateVarObj.adjustArrayToNewArraySize = async function () {
+            function resizeSubArray(subArray: any[], subArraySize: any) {
+                subArray.length = subArraySize[0];
+
+                if (subArraySize.length > 1) {
+                    let subSubArraySize = subArraySize.slice(1);
+                    for (let [
+                        ind,
+                        subSubArray,
+                    ] of subArray.entries() as Iterable<[number, any]>) {
+                        if (!subSubArray) {
+                            // add in any empty entries
+                            subSubArray = subArray[ind] = [];
                         }
-                    } else if (!arraySize || arraySize.length === 0) {
+                        resizeSubArray(subSubArray, subSubArraySize);
+                    }
+                }
+            }
+
+            let arraySize = await stateVarObj.arraySize;
+            resizeSubArray(stateVarObj.arrayValues, arraySize);
+        };
+    } else {
+        // have just one dimension
+        stateVarObj.keyToIndex = (key: string) => Number(key);
+        stateVarObj.setArrayValue = function ({
+            value,
+            arrayKey,
+            arraySize,
+            arrayValues = stateVarObj.arrayValues,
+        }: any) {
+            let ind = stateVarObj.keyToIndex(arrayKey);
+            if (ind >= 0 && ind < arraySize[0]) {
+                arrayValues[ind] = value;
+                return { nFailures: 0 };
+            } else {
+                core.addDiagnostic({
+                    type: "info",
+                    message: `Ignoring setting array values out of bounds: ${arrayKey} of ${stateVariable}`,
+                    position: component.position,
+                    sourceDoc: component.sourceDoc,
+                });
+                return { nFailures: 1 };
+            }
+        };
+        stateVarObj.getArrayValue = function ({
+            arrayKey,
+            arrayValues = stateVarObj.arrayValues,
+        }: any) {
+            return arrayValues[arrayKey];
+        };
+
+        if (!stateVarObj.getAllArrayKeys) {
+            stateVarObj.getAllArrayKeys = function (
+                arraySize: any,
+                flatten?: any,
+                desiredSize?: any,
+            ) {
+                if (desiredSize) {
+                    if (desiredSize.length === 0) {
                         return [];
                     } else {
-                        // array of numbers from 0 to arraySize[0], cast to strings
-                        return Array.from(Array(arraySize[0]), (_, i) =>
+                        // array of numbers from 0 to desiredSize[0], cast to strings
+                        return Array.from(Array(desiredSize[0]), (_, i) =>
                             String(i),
                         );
                     }
-                };
-            }
-
-            if (!stateVarObj.arrayVarNameFromArrayKey) {
-                stateVarObj.arrayVarNameFromArrayKey = function (arrayKey) {
-                    return entryPrefixes[0] + String(Number(arrayKey) + 1);
-                };
-            }
-
-            // arrayVarNameFromPropIndex is a function that calculates the name
-            // an array entry state variable that corresponds to the specified propIndex.
-            // It is a consequence of retrofitting the ability to index an array (e.g., $a.b[1])
-            // onto a system that was designed with just array entry variables (e..g, $a.b1).
-            // arrayVarNameFromPropIndex can be specified in the definition of the array state variable.
-            // Since numDimensions = 1 here, the default arrayVarNameFromPropIndex
-            // is to turn $a.b[1] to $a.p1,
-            // where "p" is the first entry prefix of the array "b".
-
-            // TODO: if we redesign arrays to be based on indices (or even slices),
-            // then arrayVarNameFromPropIndex will be obsolete.
-            if (!stateVarObj.arrayVarNameFromPropIndex) {
-                stateVarObj.arrayVarNameFromPropIndex =
-                    returnDefaultArrayVarNameFromPropIndex(1, entryPrefixes[0]);
-            }
-
-            stateVarObj.adjustArrayToNewArraySize = async function () {
-                // console.log(`adjust array ${stateVariable} of ${component.componentIdx} to new array size: ${stateVarObj.arraySize[0]}`);
-                let arraySize = await stateVarObj.arraySize;
-                stateVarObj.arrayValues.length = arraySize[0];
-            };
-        }
-
-        if (!stateVarObj.getArrayKeysFromVarName) {
-            stateVarObj.getArrayKeysFromVarName =
-                returnDefaultGetArrayKeysFromVarName(stateVarObj.numDimensions);
-        }
-
-        // converting from index to key is the same for single and multiple
-        // dimensions, as we just want the string representation
-        stateVarObj.indexToKey = (index) => String(index);
-
-        if (!stateVarObj.returnEntryDimensions) {
-            stateVarObj.returnEntryDimensions = () => 0;
-        }
-
-        if (stateVarObj.shadowingInstructions) {
-            // returnWrappingComponents is a function that returns the wrapping components for
-            // - the whole array (if called with no arguments), or
-            // - an array entry (if called with an array entry prefix as the argument)
-            // It returns wrappingComponents, which is an array of arrays.
-            // Each inner array corresponds to a dimension of the array,
-            // starting with the inner dimension,
-            // so that wrappingComponents[numDimensions-1], if it exists,
-            // corresponds to the wrapping of the entire array (or array entry),
-            // leading to the return of a single component.
-            // Each element of the inner array indicates a wrapping of the corresponding dimension,
-            // and they are applied in reverse order.
-            // Each element can be either:
-            // - a string corresponding to the component type used to wrap
-            // - an object with fields:
-            //   - componentType: a string corresponding to the component type used to wrap
-            //   - isAttributeNamed: a string giving the name of the attribute that this
-            //     wrapping component should be for the wrapping component immediately preceding
-            //     (no effect if isAttributeNamed appears in the first wrapping component)
-            // Unless the subsequent wrapping component has been designated isAttributeNamed,
-            // each wrapping component takes as children either
-            // - the subsequent wrapping component if it exists,
-            // - else the original array components.
-            //
-            // TODO: wrapping components (like most array features) was designed before
-            // we had array indexing such as $a.b[1].
-            // Hence it is based on array entries such as $a.b1, where b is the "prefix".
-            // $a.b[1] has to be converted to something like $a.b1
-            // before calculating wrapping components.
-            // We should rework wrapping components (and other array features)
-            // to make array indexing (maybe even including slices) be the basis.
-
-            if (!stateVarObj.shadowingInstructions.returnWrappingComponents) {
-                stateVarObj.shadowingInstructions.returnWrappingComponents = (
-                    prefix,
-                ) => [];
-            }
-            stateVarObj.wrappingComponents =
-                stateVarObj.shadowingInstructions.returnWrappingComponents();
-        }
-
-        stateVarObj.usedDefaultByArrayKey = {};
-
-        stateVarObj.arrayEntryNames = [];
-        stateVarObj.varNamesIncludingArrayKeys = {};
-
-        let allStateVariablesAffected = [stateVariable];
-        if (stateVarObj.additionalStateVariablesDefined) {
-            allStateVariablesAffected.push(
-                ...stateVarObj.additionalStateVariablesDefined,
-            );
-        }
-
-        // create the definition, etc., functions for the array state variable
-
-        // create returnDependencies function from returnArrayDependenciesByKey
-        stateVarObj.returnDependencies = async function (args) {
-            // console.log(`return dependencies for array ${stateVariable} of ${component.componentIdx}`)
-            // console.log(JSON.parse(JSON.stringify(args)));
-
-            args.arraySize = await stateVarObj.arraySize;
-
-            // delete the internally added dependencies from args.stateValues
-            for (let key in args.stateValues) {
-                if (key.slice(0, 8) === "__array_") {
-                    delete args.stateValues[key];
-                }
-            }
-
-            if (args.arrayKeys === undefined) {
-                args.arrayKeys = stateVarObj.getAllArrayKeys(args.arraySize);
-            }
-
-            // link all dependencyNames of additionalStateVariablesDefined
-            // to the same object, as they will share the same freshnessinfo
-            // TODO: a better idea?  This seems like it could lead to confusion.
-            if (!stateVarObj.dependencyNames) {
-                stateVarObj.dependencyNames = {
-                    namesByKey: {},
-                    keysByName: {},
-                    global: [],
-                };
-                if (stateVarObj.additionalStateVariablesDefined) {
-                    for (let vName of stateVarObj.additionalStateVariablesDefined) {
-                        component.state[vName].dependencyNames =
-                            stateVarObj.dependencyNames;
-                    }
-                }
-            }
-
-            let dependencies = {};
-
-            if (
-                stateVarObj.basedOnArrayKeyStateVariables &&
-                args.arrayKeys.length > 1
-            ) {
-                for (let arrayKey of args.arrayKeys) {
-                    for (let vName of allStateVariablesAffected) {
-                        let sObj = component.state[vName];
-                        dependencies[vName + "_" + arrayKey] = {
-                            dependencyType: "stateVariable",
-                            variableName:
-                                sObj.arrayVarNameFromArrayKey(arrayKey),
-                        };
-                    }
-                }
-            } else {
-                let arrayDependencies =
-                    stateVarObj.returnArrayDependenciesByKey(args);
-
-                if (arrayDependencies.globalDependencies) {
-                    stateVarObj.dependencyNames.global = Object.keys(
-                        arrayDependencies.globalDependencies,
-                    );
-                    Object.assign(
-                        dependencies,
-                        arrayDependencies.globalDependencies,
-                    );
-                }
-
-                if (!arrayDependencies.dependenciesByKey) {
-                    arrayDependencies.dependenciesByKey = {};
-                }
-
-                for (let arrayKey of args.arrayKeys) {
-                    // namesByKey also functions to indicate that dependencies
-                    // have been returned for that arrayKey
-
-                    // If had additional nameByKey, it should be treated as dependencies changing
-                    // so that we recalculate the value of the array variable
-                    // TODO: we are communicating this to updateDependencies by adding
-                    // an attribute to the arguments?  Is there a better way of doing it.
-                    // Didn't want to add to the return value, as that would add complexity
-                    // to how we normally define returnDependencies
-                    // We could change returnDependencies to output an object.
-                    // That would probably be cleaner.
-                    if (!(arrayKey in stateVarObj.dependencyNames.namesByKey)) {
-                        args.changedDependency = true;
-                    }
-                    stateVarObj.dependencyNames.namesByKey[arrayKey] = {};
-                    for (let depName in arrayDependencies.dependenciesByKey[
-                        arrayKey
-                    ]) {
-                        let extendedDepName = "__" + arrayKey + "_" + depName;
-                        dependencies[extendedDepName] =
-                            arrayDependencies.dependenciesByKey[arrayKey][
-                                depName
-                            ];
-                        stateVarObj.dependencyNames.namesByKey[arrayKey][
-                            depName
-                        ] = extendedDepName;
-                        if (
-                            !stateVarObj.dependencyNames.keysByName[
-                                extendedDepName
-                            ]
-                        ) {
-                            stateVarObj.dependencyNames.keysByName[
-                                extendedDepName
-                            ] = [];
-                        }
-                        if (
-                            !stateVarObj.dependencyNames.keysByName[
-                                extendedDepName
-                            ].includes(arrayKey)
-                        ) {
-                            stateVarObj.dependencyNames.keysByName[
-                                extendedDepName
-                            ].push(arrayKey);
-                        }
-                    }
-                }
-
-                // to tie into making sure array size is a dependency, below
-                stateVarObj.dependencyNames.global.push("__array_size");
-            }
-
-            // make sure array size is a dependency
-            dependencies.__array_size = {
-                dependencyType: "stateVariable",
-                variableName: stateVarObj.arraySizeStateVariable,
-            };
-
-            // console.log(`resulting dependencies for ${stateVariable} of ${component.componentIdx}`)
-            // console.log(dependencies)
-            return dependencies;
-        };
-
-        stateVarObj.getCurrentFreshness = function ({
-            freshnessInfo,
-            arrayKeys,
-            arraySize,
-        }) {
-            // console.log(`getCurrentFreshness for array ${stateVariable} of ${component.componentIdx}`)
-            // console.log(arrayKeys, arraySize);
-            // console.log(JSON.parse(JSON.stringify(freshnessInfo)))
-
-            if (arrayKeys === undefined) {
-                arrayKeys = stateVarObj.getAllArrayKeys(arraySize);
-            }
-
-            let freshByKey = freshnessInfo.freshByKey;
-
-            let numberFresh = freshnessInfo.freshArraySize ? 1 : 0;
-            for (let arrayKey of arrayKeys) {
-                if (freshByKey[arrayKey]) {
-                    numberFresh += 1;
-                }
-            }
-
-            if (numberFresh > 0) {
-                if (numberFresh === arrayKeys.length + 1) {
-                    return { fresh: { [stateVariable]: true } };
+                } else if (!arraySize || arraySize.length === 0) {
+                    return [];
                 } else {
-                    return { partiallyFresh: { [stateVariable]: numberFresh } };
+                    // array of numbers from 0 to arraySize[0], cast to strings
+                    return Array.from(Array(arraySize[0]), (_, i) => String(i));
                 }
-            } else {
-                return { fresh: { [stateVariable]: false } };
+            };
+        }
+
+        if (!stateVarObj.arrayVarNameFromArrayKey) {
+            stateVarObj.arrayVarNameFromArrayKey = function (arrayKey: string) {
+                return entryPrefixes[0] + String(Number(arrayKey) + 1);
+            };
+        }
+
+        // arrayVarNameFromPropIndex is a function that calculates the name
+        // an array entry state variable that corresponds to the specified propIndex.
+        // It is a consequence of retrofitting the ability to index an array (e.g., $a.b[1])
+        // onto a system that was designed with just array entry variables (e..g, $a.b1).
+        // arrayVarNameFromPropIndex can be specified in the definition of the array state variable.
+        // Since numDimensions = 1 here, the default arrayVarNameFromPropIndex
+        // is to turn $a.b[1] to $a.p1,
+        // where "p" is the first entry prefix of the array "b".
+
+        // TODO: if we redesign arrays to be based on indices (or even slices),
+        // then arrayVarNameFromPropIndex will be obsolete.
+        if (!stateVarObj.arrayVarNameFromPropIndex) {
+            stateVarObj.arrayVarNameFromPropIndex =
+                returnDefaultArrayVarNameFromPropIndex(1, entryPrefixes[0]);
+        }
+
+        stateVarObj.adjustArrayToNewArraySize = async function () {
+            // console.log(`adjust array ${stateVariable} of ${component.componentIdx} to new array size: ${stateVarObj.arraySize[0]}`);
+            let arraySize = await stateVarObj.arraySize;
+            stateVarObj.arrayValues.length = arraySize[0];
+        };
+    }
+
+    if (!stateVarObj.getArrayKeysFromVarName) {
+        stateVarObj.getArrayKeysFromVarName =
+            returnDefaultGetArrayKeysFromVarName(stateVarObj.numDimensions);
+    }
+
+    // converting from index to key is the same for single and multiple
+    // dimensions, as we just want the string representation
+    stateVarObj.indexToKey = (index: any) => String(index);
+
+    if (!stateVarObj.returnEntryDimensions) {
+        stateVarObj.returnEntryDimensions = () => 0;
+    }
+
+    if (stateVarObj.shadowingInstructions) {
+        // returnWrappingComponents is a function that returns the wrapping components for
+        // - the whole array (if called with no arguments), or
+        // - an array entry (if called with an array entry prefix as the argument)
+        // It returns wrappingComponents, which is an array of arrays.
+        // Each inner array corresponds to a dimension of the array,
+        // starting with the inner dimension,
+        // so that wrappingComponents[numDimensions-1], if it exists,
+        // corresponds to the wrapping of the entire array (or array entry),
+        // leading to the return of a single component.
+        // Each element of the inner array indicates a wrapping of the corresponding dimension,
+        // and they are applied in reverse order.
+        // Each element can be either:
+        // - a string corresponding to the component type used to wrap
+        // - an object with fields:
+        //   - componentType: a string corresponding to the component type used to wrap
+        //   - isAttributeNamed: a string giving the name of the attribute that this
+        //     wrapping component should be for the wrapping component immediately preceding
+        //     (no effect if isAttributeNamed appears in the first wrapping component)
+        // Unless the subsequent wrapping component has been designated isAttributeNamed,
+        // each wrapping component takes as children either
+        // - the subsequent wrapping component if it exists,
+        // - else the original array components.
+        //
+        // TODO: wrapping components (like most array features) was designed before
+        // we had array indexing such as $a.b[1].
+        // Hence it is based on array entries such as $a.b1, where b is the "prefix".
+        // $a.b[1] has to be converted to something like $a.b1
+        // before calculating wrapping components.
+        // We should rework wrapping components (and other array features)
+        // to make array indexing (maybe even including slices) be the basis.
+
+        if (!stateVarObj.shadowingInstructions.returnWrappingComponents) {
+            stateVarObj.shadowingInstructions.returnWrappingComponents = (
+                prefix: any,
+            ) => [];
+        }
+        stateVarObj.wrappingComponents =
+            stateVarObj.shadowingInstructions.returnWrappingComponents();
+    }
+
+    stateVarObj.usedDefaultByArrayKey = {};
+
+    stateVarObj.arrayEntryNames = [];
+    stateVarObj.varNamesIncludingArrayKeys = {};
+
+    let allStateVariablesAffected = [stateVariable];
+    if (stateVarObj.additionalStateVariablesDefined) {
+        allStateVariablesAffected.push(
+            ...stateVarObj.additionalStateVariablesDefined,
+        );
+    }
+
+    // create the definition, etc., functions for the array state variable
+
+    // create returnDependencies function from returnArrayDependenciesByKey
+    stateVarObj.returnDependencies = async function (args: any) {
+        // console.log(`return dependencies for array ${stateVariable} of ${component.componentIdx}`)
+        // console.log(JSON.parse(JSON.stringify(args)));
+
+        args.arraySize = await stateVarObj.arraySize;
+
+        // delete the internally added dependencies from args.stateValues
+        for (let key in args.stateValues) {
+            if (key.slice(0, 8) === "__array_") {
+                delete args.stateValues[key];
             }
+        }
+
+        if (args.arrayKeys === undefined) {
+            args.arrayKeys = stateVarObj.getAllArrayKeys(args.arraySize);
+        }
+
+        // link all dependencyNames of additionalStateVariablesDefined
+        // to the same object, as they will share the same freshnessinfo
+        // TODO: a better idea?  This seems like it could lead to confusion.
+        if (!stateVarObj.dependencyNames) {
+            stateVarObj.dependencyNames = {
+                namesByKey: {},
+                keysByName: {},
+                global: [],
+            };
+            if (stateVarObj.additionalStateVariablesDefined) {
+                for (let vName of stateVarObj.additionalStateVariablesDefined) {
+                    component.state[vName].dependencyNames =
+                        stateVarObj.dependencyNames;
+                }
+            }
+        }
+
+        let dependencies: Record<string, any> = {};
+
+        if (
+            stateVarObj.basedOnArrayKeyStateVariables &&
+            args.arrayKeys.length > 1
+        ) {
+            for (let arrayKey of args.arrayKeys) {
+                for (let vName of allStateVariablesAffected) {
+                    let sObj = component.state[vName];
+                    dependencies[vName + "_" + arrayKey] = {
+                        dependencyType: "stateVariable",
+                        variableName: sObj.arrayVarNameFromArrayKey(arrayKey),
+                    };
+                }
+            }
+        } else {
+            let arrayDependencies =
+                stateVarObj.returnArrayDependenciesByKey(args);
+
+            if (arrayDependencies.globalDependencies) {
+                stateVarObj.dependencyNames.global = Object.keys(
+                    arrayDependencies.globalDependencies,
+                );
+                Object.assign(
+                    dependencies,
+                    arrayDependencies.globalDependencies,
+                );
+            }
+
+            if (!arrayDependencies.dependenciesByKey) {
+                arrayDependencies.dependenciesByKey = {};
+            }
+
+            for (let arrayKey of args.arrayKeys) {
+                // namesByKey also functions to indicate that dependencies
+                // have been returned for that arrayKey
+
+                // If had additional nameByKey, it should be treated as dependencies changing
+                // so that we recalculate the value of the array variable
+                // TODO: we are communicating this to updateDependencies by adding
+                // an attribute to the arguments?  Is there a better way of doing it.
+                // Didn't want to add to the return value, as that would add complexity
+                // to how we normally define returnDependencies
+                // We could change returnDependencies to output an object.
+                // That would probably be cleaner.
+                if (!(arrayKey in stateVarObj.dependencyNames.namesByKey)) {
+                    args.changedDependency = true;
+                }
+                stateVarObj.dependencyNames.namesByKey[arrayKey] = {};
+                for (let depName in arrayDependencies.dependenciesByKey[
+                    arrayKey
+                ]) {
+                    let extendedDepName = "__" + arrayKey + "_" + depName;
+                    dependencies[extendedDepName] =
+                        arrayDependencies.dependenciesByKey[arrayKey][depName];
+                    stateVarObj.dependencyNames.namesByKey[arrayKey][depName] =
+                        extendedDepName;
+                    if (
+                        !stateVarObj.dependencyNames.keysByName[extendedDepName]
+                    ) {
+                        stateVarObj.dependencyNames.keysByName[
+                            extendedDepName
+                        ] = [];
+                    }
+                    if (
+                        !stateVarObj.dependencyNames.keysByName[
+                            extendedDepName
+                        ].includes(arrayKey)
+                    ) {
+                        stateVarObj.dependencyNames.keysByName[
+                            extendedDepName
+                        ].push(arrayKey);
+                    }
+                }
+            }
+
+            // to tie into making sure array size is a dependency, below
+            stateVarObj.dependencyNames.global.push("__array_size");
+        }
+
+        // make sure array size is a dependency
+        dependencies.__array_size = {
+            dependencyType: "stateVariable",
+            variableName: stateVarObj.arraySizeStateVariable,
         };
 
-        stateVarObj.markStale = function ({
-            freshnessInfo,
-            changes,
-            arrayKeys,
-            arraySize,
-        }) {
-            // console.log(`markStale for array ${stateVariable} of ${component.componentIdx}`)
-            // console.log(changes, arrayKeys, arraySize);
-            // console.log(JSON.parse(JSON.stringify(freshnessInfo)))
+        // console.log(`resulting dependencies for ${stateVariable} of ${component.componentIdx}`)
+        // console.log(dependencies)
+        return dependencies;
+    };
 
-            let result = {};
+    stateVarObj.getCurrentFreshness = function ({
+        freshnessInfo,
+        arrayKeys,
+        arraySize,
+    }: any) {
+        // console.log(`getCurrentFreshness for array ${stateVariable} of ${component.componentIdx}`)
+        // console.log(arrayKeys, arraySize);
+        // console.log(JSON.parse(JSON.stringify(freshnessInfo)))
 
-            if (arrayKeys === undefined) {
-                arrayKeys = stateVarObj.getAllArrayKeys(arraySize);
+        if (arrayKeys === undefined) {
+            arrayKeys = stateVarObj.getAllArrayKeys(arraySize);
+        }
+
+        let freshByKey = freshnessInfo.freshByKey;
+
+        let numberFresh = freshnessInfo.freshArraySize ? 1 : 0;
+        for (let arrayKey of arrayKeys) {
+            if (freshByKey[arrayKey]) {
+                numberFresh += 1;
             }
+        }
 
-            if (stateVarObj.markStaleByKey) {
-                result = stateVarObj.markStaleByKey({ arrayKeys, changes });
+        if (numberFresh > 0) {
+            if (numberFresh === arrayKeys.length + 1) {
+                return { fresh: { [stateVariable]: true } };
+            } else {
+                return { partiallyFresh: { [stateVariable]: numberFresh } };
             }
+        } else {
+            return { fresh: { [stateVariable]: false } };
+        }
+    };
 
-            let freshByKey = freshnessInfo.freshByKey;
+    stateVarObj.markStale = function ({
+        freshnessInfo,
+        changes,
+        arrayKeys,
+        arraySize,
+    }: any) {
+        // console.log(`markStale for array ${stateVariable} of ${component.componentIdx}`)
+        // console.log(changes, arrayKeys, arraySize);
+        // console.log(JSON.parse(JSON.stringify(freshnessInfo)))
 
-            if (changes.__array_size) {
-                freshnessInfo.freshArraySize = false;
-                // everything is stale
-                freshnessInfo.freshByKey = {};
+        let result: any = {};
+
+        if (arrayKeys === undefined) {
+            arrayKeys = stateVarObj.getAllArrayKeys(arraySize);
+        }
+
+        if (stateVarObj.markStaleByKey) {
+            result = stateVarObj.markStaleByKey({ arrayKeys, changes });
+        }
+
+        let freshByKey = freshnessInfo.freshByKey;
+
+        if (changes.__array_size) {
+            freshnessInfo.freshArraySize = false;
+            // everything is stale
+            freshnessInfo.freshByKey = {};
+            result.fresh = { [stateVariable]: false };
+            return result;
+        }
+
+        if (Object.keys(freshByKey).length === 0) {
+            // everything is stale, except possibly array size
+            // (check for nothing fresh as a shortcut, as mark stale could
+            // be called repeated if size doesn't change, given that it's partially fresh)
+            freshnessInfo.freshByKey = {};
+            if (freshnessInfo.freshArraySize) {
+                result.partiallyFresh = { [stateVariable]: 1 };
+                return result;
+            } else {
                 result.fresh = { [stateVariable]: false };
                 return result;
             }
+        }
 
-            if (Object.keys(freshByKey).length === 0) {
-                // everything is stale, except possibly array size
-                // (check for nothing fresh as a shortcut, as mark stale could
-                // be called repeated if size doesn't change, given that it's partially fresh)
+        for (let changeName in changes) {
+            if (stateVarObj.dependencyNames.global.includes(changeName)) {
+                // everything is stale, except possible array size
                 freshnessInfo.freshByKey = {};
                 if (freshnessInfo.freshArraySize) {
                     result.partiallyFresh = { [stateVariable]: 1 };
@@ -1048,567 +1080,538 @@ export class StateVariableInitializer {
                 }
             }
 
-            for (let changeName in changes) {
-                if (stateVarObj.dependencyNames.global.includes(changeName)) {
-                    // everything is stale, except possible array size
-                    freshnessInfo.freshByKey = {};
-                    if (freshnessInfo.freshArraySize) {
-                        result.partiallyFresh = { [stateVariable]: 1 };
-                        return result;
-                    } else {
-                        result.fresh = { [stateVariable]: false };
-                        return result;
-                    }
-                }
-
-                if (
-                    stateVarObj.basedOnArrayKeyStateVariables &&
-                    arrayKeys.length > 1
-                ) {
-                    delete freshByKey[changeName];
-                } else {
-                    for (let key of stateVarObj.dependencyNames.keysByName[
-                        changeName
-                    ]) {
-                        delete freshByKey[key];
-                    }
-                }
-            }
-
-            // check if the array keys requested are fresh
-            let numberFresh = freshnessInfo.freshArraySize ? 1 : 0;
-            for (let arrayKey of arrayKeys) {
-                if (freshByKey[arrayKey]) {
-                    numberFresh += 1;
-                }
-            }
-
-            // console.log(`ending freshness`)
-            // console.log(JSON.parse(JSON.stringify(freshnessInfo)))
-
-            if (numberFresh > 0) {
-                if (numberFresh === arrayKeys.length + 1) {
-                    result.fresh = { [stateVariable]: true };
-                    return result;
-                } else {
-                    result.partiallyFresh = { [stateVariable]: numberFresh };
-                    return result;
-                }
+            if (
+                stateVarObj.basedOnArrayKeyStateVariables &&
+                arrayKeys.length > 1
+            ) {
+                delete freshByKey[changeName];
             } else {
-                result.fresh = { [stateVariable]: false };
+                for (let key of stateVarObj.dependencyNames.keysByName[
+                    changeName
+                ]) {
+                    delete freshByKey[key];
+                }
+            }
+        }
+
+        // check if the array keys requested are fresh
+        let numberFresh = freshnessInfo.freshArraySize ? 1 : 0;
+        for (let arrayKey of arrayKeys) {
+            if (freshByKey[arrayKey]) {
+                numberFresh += 1;
+            }
+        }
+
+        // console.log(`ending freshness`)
+        // console.log(JSON.parse(JSON.stringify(freshnessInfo)))
+
+        if (numberFresh > 0) {
+            if (numberFresh === arrayKeys.length + 1) {
+                result.fresh = { [stateVariable]: true };
+                return result;
+            } else {
+                result.partiallyFresh = { [stateVariable]: numberFresh };
                 return result;
             }
-        };
+        } else {
+            result.fresh = { [stateVariable]: false };
+            return result;
+        }
+    };
 
-        stateVarObj.freshenOnNoChanges = function ({
-            arrayKeys,
-            freshnessInfo,
-            arraySize,
-        }) {
-            // console.log(`freshenOnNoChanges for ${stateVariable} of ${component.componentIdx}`)
-            let freshByKey = freshnessInfo.freshByKey;
+    stateVarObj.freshenOnNoChanges = function ({
+        arrayKeys,
+        freshnessInfo,
+        arraySize,
+    }: any) {
+        // console.log(`freshenOnNoChanges for ${stateVariable} of ${component.componentIdx}`)
+        let freshByKey = freshnessInfo.freshByKey;
 
-            if (arrayKeys === undefined) {
-                arrayKeys = stateVarObj.getAllArrayKeys(arraySize);
+        if (arrayKeys === undefined) {
+            arrayKeys = stateVarObj.getAllArrayKeys(arraySize);
+        }
+
+        for (let arrayKey of arrayKeys) {
+            freshByKey[arrayKey] = true;
+        }
+    };
+
+    function extractArrayDependencies(
+        dependencyValues: any,
+        arrayKeys: any[],
+        usedDefault: any,
+    ) {
+        // console.log(`extract array dependencies`, dependencyValues, arrayKeys, usedDefault)
+        // console.log(JSON.parse(JSON.stringify(arrayKeys)))
+
+        let globalDependencyValues: Record<string, any> = {};
+        let globalUsedDefault: Record<string, any> = {};
+        for (let dependencyName of stateVarObj.dependencyNames.global) {
+            globalDependencyValues[dependencyName] =
+                dependencyValues[dependencyName];
+            globalUsedDefault[dependencyName] = usedDefault[dependencyName];
+        }
+
+        let dependencyValuesByKey: Record<string, any> = {};
+        let usedDefaultByKey: Record<string, any> = {};
+        let foundAllDependencyValuesForKey: Record<string, any> = {};
+        for (let arrayKey of arrayKeys) {
+            dependencyValuesByKey[arrayKey] = {};
+            usedDefaultByKey[arrayKey] = {};
+            if (arrayKey in stateVarObj.dependencyNames.namesByKey) {
+                foundAllDependencyValuesForKey[arrayKey] = true;
+                for (let dependencyName in stateVarObj.dependencyNames
+                    .namesByKey[arrayKey]) {
+                    let extendedDepName =
+                        stateVarObj.dependencyNames.namesByKey[arrayKey][
+                            dependencyName
+                        ];
+                    if (extendedDepName in dependencyValues) {
+                        dependencyValuesByKey[arrayKey][dependencyName] =
+                            dependencyValues[extendedDepName];
+                        usedDefaultByKey[arrayKey][dependencyName] =
+                            usedDefault[extendedDepName];
+                    } else {
+                        foundAllDependencyValuesForKey[arrayKey] = false;
+                    }
+                }
             }
+        }
 
-            for (let arrayKey of arrayKeys) {
-                freshByKey[arrayKey] = true;
-            }
+        return {
+            globalDependencyValues,
+            globalUsedDefault,
+            dependencyValuesByKey,
+            usedDefaultByKey,
+            foundAllDependencyValuesForKey,
         };
+    }
 
-        function extractArrayDependencies(
-            dependencyValues,
-            arrayKeys,
-            usedDefault,
+    stateVarObj.definition = function (args: any) {
+        // console.log(`definition in array ${stateVariable} of ${component.componentIdx}`)
+        // console.log(JSON.parse(JSON.stringify(args)));
+        // console.log(args.arrayKeys)
+        // console.log(args.dependencyValues)
+
+        if (args.arrayKeys === undefined) {
+            args.arrayKeys = stateVarObj.getAllArrayKeys(args.arraySize);
+        }
+
+        if (
+            stateVarObj.basedOnArrayKeyStateVariables &&
+            args.arrayKeys.length > 1
         ) {
-            // console.log(`extract array dependencies`, dependencyValues, arrayKeys, usedDefault)
-            // console.log(JSON.parse(JSON.stringify(arrayKeys)))
+            // if based on array key state variables and have more than one array key
+            // then must have calculated all the relevant array keys
+            // when retrieving the dependency values
+            // Hence there is nothing to do, as arrayValues has been populated
+            // with all the requisite values
 
-            let globalDependencyValues = {};
-            let globalUsedDefault = {};
-            for (let dependencyName of stateVarObj.dependencyNames.global) {
-                globalDependencyValues[dependencyName] =
-                    dependencyValues[dependencyName];
-                globalUsedDefault[dependencyName] = usedDefault[dependencyName];
+            return {};
+        } else {
+            let extractedDeps = extractArrayDependencies(
+                args.dependencyValues,
+                args.arrayKeys,
+                args.usedDefault,
+            );
+            let globalDependencyValues = extractedDeps.globalDependencyValues;
+            let globalUsedDefault = extractedDeps.globalUsedDefault;
+            let dependencyValuesByKey = extractedDeps.dependencyValuesByKey;
+            let usedDefaultByKey = extractedDeps.usedDefaultByKey;
+            let foundAllDependencyValuesForKey =
+                extractedDeps.foundAllDependencyValuesForKey;
+
+            delete args.dependencyValues;
+            args.globalDependencyValues = globalDependencyValues;
+            args.globalUsedDefault = globalUsedDefault;
+            args.dependencyValuesByKey = dependencyValuesByKey;
+            args.usedDefaultByKey = usedDefaultByKey;
+
+            let arrayKeysToRecalculate = [];
+            let freshByKey = args.freshnessInfo.freshByKey;
+            for (let arrayKey of args.arrayKeys) {
+                // only recalculate if
+                // - arrayKey isn't fresh, and
+                // - found all dependency values for array key (i.e., have calculated dependencies for arrayKey)
+                if (
+                    !freshByKey[arrayKey] &&
+                    foundAllDependencyValuesForKey[arrayKey]
+                ) {
+                    freshByKey[arrayKey] = true;
+                    arrayKeysToRecalculate.push(arrayKey);
+                }
             }
 
-            let dependencyValuesByKey = {};
-            let usedDefaultByKey = {};
-            let foundAllDependencyValuesForKey = {};
-            for (let arrayKey of arrayKeys) {
-                dependencyValuesByKey[arrayKey] = {};
-                usedDefaultByKey[arrayKey] = {};
-                if (arrayKey in stateVarObj.dependencyNames.namesByKey) {
-                    foundAllDependencyValuesForKey[arrayKey] = true;
-                    for (let dependencyName in stateVarObj.dependencyNames
-                        .namesByKey[arrayKey]) {
-                        let extendedDepName =
-                            stateVarObj.dependencyNames.namesByKey[arrayKey][
-                                dependencyName
-                            ];
-                        if (extendedDepName in dependencyValues) {
-                            dependencyValuesByKey[arrayKey][dependencyName] =
-                                dependencyValues[extendedDepName];
-                            usedDefaultByKey[arrayKey][dependencyName] =
-                                usedDefault[extendedDepName];
-                        } else {
-                            foundAllDependencyValuesForKey[arrayKey] = false;
+            let result;
+            if (arrayKeysToRecalculate.length === 0) {
+                result = {};
+            } else {
+                args.arrayKeys = arrayKeysToRecalculate;
+
+                if (!stateVarObj.arrayDefinitionByKey) {
+                    throw Error(
+                        `For ${stateVariable} of ${component.componentType}, arrayDefinitionByKey must be a function`,
+                    );
+                }
+
+                result = stateVarObj.arrayDefinitionByKey(args);
+
+                // in case definition returns additional array entries,
+                // mark all array keys received as fresh as well
+                if (result.setValue && result.setValue[stateVariable]) {
+                    for (let arrayKey in result.setValue[stateVariable]) {
+                        freshByKey[arrayKey] = true;
+                    }
+                }
+                if (
+                    result.useEssentialOrDefaultValue &&
+                    result.useEssentialOrDefaultValue[stateVariable]
+                ) {
+                    for (let arrayKey in result.useEssentialOrDefaultValue[
+                        stateVariable
+                    ]) {
+                        freshByKey[arrayKey] = true;
+                    }
+                }
+            }
+
+            if (!args.freshnessInfo.freshArraySize) {
+                if (args.changes.__array_size) {
+                    result.arraySizeChanged = [stateVariable];
+                    if (stateVarObj.additionalStateVariablesDefined) {
+                        for (let varName of stateVarObj.additionalStateVariablesDefined) {
+                            // do we have to check if it is array?
+                            if (component.state[varName].isArray) {
+                                result.arraySizeChanged.push(varName);
+                            }
                         }
+                    }
+                }
+                args.freshnessInfo.freshArraySize = true;
+            }
+
+            return result;
+        }
+    };
+
+    stateVarObj.inverseDefinition = function (args: any) {
+        // console.log(`inverse definition args for ${stateVariable}`)
+        // console.log(args)
+
+        if (!stateVarObj.inverseArrayDefinitionByKey) {
+            return { success: false };
+        }
+
+        if (args.arrayKeys === undefined) {
+            args.arrayKeys = stateVarObj.getAllArrayKeys(args.arraySize);
+        }
+
+        if (
+            stateVarObj.basedOnArrayKeyStateVariables &&
+            args.arrayKeys.length > 1
+        ) {
+            let instructions = [];
+
+            for (let vName of allStateVariablesAffected) {
+                for (let key in args.desiredStateVariableValues[vName]) {
+                    let depName = vName + "_" + key;
+                    if (depName in args.dependencyValues) {
+                        instructions.push({
+                            setDependency: depName,
+                            desiredValue:
+                                args.desiredStateVariableValues[vName][key],
+                            treatAsInitialChange: args.initialChange,
+                        });
                     }
                 }
             }
 
             return {
-                globalDependencyValues,
-                globalUsedDefault,
-                dependencyValuesByKey,
-                usedDefaultByKey,
-                foundAllDependencyValuesForKey,
+                success: true,
+                instructions,
             };
-        }
+        } else {
+            let extractedDeps = extractArrayDependencies(
+                args.dependencyValues,
+                args.arrayKeys,
+                args.usedDefault,
+            );
+            let globalDependencyValues = extractedDeps.globalDependencyValues;
+            let globalUsedDefault = extractedDeps.globalUsedDefault;
+            let dependencyValuesByKey = extractedDeps.dependencyValuesByKey;
+            let usedDefaultByKey = extractedDeps.usedDefaultByKey;
 
-        stateVarObj.definition = function (args) {
-            // console.log(`definition in array ${stateVariable} of ${component.componentIdx}`)
-            // console.log(JSON.parse(JSON.stringify(args)));
-            // console.log(args.arrayKeys)
-            // console.log(args.dependencyValues)
+            delete args.dependencyValues;
+            args.globalDependencyValues = globalDependencyValues;
+            args.globalUsedDefault = globalUsedDefault;
+            args.dependencyValuesByKey = dependencyValuesByKey;
+            args.usedDefaultByKey = usedDefaultByKey;
 
-            if (args.arrayKeys === undefined) {
-                args.arrayKeys = stateVarObj.getAllArrayKeys(args.arraySize);
-            }
+            args.dependencyNamesByKey = stateVarObj.dependencyNames.namesByKey;
 
-            if (
-                stateVarObj.basedOnArrayKeyStateVariables &&
-                args.arrayKeys.length > 1
-            ) {
-                // if based on array key state variables and have more than one array key
-                // then must have calculated all the relevant array keys
-                // when retrieving the dependency values
-                // Hence there is nothing to do, as arrayValues has been populated
-                // with all the requisite values
-
-                return {};
-            } else {
-                let extractedDeps = extractArrayDependencies(
-                    args.dependencyValues,
-                    args.arrayKeys,
-                    args.usedDefault,
-                );
-                let globalDependencyValues =
-                    extractedDeps.globalDependencyValues;
-                let globalUsedDefault = extractedDeps.globalUsedDefault;
-                let dependencyValuesByKey = extractedDeps.dependencyValuesByKey;
-                let usedDefaultByKey = extractedDeps.usedDefaultByKey;
-                let foundAllDependencyValuesForKey =
-                    extractedDeps.foundAllDependencyValuesForKey;
-
-                delete args.dependencyValues;
-                args.globalDependencyValues = globalDependencyValues;
-                args.globalUsedDefault = globalUsedDefault;
-                args.dependencyValuesByKey = dependencyValuesByKey;
-                args.usedDefaultByKey = usedDefaultByKey;
-
-                let arrayKeysToRecalculate = [];
-                let freshByKey = args.freshnessInfo.freshByKey;
-                for (let arrayKey of args.arrayKeys) {
-                    // only recalculate if
-                    // - arrayKey isn't fresh, and
-                    // - found all dependency values for array key (i.e., have calculated dependencies for arrayKey)
-                    if (
-                        !freshByKey[arrayKey] &&
-                        foundAllDependencyValuesForKey[arrayKey]
-                    ) {
-                        freshByKey[arrayKey] = true;
-                        arrayKeysToRecalculate.push(arrayKey);
-                    }
-                }
-
-                let result;
-                if (arrayKeysToRecalculate.length === 0) {
-                    // console.log(`nothing to recalculate`)
-                    // console.log(`was going to recalculate`, args.arrayKeys)
-                    // console.log(JSON.parse(JSON.stringify(args.freshnessInfo)))
-                    // console.log(JSON.parse(JSON.stringify(stateVarObj.dependencyNames)))
-                    result = {};
-                } else {
-                    args.arrayKeys = arrayKeysToRecalculate;
-
-                    if (!stateVarObj.arrayDefinitionByKey) {
-                        throw Error(
-                            `For ${stateVariable} of ${component.componentType}, arrayDefinitionByKey must be a function`,
-                        );
-                    }
-
-                    result = stateVarObj.arrayDefinitionByKey(args);
-
-                    // in case definition returns additional array entries,
-                    // mark all array keys received as fresh as well
-                    if (result.setValue && result.setValue[stateVariable]) {
-                        for (let arrayKey in result.setValue[stateVariable]) {
-                            freshByKey[arrayKey] = true;
-                        }
-                    }
-                    if (
-                        result.useEssentialOrDefaultValue &&
-                        result.useEssentialOrDefaultValue[stateVariable]
-                    ) {
-                        for (let arrayKey in result.useEssentialOrDefaultValue[
-                            stateVariable
-                        ]) {
-                            freshByKey[arrayKey] = true;
-                        }
-                    }
-                }
-
-                if (!args.freshnessInfo.freshArraySize) {
-                    if (args.changes.__array_size) {
-                        result.arraySizeChanged = [stateVariable];
-                        if (stateVarObj.additionalStateVariablesDefined) {
-                            for (let varName of stateVarObj.additionalStateVariablesDefined) {
-                                // do we have to check if it is array?
-                                if (component.state[varName].isArray) {
-                                    result.arraySizeChanged.push(varName);
-                                }
-                            }
-                        }
-                    }
-                    args.freshnessInfo.freshArraySize = true;
-                }
-
-                // console.log(`result of array definition of ${stateVariable} of ${component.componentIdx}`)
-                // console.log(JSON.parse(JSON.stringify(result)))
-                // console.log(JSON.parse(JSON.stringify(args.freshnessInfo)))
-                return result;
-            }
-        };
-
-        stateVarObj.inverseDefinition = function (args) {
-            // console.log(`inverse definition args for ${stateVariable}`)
-            // console.log(args)
-
-            if (!stateVarObj.inverseArrayDefinitionByKey) {
-                return { success: false };
-            }
-
-            if (args.arrayKeys === undefined) {
-                args.arrayKeys = stateVarObj.getAllArrayKeys(args.arraySize);
-            }
-
-            if (
-                stateVarObj.basedOnArrayKeyStateVariables &&
-                args.arrayKeys.length > 1
-            ) {
-                let instructions = [];
-
-                for (let vName of allStateVariablesAffected) {
+            if (!stateVarObj.allowExtraArrayKeysInInverse) {
+                // by default, inverseArrayDefinitionByKey does not need to be
+                // programmed defensively against arrayKeys that don't exist
+                // as they are filtered out here.
+                // However, if allowExtraArrayKeysInInverse, then we skip this
+                // filtering to allow the possibility that the array size
+                // could be changed.
+                let newDesiredStateVariableValues: Record<string, any> = {};
+                for (let vName in args.desiredStateVariableValues) {
+                    newDesiredStateVariableValues[vName] = {};
                     for (let key in args.desiredStateVariableValues[vName]) {
-                        let depName = vName + "_" + key;
-                        if (depName in args.dependencyValues) {
-                            instructions.push({
-                                setDependency: depName,
-                                desiredValue:
-                                    args.desiredStateVariableValues[vName][key],
-                                treatAsInitialChange: args.initialChange,
-                            });
+                        if (args.arrayKeys.includes(key)) {
+                            newDesiredStateVariableValues[vName][key] =
+                                args.desiredStateVariableValues[vName][key];
                         }
                     }
                 }
-
-                return {
-                    success: true,
-                    instructions,
-                };
-            } else {
-                let extractedDeps = extractArrayDependencies(
-                    args.dependencyValues,
-                    args.arrayKeys,
-                    args.usedDefault,
-                );
-                let globalDependencyValues =
-                    extractedDeps.globalDependencyValues;
-                let globalUsedDefault = extractedDeps.globalUsedDefault;
-                let dependencyValuesByKey = extractedDeps.dependencyValuesByKey;
-                let usedDefaultByKey = extractedDeps.usedDefaultByKey;
-                // let foundAllDependencyValuesForKey = extractedDeps.foundAllDependencyValuesForKey;
-
-                delete args.dependencyValues;
-                args.globalDependencyValues = globalDependencyValues;
-                args.globalUsedDefault = globalUsedDefault;
-                args.dependencyValuesByKey = dependencyValuesByKey;
-                args.usedDefaultByKey = usedDefaultByKey;
-
-                args.dependencyNamesByKey =
-                    stateVarObj.dependencyNames.namesByKey;
-
-                if (!stateVarObj.allowExtraArrayKeysInInverse) {
-                    // by default, inverseArrayDefinitionByKey does not need to be
-                    // programmed defensively against arrayKeys that don't exist
-                    // as they are filtered out here.
-                    // However, if allowExtraArrayKeysInInverse, then we skip this
-                    // filtering to allow the possibility that the array size
-                    // could be changed.
-                    let newDesiredStateVariableValues = {};
-                    for (let vName in args.desiredStateVariableValues) {
-                        newDesiredStateVariableValues[vName] = {};
-                        for (let key in args.desiredStateVariableValues[
-                            vName
-                        ]) {
-                            if (args.arrayKeys.includes(key)) {
-                                newDesiredStateVariableValues[vName][key] =
-                                    args.desiredStateVariableValues[vName][key];
-                            }
-                        }
-                    }
-                    args.desiredStateVariableValues =
-                        newDesiredStateVariableValues;
-                }
-
-                let result = stateVarObj.inverseArrayDefinitionByKey(args);
-                // console.log(`result of inverse definition of array`)
-                // console.log(JSON.parse(JSON.stringify(result)))
-                return result;
+                args.desiredStateVariableValues = newDesiredStateVariableValues;
             }
-        };
 
-        await this.createArraySizeStateVariable({
-            stateVarObj,
-            component,
-            stateVariable,
-        });
-
-        stateVarObj.arraySizeStale = true;
-        stateVarObj.previousArraySize = [];
-
-        Object.defineProperty(stateVarObj, "arraySize", {
-            get: function () {
-                return (async () => {
-                    if (
-                        !component.state[stateVarObj.arraySizeStateVariable]
-                            .initiallyResolved
-                    ) {
-                        return [];
-                    }
-                    if (stateVarObj.arraySizeStale) {
-                        await stateVarObj.recalculateArraySizeDependentQuantities();
-                    }
-                    return await component.stateValues[
-                        stateVarObj.arraySizeStateVariable
-                    ];
-                })();
-            },
-        });
-
-        stateVarObj.recalculateArraySizeDependentQuantities =
-            async function () {
-                let newArraySize =
-                    await component.stateValues[
-                        stateVarObj.arraySizeStateVariable
-                    ];
-                if (
-                    stateVarObj.previousArraySize.length !==
-                        newArraySize.length ||
-                    stateVarObj.previousArraySize.some(
-                        (v, i) => v != newArraySize[i],
-                    )
-                ) {
-                    stateVarObj.previousArraySize = [...newArraySize];
-                    let varNamesIncluding =
-                        (stateVarObj.varNamesIncludingArrayKeys = {});
-                    for (let entryName of stateVarObj.arrayEntryNames) {
-                        let entryStateVarObj = component.state[entryName];
-                        let arrayKeys = stateVarObj.getArrayKeysFromVarName({
-                            arrayEntryPrefix: entryStateVarObj.entryPrefix,
-                            varEnding: entryStateVarObj.varEnding,
-                            arraySize: newArraySize,
-                            numDimensions: stateVarObj.numDimensions,
-                        });
-                        entryStateVarObj._unflattenedArrayKeys = arrayKeys;
-                        entryStateVarObj._arrayKeys = flattenDeep(arrayKeys);
-
-                        // for each arrayKey, add this entry name to the array's list variables
-                        for (let arrayKey of entryStateVarObj._arrayKeys) {
-                            if (!varNamesIncluding[arrayKey]) {
-                                varNamesIncluding[arrayKey] = [];
-                            }
-                            varNamesIncluding[arrayKey].push(entryName);
-                        }
-                    }
-                }
-                stateVarObj.arraySizeStale = false;
-            };
-
-        // link all freshnessInfo of additionalStateVariablesDefined
-        // to the same object, as they will share the same freshnessinfo
-        // TODO: a better idea?  This seems like it could lead to confusion.
-        if (!stateVarObj.freshnessInfo) {
-            stateVarObj.freshnessInfo = { freshByKey: {} };
-            if (stateVarObj.additionalStateVariablesDefined) {
-                for (let vName of stateVarObj.additionalStateVariablesDefined) {
-                    if (!component.state[vName]) {
-                        component.state[vName] = {};
-                    }
-                    component.state[vName].freshnessInfo =
-                        stateVarObj.freshnessInfo;
-                }
-            }
+            let result = stateVarObj.inverseArrayDefinitionByKey(args);
+            return result;
         }
-    }
+    };
 
-    async createArraySizeStateVariable({
+    await createArraySizeStateVariable({
+        core,
         stateVarObj,
         component,
         stateVariable,
-    }) {
-        let allStateVariablesAffected = [stateVariable];
-        if (stateVarObj.additionalStateVariablesDefined) {
-            allStateVariablesAffected.push(
-                ...stateVarObj.additionalStateVariablesDefined,
-            );
-        }
-        allStateVariablesAffected.sort();
+    });
 
-        let arraySizeStateVar =
-            `__array_size_` + allStateVariablesAffected.join("_");
-        stateVarObj.arraySizeStateVariable = arraySizeStateVar;
+    stateVarObj.arraySizeStale = true;
+    stateVarObj.previousArraySize = [];
 
-        let originalStateVariablesDeterminingDependencies;
-        let originalAdditionalStateVariablesDefined;
-
-        // Make the array's dependencies depend on the array size state variable
-        if (stateVarObj.stateVariablesDeterminingDependencies) {
-            originalStateVariablesDeterminingDependencies = [
-                ...stateVarObj.stateVariablesDeterminingDependencies,
-            ];
-            stateVarObj.stateVariablesDeterminingDependencies.push(
-                arraySizeStateVar,
-            );
-        } else {
-            stateVarObj.stateVariablesDeterminingDependencies = [
-                arraySizeStateVar,
-            ];
-        }
-
-        // If array size state variable has already been created,
-        // either it was created due to being shadowed
-        // or from an additional state variable defined.
-        // If it is shadowing target array size state variable,
-        // make it mark the array's arraySize as stale on markStale
-        if (component.state[arraySizeStateVar]) {
-            if (component.state[arraySizeStateVar].isShadow) {
-                let arraySizeStateVarObj = component.state[arraySizeStateVar];
-                arraySizeStateVarObj.markStale = function () {
-                    for (let varName of allStateVariablesAffected) {
-                        component.state[varName].arraySizeStale = true;
-                    }
-                    return {};
-                };
-            }
-            return;
-        }
-
-        component.state[arraySizeStateVar] = {
-            returnDependencies: stateVarObj.returnArraySizeDependencies,
-            definition({ dependencyValues }) {
-                let arraySize = stateVarObj.returnArraySize({
-                    dependencyValues,
-                });
-                for (let [ind, value] of arraySize.entries()) {
-                    if (!(Number.isInteger(value) && value >= 0)) {
-                        arraySize[ind] = 0;
-                    }
+    Object.defineProperty(stateVarObj, "arraySize", {
+        get: function () {
+            return (async () => {
+                if (
+                    !component.state[stateVarObj.arraySizeStateVariable]
+                        .initiallyResolved
+                ) {
+                    return [];
                 }
-                return { setValue: { [arraySizeStateVar]: arraySize } };
-            },
-            markStale() {
+                if (stateVarObj.arraySizeStale) {
+                    await stateVarObj.recalculateArraySizeDependentQuantities();
+                }
+                return await component.stateValues[
+                    stateVarObj.arraySizeStateVariable
+                ];
+            })();
+        },
+    });
+
+    stateVarObj.recalculateArraySizeDependentQuantities = async function () {
+        let newArraySize =
+            await component.stateValues[stateVarObj.arraySizeStateVariable];
+        if (
+            stateVarObj.previousArraySize.length !== newArraySize.length ||
+            stateVarObj.previousArraySize.some(
+                (v: any, i: number) => v != newArraySize[i],
+            )
+        ) {
+            stateVarObj.previousArraySize = [...newArraySize];
+            let varNamesIncluding = (stateVarObj.varNamesIncludingArrayKeys =
+                {});
+            for (let entryName of stateVarObj.arrayEntryNames) {
+                let entryStateVarObj = component.state[entryName];
+                let arrayKeys = stateVarObj.getArrayKeysFromVarName({
+                    arrayEntryPrefix: entryStateVarObj.entryPrefix,
+                    varEnding: entryStateVarObj.varEnding,
+                    arraySize: newArraySize,
+                    numDimensions: stateVarObj.numDimensions,
+                });
+                entryStateVarObj._unflattenedArrayKeys = arrayKeys;
+                entryStateVarObj._arrayKeys = flattenDeep(arrayKeys);
+
+                // for each arrayKey, add this entry name to the array's list variables
+                for (let arrayKey of entryStateVarObj._arrayKeys) {
+                    if (!varNamesIncluding[arrayKey]) {
+                        varNamesIncluding[arrayKey] = [];
+                    }
+                    varNamesIncluding[arrayKey].push(entryName);
+                }
+            }
+        }
+        stateVarObj.arraySizeStale = false;
+    };
+
+    // link all freshnessInfo of additionalStateVariablesDefined
+    // to the same object, as they will share the same freshnessinfo
+    // TODO: a better idea?  This seems like it could lead to confusion.
+    if (!stateVarObj.freshnessInfo) {
+        stateVarObj.freshnessInfo = { freshByKey: {} };
+        if (stateVarObj.additionalStateVariablesDefined) {
+            for (let vName of stateVarObj.additionalStateVariablesDefined) {
+                if (!component.state[vName]) {
+                    component.state[vName] = {};
+                }
+                component.state[vName].freshnessInfo =
+                    stateVarObj.freshnessInfo;
+            }
+        }
+    }
+}
+
+async function createArraySizeStateVariable({
+    core,
+    stateVarObj,
+    component,
+    stateVariable,
+}: {
+    core: Core;
+    stateVarObj: any;
+    component: any;
+    stateVariable: any;
+}) {
+    let allStateVariablesAffected = [stateVariable];
+    if (stateVarObj.additionalStateVariablesDefined) {
+        allStateVariablesAffected.push(
+            ...stateVarObj.additionalStateVariablesDefined,
+        );
+    }
+    allStateVariablesAffected.sort();
+
+    let arraySizeStateVar =
+        `__array_size_` + allStateVariablesAffected.join("_");
+    stateVarObj.arraySizeStateVariable = arraySizeStateVar;
+
+    // Make the array's dependencies depend on the array size state variable
+    if (stateVarObj.stateVariablesDeterminingDependencies) {
+        stateVarObj.stateVariablesDeterminingDependencies.push(
+            arraySizeStateVar,
+        );
+    } else {
+        stateVarObj.stateVariablesDeterminingDependencies = [arraySizeStateVar];
+    }
+
+    // If array size state variable has already been created,
+    // either it was created due to being shadowed
+    // or from an additional state variable defined.
+    // If it is shadowing target array size state variable,
+    // make it mark the array's arraySize as stale on markStale
+    if (component.state[arraySizeStateVar]) {
+        if (component.state[arraySizeStateVar].isShadow) {
+            let arraySizeStateVarObj = component.state[arraySizeStateVar];
+            arraySizeStateVarObj.markStale = function () {
                 for (let varName of allStateVariablesAffected) {
                     component.state[varName].arraySizeStale = true;
                 }
                 return {};
-            },
-        };
-
-        if (stateVarObj.stateVariablesDeterminingArraySizeDependencies) {
-            component.state[
-                arraySizeStateVar
-            ].stateVariablesDeterminingDependencies =
-                stateVarObj.stateVariablesDeterminingArraySizeDependencies;
+            };
         }
-
-        await this.initializeStateVariable({
-            component,
-            stateVariable: arraySizeStateVar,
-        });
+        return;
     }
 
-    // arrayEntryNamesFromPropIndex is essentially a wrapper around
-    // stateVarObj.arrayVarNameFromPropIndex.
-    // (See above description of arrayVarNameFromPropIndex for technical debt commentary.)
-    // It calls arrayVarNameFromPropIndex on each of an array of stateVariables,
-    // first creating any missing array entry state variables,
-    // logs diagnostics,
-    // and returns an array of the resulting state variables.
-    async arrayEntryNamesFromPropIndex({
-        stateVariables,
-        component,
-        propIndex,
-    }) {
-        let newVarNames = [];
-        for (let varName of stateVariables) {
-            let stateVarObj = component.state[varName];
-            if (!stateVarObj) {
-                if (
-                    !this.core.checkIfArrayEntry({
-                        stateVariable: varName,
-                        component,
-                    }).isArrayEntry
-                ) {
-                    // varName doesn't exist.  Ignore error here
-                    newVarNames.push(varName);
-                    continue;
+    component.state[arraySizeStateVar] = {
+        returnDependencies: stateVarObj.returnArraySizeDependencies,
+        definition({ dependencyValues }: any) {
+            let arraySize = stateVarObj.returnArraySize({
+                dependencyValues,
+            });
+            for (let [ind, value] of arraySize.entries() as Iterable<
+                [number, any]
+            >) {
+                if (!(Number.isInteger(value) && value >= 0)) {
+                    arraySize[ind] = 0;
                 }
-                await this.core.createFromArrayEntry({
+            }
+            return { setValue: { [arraySizeStateVar]: arraySize } };
+        },
+        markStale() {
+            for (let varName of allStateVariablesAffected) {
+                component.state[varName].arraySizeStale = true;
+            }
+            return {};
+        },
+    };
+
+    if (stateVarObj.stateVariablesDeterminingArraySizeDependencies) {
+        component.state[
+            arraySizeStateVar
+        ].stateVariablesDeterminingDependencies =
+            stateVarObj.stateVariablesDeterminingArraySizeDependencies;
+    }
+
+    await initializeStateVariable({
+        core,
+        component,
+        stateVariable: arraySizeStateVar,
+    });
+}
+
+// arrayEntryNamesFromPropIndex is essentially a wrapper around
+// stateVarObj.arrayVarNameFromPropIndex.
+// (See above description of arrayVarNameFromPropIndex for technical debt commentary.)
+// It calls arrayVarNameFromPropIndex on each of an array of stateVariables,
+// first creating any missing array entry state variables,
+// logs diagnostics,
+// and returns an array of the resulting state variables.
+export async function arrayEntryNamesFromPropIndex({
+    core,
+    stateVariables,
+    component,
+    propIndex,
+}: {
+    core: Core;
+    stateVariables: any;
+    component: any;
+    propIndex: any;
+}) {
+    let newVarNames = [];
+    for (let varName of stateVariables) {
+        let stateVarObj = component.state[varName];
+        if (!stateVarObj) {
+            if (
+                !core.checkIfArrayEntry({
                     stateVariable: varName,
                     component,
-                });
-                stateVarObj = component.state[varName];
-            }
-
-            let newName;
-            if (stateVarObj.isArray) {
-                newName = stateVarObj.arrayVarNameFromPropIndex(
-                    propIndex,
-                    varName,
-                );
-            } else if (stateVarObj.isArrayEntry) {
-                let arrayStateVarObj =
-                    component.state[stateVarObj.arrayStateVariable];
-                newName = arrayStateVarObj.arrayVarNameFromPropIndex(
-                    propIndex,
-                    varName,
-                );
-            } else {
-                this.core.addDiagnostic({
-                    type: "warning",
-                    message: `Cannot get propIndex from ${varName} of ${component.componentIdx} as it is not an array or array entry state variable`,
-                    position: component.position,
-                    sourceDoc: component.sourceDoc,
-                });
-                newName = varName;
-            }
-            if (newName) {
-                newVarNames.push(newName);
-            } else {
-                this.core.addDiagnostic({
-                    type: "warning",
-                    message: `Cannot get propIndex from ${varName} of ${component.componentIdx}`,
-                    position: component.position,
-                    sourceDoc: component.sourceDoc,
-                });
+                }).isArrayEntry
+            ) {
+                // varName doesn't exist.  Ignore error here
                 newVarNames.push(varName);
+                continue;
             }
+            await core.createFromArrayEntry({
+                stateVariable: varName,
+                component,
+            });
+            stateVarObj = component.state[varName];
         }
 
-        return newVarNames;
+        let newName;
+        if (stateVarObj.isArray) {
+            newName = stateVarObj.arrayVarNameFromPropIndex(propIndex, varName);
+        } else if (stateVarObj.isArrayEntry) {
+            let arrayStateVarObj =
+                component.state[stateVarObj.arrayStateVariable];
+            newName = arrayStateVarObj.arrayVarNameFromPropIndex(
+                propIndex,
+                varName,
+            );
+        } else {
+            core.addDiagnostic({
+                type: "warning",
+                message: `Cannot get propIndex from ${varName} of ${component.componentIdx} as it is not an array or array entry state variable`,
+                position: component.position,
+                sourceDoc: component.sourceDoc,
+            });
+            newName = varName;
+        }
+        if (newName) {
+            newVarNames.push(newName);
+        } else {
+            core.addDiagnostic({
+                type: "warning",
+                message: `Cannot get propIndex from ${varName} of ${component.componentIdx}`,
+                position: component.position,
+                sourceDoc: component.sourceDoc,
+            });
+            newVarNames.push(varName);
+        }
     }
+
+    return newVarNames;
 }


### PR DESCRIPTION
## Summary

Convert `StateVariableInitializer` from a class to module-level functions, the fourth piece of the Phase 5c stateless-manager pass.

- `initializeComponentStateVariables`, `initializeStateVariable`, `arrayEntryNamesFromPropIndex` are exported.
- `initializeArrayEntryStateVariable`, `initializeArrayStateVariable`, `createArraySizeStateVariable` are module-private.
- Cross-module callers — `ComponentBuilder`, `StalenessPropagator`, `Dependencies.js` — import the functions directly.
- The `stateVariableInitializer` field, instantiation, and 6 delegate-only wrappers in `Core.ts` are removed.

The `let core = this.core;` capture inside `initializeArrayStateVariable` (needed when `core.addDiagnostic` is called from inner closures) is replaced by closure-capture of the function's `core` parameter; the behaviour is identical.

## Follow-up commit: tighten signatures

A second commit on this branch replaces the `any` annotations on the public destructure parameters with their actual shapes (`ComponentInstance`, `string`, `string[]`, `number[]`); `stateVarObj` stays `any` since it is partially built during initialization. The `arrayEntryPrefix !== undefined` branch in `initializeStateVariable` asserts `arrayStateVariable!` because the two parameters are always paired by callers — the dependency is not expressible in the destructure type. Also tightens the module docstring (the prior text mentioned `_components` and `componentInfoObjects`, neither read in this file) and adds two pre-existing-duplication notes to `CORE_REFACTOR_DEFERRED.md` (1-D vs N-D branch duplication in `initializeArrayStateVariable`, and the five-site `getAllArrayKeys` default).

## Notes on the typecheck delta

Package typecheck baseline: 189 on `main` → 94 on this branch (–95, the largest single drop yet because `StateVariableInitializer` had the most untyped destructure params). No new errors; only the same single `CompositeExpander` TS2345 signature-mismatch from prior PRs remains as a noisy carry-over.

## Test plan

- [x] `pnpm typecheck` — 94 (down from 189, no new errors).
- [x] Targeted vitest: external_references, calcStartEndIdx, sectioning, group — 49 passing.
- [x] Full vitest + Cypress in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)