### PR TITLE
refactor(worker-javascript): StateVariableDefinitionFactory → module functions

### DIFF
--- a/CORE_REFACTOR_DEFERRED.md
+++ b/CORE_REFACTOR_DEFERRED.md
@@ -314,6 +314,24 @@ Phase 3 hit two regressions of the same shape (fixed in `caf3033f5`) that future
 
 Quick grep targets when reviewing the next phase: `let core = this`, `\.bind(this)`, and arrow vs. `function` callback choices on objects assigned to `stateDef`/`stateVarObj`.
 
+### Further de-duplication in `StateVariableDefinitionFactory`
+
+The class→module conversion (`core-refactor-18`) preserved three small duplications that are still candidates for follow-up extraction. They pre-date the conversion and were intentionally left alone there to keep the diff scoped to the structural change:
+
+1. **`primaryStateVariableForDefinition` resolution.** The 8-line block that picks `redefineDependencies.substituteForPrimaryStateVariable` → `componentClass.primaryStateVariableForDefinition` → `"value"` and then looks the resulting key up in `stateVariableDefinitions` appears in both `createAdapterStateVariableDefinitions` (~line 333) and `createReferenceShadowStateVariableDefinitions` (~line 515, with an additional `throw` on missing `stateDef`). Extracting `_resolvePrimaryStateVariableForDefinition({ redefineDependencies, componentClass, stateVariableDefinitions, throwIfMissing })` would centralise the precedence rule and the error message.
+2. **Attribute-spec → dependency-shape switch.** The four-way branch on `attributeSpecification` (`createPrimitiveOfType` → `attributePrimitive`, `createReferences` → `attributeRefResolutions`, else → `attributeComponent`, plus the two `fallBack*` branches) is structurally identical between `createAttributeStateVariableDefinitions` (~lines 180–196 inside the `returnDependencies` closure) and `createReferenceShadowStateVariableDefinitions` (~lines 452–483 building `thisDependencies`). A small `_buildAttributeValueDependencies(spec, attrName, stateVariableForAttributeValue)` helper that returns the dependency map would consolidate them; the only behavioural difference is the order in which `fallBack*` and the value-source branch are added, which the helper can preserve by returning a map both call sites spread into their own object.
+3. **Shadow-variable scan.** Inside `createReferenceShadowStateVariableDefinitions`, the same `for (let varName in targetComponent.state) { if (stateObj.shadowVariable || stateObj.isShadow) stateVariablesToShadow.push(varName); }` loop appears twice — at lines ~650–655 (the prop-variable branch) and again at lines ~733–738 (the no-prop-variable branch). Lifting it into a tiny `_collectShadowVariableNames(targetComponent)` would be one line at each call site.
+
+None of these are urgent; each is a 5–15 line collapse and would land cleanly with no behavioural change.
+
+### Tighten remaining `: any` in `StateVariableDefinitionFactory`
+
+`core-refactor-18` (and the small follow-up review pass) tightened the public destructure shapes (`componentIdx: ComponentIdx`, `prescribedDependencies: Record<string, any[]> | undefined`, `stateVariableDefinitions: Record<string, any>`, etc.) but several inner positions remain `any`:
+
+- `componentClass: any`, `redefineDependencies: any`, and `targetComponent`/`adapterTargetComponent: any` — tightening requires real types for the component-class shape (`createAttributesObject`, `returnNormalizedStateVariableDefinitions`, `primaryStateVariableForDefinition`, `implicitPropReturnsSameType`) and a `RedefineDependencies` discriminated union (`{ linkSource: "adapter" | "referenceShadow"; … }`). Both are bigger pieces of typing work than fits in a tightening pass on this file alone.
+- `attributeSpecification: any` in the four `_*Attribute*` helpers — `AttributeDefinition<unknown>` (from `utils/dast/types.ts`) covers most fields, but the runtime additionally reads `noInverse`, `componentStateVariableForAttributeValue`, `fallBackToSourceCompositeStateVariable`, `essentialVarName`, `isLocation`, and (for the inverse path) more. `AttributeDefinition` would need to grow to cover them before the parameter type can be tightened.
+- The internal callbacks attached to `stateDef` (e.g. `function ({ dependencyValues, usedDefault, essentialValues }) { … }`) carry implicit-`any` errors. They run in the StateVariableEvaluator's call-time context; tightening would mean importing/exporting the dep-value/usedDefault/essentialValues bag types from the evaluator. Cheap interim fix: explicit `(args: any)` annotations to silence the ~20 implicit-any errors in this file without changing semantics.
+
 ## Notes for the next agent
 
 - The applied items in this PR are self-contained — see the diff against the previous commit. The structural deferrals above don't depend on each other except that #1 (typing) makes #2 (stateless→plain) cleaner since the back-reference type would already exist.

--- a/packages/doenetml-worker-javascript/src/ComponentBuilder.ts
+++ b/packages/doenetml-worker-javascript/src/ComponentBuilder.ts
@@ -10,6 +10,7 @@ import {
     expandAllComposites,
 } from "./CompositeExpander";
 import { addComponentsToResolver } from "./ResolverAdapter";
+import { createStateVariableDefinitions } from "./StateVariableDefinitionFactory";
 import { initializeComponentStateVariables } from "./StateVariableInitializer";
 import { convertToErrorComponent } from "./utils/dast/errors";
 import { gatherVariantComponents } from "./utils/variants";
@@ -636,7 +637,8 @@ export async function createChildrenThenComponent({
         }
     }
 
