### PR TITLE
docs: add PR review guidelines and configure auto-injection for /review skill

### DIFF
--- a/.changeset/docs-pr-review.md
+++ b/.changeset/docs-pr-review.md
@@ -1,4 +1,0 @@
----
----
-
-docs: add PR review guidelines and configure auto-injection for /review skill

--- a/.changeset/docs-pr-review.md
+++ b/.changeset/docs-pr-review.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: add PR review guidelines and configure auto-injection for /review skill

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,17 @@
                     }
                 ]
             }
+        ],
+        "UserPromptExpansion": [
+            {
+                "matcher": "*",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "msg=$(jq -r '.userMessage'); if echo \"$msg\" | grep -qE '^/review'; then cat docs/PR_REVIEW_GUIDELINES.md && echo \"\" && echo \"$msg\"; else echo \"$msg\"; fi | jq -Rs '{userMessage: .}'"
+                    }
+                ]
+            }
         ]
     }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,7 @@
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "msg=$(jq -r '.userMessage'); if echo \"$msg\" | grep -qE '^/review'; then cat docs/PR_REVIEW_GUIDELINES.md && echo \"\" && echo \"$msg\"; else echo \"$msg\"; fi | jq -Rs '{userMessage: .}'"
+                        "command": "msg=$(jq -r '.userMessage'); if echo \"$msg\" | grep -qE '^/review'; then repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd); echo \"$msg\" && echo \"\" && cat \"$repo_root/docs/PR_REVIEW_GUIDELINES.md\" 2>/dev/null; else echo \"$msg\"; fi | jq -Rs '{userMessage: .}'"
                     }
                 ]
             }

--- a/docs/PR_REVIEW_GUIDELINES.md
+++ b/docs/PR_REVIEW_GUIDELINES.md
@@ -1,0 +1,3 @@
+Perform a thorough review of this PR. Look for ways in which the code can be made more concise, redundancy can be eliminated, and the codebase can be made easier to maintain. Look for simplifications of the code that could perform the same functions. Abstract repeated code to helper functions if that will increase readability. Prefer conventions established in AGENTS.md.
+
+Review all the documentation and comments for consistency, clarity of intent, and accuracy. Add additional doc strings to functions or code blocks if they would help clarify the intent and make the code easier to maintain.


### PR DESCRIPTION
## Summary
- Move PR review guidelines from root to `docs/PR_REVIEW_GUIDELINES.md` for broader applicability beyond Claude
- Update `.claude/settings.json` to automatically inject these guidelines when team members use the `/review` skill
- Ensures consistent review standards across the project for all team members

## Test plan
- Run `/review` skill and verify the PR review guidelines are automatically prepended to your prompt
- Check that the guidelines file is accessible in the docs directory
- Verify the hook configuration works for team members

🤖 Generated with [Claude Code](https://claude.com/claude-code)