-    const stateVariableDefinitions = await core.createStateVariableDefinitions({
+    const stateVariableDefinitions = await createStateVariableDefinitions({
+        core,
         componentClass,
         prescribedDependencies,
         componentIdx,

--- a/packages/doenetml-worker-javascript/src/Core.ts
+++ b/packages/doenetml-worker-javascript/src/Core.ts
@@ -27,7 +27,6 @@ import { ProcessQueue } from "./ProcessQueue";
 import { RendererInstructionBuilder } from "./RendererInstructionBuilder";
 import { StalenessPropagator } from "./StalenessPropagator";
 import { StatePersistence } from "./StatePersistence";
-import { StateVariableDefinitionFactory } from "./StateVariableDefinitionFactory";
 import { StateVariableEvaluator } from "./StateVariableEvaluator";
 import { UpdateExecutor } from "./UpdateExecutor";
 import { VisibilityTracker } from "./VisibilityTracker";
@@ -106,15 +105,14 @@ export interface CoreInfo {
  * own modules. Some are class instances held on Core (DiagnosticsManager,
  * VisibilityTracker, StatePersistence, AutoSubmitManager,
  * RendererInstructionBuilder, ProcessQueue, ActionTriggerScheduler,
- * StateVariableDefinitionFactory,
  * StateVariableEvaluator, StalenessPropagator, EssentialValueWriter,
  * CompositeReplacementUpdater, UpdateExecutor, and the `nameResolver`
  * namespace); others (NavigationHandler, ResolverAdapter, ComponentLifecycle,
  * ChildMatcher, DeletionEngine, CompositeExpander, ComponentBuilder,
- * StateVariableInitializer) are plain module-level functions imported
- * directly by callers. Each delegating block still held on Core is grouped
- * near its original location and tagged with a `// → managerName` marker;
- * see the corresponding module for details.
+ * StateVariableInitializer, StateVariableDefinitionFactory) are plain
+ * module-level functions imported directly by callers. Each delegating
+ * block still held on Core is grouped near its original location and tagged
+ * with a `// → managerName` marker; see the corresponding module for details.
  */
 export default class Core {
     // ─── Identity / configuration ─────────────────────────────────────────
@@ -197,7 +195,6 @@ export default class Core {
     rendererInstructionBuilder: RendererInstructionBuilder;
     processQueue: ProcessQueue;
     actionTriggerScheduler: ActionTriggerScheduler;
-    stateVariableDefinitionFactory: StateVariableDefinitionFactory;
     stateVariableEvaluator: StateVariableEvaluator;
     stalenessPropagator: StalenessPropagator;
     essentialValueWriter: EssentialValueWriter;
@@ -358,10 +355,6 @@ export default class Core {
         this.actionTriggerScheduler = new ActionTriggerScheduler({
             core: this,
         });
-        this.stateVariableDefinitionFactory =
-            new StateVariableDefinitionFactory({
-                core: this,
-            });
         this.stateVariableEvaluator = new StateVariableEvaluator({
             core: this,
         });
@@ -711,32 +704,6 @@ export default class Core {
 
     async checkForActionChaining(args: any): Promise<any> {
         return this.actionTriggerScheduler.checkForActionChaining(args);
-    }
-
-    async createStateVariableDefinitions(args: any): Promise<any> {
-        return this.stateVariableDefinitionFactory.createStateVariableDefinitions(
-            args,
-        );
-    }
-
-    createAttributeStateVariableDefinitions(args: any): any {
-        return this.stateVariableDefinitionFactory.createAttributeStateVariableDefinitions(
-            args,
-        );
-    }
-
-    createAdapterStateVariableDefinitions(args: any): any {
-        return this.stateVariableDefinitionFactory.createAdapterStateVariableDefinitions(
-            args,
-        );
-    }
-
-    async createReferenceShadowStateVariableDefinitions(
-        args: any,
-    ): Promise<any> {
-        return this.stateVariableDefinitionFactory.createReferenceShadowStateVariableDefinitions(
-            args,
-        );
     }
 
     // → stateVariableEvaluator

--- a/packages/doenetml-worker-javascript/src/StateVariableDefinitionFactory.ts
+++ b/packages/doenetml-worker-javascript/src/StateVariableDefinitionFactory.ts
@@ -26,749 +26,715 @@ const PRIMITIVE_TO_COMPONENT_TYPE: Record<string, string> = {
  * The runtime side — wiring `getStateVariableValue` getters, resolving
  * dependencies, materializing array entries — is in `StateVariableInitializer`.
  *
- * Holds a back-reference to Core to read `_components`, `componentInfoObjects`,
- * and `numerics`, and to invoke `checkIfArrayEntry` and `createFromArrayEntry`.
- * (`arrayVarNameFromArrayKey` is invoked on the per-variable `stateDef`, not
- * on Core.)
+ * Stateless — each function takes a back-reference to Core to read
+ * `_components`, `componentInfoObjects`, and `numerics`, and to invoke
+ * `checkIfArrayEntry` and `createFromArrayEntry`.
+ * (`arrayVarNameFromArrayKey` is invoked on the per-variable `stateDef`,
+ * not on Core.)
  */
-export class StateVariableDefinitionFactory {
+
+export async function createStateVariableDefinitions({
+    core,
+    componentClass,
+    prescribedDependencies,
+    componentIdx,
+}: {
     core: Core;
+    componentClass: any;
+    prescribedDependencies: any;
+    componentIdx: any;
+}) {
+    let redefineDependencies;
 
-    constructor({ core }: { core: Core }) {
-        this.core = core;
-    }
-
-    async createStateVariableDefinitions({
-        componentClass,
-        prescribedDependencies,
-        componentIdx,
-    }) {
-        let redefineDependencies;
-
-        if (prescribedDependencies) {
-            for (const idxStr in prescribedDependencies) {
-                const idx = Number(idxStr);
-                let depArray = prescribedDependencies[idx];
-                for (let dep of depArray) {
-                    if (dep.dependencyType === "referenceShadow") {
-                        if (idx === componentIdx) {
-                            throw Error(
-                                `Circular dependency involving ${componentIdx}.`,
-                            );
-                        }
-                        redefineDependencies = {
-                            linkSource: "referenceShadow",
-                            targetIdx: idx,
-                            compositeIdx: dep.compositeIdx,
-                            propVariable: dep.propVariable,
-                            fromImplicitProp: dep.fromImplicitProp,
-                            arrayStateVariable: dep.arrayStateVariable,
-                            arrayKey: dep.arrayKey,
-                            ignorePrimaryStateVariable:
-                                dep.ignorePrimaryStateVariable,
-                            substituteForPrimaryStateVariable:
-                                dep.substituteForPrimaryStateVariable,
-                            firstLevelReplacement: dep.firstLevelReplacement,
-                            additionalStateVariableShadowing:
-                                dep.additionalStateVariableShadowing,
-                        };
-                    } else if (dep.dependencyType === "adapter") {
-                        redefineDependencies = {
-                            linkSource: "adapter",
-                            adapterTargetIdentity: dep.adapterTargetIdentity,
-                            adapterVariable: dep.adapterVariable,
-                            substituteForPrimaryStateVariable:
-                                dep.substituteForPrimaryStateVariable,
-                            stateVariablesToShadow: dep.stateVariablesToShadow,
-                        };
+    if (prescribedDependencies) {
+        for (const idxStr in prescribedDependencies) {
+            const idx = Number(idxStr);
+            let depArray = prescribedDependencies[idx];
+            for (let dep of depArray) {
+                if (dep.dependencyType === "referenceShadow") {
+                    if (idx === componentIdx) {
+                        throw Error(
+                            `Circular dependency involving ${componentIdx}.`,
+                        );
                     }
+                    redefineDependencies = {
+                        linkSource: "referenceShadow",
+                        targetIdx: idx,
+                        compositeIdx: dep.compositeIdx,
+                        propVariable: dep.propVariable,
+                        fromImplicitProp: dep.fromImplicitProp,
+                        arrayStateVariable: dep.arrayStateVariable,
+                        arrayKey: dep.arrayKey,
+                        ignorePrimaryStateVariable:
+                            dep.ignorePrimaryStateVariable,
+                        substituteForPrimaryStateVariable:
+                            dep.substituteForPrimaryStateVariable,
+                        firstLevelReplacement: dep.firstLevelReplacement,
+                        additionalStateVariableShadowing:
+                            dep.additionalStateVariableShadowing,
+                    };
+                } else if (dep.dependencyType === "adapter") {
+                    redefineDependencies = {
+                        linkSource: "adapter",
+                        adapterTargetIdentity: dep.adapterTargetIdentity,
+                        adapterVariable: dep.adapterVariable,
+                        substituteForPrimaryStateVariable:
+                            dep.substituteForPrimaryStateVariable,
+                        stateVariablesToShadow: dep.stateVariablesToShadow,
+                    };
                 }
             }
         }
+    }
 
-        let stateVariableDefinitions = {};
+    let stateVariableDefinitions = {};
 
-        if (!redefineDependencies) {
-            this.createAttributeStateVariableDefinitions({
+    if (!redefineDependencies) {
+        createAttributeStateVariableDefinitions({
+            core,
+            stateVariableDefinitions,
+            componentClass,
+        });
+    }
+
+    //  add state variable definitions from component class
+    let newDefinitions =
+        componentClass.returnNormalizedStateVariableDefinitions(core.numerics);
+
+    Object.assign(stateVariableDefinitions, newDefinitions);
+
+    if (redefineDependencies) {
+        if (redefineDependencies.linkSource === "adapter") {
+            createAdapterStateVariableDefinitions({
+                core,
+                redefineDependencies,
+                stateVariableDefinitions,
+                componentClass,
+            });
+        } else {
+            await createReferenceShadowStateVariableDefinitions({
+                core,
+                redefineDependencies,
                 stateVariableDefinitions,
                 componentClass,
             });
         }
-
-        //  add state variable definitions from component class
-        let newDefinitions =
-            componentClass.returnNormalizedStateVariableDefinitions(
-                this.core.numerics,
-            );
-
-        Object.assign(stateVariableDefinitions, newDefinitions);
-
-        if (redefineDependencies) {
-            if (redefineDependencies.linkSource === "adapter") {
-                this.createAdapterStateVariableDefinitions({
-                    redefineDependencies,
-                    stateVariableDefinitions,
-                    componentClass,
-                });
-            } else {
-                await this.createReferenceShadowStateVariableDefinitions({
-                    redefineDependencies,
-                    stateVariableDefinitions,
-                    componentClass,
-                });
-            }
-        }
-
-        return stateVariableDefinitions;
     }
 
-    createAttributeStateVariableDefinitions({
-        componentClass,
-        stateVariableDefinitions,
-    }) {
-        let attributes = preprocessAttributesObject(
-            componentClass.createAttributesObject(),
-        );
+    return stateVariableDefinitions;
+}
 
-        for (let attrName in attributes) {
-            let attributeSpecification = attributes[attrName];
-            if (!attributeSpecification.createStateVariable) {
-                continue;
-            }
+function createAttributeStateVariableDefinitions({
+    core,
+    componentClass,
+    stateVariableDefinitions,
+}: any) {
+    let attributes = preprocessAttributesObject(
+        componentClass.createAttributesObject(),
+    );
 
-            let varName = attributeSpecification.createStateVariable;
-
-            let stateVarDef = (stateVariableDefinitions[varName] = {
-                isAttribute: true,
-                hasEssential: true,
-                provideEssentialValuesInDefinition: true,
-            });
-
-            if (attributeSpecification.public) {
-                this._setShadowingInstructionsFromAttribute(
-                    stateVarDef,
-                    attributeSpecification,
-                );
-            }
-
-            let stateVariableForAttributeValue =
-                this._resolveAttributeValueVariable(
-                    attributeSpecification,
-                    attrName,
-                    componentClass,
-                );
-
-            stateVarDef.returnDependencies = function () {
-                let dependencies = {};
-                if (attributeSpecification.fallBackToParentStateVariable) {
-                    dependencies.parentValue = {
-                        dependencyType: "parentStateVariable",
-                        variableName:
-                            attributeSpecification.fallBackToParentStateVariable,
-                    };
-                }
-                if (
-                    attributeSpecification.fallBackToSourceCompositeStateVariable
-                ) {
-                    dependencies.sourceCompositeValue = {
-                        dependencyType: "sourceCompositeStateVariable",
-                        variableName:
-                            attributeSpecification.fallBackToSourceCompositeStateVariable,
-                    };
-                }
-                if (attributeSpecification.createPrimitiveOfType) {
-                    dependencies.attributePrimitive = {
-                        dependencyType: "attributePrimitive",
-                        attributeName: attrName,
-                    };
-                } else if (attributeSpecification.createReferences) {
-                    dependencies.attributeRefResolutions = {
-                        dependencyType: "attributeRefResolutions",
-                        attributeName: attrName,
-                    };
-                } else {
-                    dependencies.attributeComponent = {
-                        dependencyType: "attributeComponent",
-                        attributeName: attrName,
-                        variableNames: [stateVariableForAttributeValue],
-                    };
-                }
-
-                return dependencies;
-            };
-
-            const { definition, inverseDefinition } =
-                this._buildAttributeDerivedDefinitions({
-                    varName,
-                    stateVariableForAttributeValue,
-                    attributeSpecification,
-                    attrName,
-                });
-            stateVarDef.definition = definition;
-            if (!attributeSpecification.noInverse) {
-                stateVarDef.inverseDefinition = inverseDefinition;
-            }
-
-            this._copyPassthroughAttributes(
-                stateVarDef,
-                attributeSpecification,
-                {
-                    includeTriggerActionOnChange: true,
-                },
-            );
-        }
-    }
-
-    createAdapterStateVariableDefinitions({
-        redefineDependencies,
-        stateVariableDefinitions,
-        componentClass,
-    }) {
-        // attributes depend on adapterTarget (if attribute exists in adapterTarget)
-        let adapterTargetComponent =
-            this.core._components[
-                redefineDependencies.adapterTargetIdentity.componentIdx
-            ];
-
-        let attributes = preprocessAttributesObject(
-            componentClass.createAttributesObject(),
-        );
-
-        for (let attrName in attributes) {
-            let attributeSpecification = attributes[attrName];
-            if (!attributeSpecification.createStateVariable) {
-                continue;
-            }
-
-            let varName = attributeSpecification.createStateVariable;
-
-            let stateVarDef = (stateVariableDefinitions[varName] = {
-                isAttribute: true,
-                hasEssential: true,
-            });
-
-            if (attributeSpecification.public) {
-                this._setShadowingInstructionsFromAttribute(
-                    stateVarDef,
-                    attributeSpecification,
-                );
-            }
-
-            if (varName in adapterTargetComponent.state) {
-                stateVarDef.returnDependencies = () => ({
-                    adapterTargetVariable: {
-                        dependencyType: "stateVariable",
-                        componentIdx:
-                            redefineDependencies.adapterTargetIdentity
-                                .componentIdx,
-                        variableName: varName,
-                    },
-                });
-            } else {
-                stateVarDef.returnDependencies = () => ({});
-            }
-
-            stateVarDef.definition = function ({
-                dependencyValues,
-                usedDefault,
-            }) {
-                if (
-                    dependencyValues.adapterTargetVariable === undefined ||
-                    usedDefault.adapterTargetVariable
-                ) {
-                    return {
-                        useEssentialOrDefaultValue: {
-                            [varName]: true,
-                        },
-                        checkForActualChange: { [varName]: true },
-                    };
-                } else {
-                    return {
-                        setValue: {
-                            [varName]: dependencyValues.adapterTargetVariable,
-                        },
-                        checkForActualChange: { [varName]: true },
-                    };
-                }
-            };
-
-            if (!attributeSpecification.noInverse) {
-                stateVarDef.inverseDefinition = async function ({
-                    desiredStateVariableValues,
-                    dependencyValues,
-                }) {
-                    if (dependencyValues.adapterTargetVariable === undefined) {
-                        return {
-                            success: true,
-                            instructions: [
-                                {
-                                    setEssentialValue: varName,
-                                    value: desiredStateVariableValues[varName],
-                                },
-                            ],
-                        };
-                    } else {
-                        return {
-                            success: true,
-                            instructions: [
-                                {
-                                    setDependency: "adapterTargetVariable",
-                                    desiredValue:
-                                        desiredStateVariableValues[varName],
-                                },
-                            ],
-                        };
-                    }
-                };
-            }
-
-            this._copyPassthroughAttributes(
-                stateVarDef,
-                attributeSpecification,
-            );
+    for (let attrName in attributes) {
+        let attributeSpecification = attributes[attrName];
+        if (!attributeSpecification.createStateVariable) {
+            continue;
         }
 
-        // primaryStateVariableForDefinition is the state variable that the componentClass
-        // being created has specified should be given the value when it
-        // is created from an outside source like a reference to a prop or an adapter
-        let primaryStateVariableForDefinition = "value";
-        if (redefineDependencies.substituteForPrimaryStateVariable) {
-            primaryStateVariableForDefinition =
-                redefineDependencies.substituteForPrimaryStateVariable;
-        } else if (componentClass.primaryStateVariableForDefinition) {
-            primaryStateVariableForDefinition =
-                componentClass.primaryStateVariableForDefinition;
-        }
-        let stateDef =
-            stateVariableDefinitions[primaryStateVariableForDefinition];
-        stateDef.isShadow = true;
-        stateDef.returnDependencies = () => ({
-            adapterTargetVariable: {
-                dependencyType: "stateVariable",
-                componentIdx:
-                    redefineDependencies.adapterTargetIdentity.componentIdx,
-                variableName: redefineDependencies.adapterVariable,
-            },
+        let varName = attributeSpecification.createStateVariable;
+
+        let stateVarDef = (stateVariableDefinitions[varName] = {
+            isAttribute: true,
+            hasEssential: true,
+            provideEssentialValuesInDefinition: true,
         });
-        if (stateDef.set) {
-            stateDef.definition = function ({ dependencyValues }) {
-                return {
-                    setValue: {
-                        [primaryStateVariableForDefinition]: stateDef.set(
-                            dependencyValues.adapterTargetVariable,
-                        ),
-                    },
-                };
-            };
-        } else {
-            stateDef.definition = function ({ dependencyValues }) {
-                return {
-                    setValue: {
-                        [primaryStateVariableForDefinition]:
-                            dependencyValues.adapterTargetVariable,
-                    },
-                };
-            };
-        }
-        stateDef.inverseDefinition = function ({ desiredStateVariableValues }) {
-            return {
-                success: true,
-                instructions: [
-                    {
-                        setDependency: "adapterTargetVariable",
-                        desiredValue:
-                            desiredStateVariableValues[
-                                primaryStateVariableForDefinition
-                            ],
-                    },
-                ],
-            };
-        };
 
-        if (redefineDependencies.stateVariablesToShadow) {
-            this.modifyStateDefsToBeShadows({
-                stateVariablesToShadow:
-                    redefineDependencies.stateVariablesToShadow,
-                stateVariableDefinitions,
-                targetComponent: adapterTargetComponent,
-            });
-        }
-    }
-
-    async createReferenceShadowStateVariableDefinitions({
-        redefineDependencies,
-        stateVariableDefinitions,
-        componentClass,
-    }) {
-        let targetComponent =
-            this.core._components[redefineDependencies.targetIdx];
-
-        if (redefineDependencies.propVariable) {
-            // if we have an array entry state variable that hasn't been created yet
-            // create it now
-            if (
-                !targetComponent.state[redefineDependencies.propVariable] &&
-                this.core.checkIfArrayEntry({
-                    stateVariable: redefineDependencies.propVariable,
-                    component: targetComponent,
-                }).isArrayEntry
-            ) {
-                await this.core.createFromArrayEntry({
-                    stateVariable: redefineDependencies.propVariable,
-                    component: targetComponent,
-                });
-            }
+        if (attributeSpecification.public) {
+            _setShadowingInstructionsFromAttribute(
+                stateVarDef,
+                attributeSpecification,
+            );
         }
 
-        // attributes depend
-        // - first on attributes from component attribute components, if they exist
-        // - then on targetComponent (if not copying a prop and attribute exists in targetComponent)
-
-        let attributes = preprocessAttributesObject(
-            componentClass.createAttributesObject(),
+        let stateVariableForAttributeValue = _resolveAttributeValueVariable(
+            core,
+            attributeSpecification,
+            attrName,
+            componentClass,
         );
 
-        for (let attrName in attributes) {
-            let attributeSpecification = attributes[attrName];
-            let varName = attributeSpecification.createStateVariable;
-            if (!varName) {
-                continue;
-            }
-
-            let stateVarDef = (stateVariableDefinitions[varName] = {
-                isAttribute: true,
-                hasEssential: true,
-                provideEssentialValuesInDefinition: true,
-            });
-
-            let attributeFromPrimitive =
-                !attributeSpecification.createComponentOfType;
-
-            if (attributeSpecification.public) {
-                this._setShadowingInstructionsFromAttribute(
-                    stateVarDef,
-                    attributeSpecification,
-                );
-            }
-
-            let stateVariableForAttributeValue =
-                this._resolveAttributeValueVariable(
-                    attributeSpecification,
-                    attrName,
-                    componentClass,
-                );
-
-            let thisDependencies = {};
-
-            if (attributeSpecification.createPrimitiveOfType) {
-                thisDependencies.attributePrimitive = {
-                    dependencyType: "attributePrimitive",
-                    attributeName: attrName,
-                };
-            } else if (attributeSpecification.createReferences) {
-                thisDependencies.attributeRefResolutions = {
-                    dependencyType: "attributeRefResolutions",
-                    attributeName: attrName,
-                };
-            } else {
-                thisDependencies.attributeComponent = {
-                    dependencyType: "attributeComponent",
-                    attributeName: attrName,
-                    variableNames: [stateVariableForAttributeValue],
-                };
-            }
-
+        stateVarDef.returnDependencies = function () {
+            let dependencies = {};
             if (attributeSpecification.fallBackToParentStateVariable) {
-                thisDependencies.parentValue = {
+                dependencies.parentValue = {
                     dependencyType: "parentStateVariable",
                     variableName:
                         attributeSpecification.fallBackToParentStateVariable,
                 };
             }
             if (attributeSpecification.fallBackToSourceCompositeStateVariable) {
-                thisDependencies.sourceCompositeValue = {
+                dependencies.sourceCompositeValue = {
                     dependencyType: "sourceCompositeStateVariable",
                     variableName:
                         attributeSpecification.fallBackToSourceCompositeStateVariable,
                 };
             }
-
-            stateVarDef.returnDependencies = () => thisDependencies;
-
-            const { definition, inverseDefinition } =
-                this._buildAttributeDerivedDefinitions({
-                    varName,
-                    stateVariableForAttributeValue,
-                    attributeSpecification,
-                    attrName,
-                });
-            stateVarDef.definition = definition;
-            if (!attributeSpecification.noInverse) {
-                stateVarDef.inverseDefinition = inverseDefinition;
+            if (attributeSpecification.createPrimitiveOfType) {
+                dependencies.attributePrimitive = {
+                    dependencyType: "attributePrimitive",
+                    attributeName: attrName,
+                };
+            } else if (attributeSpecification.createReferences) {
+                dependencies.attributeRefResolutions = {
+                    dependencyType: "attributeRefResolutions",
+                    attributeName: attrName,
+                };
+            } else {
+                dependencies.attributeComponent = {
+                    dependencyType: "attributeComponent",
+                    attributeName: attrName,
+                    variableNames: [stateVariableForAttributeValue],
+                };
             }
 
-            this._copyPassthroughAttributes(
+            return dependencies;
+        };
+
+        const { definition, inverseDefinition } =
+            _buildAttributeDerivedDefinitions({
+                varName,
+                stateVariableForAttributeValue,
+                attributeSpecification,
+                attrName,
+            });
+        stateVarDef.definition = definition;
+        if (!attributeSpecification.noInverse) {
+            stateVarDef.inverseDefinition = inverseDefinition;
+        }
+
+        _copyPassthroughAttributes(stateVarDef, attributeSpecification, {
+            includeTriggerActionOnChange: true,
+        });
+    }
+}
+
+function createAdapterStateVariableDefinitions({
+    core,
+    redefineDependencies,
+    stateVariableDefinitions,
+    componentClass,
+}: any) {
+    // attributes depend on adapterTarget (if attribute exists in adapterTarget)
+    let adapterTargetComponent =
+        core._components[
+            redefineDependencies.adapterTargetIdentity.componentIdx
+        ];
+
+    let attributes = preprocessAttributesObject(
+        componentClass.createAttributesObject(),
+    );
+
+    for (let attrName in attributes) {
+        let attributeSpecification = attributes[attrName];
+        if (!attributeSpecification.createStateVariable) {
+            continue;
+        }
+
+        let varName = attributeSpecification.createStateVariable;
+
+        let stateVarDef = (stateVariableDefinitions[varName] = {
+            isAttribute: true,
+            hasEssential: true,
+        });
+
+        if (attributeSpecification.public) {
+            _setShadowingInstructionsFromAttribute(
                 stateVarDef,
                 attributeSpecification,
             );
         }
 
-        if (redefineDependencies.propVariable) {
-            if (!redefineDependencies.ignorePrimaryStateVariable) {
-                // primaryStateVariableForDefinition is the state variable that the componentClass
-                // being created has specified should be given the value when it
-                // is created from an outside source like a reference to a prop or an adapter
-                let primaryStateVariableForDefinition = "value";
-                if (redefineDependencies.substituteForPrimaryStateVariable) {
-                    primaryStateVariableForDefinition =
-                        redefineDependencies.substituteForPrimaryStateVariable;
-                } else if (componentClass.primaryStateVariableForDefinition) {
-                    primaryStateVariableForDefinition =
-                        componentClass.primaryStateVariableForDefinition;
-                }
-                let stateDef =
-                    stateVariableDefinitions[primaryStateVariableForDefinition];
-                if (!stateDef) {
-                    if (
-                        redefineDependencies.substituteForPrimaryStateVariable
-                    ) {
-                        throw Error(
-                            `Invalid public state variable of componentType ${componentClass.componentType}: substituteForPrimaryStateVariable ${redefineDependencies.substituteForPrimaryStateVariable} does not exist`,
-                        );
-                    } else {
-                        throw Error(
-                            `Cannot have a public state variable with componentType ${componentClass.componentType} as the class doesn't have a primary state variable for definition`,
-                        );
-                    }
-                }
-                stateDef.isShadow = true;
-                stateDef.returnDependencies = () => ({
-                    targetVariable: {
-                        dependencyType: "stateVariable",
-                        componentIdx: targetComponent.componentIdx,
-                        variableName: redefineDependencies.propVariable,
+        if (varName in adapterTargetComponent.state) {
+            stateVarDef.returnDependencies = () => ({
+                adapterTargetVariable: {
+                    dependencyType: "stateVariable",
+                    componentIdx:
+                        redefineDependencies.adapterTargetIdentity.componentIdx,
+                    variableName: varName,
+                },
+            });
+        } else {
+            stateVarDef.returnDependencies = () => ({});
+        }
+
+        stateVarDef.definition = function ({ dependencyValues, usedDefault }) {
+            if (
+                dependencyValues.adapterTargetVariable === undefined ||
+                usedDefault.adapterTargetVariable
+            ) {
+                return {
+                    useEssentialOrDefaultValue: {
+                        [varName]: true,
                     },
-                });
+                    checkForActualChange: { [varName]: true },
+                };
+            } else {
+                return {
+                    setValue: {
+                        [varName]: dependencyValues.adapterTargetVariable,
+                    },
+                    checkForActualChange: { [varName]: true },
+                };
+            }
+        };
 
-                let setDefault = false;
-                if (
-                    targetComponent.state[redefineDependencies.propVariable]
-                        .defaultValue !== undefined
-                ) {
-                    stateDef.defaultValue =
-                        targetComponent.state[
-                            redefineDependencies.propVariable
-                        ].defaultValue;
-                    if (stateDef.set) {
-                        stateDef.defaultValue = stateDef.set(
-                            stateDef.defaultValue,
-                        );
-                    }
-                    stateDef.hasEssential = true;
-                    setDefault = true;
-                }
-
-                let targetVariableIsArray =
-                    targetComponent.state[redefineDependencies.propVariable]
-                        .isArray;
-
-                if (stateDef.set) {
-                    stateDef.definition = function ({
-                        dependencyValues,
-                        usedDefault,
-                    }) {
-                        let targetVariable = dependencyValues.targetVariable;
-                        if (
-                            targetVariable === undefined ||
-                            (targetVariableIsArray &&
-                                targetVariable.length === 0)
-                        ) {
-                            // allow for case where we depend on array entry that does not yet exist
-                            return {
-                                useEssentialOrDefaultValue: {
-                                    [primaryStateVariableForDefinition]: true,
-                                },
-                            };
-                        }
-                        let valueFromTarget = stateDef.set(targetVariable);
-                        if (setDefault && usedDefault.targetVariable) {
-                            return {
-                                useEssentialOrDefaultValue: {
-                                    [primaryStateVariableForDefinition]: {
-                                        defaultValue: valueFromTarget,
-                                    },
-                                },
-                            };
-                        }
-                        return {
-                            setValue: {
-                                [primaryStateVariableForDefinition]:
-                                    valueFromTarget,
-                            },
-                        };
-                    };
-                } else {
-                    stateDef.definition = function ({
-                        dependencyValues,
-                        usedDefault,
-                    }) {
-                        let targetVariable = dependencyValues.targetVariable;
-                        if (
-                            targetVariable === undefined ||
-                            (targetVariableIsArray &&
-                                targetVariable.length === 0)
-                        ) {
-                            // allow for case where we depend on array entry that does not yet exist
-                            return {
-                                useEssentialOrDefaultValue: {
-                                    [primaryStateVariableForDefinition]: true,
-                                },
-                            };
-                        }
-                        if (setDefault && usedDefault.targetVariable) {
-                            return {
-                                useEssentialOrDefaultValue: {
-                                    [primaryStateVariableForDefinition]: {
-                                        defaultValue: targetVariable,
-                                    },
-                                },
-                            };
-                        }
-                        return {
-                            setValue: {
-                                [primaryStateVariableForDefinition]:
-                                    targetVariable,
-                            },
-                        };
-                    };
-                }
-                stateDef.inverseDefinition = function ({
-                    desiredStateVariableValues,
-                }) {
+        if (!attributeSpecification.noInverse) {
+            stateVarDef.inverseDefinition = async function ({
+                desiredStateVariableValues,
+                dependencyValues,
+            }) {
+                if (dependencyValues.adapterTargetVariable === undefined) {
                     return {
                         success: true,
                         instructions: [
                             {
-                                setDependency: "targetVariable",
-                                desiredValue:
-                                    desiredStateVariableValues[
-                                        primaryStateVariableForDefinition
-                                    ],
+                                setEssentialValue: varName,
+                                value: desiredStateVariableValues[varName],
                             },
                         ],
                     };
-                };
-            }
-
-            let shadowStandardVariables = false;
-            let stateVariablesToShadow = [];
-            if (targetComponent.constructor.implicitPropReturnsSameType) {
-                if (redefineDependencies.fromImplicitProp) {
-                    shadowStandardVariables = true;
+                } else {
+                    return {
+                        success: true,
+                        instructions: [
+                            {
+                                setDependency: "adapterTargetVariable",
+                                desiredValue:
+                                    desiredStateVariableValues[varName],
+                            },
+                        ],
+                    };
                 }
-
-                // shadow any variables marked as shadowVariable
-                for (let varName in targetComponent.state) {
-                    let stateObj = targetComponent.state[varName];
-                    if (stateObj.shadowVariable || stateObj.isShadow) {
-                        stateVariablesToShadow.push(varName);
-                    }
-                }
-            }
-
-            if (redefineDependencies.additionalStateVariableShadowing) {
-                // since using parallel arrays, start with empty array to match next indices
-                let differentStateVariablesInTarget = Array(
-                    stateVariablesToShadow.length,
-                );
-                for (let varName in redefineDependencies.additionalStateVariableShadowing) {
-                    if (!stateVariablesToShadow.includes(varName)) {
-                        stateVariablesToShadow.push(varName);
-                        differentStateVariablesInTarget.push(
-                            redefineDependencies
-                                .additionalStateVariableShadowing[varName]
-                                .stateVariableToShadow,
-                        );
-                    }
-                }
-
-                this.modifyStateDefsToBeShadows({
-                    stateVariablesToShadow,
-                    stateVariableDefinitions,
-                    targetComponent,
-                    differentStateVariablesInTarget,
-                });
-            } else if (shadowStandardVariables) {
-                this.modifyStateDefsToBeShadows({
-                    stateVariablesToShadow,
-                    stateVariableDefinitions,
-                    targetComponent,
-                });
-            }
-
-            // for referencing a prop variable, don't shadow standard state variables
-            // (unless except for above cases)
-            // so just return now
-            return;
+            };
         }
 
-        let foundReadyToExpandWhenResolved = false;
-        if ("readyToExpandWhenResolved" in stateVariableDefinitions) {
-            // if shadowing a composite
-            // make readyToExpandWhenResolved depend on the same variable
-            // of the targetComponent also being resolved
+        _copyPassthroughAttributes(stateVarDef, attributeSpecification);
+    }
 
-            foundReadyToExpandWhenResolved = true;
+    // primaryStateVariableForDefinition is the state variable that the componentClass
+    // being created has specified should be given the value when it
+    // is created from an outside source like a reference to a prop or an adapter
+    let primaryStateVariableForDefinition = "value";
+    if (redefineDependencies.substituteForPrimaryStateVariable) {
+        primaryStateVariableForDefinition =
+            redefineDependencies.substituteForPrimaryStateVariable;
+    } else if (componentClass.primaryStateVariableForDefinition) {
+        primaryStateVariableForDefinition =
+            componentClass.primaryStateVariableForDefinition;
+    }
+    let stateDef = stateVariableDefinitions[primaryStateVariableForDefinition];
+    stateDef.isShadow = true;
+    stateDef.returnDependencies = () => ({
+        adapterTargetVariable: {
+            dependencyType: "stateVariable",
+            componentIdx:
+                redefineDependencies.adapterTargetIdentity.componentIdx,
+            variableName: redefineDependencies.adapterVariable,
+        },
+    });
+    if (stateDef.set) {
+        stateDef.definition = function ({ dependencyValues }) {
+            return {
+                setValue: {
+                    [primaryStateVariableForDefinition]: stateDef.set(
+                        dependencyValues.adapterTargetVariable,
+                    ),
+                },
+            };
+        };
+    } else {
+        stateDef.definition = function ({ dependencyValues }) {
+            return {
+                setValue: {
+                    [primaryStateVariableForDefinition]:
+                        dependencyValues.adapterTargetVariable,
+                },
+            };
+        };
+    }
+    stateDef.inverseDefinition = function ({ desiredStateVariableValues }) {
+        return {
+            success: true,
+            instructions: [
+                {
+                    setDependency: "adapterTargetVariable",
+                    desiredValue:
+                        desiredStateVariableValues[
+                            primaryStateVariableForDefinition
+                        ],
+                },
+            ],
+        };
+    };
 
-            let stateDef = stateVariableDefinitions.readyToExpandWhenResolved;
-            let originalReturnDependencies =
-                stateDef.returnDependencies.bind(stateDef);
-            let originalDefinition = stateDef.definition;
+    if (redefineDependencies.stateVariablesToShadow) {
+        modifyStateDefsToBeShadows({
+            stateVariablesToShadow: redefineDependencies.stateVariablesToShadow,
+            stateVariableDefinitions,
+            targetComponent: adapterTargetComponent,
+        });
+    }
+}
 
-            stateDef.returnDependencies = function (args) {
-                let dependencies = originalReturnDependencies(args);
-                dependencies.targetReadyToExpandWhenResolved = {
+async function createReferenceShadowStateVariableDefinitions({
+    core,
+    redefineDependencies,
+    stateVariableDefinitions,
+    componentClass,
+}: any) {
+    let targetComponent = core._components[redefineDependencies.targetIdx];
+
+    if (redefineDependencies.propVariable) {
+        // if we have an array entry state variable that hasn't been created yet
+        // create it now
+        if (
+            !targetComponent.state[redefineDependencies.propVariable] &&
+            core.checkIfArrayEntry({
+                stateVariable: redefineDependencies.propVariable,
+                component: targetComponent,
+            }).isArrayEntry
+        ) {
+            await core.createFromArrayEntry({
+                stateVariable: redefineDependencies.propVariable,
+                component: targetComponent,
+            });
+        }
+    }
+
+    // attributes depend
+    // - first on attributes from component attribute components, if they exist
+    // - then on targetComponent (if not copying a prop and attribute exists in targetComponent)
+
+    let attributes = preprocessAttributesObject(
+        componentClass.createAttributesObject(),
+    );
+
+    for (let attrName in attributes) {
+        let attributeSpecification = attributes[attrName];
+        let varName = attributeSpecification.createStateVariable;
+        if (!varName) {
+            continue;
+        }
+
+        let stateVarDef = (stateVariableDefinitions[varName] = {
+            isAttribute: true,
+            hasEssential: true,
+            provideEssentialValuesInDefinition: true,
+        });
+
+        let attributeFromPrimitive =
+            !attributeSpecification.createComponentOfType;
+
+        if (attributeSpecification.public) {
+            _setShadowingInstructionsFromAttribute(
+                stateVarDef,
+                attributeSpecification,
+            );
+        }
+
+        let stateVariableForAttributeValue = _resolveAttributeValueVariable(
+            core,
+            attributeSpecification,
+            attrName,
+            componentClass,
+        );
+
+        let thisDependencies = {};
+
+        if (attributeSpecification.createPrimitiveOfType) {
+            thisDependencies.attributePrimitive = {
+                dependencyType: "attributePrimitive",
+                attributeName: attrName,
+            };
+        } else if (attributeSpecification.createReferences) {
+            thisDependencies.attributeRefResolutions = {
+                dependencyType: "attributeRefResolutions",
+                attributeName: attrName,
+            };
+        } else {
+            thisDependencies.attributeComponent = {
+                dependencyType: "attributeComponent",
+                attributeName: attrName,
+                variableNames: [stateVariableForAttributeValue],
+            };
+        }
+
+        if (attributeSpecification.fallBackToParentStateVariable) {
+            thisDependencies.parentValue = {
+                dependencyType: "parentStateVariable",
+                variableName:
+                    attributeSpecification.fallBackToParentStateVariable,
+            };
+        }
+        if (attributeSpecification.fallBackToSourceCompositeStateVariable) {
+            thisDependencies.sourceCompositeValue = {
+                dependencyType: "sourceCompositeStateVariable",
+                variableName:
+                    attributeSpecification.fallBackToSourceCompositeStateVariable,
+            };
+        }
+
+        stateVarDef.returnDependencies = () => thisDependencies;
+
+        const { definition, inverseDefinition } =
+            _buildAttributeDerivedDefinitions({
+                varName,
+                stateVariableForAttributeValue,
+                attributeSpecification,
+                attrName,
+            });
+        stateVarDef.definition = definition;
+        if (!attributeSpecification.noInverse) {
+            stateVarDef.inverseDefinition = inverseDefinition;
+        }
+
+        _copyPassthroughAttributes(stateVarDef, attributeSpecification);
+    }
+
+    if (redefineDependencies.propVariable) {
+        if (!redefineDependencies.ignorePrimaryStateVariable) {
+            // primaryStateVariableForDefinition is the state variable that the componentClass
+            // being created has specified should be given the value when it
+            // is created from an outside source like a reference to a prop or an adapter
+            let primaryStateVariableForDefinition = "value";
+            if (redefineDependencies.substituteForPrimaryStateVariable) {
+                primaryStateVariableForDefinition =
+                    redefineDependencies.substituteForPrimaryStateVariable;
+            } else if (componentClass.primaryStateVariableForDefinition) {
+                primaryStateVariableForDefinition =
+                    componentClass.primaryStateVariableForDefinition;
+            }
+            let stateDef =
+                stateVariableDefinitions[primaryStateVariableForDefinition];
+            if (!stateDef) {
+                if (redefineDependencies.substituteForPrimaryStateVariable) {
+                    throw Error(
+                        `Invalid public state variable of componentType ${componentClass.componentType}: substituteForPrimaryStateVariable ${redefineDependencies.substituteForPrimaryStateVariable} does not exist`,
+                    );
+                } else {
+                    throw Error(
+                        `Cannot have a public state variable with componentType ${componentClass.componentType} as the class doesn't have a primary state variable for definition`,
+                    );
+                }
+            }
+            stateDef.isShadow = true;
+            stateDef.returnDependencies = () => ({
+                targetVariable: {
                     dependencyType: "stateVariable",
                     componentIdx: targetComponent.componentIdx,
-                    variableName: "readyToExpandWhenResolved",
-                };
-                return dependencies;
-            };
+                    variableName: redefineDependencies.propVariable,
+                },
+            });
 
-            // change definition so that it is false if targetComponent isn't ready to expand
-            stateDef.definition = function (args) {
-                let result = originalDefinition(args);
-
-                if (
-                    result.setValue &&
-                    result.setValue.readyToExpandWhenResolved
-                ) {
-                    if (
-                        !args.dependencyValues.targetReadyToExpandWhenResolved
-                    ) {
-                        result.setValue.readyToExpandWhenResolved = false;
-                    }
+            let setDefault = false;
+            if (
+                targetComponent.state[redefineDependencies.propVariable]
+                    .defaultValue !== undefined
+            ) {
+                stateDef.defaultValue =
+                    targetComponent.state[
+                        redefineDependencies.propVariable
+                    ].defaultValue;
+                if (stateDef.set) {
+                    stateDef.defaultValue = stateDef.set(stateDef.defaultValue);
                 }
-                return result;
+                stateDef.hasEssential = true;
+                setDefault = true;
+            }
+
+            let targetVariableIsArray =
+                targetComponent.state[redefineDependencies.propVariable]
+                    .isArray;
+
+            if (stateDef.set) {
+                stateDef.definition = function ({
+                    dependencyValues,
+                    usedDefault,
+                }) {
+                    let targetVariable = dependencyValues.targetVariable;
+                    if (
+                        targetVariable === undefined ||
+                        (targetVariableIsArray && targetVariable.length === 0)
+                    ) {
+                        // allow for case where we depend on array entry that does not yet exist
+                        return {
+                            useEssentialOrDefaultValue: {
+                                [primaryStateVariableForDefinition]: true,
+                            },
+                        };
+                    }
+                    let valueFromTarget = stateDef.set(targetVariable);
+                    if (setDefault && usedDefault.targetVariable) {
+                        return {
+                            useEssentialOrDefaultValue: {
+                                [primaryStateVariableForDefinition]: {
+                                    defaultValue: valueFromTarget,
+                                },
+                            },
+                        };
+                    }
+                    return {
+                        setValue: {
+                            [primaryStateVariableForDefinition]:
+                                valueFromTarget,
+                        },
+                    };
+                };
+            } else {
+                stateDef.definition = function ({
+                    dependencyValues,
+                    usedDefault,
+                }) {
+                    let targetVariable = dependencyValues.targetVariable;
+                    if (
+                        targetVariable === undefined ||
+                        (targetVariableIsArray && targetVariable.length === 0)
+                    ) {
+                        // allow for case where we depend on array entry that does not yet exist
+                        return {
+                            useEssentialOrDefaultValue: {
+                                [primaryStateVariableForDefinition]: true,
+                            },
+                        };
+                    }
+                    if (setDefault && usedDefault.targetVariable) {
+                        return {
+                            useEssentialOrDefaultValue: {
+                                [primaryStateVariableForDefinition]: {
+                                    defaultValue: targetVariable,
+                                },
+                            },
+                        };
+                    }
+                    return {
+                        setValue: {
+                            [primaryStateVariableForDefinition]: targetVariable,
+                        },
+                    };
+                };
+            }
+            stateDef.inverseDefinition = function ({
+                desiredStateVariableValues,
+            }) {
+                return {
+                    success: true,
+                    instructions: [
+                        {
+                            setDependency: "targetVariable",
+                            desiredValue:
+                                desiredStateVariableValues[
+                                    primaryStateVariableForDefinition
+                                ],
+                        },
+                    ],
+                };
             };
         }
 
+        let shadowStandardVariables = false;
         let stateVariablesToShadow = [];
+        if (targetComponent.constructor.implicitPropReturnsSameType) {
+            if (redefineDependencies.fromImplicitProp) {
+                shadowStandardVariables = true;
+            }
 
-        // shadow any variables marked as shadowVariable
-        for (let varName in targetComponent.state) {
-            let stateObj = targetComponent.state[varName];
-            if (stateObj.shadowVariable || stateObj.isShadow) {
-                stateVariablesToShadow.push(varName);
+            // shadow any variables marked as shadowVariable
+            for (let varName in targetComponent.state) {
+                let stateObj = targetComponent.state[varName];
+                if (stateObj.shadowVariable || stateObj.isShadow) {
+                    stateVariablesToShadow.push(varName);
+                }
             }
         }
 
-        this.modifyStateDefsToBeShadows({
-            stateVariablesToShadow,
-            stateVariableDefinitions,
-            foundReadyToExpandWhenResolved,
-            targetComponent,
-        });
+        if (redefineDependencies.additionalStateVariableShadowing) {
+            // since using parallel arrays, start with empty array to match next indices
+            let differentStateVariablesInTarget = Array(
+                stateVariablesToShadow.length,
+            );
+            for (let varName in redefineDependencies.additionalStateVariableShadowing) {
+                if (!stateVariablesToShadow.includes(varName)) {
+                    stateVariablesToShadow.push(varName);
+                    differentStateVariablesInTarget.push(
+                        redefineDependencies.additionalStateVariableShadowing[
+                            varName
+                        ].stateVariableToShadow,
+                    );
+                }
+            }
+
+            modifyStateDefsToBeShadows({
+                stateVariablesToShadow,
+                stateVariableDefinitions,
+                targetComponent,
+                differentStateVariablesInTarget,
+            });
+        } else if (shadowStandardVariables) {
+            modifyStateDefsToBeShadows({
+                stateVariablesToShadow,
+                stateVariableDefinitions,
+                targetComponent,
+            });
+        }
+
+        // for referencing a prop variable, don't shadow standard state variables
+        // (unless except for above cases)
+        // so just return now
+        return;
+    }
+
+    let foundReadyToExpandWhenResolved = false;
+    if ("readyToExpandWhenResolved" in stateVariableDefinitions) {
+        // if shadowing a composite
+        // make readyToExpandWhenResolved depend on the same variable
+        // of the targetComponent also being resolved
+
+        foundReadyToExpandWhenResolved = true;
+
+        let stateDef = stateVariableDefinitions.readyToExpandWhenResolved;
+        let originalReturnDependencies =
+            stateDef.returnDependencies.bind(stateDef);
+        let originalDefinition = stateDef.definition;
+
+        stateDef.returnDependencies = function (args) {
+            let dependencies = originalReturnDependencies(args);
+            dependencies.targetReadyToExpandWhenResolved = {
+                dependencyType: "stateVariable",
+                componentIdx: targetComponent.componentIdx,
+                variableName: "readyToExpandWhenResolved",
+            };
+            return dependencies;
+        };
+
+        // change definition so that it is false if targetComponent isn't ready to expand
+        stateDef.definition = function (args) {
+            let result = originalDefinition(args);
+
+            if (result.setValue && result.setValue.readyToExpandWhenResolved) {
+                if (!args.dependencyValues.targetReadyToExpandWhenResolved) {
+                    result.setValue.readyToExpandWhenResolved = false;
+                }
+            }
+            return result;
+        };
+    }
+
+    let stateVariablesToShadow = [];
+
+    // shadow any variables marked as shadowVariable
+    for (let varName in targetComponent.state) {
+        let stateObj = targetComponent.state[varName];
+        if (stateObj.shadowVariable || stateObj.isShadow) {
+            stateVariablesToShadow.push(varName);
+        }
     }
 
     modifyStateDefsToBeShadows({
@@ -776,601 +742,593 @@ export class StateVariableDefinitionFactory {
         stateVariableDefinitions,
         foundReadyToExpandWhenResolved,
         targetComponent,
-        differentStateVariablesInTarget = [],
-    }) {
-        // Note: if add a markStale function to these shadow,
-        // will need to modify array size state variable definition
-        // (createArraySizeStateVariable)
-        // to not overwrite markStale when it finds a shadow
+    });
+}
 
-        let deleteStateVariablesFromDefinition = {};
-        for (let [varInd, varName] of stateVariablesToShadow.entries()) {
-            let stateDef = stateVariableDefinitions[varName];
+function modifyStateDefsToBeShadows({
+    stateVariablesToShadow,
+    stateVariableDefinitions,
+    foundReadyToExpandWhenResolved,
+    targetComponent,
+    differentStateVariablesInTarget = [],
+}: any) {
+    // Note: if add a markStale function to these shadow,
+    // will need to modify array size state variable definition
+    // (createArraySizeStateVariable)
+    // to not overwrite markStale when it finds a shadow
 
-            if (stateDef === undefined) {
-                if (varName.slice(0, 8) === "__array_") {
-                    // have an array variable name that is created on the fly
-                    // rather than being specified in original definition.
-                    stateDef = stateVariableDefinitions[varName] = {};
-                } else {
-                    continue;
+    let deleteStateVariablesFromDefinition = {};
+    for (let [varInd, varName] of stateVariablesToShadow.entries()) {
+        let stateDef = stateVariableDefinitions[varName];
+
+        if (stateDef === undefined) {
+            if (varName.slice(0, 8) === "__array_") {
+                // have an array variable name that is created on the fly
+                // rather than being specified in original definition.
+                stateDef = stateVariableDefinitions[varName] = {};
+            } else {
+                continue;
+            }
+        }
+
+        stateDef.isShadow = true;
+
+        if (stateDef.additionalStateVariablesDefined) {
+            for (let varName2 of stateDef.additionalStateVariablesDefined) {
+                if (!stateVariablesToShadow.includes(varName2)) {
+                    // varName2 is not shadowed, however, it includes varName
+                    // in its definition
+                    if (!deleteStateVariablesFromDefinition[varName2]) {
+                        deleteStateVariablesFromDefinition[varName2] = [];
+                    }
+                    deleteStateVariablesFromDefinition[varName2].push(varName);
                 }
             }
+        }
+        delete stateDef.additionalStateVariablesDefined;
+        if (!foundReadyToExpandWhenResolved) {
+            // if didn't find a readyToExpandWhenResolved,
+            // then won't use original dependencies so can delete any
+            // stateVariablesDeterminingDependencies
+            delete stateDef.stateVariablesDeterminingDependencies;
+        }
 
-            stateDef.isShadow = true;
+        let copyComponentType =
+            stateDef.public &&
+            stateDef.shadowingInstructions.hasVariableComponentType;
 
-            if (stateDef.additionalStateVariablesDefined) {
-                for (let varName2 of stateDef.additionalStateVariablesDefined) {
-                    if (!stateVariablesToShadow.includes(varName2)) {
-                        // varName2 is not shadowed, however, it includes varName
-                        // in its definition
-                        if (!deleteStateVariablesFromDefinition[varName2]) {
-                            deleteStateVariablesFromDefinition[varName2] = [];
-                        }
-                        deleteStateVariablesFromDefinition[varName2].push(
-                            varName,
-                        );
-                    }
-                }
-            }
-            delete stateDef.additionalStateVariablesDefined;
-            if (!foundReadyToExpandWhenResolved) {
-                // if didn't find a readyToExpandWhenResolved,
-                // then won't use original dependencies so can delete any
-                // stateVariablesDeterminingDependencies
-                delete stateDef.stateVariablesDeterminingDependencies;
-            }
+        if (stateDef.isArray) {
+            let overrideVarNameWith = differentStateVariablesInTarget[varInd];
 
-            let copyComponentType =
-                stateDef.public &&
-                stateDef.shadowingInstructions.hasVariableComponentType;
+            stateDef.returnArrayDependenciesByKey = function ({ arrayKeys }) {
+                let dependenciesByKey = {};
 
-            if (stateDef.isArray) {
-                let overrideVarNameWith =
-                    differentStateVariablesInTarget[varInd];
-
-                stateDef.returnArrayDependenciesByKey = function ({
-                    arrayKeys,
-                }) {
-                    let dependenciesByKey = {};
-
-                    for (let key of arrayKeys) {
-                        dependenciesByKey[key] = {
-                            targetVariable: {
-                                dependencyType: "stateVariable",
-                                componentIdx: targetComponent.componentIdx,
-                                variableName:
-                                    overrideVarNameWith ||
-                                    this.arrayVarNameFromArrayKey(key),
-                            },
-                        };
-                    }
-
-                    let globalDependencies = {};
-
-                    if (copyComponentType) {
-                        globalDependencies.targetVariableComponentType = {
-                            dependencyType: "stateVariableComponentType",
-                            componentIdx: targetComponent.componentIdx,
-                            variableName: varName,
-                        };
-                    }
-
-                    if (stateDef.inverseShadowToSetEntireArray) {
-                        globalDependencies.targetArray = {
+                for (let key of arrayKeys) {
+                    dependenciesByKey[key] = {
+                        targetVariable: {
                             dependencyType: "stateVariable",
                             componentIdx: targetComponent.componentIdx,
-                            variableName: varName,
-                        };
-                    }
-
-                    return { globalDependencies, dependenciesByKey };
-                };
-
-                stateDef.arrayDefinitionByKey = function ({
-                    globalDependencyValues,
-                    dependencyValuesByKey,
-                    arrayKeys,
-                }) {
-                    let newEntries = {};
-
-                    for (let arrayKey of arrayKeys) {
-                        if (
-                            "targetVariable" in dependencyValuesByKey[arrayKey]
-                        ) {
-                            newEntries[arrayKey] =
-                                dependencyValuesByKey[arrayKey].targetVariable;
-                        } else {
-                            // put in a placeholder value until this can be rerun
-                            // with the updated dependencies
-                            newEntries[arrayKey] =
-                                stateDef.defaultValueByArrayKey?.(arrayKey);
-                        }
-                    }
-
-                    let result = {
-                        setValue: { [varName]: newEntries },
+                            variableName:
+                                overrideVarNameWith ||
+                                this.arrayVarNameFromArrayKey(key),
+                        },
                     };
-
-                    // TODO: how do we make it do this just once?
-                    if (
-                        "targetVariableComponentType" in globalDependencyValues
-                    ) {
-                        result.setCreateComponentOfType = {
-                            [varName]:
-                                globalDependencyValues.targetVariableComponentType,
-                        };
-                    }
-
-                    return result;
-                };
-
-                stateDef.inverseArrayDefinitionByKey = function ({
-                    desiredStateVariableValues,
-                    dependencyValuesByKey,
-                    dependencyNamesByKey,
-                    arraySize,
-                    initialChange,
-                }) {
-                    if (stateDef.inverseShadowToSetEntireArray) {
-                        return {
-                            success: true,
-                            instructions: [
-                                {
-                                    setDependency: "targetArray",
-                                    desiredValue:
-                                        desiredStateVariableValues[varName],
-                                    treatAsInitialChange: initialChange,
-                                },
-                            ],
-                        };
-                    }
-
-                    let instructions = [];
-                    for (let key in desiredStateVariableValues[varName]) {
-                        if (!dependencyValuesByKey[key]) {
-                            continue;
-                        }
-
-                        instructions.push({
-                            setDependency:
-                                dependencyNamesByKey[key].targetVariable,
-                            desiredValue:
-                                desiredStateVariableValues[varName][key],
-                            shadowedVariable: true,
-                        });
-                    }
-                    return {
-                        success: true,
-                        instructions,
-                    };
-                };
-            } else {
-                let returnStartingDependencies = () => ({});
-
-                if (foundReadyToExpandWhenResolved) {
-                    // even though won't use original dependencies
-                    // if found a readyToExpandWhenResolved
-                    // keep original dependencies so that readyToExpandWhenResolved
-                    // won't be resolved until all its dependent variables are resolved
-                    returnStartingDependencies =
-                        stateDef.returnDependencies.bind(stateDef);
                 }
 
-                let varNameInTarget = differentStateVariablesInTarget[varInd];
-                if (!varNameInTarget) {
-                    varNameInTarget = varName;
+                let globalDependencies = {};
+
+                if (copyComponentType) {
+                    globalDependencies.targetVariableComponentType = {
+                        dependencyType: "stateVariableComponentType",
+                        componentIdx: targetComponent.componentIdx,
+                        variableName: varName,
+                    };
                 }
 
-                stateDef.returnDependencies = function (args) {
-                    let dependencies = Object.assign(
-                        {},
-                        returnStartingDependencies(args),
-                    );
-
-                    dependencies.targetVariable = {
+                if (stateDef.inverseShadowToSetEntireArray) {
+                    globalDependencies.targetArray = {
                         dependencyType: "stateVariable",
                         componentIdx: targetComponent.componentIdx,
-                        variableName: varNameInTarget,
+                        variableName: varName,
                     };
-                    if (copyComponentType) {
-                        dependencies.targetVariableComponentType = {
-                            dependencyType: "stateVariableComponentType",
-                            componentIdx: targetComponent.componentIdx,
-                            variableName: varNameInTarget,
-                        };
-                    }
-                    return dependencies;
-                };
-                stateDef.definition = function ({
-                    dependencyValues,
-                    usedDefault,
-                }) {
-                    let result = {};
+                }
 
-                    // TODO: how do we make it do this just once?
-                    if ("targetVariableComponentType" in dependencyValues) {
-                        result.setCreateComponentOfType = {
-                            [varName]:
-                                dependencyValues.targetVariableComponentType,
-                        };
-                    }
+                return { globalDependencies, dependenciesByKey };
+            };
 
-                    if (
-                        usedDefault.targetVariable &&
-                        "defaultValue" in stateDef &&
-                        stateDef.hasEssential
-                    ) {
-                        result.useEssentialOrDefaultValue = {
-                            [varName]: {
-                                defaultValue: dependencyValues.targetVariable,
-                            },
-                        };
+            stateDef.arrayDefinitionByKey = function ({
+                globalDependencyValues,
+                dependencyValuesByKey,
+                arrayKeys,
+            }) {
+                let newEntries = {};
+
+                for (let arrayKey of arrayKeys) {
+                    if ("targetVariable" in dependencyValuesByKey[arrayKey]) {
+                        newEntries[arrayKey] =
+                            dependencyValuesByKey[arrayKey].targetVariable;
                     } else {
-                        result.setValue = {
-                            [varName]: dependencyValues.targetVariable,
-                        };
+                        // put in a placeholder value until this can be rerun
+                        // with the updated dependencies
+                        newEntries[arrayKey] =
+                            stateDef.defaultValueByArrayKey?.(arrayKey);
                     }
+                }
 
-                    return result;
+                let result = {
+                    setValue: { [varName]: newEntries },
                 };
-                stateDef.excludeDependencyValuesInInverseDefinition = true;
-                stateDef.inverseDefinition = function ({
-                    desiredStateVariableValues,
-                }) {
+
+                // TODO: how do we make it do this just once?
+                if ("targetVariableComponentType" in globalDependencyValues) {
+                    result.setCreateComponentOfType = {
+                        [varName]:
+                            globalDependencyValues.targetVariableComponentType,
+                    };
+                }
+
+                return result;
+            };
+
+            stateDef.inverseArrayDefinitionByKey = function ({
+                desiredStateVariableValues,
+                dependencyValuesByKey,
+                dependencyNamesByKey,
+                arraySize,
+                initialChange,
+            }) {
+                if (stateDef.inverseShadowToSetEntireArray) {
                     return {
                         success: true,
                         instructions: [
                             {
-                                setDependency: "targetVariable",
+                                setDependency: "targetArray",
                                 desiredValue:
                                     desiredStateVariableValues[varName],
-                                shadowedVariable: true,
+                                treatAsInitialChange: initialChange,
                             },
                         ],
                     };
+                }
+
+                let instructions = [];
+                for (let key in desiredStateVariableValues[varName]) {
+                    if (!dependencyValuesByKey[key]) {
+                        continue;
+                    }
+
+                    instructions.push({
+                        setDependency: dependencyNamesByKey[key].targetVariable,
+                        desiredValue: desiredStateVariableValues[varName][key],
+                        shadowedVariable: true,
+                    });
+                }
+                return {
+                    success: true,
+                    instructions,
                 };
+            };
+        } else {
+            let returnStartingDependencies = () => ({});
+
+            if (foundReadyToExpandWhenResolved) {
+                // even though won't use original dependencies
+                // if found a readyToExpandWhenResolved
+                // keep original dependencies so that readyToExpandWhenResolved
+                // won't be resolved until all its dependent variables are resolved
+                returnStartingDependencies =
+                    stateDef.returnDependencies.bind(stateDef);
             }
-        }
-        for (let varName in deleteStateVariablesFromDefinition) {
-            this.modifyStateDefToDeleteVariableReferences({
-                varNamesToDelete: deleteStateVariablesFromDefinition[varName],
-                stateDef: stateVariableDefinitions[varName],
-            });
+
+            let varNameInTarget = differentStateVariablesInTarget[varInd];
+            if (!varNameInTarget) {
+                varNameInTarget = varName;
+            }
+
+            stateDef.returnDependencies = function (args) {
+                let dependencies = Object.assign(
+                    {},
+                    returnStartingDependencies(args),
+                );
+
+                dependencies.targetVariable = {
+                    dependencyType: "stateVariable",
+                    componentIdx: targetComponent.componentIdx,
+                    variableName: varNameInTarget,
+                };
+                if (copyComponentType) {
+                    dependencies.targetVariableComponentType = {
+                        dependencyType: "stateVariableComponentType",
+                        componentIdx: targetComponent.componentIdx,
+                        variableName: varNameInTarget,
+                    };
+                }
+                return dependencies;
+            };
+            stateDef.definition = function ({ dependencyValues, usedDefault }) {
+                let result = {};
+
+                // TODO: how do we make it do this just once?
+                if ("targetVariableComponentType" in dependencyValues) {
+                    result.setCreateComponentOfType = {
+                        [varName]: dependencyValues.targetVariableComponentType,
+                    };
+                }
+
+                if (
+                    usedDefault.targetVariable &&
+                    "defaultValue" in stateDef &&
+                    stateDef.hasEssential
+                ) {
+                    result.useEssentialOrDefaultValue = {
+                        [varName]: {
+                            defaultValue: dependencyValues.targetVariable,
+                        },
+                    };
+                } else {
+                    result.setValue = {
+                        [varName]: dependencyValues.targetVariable,
+                    };
+                }
+
+                return result;
+            };
+            stateDef.excludeDependencyValuesInInverseDefinition = true;
+            stateDef.inverseDefinition = function ({
+                desiredStateVariableValues,
+            }) {
+                return {
+                    success: true,
+                    instructions: [
+                        {
+                            setDependency: "targetVariable",
+                            desiredValue: desiredStateVariableValues[varName],
+                            shadowedVariable: true,
+                        },
+                    ],
+                };
+            };
         }
     }
+    for (let varName in deleteStateVariablesFromDefinition) {
+        modifyStateDefToDeleteVariableReferences({
+            varNamesToDelete: deleteStateVariablesFromDefinition[varName],
+            stateDef: stateVariableDefinitions[varName],
+        });
+    }
+}
 
-    modifyStateDefToDeleteVariableReferences({ varNamesToDelete, stateDef }) {
-        // delete variables from additionalStateVariablesDefined
-        for (let varName2 of varNamesToDelete) {
-            let ind =
-                stateDef.additionalStateVariablesDefined.indexOf(varName2);
-            stateDef.additionalStateVariablesDefined.splice(ind, 1);
-        }
+function modifyStateDefToDeleteVariableReferences({
+    varNamesToDelete,
+    stateDef,
+}: any) {
+    // delete variables from additionalStateVariablesDefined
+    for (let varName2 of varNamesToDelete) {
+        let ind = stateDef.additionalStateVariablesDefined.indexOf(varName2);
+        stateDef.additionalStateVariablesDefined.splice(ind, 1);
+    }
 
-        // remove variables from definition
-        let originalDefinition = stateDef.definition;
-        stateDef.definition = function (args) {
-            let results = originalDefinition(args);
-            for (let key in results) {
-                if (Array.isArray(results[key])) {
-                    for (let varName2 of varNamesToDelete) {
-                        let ind = results[key].indexOf(varName2);
-                        if (ind !== -1) {
-                            results[key].splice(ind, 1);
-                        }
-                    }
-                } else {
-                    for (let varName2 of varNamesToDelete) {
-                        delete results[key][varName2];
+    // remove variables from definition
+    let originalDefinition = stateDef.definition;
+    stateDef.definition = function (args) {
+        let results = originalDefinition(args);
+        for (let key in results) {
+            if (Array.isArray(results[key])) {
+                for (let varName2 of varNamesToDelete) {
+                    let ind = results[key].indexOf(varName2);
+                    if (ind !== -1) {
+                        results[key].splice(ind, 1);
                     }
                 }
-            }
-            return results;
-        };
-    }
-
-    /**
-     * Mark `stateVarDef` as public and populate
-     * `shadowingInstructions.createComponentOfType` from
-     * `attributeSpecification`. Maps `createPrimitiveOfType` codes
-     * (`string`/`stringArray`/`numberArray`) to their component-shaped
-     * equivalents (`text`/`textList`/`numberList`); falls back to
-     * `attributeSpecification.createComponentOfType` if no primitive type.
-     * Throws when `createReferences` is set, since references can't shadow
-     * publicly.
-     */
-    _setShadowingInstructionsFromAttribute(
-        stateVarDef: any,
-        attributeSpecification: any,
-    ) {
-        stateVarDef.public = true;
-        stateVarDef.shadowingInstructions = {};
-        if (attributeSpecification.createPrimitiveOfType) {
-            const primitive = attributeSpecification.createPrimitiveOfType;
-            stateVarDef.shadowingInstructions.createComponentOfType =
-                PRIMITIVE_TO_COMPONENT_TYPE[primitive] ?? primitive;
-        } else if (attributeSpecification.createReferences) {
-            throw Error(
-                "Cannot make a public state variable from an attribute with createReferences",
-            );
-        } else {
-            stateVarDef.shadowingInstructions.createComponentOfType =
-                attributeSpecification.createComponentOfType;
-        }
-    }
-
-    /**
-     * Decide which state-variable name to read from the attribute's
-     * component to populate the dependency value: prefer the explicit
-     * `componentStateVariableForAttributeValue`, fall back to the attribute
-     * class's `stateVariableToBeShadowed`, then default to `"value"`.
-     * Returns `undefined` when no `createComponentOfType` is specified
-     * (the dependency will use a different shape, e.g. `attributePrimitive`).
-     * Throws if the attribute class doesn't exist.
-     */
-    _resolveAttributeValueVariable(
-        attributeSpecification: any,
-        attrName: string,
-        componentClass: any,
-    ): string | undefined {
-        if (!attributeSpecification.createComponentOfType) {
-            return undefined;
-        }
-        const attributeClass =
-            this.core.componentInfoObjects.allComponentClasses[
-                attributeSpecification.createComponentOfType
-            ];
-        if (!attributeClass) {
-            throw Error(
-                `Component type ${attributeSpecification.createComponentOfType} does not exist so cannot create state variable for attribute ${attrName} of componentType ${componentClass.componentType}.`,
-            );
-        }
-        let stateVariableForAttributeValue =
-            attributeSpecification.componentStateVariableForAttributeValue;
-        if (stateVariableForAttributeValue === undefined) {
-            stateVariableForAttributeValue =
-                attributeClass.stateVariableToBeShadowed;
-            if (stateVariableForAttributeValue === undefined) {
-                stateVariableForAttributeValue = "value";
-            }
-        }
-        return stateVariableForAttributeValue;
-    }
-
-    /**
-     * Copy the canonical pass-through fields from `attributeSpecification`
-     * onto `stateVarDef`. Only fields that are explicitly present on the
-     * spec are copied (so that defaults stay defaults). The
-     * `triggerActionOnChange` field is opt-in via
-     * `includeTriggerActionOnChange` because only the
-     * `createAttributeStateVariableDefinitions` site forwards it; the
-     * adapter-shadow and reference-shadow paths intentionally don't.
-     */
-    _copyPassthroughAttributes(
-        stateVarDef: any,
-        attributeSpecification: any,
-        { includeTriggerActionOnChange = false } = {},
-    ) {
-        const attributesToCopy = [
-            "forRenderer",
-            "defaultValue",
-            "propagateToProps",
-            ...(includeTriggerActionOnChange ? ["triggerActionOnChange"] : []),
-            "ignoreFixed",
-            "isLocation",
-            "essentialVarName",
-        ];
-        for (const attrName2 of attributesToCopy) {
-            if (attrName2 in attributeSpecification) {
-                stateVarDef[attrName2] = attributeSpecification[attrName2];
-            }
-        }
-    }
-
-    /**
-     * Build the `definition` / `inverseDefinition` callback pair for an
-     * attribute-derived state variable. Both callbacks close over `varName`,
-     * `stateVariableForAttributeValue`, `attributeSpecification`, and
-     * `attrName`; the callers attach the returned closures to a
-     * `stateVarDef` they own.
-     *
-     * The `definition` resolves the attribute value from one of the four
-     * dependency shapes (`attributeComponent` / `attributePrimitive` /
-     * `attributeRefResolutions` / fall-back via parent or
-     * source-composite), then validates it via `validateAttributeValue`.
-     *
-     * The `inverseDefinition` (used unless `noInverse` is set) routes a
-     * desired value back to the same source — propagating to the parent
-     * state variable, source-composite state variable, or essential value
-     * when no underlying component is present, or back to the attribute
-     * component when one is.
-     */
-    _buildAttributeDerivedDefinitions({
-        varName,
-        stateVariableForAttributeValue,
-        attributeSpecification,
-        attrName,
-    }: {
-        varName: string;
-        stateVariableForAttributeValue: string | undefined;
-        attributeSpecification: any;
-        attrName: string;
-    }): {
-        definition: (args: any) => any;
-        inverseDefinition: (args: any) => Promise<any>;
-    } {
-        const definition = function ({
-            dependencyValues,
-            usedDefault,
-            essentialValues,
-        }: any) {
-            let attributeValue;
-            if (dependencyValues.attributeComponent) {
-                // The `attributeComponent` dependency is wired only when
-                // `createComponentOfType` is set (see the call sites'
-                // `returnDependencies`), which is exactly when
-                // `_resolveAttributeValueVariable` returns a defined name —
-                // so the non-null assertion is safe here.
-                attributeValue =
-                    dependencyValues.attributeComponent.stateValues[
-                        stateVariableForAttributeValue!
-                    ];
-            } else if (dependencyValues.attributePrimitive != null) {
-                attributeValue = dependencyValues.attributePrimitive;
-            } else if (
-                dependencyValues.attributeRefResolutions != null &&
-                !usedDefault.attributeRefResolutions
-            ) {
-                attributeValue = dependencyValues.attributeRefResolutions;
             } else {
-                // parentValue would be undefined if fallBackToParentStateVariable wasn't specified
-                // parentValue would be null if the parentValue state variables
+                for (let varName2 of varNamesToDelete) {
+                    delete results[key][varName2];
+                }
+            }
+        }
+        return results;
+    };
+}
+
+/**
+ * Mark `stateVarDef` as public and populate
+ * `shadowingInstructions.createComponentOfType` from
+ * `attributeSpecification`. Maps `createPrimitiveOfType` codes
+ * (`string`/`stringArray`/`numberArray`) to their component-shaped
+ * equivalents (`text`/`textList`/`numberList`); falls back to
+ * `attributeSpecification.createComponentOfType` if no primitive type.
+ * Throws when `createReferences` is set, since references can't shadow
+ * publicly.
+ */
+function _setShadowingInstructionsFromAttribute(
+    stateVarDef: any,
+    attributeSpecification: any,
+) {
+    stateVarDef.public = true;
+    stateVarDef.shadowingInstructions = {};
+    if (attributeSpecification.createPrimitiveOfType) {
+        const primitive = attributeSpecification.createPrimitiveOfType;
+        stateVarDef.shadowingInstructions.createComponentOfType =
+            PRIMITIVE_TO_COMPONENT_TYPE[primitive] ?? primitive;
+    } else if (attributeSpecification.createReferences) {
+        throw Error(
+            "Cannot make a public state variable from an attribute with createReferences",
+        );
+    } else {
+        stateVarDef.shadowingInstructions.createComponentOfType =
+            attributeSpecification.createComponentOfType;
+    }
+}
+
+/**
+ * Decide which state-variable name to read from the attribute's
+ * component to populate the dependency value: prefer the explicit
+ * `componentStateVariableForAttributeValue`, fall back to the attribute
+ * class's `stateVariableToBeShadowed`, then default to `"value"`.
+ * Returns `undefined` when no `createComponentOfType` is specified
+ * (the dependency will use a different shape, e.g. `attributePrimitive`).
+ * Throws if the attribute class doesn't exist.
+ */
+function _resolveAttributeValueVariable(
+    core: Core,
+    attributeSpecification: any,
+    attrName: string,
+    componentClass: any,
+): string | undefined {
+    if (!attributeSpecification.createComponentOfType) {
+        return undefined;
+    }
+    const attributeClass =
+        core.componentInfoObjects.allComponentClasses[
+            attributeSpecification.createComponentOfType
+        ];
+    if (!attributeClass) {
+        throw Error(
+            `Component type ${attributeSpecification.createComponentOfType} does not exist so cannot create state variable for attribute ${attrName} of componentType ${componentClass.componentType}.`,
+        );
+    }
+    let stateVariableForAttributeValue =
+        attributeSpecification.componentStateVariableForAttributeValue;
+    if (stateVariableForAttributeValue === undefined) {
+        stateVariableForAttributeValue =
+            attributeClass.stateVariableToBeShadowed;
+        if (stateVariableForAttributeValue === undefined) {
+            stateVariableForAttributeValue = "value";
+        }
+    }
+    return stateVariableForAttributeValue;
+}
+
+/**
+ * Copy the canonical pass-through fields from `attributeSpecification`
+ * onto `stateVarDef`. Only fields that are explicitly present on the
+ * spec are copied (so that defaults stay defaults). The
+ * `triggerActionOnChange` field is opt-in via
+ * `includeTriggerActionOnChange` because only the
+ * `createAttributeStateVariableDefinitions` site forwards it; the
+ * adapter-shadow and reference-shadow paths intentionally don't.
+ */
+function _copyPassthroughAttributes(
+    stateVarDef: any,
+    attributeSpecification: any,
+    { includeTriggerActionOnChange = false } = {},
+) {
+    const attributesToCopy = [
+        "forRenderer",
+        "defaultValue",
+        "propagateToProps",
+        ...(includeTriggerActionOnChange ? ["triggerActionOnChange"] : []),
+        "ignoreFixed",
+        "isLocation",
+        "essentialVarName",
+    ];
+    for (const attrName2 of attributesToCopy) {
+        if (attrName2 in attributeSpecification) {
+            stateVarDef[attrName2] = attributeSpecification[attrName2];
+        }
+    }
+}
+
+/**
+ * Build the `definition` / `inverseDefinition` callback pair for an
+ * attribute-derived state variable. Both callbacks close over `varName`,
+ * `stateVariableForAttributeValue`, `attributeSpecification`, and
+ * `attrName`; the callers attach the returned closures to a
+ * `stateVarDef` they own.
+ *
+ * The `definition` resolves the attribute value from one of the four
+ * dependency shapes (`attributeComponent` / `attributePrimitive` /
+ * `attributeRefResolutions` / fall-back via parent or
+ * source-composite), then validates it via `validateAttributeValue`.
+ *
+ * The `inverseDefinition` (used unless `noInverse` is set) routes a
+ * desired value back to the same source — propagating to the parent
+ * state variable, source-composite state variable, or essential value
+ * when no underlying component is present, or back to the attribute
+ * component when one is.
+ */
+function _buildAttributeDerivedDefinitions({
+    varName,
+    stateVariableForAttributeValue,
+    attributeSpecification,
+    attrName,
+}: {
+    varName: string;
+    stateVariableForAttributeValue: string | undefined;
+    attributeSpecification: any;
+    attrName: string;
+}): {
+    definition: (args: any) => any;
+    inverseDefinition: (args: any) => Promise<any>;
+} {
+    const definition = function ({
+        dependencyValues,
+        usedDefault,
+        essentialValues,
+    }: any) {
+        let attributeValue;
+        if (dependencyValues.attributeComponent) {
+            // The `attributeComponent` dependency is wired only when
+            // `createComponentOfType` is set (see the call sites'
+            // `returnDependencies`), which is exactly when
+            // `_resolveAttributeValueVariable` returns a defined name —
+            // so the non-null assertion is safe here.
+            attributeValue =
+                dependencyValues.attributeComponent.stateValues[
+                    stateVariableForAttributeValue!
+                ];
+        } else if (dependencyValues.attributePrimitive != null) {
+            attributeValue = dependencyValues.attributePrimitive;
+        } else if (
+            dependencyValues.attributeRefResolutions != null &&
+            !usedDefault.attributeRefResolutions
+        ) {
+            attributeValue = dependencyValues.attributeRefResolutions;
+        } else {
+            // parentValue would be undefined if fallBackToParentStateVariable wasn't specified
+            // parentValue would be null if the parentValue state variables
+            // did not exist or its value was null
+            let haveParentValue = dependencyValues.parentValue != null;
+            if (
+                haveParentValue &&
+                !usedDefault.parentValue &&
+                essentialValues[varName] === undefined
+            ) {
+                return {
+                    setValue: {
+                        [varName]: dependencyValues.parentValue,
+                    },
+                    checkForActualChange: { [varName]: true },
+                };
+            } else {
+                // sourceCompositeValue would be undefined if fallBackToSourceCompositeStateVariable wasn't specified
+                // sourceCompositeValue would be null if the sourceCompositeValue state variables
                 // did not exist or its value was null
-                let haveParentValue = dependencyValues.parentValue != null;
+
+                let haveSourceCompositeValue =
+                    dependencyValues.sourceCompositeValue != null;
                 if (
-                    haveParentValue &&
-                    !usedDefault.parentValue &&
+                    haveSourceCompositeValue &&
+                    !usedDefault.sourceCompositeValue &&
                     essentialValues[varName] === undefined
                 ) {
                     return {
                         setValue: {
-                            [varName]: dependencyValues.parentValue,
+                            [varName]: dependencyValues.sourceCompositeValue,
                         },
                         checkForActualChange: { [varName]: true },
                     };
                 } else {
-                    // sourceCompositeValue would be undefined if fallBackToSourceCompositeStateVariable wasn't specified
-                    // sourceCompositeValue would be null if the sourceCompositeValue state variables
-                    // did not exist or its value was null
-
-                    let haveSourceCompositeValue =
-                        dependencyValues.sourceCompositeValue != null;
-                    if (
-                        haveSourceCompositeValue &&
-                        !usedDefault.sourceCompositeValue &&
-                        essentialValues[varName] === undefined
-                    ) {
-                        return {
-                            setValue: {
-                                [varName]:
-                                    dependencyValues.sourceCompositeValue,
-                            },
-                            checkForActualChange: { [varName]: true },
-                        };
-                    } else {
-                        return {
-                            useEssentialOrDefaultValue: {
-                                [varName]: true,
-                            },
-                            checkForActualChange: { [varName]: true },
-                        };
-                    }
+                    return {
+                        useEssentialOrDefaultValue: {
+                            [varName]: true,
+                        },
+                        checkForActualChange: { [varName]: true },
+                    };
                 }
             }
+        }
 
-            const res = validateAttributeValue({
-                value: attributeValue,
-                attributeSpecification,
-                attribute: attrName,
-            });
+        const res = validateAttributeValue({
+            value: attributeValue,
+            attributeSpecification,
+            attribute: attrName,
+        });
 
-            return {
-                setValue: { [varName]: res.value },
-                checkForActualChange: { [varName]: true },
-                sendDiagnostics: res.diagnostics,
-            };
+        return {
+            setValue: { [varName]: res.value },
+            checkForActualChange: { [varName]: true },
+            sendDiagnostics: res.diagnostics,
         };
+    };
 
-        const inverseDefinition = async function ({
-            desiredStateVariableValues,
-            dependencyValues,
-            usedDefault,
-            essentialValues,
-        }: any) {
-            if (!dependencyValues.attributeComponent) {
-                if (dependencyValues.attributePrimitive != null) {
-                    // can't invert if have primitive
-                    return { success: false };
-                }
-                if (dependencyValues.attributeRefResolutions != null) {
-                    // can't invert if have attribute ref resolutions
-                    return { success: false };
-                }
+    const inverseDefinition = async function ({
+        desiredStateVariableValues,
+        dependencyValues,
+        usedDefault,
+        essentialValues,
+    }: any) {
+        if (!dependencyValues.attributeComponent) {
+            if (dependencyValues.attributePrimitive != null) {
+                // can't invert if have primitive
+                return { success: false };
+            }
+            if (dependencyValues.attributeRefResolutions != null) {
+                // can't invert if have attribute ref resolutions
+                return { success: false };
+            }
 
-                let haveParentValue = dependencyValues.parentValue != null;
+            let haveParentValue = dependencyValues.parentValue != null;
+            if (
+                haveParentValue &&
+                !usedDefault.parentValue &&
+                essentialValues[varName] === undefined
+            ) {
+                // value from parent was used, so propagate back to parent
+                return {
+                    success: true,
+                    instructions: [
+                        {
+                            setDependency: "parentValue",
+                            desiredValue: desiredStateVariableValues[varName],
+                        },
+                    ],
+                };
+            } else {
+                let haveSourceCompositeValue =
+                    dependencyValues.sourceCompositeValue != null;
                 if (
-                    haveParentValue &&
-                    !usedDefault.parentValue &&
+                    haveSourceCompositeValue &&
+                    !usedDefault.sourceCompositeValue &&
                     essentialValues[varName] === undefined
                 ) {
-                    // value from parent was used, so propagate back to parent
+                    // value from source composite was used, so propagate back to source composite
                     return {
                         success: true,
                         instructions: [
                             {
-                                setDependency: "parentValue",
+                                setDependency: "sourceCompositeValue",
                                 desiredValue:
                                     desiredStateVariableValues[varName],
                             },
                         ],
                     };
                 } else {
-                    let haveSourceCompositeValue =
-                        dependencyValues.sourceCompositeValue != null;
-                    if (
-                        haveSourceCompositeValue &&
-                        !usedDefault.sourceCompositeValue &&
-                        essentialValues[varName] === undefined
-                    ) {
-                        // value from source composite was used, so propagate back to source composite
-                        return {
-                            success: true,
-                            instructions: [
-                                {
-                                    setDependency: "sourceCompositeValue",
-                                    desiredValue:
-                                        desiredStateVariableValues[varName],
-                                },
-                            ],
-                        };
-                    } else {
-                        // no component or primitive, so value is essential and give it the desired value, but validated
-                        const res = validateAttributeValue({
-                            value: desiredStateVariableValues[varName],
-                            attributeSpecification,
-                            attribute: attrName,
-                        });
+                    // no component or primitive, so value is essential and give it the desired value, but validated
+                    const res = validateAttributeValue({
+                        value: desiredStateVariableValues[varName],
+                        attributeSpecification,
+                        attribute: attrName,
+                    });
 
-                        return {
-                            success: true,
-                            instructions: [
-                                {
-                                    setEssentialValue: varName,
-                                    value: res.value,
-                                },
-                            ],
-                            sendDiagnostics: res.diagnostics,
-                        };
-                    }
+                    return {
+                        success: true,
+                        instructions: [
+                            {
+                                setEssentialValue: varName,
+                                value: res.value,
+                            },
+                        ],
+                        sendDiagnostics: res.diagnostics,
+                    };
                 }
             }
+        }
 
-            // attribute based on component
-            return {
-                success: true,
-                instructions: [
-                    {
-                        setDependency: "attributeComponent",
-                        desiredValue: desiredStateVariableValues[varName],
-                        variableIndex: 0,
-                    },
-                ],
-            };
+        // attribute based on component
+        return {
+            success: true,
+            instructions: [
+                {
+                    setDependency: "attributeComponent",
+                    desiredValue: desiredStateVariableValues[varName],
+                    variableIndex: 0,
+                },
+            ],
         };
+    };
 
-        return { definition, inverseDefinition };
-    }
+    return { definition, inverseDefinition };
 }
 
 function validateAttributeValue({

--- a/packages/doenetml-worker-javascript/src/StateVariableDefinitionFactory.ts
+++ b/packages/doenetml-worker-javascript/src/StateVariableDefinitionFactory.ts
@@ -1,3 +1,4 @@
+import type { ComponentIdx } from "@doenet/utils";
 import type Core from "./Core";
 import { preprocessAttributesObject } from "./utils/attributes";
 
@@ -32,7 +33,6 @@ const PRIMITIVE_TO_COMPONENT_TYPE: Record<string, string> = {
  * (`arrayVarNameFromArrayKey` is invoked on the per-variable `stateDef`,
  * not on Core.)
  */
-
 export async function createStateVariableDefinitions({
     core,
     componentClass,
@@ -41,9 +41,9 @@ export async function createStateVariableDefinitions({
 }: {
     core: Core;
     componentClass: any;
-    prescribedDependencies: any;
-    componentIdx: any;
-}) {
+    prescribedDependencies: Record<string, any[]> | undefined;
+    componentIdx: ComponentIdx;
+}): Promise<Record<string, any>> {
     let redefineDependencies;
 
     if (prescribedDependencies) {
@@ -124,11 +124,23 @@ export async function createStateVariableDefinitions({
     return stateVariableDefinitions;
 }
 
+/**
+ * Build a state-variable definition for each attribute on `componentClass`
+ * that has `createStateVariable` set. Used when the component is created
+ * directly (i.e. not as an adapter or reference shadow); the resulting
+ * variables read their value from the attribute component / primitive /
+ * ref-resolutions, with optional fall-backs to a parent or
+ * source-composite state variable.
+ */
 function createAttributeStateVariableDefinitions({
     core,
     componentClass,
     stateVariableDefinitions,
-}: any) {
+}: {
+    core: Core;
+    componentClass: any;
+    stateVariableDefinitions: Record<string, any>;
+}) {
     let attributes = preprocessAttributesObject(
         componentClass.createAttributesObject(),
     );
@@ -216,12 +228,26 @@ function createAttributeStateVariableDefinitions({
     }
 }
 
+/**
+ * Override `stateVariableDefinitions` for a component being created as an
+ * adapter for another component. Attribute-derived variables shadow the
+ * adapter target's matching state variable (if it exists), and the
+ * primary state variable is rewired to read from
+ * `redefineDependencies.adapterVariable`. Variables in
+ * `stateVariablesToShadow` are subsequently rewritten via
+ * `modifyStateDefsToBeShadows`.
+ */
 function createAdapterStateVariableDefinitions({
     core,
     redefineDependencies,
     stateVariableDefinitions,
     componentClass,
-}: any) {
+}: {
+    core: Core;
+    redefineDependencies: any;
+    stateVariableDefinitions: Record<string, any>;
+    componentClass: any;
+}) {
     // attributes depend on adapterTarget (if attribute exists in adapterTarget)
     let adapterTargetComponent =
         core._components[
@@ -384,12 +410,37 @@ function createAdapterStateVariableDefinitions({
     }
 }
 
+/**
+ * Override `stateVariableDefinitions` for a component being created as a
+ * reference shadow of another component (via `<copy>` / prop reference /
+ * implicit prop / etc.).
+ *
+ * Two sub-flows:
+ *   - `propVariable` is set: the shadow points at a single prop on the
+ *     target. The primary state variable becomes a thin shadow of that
+ *     prop (unless `ignorePrimaryStateVariable`), other variables are
+ *     left alone, and only `shadowVariable`/`isShadow` flagged variables
+ *     and any explicit `additionalStateVariableShadowing` are made into
+ *     shadows.
+ *   - no `propVariable`: the shadow points at the whole target component.
+ *     `readyToExpandWhenResolved` is augmented to also wait on the
+ *     target's, and every `shadowVariable`/`isShadow` flagged variable
+ *     in the target is shadowed.
+ *
+ * May be `await`ed because it can call into `core.createFromArrayEntry`
+ * to materialize an array-entry prop on the target before shadowing it.
+ */
 async function createReferenceShadowStateVariableDefinitions({
     core,
     redefineDependencies,
     stateVariableDefinitions,
     componentClass,
-}: any) {
+}: {
+    core: Core;
+    redefineDependencies: any;
+    stateVariableDefinitions: Record<string, any>;
+    componentClass: any;
+}) {
     let targetComponent = core._components[redefineDependencies.targetIdx];
 
     if (redefineDependencies.propVariable) {
@@ -745,13 +796,29 @@ async function createReferenceShadowStateVariableDefinitions({
     });
 }
 
+/**
+ * Rewrite each named state-variable definition in
+ * `stateVariableDefinitions` so it reads from the corresponding variable
+ * on `targetComponent` instead of computing its own value. Handles both
+ * scalar and array variables; `differentStateVariablesInTarget[i]` (if
+ * provided) overrides the target variable name for shadow `i`. When a
+ * shadowed variable was used by an `additionalStateVariablesDefined`
+ * group, the un-shadowed siblings get the variable scrubbed from their
+ * definition output via `modifyStateDefToDeleteVariableReferences`.
+ */
 function modifyStateDefsToBeShadows({
     stateVariablesToShadow,
     stateVariableDefinitions,
     foundReadyToExpandWhenResolved,
     targetComponent,
     differentStateVariablesInTarget = [],
-}: any) {
+}: {
+    stateVariablesToShadow: string[];
+    stateVariableDefinitions: Record<string, any>;
+    foundReadyToExpandWhenResolved?: boolean;
+    targetComponent: any;
+    differentStateVariablesInTarget?: (string | undefined)[];
+}) {
     // Note: if add a markStale function to these shadow,
     // will need to modify array size state variable definition
     // (createArraySizeStateVariable)
@@ -998,10 +1065,20 @@ function modifyStateDefsToBeShadows({
     }
 }
 
+/**
+ * Strip references to `varNamesToDelete` from a `stateDef` that defined
+ * those variables alongside others via `additionalStateVariablesDefined`.
+ * Removes them from the sibling list and wraps the original `definition`
+ * so its returned `setValue` / `useEssentialOrDefaultValue` / etc. no
+ * longer mention the now-shadowed variables.
+ */
 function modifyStateDefToDeleteVariableReferences({
     varNamesToDelete,
     stateDef,
-}: any) {
+}: {
+    varNamesToDelete: string[];
+    stateDef: any;
+}) {
     // delete variables from additionalStateVariablesDefined
     for (let varName2 of varNamesToDelete) {
         let ind = stateDef.additionalStateVariablesDefined.indexOf(varName2);
@@ -1331,6 +1408,13 @@ function _buildAttributeDerivedDefinitions({
     return { definition, inverseDefinition };
 }
 
+/**
+ * Coerce / validate an attribute value against its spec. Applies
+ * `transformNonFiniteTo`, `toLowerCase`, `trim`, and either
+ * `validValues` (falling back to the default with a diagnostic when the
+ * value isn't allowed) or `clamp`. Returns the (possibly modified)
+ * value alongside any user-facing diagnostics produced along the way.
+ */
 function validateAttributeValue({
     value,
     attributeSpecification,


### PR DESCRIPTION
## Summary

Convert `StateVariableDefinitionFactory` from a class to module-level functions, the **fifth and final** piece of the Phase 5c stateless-manager pass.

- `createStateVariableDefinitions` is the only exported entry point.
- `createAttributeStateVariableDefinitions`, `createAdapterStateVariableDefinitions`, `createReferenceShadowStateVariableDefinitions`, `modifyStateDefsToBeShadows`, `modifyStateDefToDeleteVariableReferences`, `_setShadowingInstructionsFromAttribute`, `_resolveAttributeValueVariable`, `_copyPassthroughAttributes`, `_buildAttributeDerivedDefinitions` are now module-private.
- `ComponentBuilder` is the only external caller; it imports `createStateVariableDefinitions` directly. The `stateVariableDefinitionFactory` field, instantiation, and 4 delegate-only wrappers in `Core.ts` are removed.

The `this.arrayVarNameFromArrayKey(key)` reference inside the inner `returnArrayDependenciesByKey` closure is intentionally **NOT** changed — that `this` resolves at the call site to the per-variable `stateDef` object, not to the factory (one of the audit-class traps in `CORE_REFACTOR_DEFERRED.md` §"`this`-rebinding traps").

A follow-up commit on this branch tightens the public destructure signatures (`componentIdx: ComponentIdx`, `prescribedDependencies`, `stateVariableDefinitions`, etc.), adds JSDoc to the six top-level functions that lacked it, and records the remaining same-file de-duplication candidates in `CORE_REFACTOR_DEFERRED.md`.

After all 5 PRs land, the Phase 5c follow-up "Reduce stateless managers to plain functions" is complete; only `Phase 5e regression test` and `Phase 5h TODO triage` remain in the deferred doc.

## Notes on the typecheck delta

Baseline drops 96 → 75 (–21, smaller than prior conversions because most parameters had already been typed via the runtime closures). No new errors; only the pre-existing CompositeExpander TS2345 signature-mismatch carries over.

## Test plan

- [x] `pnpm typecheck` — 75 (down from 96, no new errors).
- [x] Targeted vitest: external_references, calcStartEndIdx, sectioning, group — 49 passing.
- [x] Full vitest + Cypress in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)