### PR TITLE
refactor(renderers): incremental dedup pass — attribute builders, hooks, event helper

### DIFF
--- a/packages/doenetml/src/Viewer/renderers/circle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/circle.tsx
@@ -30,6 +30,7 @@ import {
 } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import {
+    removeJXGEventHandlers,
     syncLabelStrokeColor,
     syncLayer,
     syncLineStrokeStyle,
@@ -483,21 +484,11 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
         if (!circleJXG.current || !indicatorJXG.current) {
             return;
         }
-        indicatorJXG.current.off("drag");
-        indicatorJXG.current.off("down");
-        indicatorJXG.current.off("up");
-        indicatorJXG.current.off("hit");
-        indicatorJXG.current.off("keyfocusout");
-        indicatorJXG.current.off("keydown");
+        removeJXGEventHandlers(indicatorJXG.current);
         board?.removeObject(indicatorJXG.current);
         indicatorJXG.current = null;
 
-        circleJXG.current.off("drag");
-        circleJXG.current.off("down");
-        circleJXG.current.off("up");
-        circleJXG.current.off("hit");
-        circleJXG.current.off("keyfocusout");
-        circleJXG.current.off("keydown");
+        removeJXGEventHandlers(circleJXG.current);
         board?.removeObject(circleJXG.current);
         circleJXG.current = null;
     }

--- a/packages/doenetml/src/Viewer/renderers/circle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/circle.tsx
@@ -150,7 +150,6 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
             jsxCircleAttributes.fillColor = "none";
             jsxCircleAttributes.highlightFillColor = "none";
         }
-        const fillColor = jsxCircleAttributes.fillColor;
 
         if (SVs.filled) {
             jsxCircleAttributes.hasInnerPoints = true;

--- a/packages/doenetml/src/Viewer/renderers/circle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/circle.tsx
@@ -37,6 +37,7 @@ import {
 } from "./utils/jsxgraph";
 import { buildFilledShapeAttributes } from "./utils/buildGraphicalAttributes";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
+import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
 
 interface CircleSVs extends DraggableGraphicalSVs {
     numericalCenter: [number, number];
@@ -86,14 +87,10 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
 
     useBoardPointerTracking(board, dragState);
 
-    React.useEffect(() => {
-        //On unmount
-        return () => {
-            if (circleJXG.current) {
-                deleteCircleJXG();
-            }
-        };
-    }, []);
+    useJSXGraphCleanup({
+        objectRef: circleJXG,
+        destroy: () => deleteCircleJXG(),
+    });
 
     function createCircleJXG() {
         if (board === null) {

--- a/packages/doenetml/src/Viewer/renderers/circle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/circle.tsx
@@ -278,7 +278,7 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
 
             circleJXG.current!.center.coords.setCoordinates(
                 JXG.COORDS_BY_USER,
-                [...lastCenterFromCore.current!],
+                [...lastCenterFromCore.current],
             );
         });
 
@@ -507,10 +507,7 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
 
             if (centerOffResults.needIndicator) {
                 // center is off graph
-                if (
-                    !offGraphIndicatorCoords.current ||
-                    !lastCenterFromCore.current
-                ) {
+                if (!offGraphIndicatorCoords.current) {
                     return;
                 }
 

--- a/packages/doenetml/src/Viewer/renderers/circle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/circle.tsx
@@ -36,6 +36,7 @@ import {
     syncWithLabelToggle,
 } from "./utils/jsxgraph";
 import { buildFilledShapeAttributes } from "./utils/buildGraphicalAttributes";
+import { useDraggableRefs } from "./utils/useDraggableRefs";
 
 interface CircleSVs extends DraggableGraphicalSVs {
     numericalCenter: [number, number];
@@ -67,21 +68,19 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
     let previousPointLabelPosition = useRef<LabelPosition | null>(null);
     let centerCoords = useRef<[number, number] | null>(null);
 
-    let lastCenterFromCore = useRef<number[] | null>(null);
+    const {
+        lastPositionFromCore: lastCenterFromCore,
+        fixed,
+        fixLocation,
+    } = useDraggableRefs<number[]>(SVs, SVs.numericalCenter);
     let throughAnglesFromCore = useRef<[number, number] | null>(null);
-    let fixed = useRef(false);
-    let fixLocation = useRef(false);
+    throughAnglesFromCore.current = SVs.throughAngles;
 
     // for each coordinate, will be -1 or 1 if moved off graph in that direction
     let displayOffGraphIndicator = useRef(false);
     let offGraphIndicatorOrientation = useRef<[number, number] | null>([0, 0]);
     let offGraphIndicatorCoords = useRef<[number, number] | null>([0, 0]);
     let offGraphIndicatorOffsetAtDown = useRef([0, 0]);
-
-    lastCenterFromCore.current = SVs.numericalCenter;
-    throughAnglesFromCore.current = SVs.throughAngles;
-    fixed.current = SVs.fixed;
-    fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
 
     const { darkMode } = useContext(DocContext) || {};
 

--- a/packages/doenetml/src/Viewer/renderers/circle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/circle.tsx
@@ -35,6 +35,7 @@ import {
     syncLineStrokeStyle,
     syncWithLabelToggle,
 } from "./utils/jsxgraph";
+import { buildFilledShapeAttributes } from "./utils/buildGraphicalAttributes";
 
 interface CircleSVs extends DraggableGraphicalSVs {
     numericalCenter: [number, number];
@@ -135,32 +136,24 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
         }
 
         const lineColor = resolveLineColor(SVs.selectedStyle, darkMode);
-        let fillColor = SVs.filled
-            ? resolveFillColor(SVs.selectedStyle, darkMode)
-            : "none";
         const markerColor = resolveMarkerColor(SVs.selectedStyle, darkMode);
 
         let withlabel = SVs.labelForGraph !== "";
 
-        var jsxCircleAttributes: Record<string, any> = {
-            name: SVs.labelForGraph,
-            visible: !SVs.hidden,
-            withlabel,
-            fixed: fixed.current,
-            layer: 10 * SVs.layer + LINE_LAYER_OFFSET,
-            strokeColor: lineColor,
-            strokeOpacity: SVs.selectedStyle.lineOpacity,
-            highlightStrokeColor: lineColor,
-            strokeWidth: SVs.selectedStyle.lineWidth,
-            highlightStrokeWidth: SVs.selectedStyle.lineWidth,
-            highlightStrokeOpacity: SVs.selectedStyle.lineOpacity * 0.5,
-            dash: styleToDash(SVs.selectedStyle.lineStyle),
-            fillColor,
-            fillOpacity: SVs.selectedStyle.fillOpacity,
-            highlightFillColor: fillColor,
-            highlightFillOpacity: SVs.selectedStyle.fillOpacity * 0.5,
-            highlight: !fixLocation.current,
-        };
+        var jsxCircleAttributes: Record<string, any> =
+            buildFilledShapeAttributes({
+                SVs,
+                layerOffset: LINE_LAYER_OFFSET,
+                fixed: fixed.current,
+                fixLocation: fixLocation.current,
+                darkMode,
+            });
+
+        if (!SVs.filled) {
+            jsxCircleAttributes.fillColor = "none";
+            jsxCircleAttributes.highlightFillColor = "none";
+        }
+        const fillColor = jsxCircleAttributes.fillColor;
 
         if (SVs.filled) {
             jsxCircleAttributes.hasInnerPoints = true;

--- a/packages/doenetml/src/Viewer/renderers/curve.tsx
+++ b/packages/doenetml/src/Viewer/renderers/curve.tsx
@@ -17,6 +17,7 @@ import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
 import { resolveLineColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import { syncLabelStrokeColor, syncLayer } from "./utils/jsxgraph";
+import { useDraggableRefs } from "./utils/useDraggableRefs";
 
 interface CurveSVs extends DraggableGraphicalSVs {
     curveType: "function" | "parameterization" | "bezier";
@@ -70,23 +71,19 @@ export default React.memo(function Curve(props: UseDoenetRendererProps) {
     let hitObject = useRef<any>(null);
     let vectorControlDirections = useRef<any[] | null>(null);
     let previousVectorControlDirections = useRef<any[] | null>(null);
-    let fixed = useRef(false);
-    let fixLocation = useRef(false);
+    const {
+        lastPositionFromCore: lastThroughPointPositionsFromCore,
+        fixed,
+        fixLocation,
+    } = useDraggableRefs<[number, number][]>(SVs, SVs.numericalThroughPoints);
     let switchable = useRef(false);
 
     let tpCoords = useRef<any[]>([]);
     let cvCoords = useRef<any[]>([]);
 
-    fixed.current = SVs.fixed;
-    fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
     switchable.current = SVs.switchable && !SVs.fixed;
 
     vectorControlDirections.current = SVs.vectorControlDirections;
-
-    let lastThroughPointPositionsFromCore = useRef<[number, number][] | null>(
-        null,
-    );
-    lastThroughPointPositionsFromCore.current = SVs.numericalThroughPoints;
 
     let lastControlPointPositionsFromCore = useRef<[number, number][][] | null>(
         null,

--- a/packages/doenetml/src/Viewer/renderers/curve.tsx
+++ b/packages/doenetml/src/Viewer/renderers/curve.tsx
@@ -529,7 +529,7 @@ export default React.memo(function Curve(props: UseDoenetRendererProps) {
 
         throughPointsJXG.current![i].coords.setCoordinates(
             JXG.COORDS_BY_USER,
-            lastThroughPointPositionsFromCore.current![i],
+            lastThroughPointPositionsFromCore.current[i],
         );
         board!.updateInfobox(throughPointsJXG.current![i]);
     }

--- a/packages/doenetml/src/Viewer/renderers/curve.tsx
+++ b/packages/doenetml/src/Viewer/renderers/curve.tsx
@@ -18,6 +18,7 @@ import { resolveLineColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import { syncLabelStrokeColor, syncLayer } from "./utils/jsxgraph";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
+import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
 
 interface CurveSVs extends DraggableGraphicalSVs {
     curveType: "function" | "parameterization" | "bezier";
@@ -94,13 +95,10 @@ export default React.memo(function Curve(props: UseDoenetRendererProps) {
 
     useBoardPointerTracking(board, dragState);
 
-    React.useEffect(() => {
-        return () => {
-            if (curveJXG.current) {
-                deleteCurveJXG();
-            }
-        };
-    }, []);
+    useJSXGraphCleanup({
+        objectRef: curveJXG,
+        destroy: () => deleteCurveJXG(),
+    });
 
     function createCurveJXG() {
         if (board === null) {

--- a/packages/doenetml/src/Viewer/renderers/line.tsx
+++ b/packages/doenetml/src/Viewer/renderers/line.tsx
@@ -27,6 +27,7 @@ import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
 import { resolveLineColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
+import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
 
 interface LineSVs extends DraggableGraphicalSVs {
     numericalPoints: [number, number][];
@@ -67,15 +68,11 @@ export default React.memo(function Line(props: UseDoenetRendererProps) {
 
     useBoardPointerTracking(board, dragState);
 
-    React.useEffect(() => {
-        //On unmount
-        return () => {
-            cancelInitialLabelPlacement.current?.();
-            if (lineJXG.current !== null) {
-                deleteLineJXG();
-            }
-        };
-    }, []);
+    useJSXGraphCleanup({
+        objectRef: lineJXG,
+        destroy: () => deleteLineJXG(),
+        cancelLabelPlacementRef: cancelInitialLabelPlacement,
+    });
 
     function createLineJXG() {
         if (board === null) {

--- a/packages/doenetml/src/Viewer/renderers/line.tsx
+++ b/packages/doenetml/src/Viewer/renderers/line.tsx
@@ -171,11 +171,11 @@ export default React.memo(function Line(props: UseDoenetRendererProps) {
 
             newLineJXG.point1.coords.setCoordinates(
                 JXG.COORDS_BY_USER,
-                lastPositionsFromCore.current![0],
+                lastPositionsFromCore.current[0],
             );
             newLineJXG.point2.coords.setCoordinates(
                 JXG.COORDS_BY_USER,
-                lastPositionsFromCore.current![1],
+                lastPositionsFromCore.current[1],
             );
         });
 

--- a/packages/doenetml/src/Viewer/renderers/line.tsx
+++ b/packages/doenetml/src/Viewer/renderers/line.tsx
@@ -26,6 +26,7 @@ import { exceededDragThreshold } from "./utils/dragThreshold";
 import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
 import { resolveLineColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
+import { useDraggableRefs } from "./utils/useDraggableRefs";
 
 interface LineSVs extends DraggableGraphicalSVs {
     numericalPoints: [number, number][];
@@ -54,14 +55,12 @@ export default React.memo(function Line(props: UseDoenetRendererProps) {
     let cancelInitialLabelPlacement = useRef<(() => void) | null>(null);
     let pointCoords = useRef<[number, number][] | null>(null);
 
-    let lastPositionsFromCore = useRef<[number, number][] | null>(null);
-    let fixed = useRef(false);
-    let fixLocation = useRef(false);
+    const {
+        lastPositionFromCore: lastPositionsFromCore,
+        fixed,
+        fixLocation,
+    } = useDraggableRefs<[number, number][]>(SVs, SVs.numericalPoints);
     let switchable = useRef(false);
-
-    lastPositionsFromCore.current = SVs.numericalPoints;
-    fixed.current = SVs.fixed;
-    fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
     switchable.current = SVs.switchable && !SVs.fixed;
 
     const { darkMode } = useContext(DocContext) || {};

--- a/packages/doenetml/src/Viewer/renderers/line.tsx
+++ b/packages/doenetml/src/Viewer/renderers/line.tsx
@@ -10,6 +10,7 @@ import { ChoiceInputInlineContext } from "./choiceInput";
 import {
     applyLineFamilyLabelPlacement,
     buildLineFamilyLabelAttributes,
+    removeJXGEventHandlers,
     stabilizeInitialLineFamilyLabelPlacement,
     syncLabelStrokeColor,
     syncLayer,
@@ -313,12 +314,7 @@ export default React.memo(function Line(props: UseDoenetRendererProps) {
         if (!lineJXG.current) {
             return;
         }
-        lineJXG.current.off("drag");
-        lineJXG.current.off("down");
-        lineJXG.current.off("hit");
-        lineJXG.current.off("up");
-        lineJXG.current.off("keyfocusout");
-        lineJXG.current.off("keydown");
+        removeJXGEventHandlers(lineJXG.current);
         board?.removeObject(lineJXG.current);
         lineJXG.current = null;
     }

--- a/packages/doenetml/src/Viewer/renderers/line.tsx
+++ b/packages/doenetml/src/Viewer/renderers/line.tsx
@@ -17,6 +17,7 @@ import {
     syncLineStrokeStyle,
     syncWithLabelToggle,
 } from "./utils/jsxgraph";
+import { buildLineLikeAttributes } from "./utils/buildGraphicalAttributes";
 import { JXGLine } from "./jsxgraph-distrib/types";
 import { DraggableGraphicalSVs } from "./utils/graphicalSVs";
 import { usePointerDragState } from "./utils/pointerDragState";
@@ -90,26 +91,17 @@ export default React.memo(function Line(props: UseDoenetRendererProps) {
             return;
         }
 
-        let withlabel = SVs.labelForGraph !== "";
-
         const lineColor = resolveLineColor(SVs.selectedStyle, darkMode);
 
         //things to be passed to JSXGraph as attributes
-        var jsxLineAttributes: Record<string, any> = {
-            name: SVs.labelForGraph,
-            visible: !SVs.hidden,
-            withlabel,
+        var jsxLineAttributes: Record<string, any> = buildLineLikeAttributes({
+            SVs,
+            layerOffset: LINE_LAYER_OFFSET,
             fixed: fixed.current,
-            layer: 10 * SVs.layer + LINE_LAYER_OFFSET,
-            strokeColor: lineColor,
-            strokeOpacity: SVs.selectedStyle.lineOpacity,
-            highlightStrokeColor: lineColor,
-            highlightStrokeOpacity: SVs.selectedStyle.lineOpacity * 0.5,
-            strokeWidth: SVs.selectedStyle.lineWidth,
-            highlightStrokeWidth: SVs.selectedStyle.lineWidth,
-            dash: styleToDash(SVs.selectedStyle.lineStyle, SVs.dashed),
-            highlight: !fixLocation.current,
-        };
+            fixLocation: fixLocation.current,
+            darkMode,
+            dashed: SVs.dashed,
+        });
 
         jsxLineAttributes.label = buildLineFamilyLabelAttributes({
             labelForGraph: SVs.labelForGraph,
@@ -293,7 +285,7 @@ export default React.memo(function Line(props: UseDoenetRendererProps) {
 
         lineJXG.current = newLineJXG;
 
-        if (withlabel && newLineJXG.hasLabel) {
+        if (SVs.labelForGraph !== "" && newLineJXG.hasLabel) {
             cancelInitialLabelPlacement.current =
                 stabilizeInitialLineFamilyLabelPlacement({
                     board,

--- a/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
+++ b/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
@@ -24,6 +24,7 @@ import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
 import { resolveLineColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
+import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
 
 interface LineSegmentSVs extends DraggableGraphicalSVs {
     numericalEndpoints: [number, number][];
@@ -66,14 +67,11 @@ export default React.memo(function LineSegment(props: UseDoenetRendererProps) {
 
     useBoardPointerTracking(board, dragState);
 
-    React.useEffect(() => {
-        return () => {
-            cancelInitialLabelPlacement.current?.();
-            if (lineSegmentJXG.current) {
-                deleteLineSegmentJXG();
-            }
-        };
-    }, []);
+    useJSXGraphCleanup({
+        objectRef: lineSegmentJXG,
+        destroy: () => deleteLineSegmentJXG(),
+        cancelLabelPlacementRef: cancelInitialLabelPlacement,
+    });
 
     function createLineSegmentJXG() {
         if (board === null) {

--- a/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
+++ b/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
@@ -7,6 +7,7 @@ import { DocContext } from "../DocViewer";
 import {
     applyLineFamilyLabelPlacement,
     buildLineFamilyLabelAttributes,
+    removeJXGEventHandlers,
     stabilizeInitialLineFamilyLabelPlacement,
     syncLabelStrokeColor,
     syncLayer,
@@ -517,34 +518,19 @@ export default React.memo(function LineSegment(props: UseDoenetRendererProps) {
         cancelInitialLabelPlacement.current?.();
         cancelInitialLabelPlacement.current = null;
         if (lineSegmentJXG.current) {
-            lineSegmentJXG.current.off("drag");
-            lineSegmentJXG.current.off("down");
-            lineSegmentJXG.current.off("hit");
-            lineSegmentJXG.current.off("up");
-            lineSegmentJXG.current.off("keydown");
-            lineSegmentJXG.current.off("keyfocusout");
+            removeJXGEventHandlers(lineSegmentJXG.current);
             board?.removeObject(lineSegmentJXG.current);
             lineSegmentJXG.current = null;
         }
 
         if (point1JXG.current) {
-            point1JXG.current.off("drag");
-            point1JXG.current.off("down");
-            point1JXG.current.off("hit");
-            point1JXG.current.off("up");
-            point1JXG.current.off("keydown");
-            point1JXG.current.off("keyfocusout");
+            removeJXGEventHandlers(point1JXG.current);
             board?.removeObject(point1JXG.current);
             point1JXG.current = null;
         }
 
         if (point2JXG.current) {
-            point2JXG.current.off("drag");
-            point2JXG.current.off("down");
-            point2JXG.current.off("hit");
-            point2JXG.current.off("up");
-            point2JXG.current.off("keydown");
-            point2JXG.current.off("keyfocusout");
+            removeJXGEventHandlers(point2JXG.current);
             board?.removeObject(point2JXG.current);
             point2JXG.current = null;
         }

--- a/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
+++ b/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
@@ -14,6 +14,7 @@ import {
     syncLineStrokeStyle,
     syncWithLabelToggle,
 } from "./utils/jsxgraph";
+import { buildLineLikeAttributes } from "./utils/buildGraphicalAttributes";
 import { JXGLine, JXGPoint } from "./jsxgraph-distrib/types";
 import { DraggableGraphicalSVs } from "./utils/graphicalSVs";
 import { usePointerDragState } from "./utils/pointerDragState";
@@ -92,26 +93,18 @@ export default React.memo(function LineSegment(props: UseDoenetRendererProps) {
             return;
         }
 
-        let withlabel = SVs.labelForGraph !== "";
-
         const lineColor = resolveLineColor(SVs.selectedStyle, darkMode);
 
         //things to be passed to JSXGraph as attributes
-        var jsxSegmentAttributes: Record<string, any> = {
-            name: SVs.labelForGraph,
-            visible: !SVs.hidden,
-            withlabel,
-            fixed: fixed.current,
-            layer: 10 * SVs.layer + LINE_LAYER_OFFSET,
-            strokeColor: lineColor,
-            strokeOpacity: SVs.selectedStyle.lineOpacity,
-            highlightStrokeColor: lineColor,
-            highlightStrokeOpacity: SVs.selectedStyle.lineOpacity * 0.5,
-            strokeWidth: SVs.selectedStyle.lineWidth,
-            highlightStrokeWidth: SVs.selectedStyle.lineWidth,
-            dash: styleToDash(SVs.selectedStyle.lineStyle),
-            highlight: !fixLocation.current,
-        };
+        var jsxSegmentAttributes: Record<string, any> = buildLineLikeAttributes(
+            {
+                SVs,
+                layerOffset: LINE_LAYER_OFFSET,
+                fixed: fixed.current,
+                fixLocation: fixLocation.current,
+                darkMode,
+            },
+        );
 
         jsxSegmentAttributes.label = buildLineFamilyLabelAttributes({
             labelForGraph: SVs.labelForGraph,
@@ -392,7 +385,7 @@ export default React.memo(function LineSegment(props: UseDoenetRendererProps) {
         cancelInitialLabelPlacement.current?.();
         cancelInitialLabelPlacement.current = null;
 
-        if (withlabel && lineSegmentJXG.current.hasLabel) {
+        if (SVs.labelForGraph !== "" && lineSegmentJXG.current.hasLabel) {
             const createdLineSegment = lineSegmentJXG.current;
             cancelInitialLabelPlacement.current =
                 stabilizeInitialLineFamilyLabelPlacement({
@@ -417,7 +410,7 @@ export default React.memo(function LineSegment(props: UseDoenetRendererProps) {
                 });
         }
 
-        previousWithLabel.current = withlabel;
+        previousWithLabel.current = SVs.labelForGraph !== "";
 
         return lineSegmentJXG.current;
     }

--- a/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
+++ b/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
@@ -501,11 +501,11 @@ export default React.memo(function LineSegment(props: UseDoenetRendererProps) {
 
         lineSegmentJXG.current.point1.coords.setCoordinates(
             JXG.COORDS_BY_USER,
-            lastPositionsFromCore.current![0],
+            lastPositionsFromCore.current[0],
         );
         lineSegmentJXG.current.point2.coords.setCoordinates(
             JXG.COORDS_BY_USER,
-            lastPositionsFromCore.current![1],
+            lastPositionsFromCore.current[1],
         );
         if (i == 1) {
             board.updateInfobox(lineSegmentJXG.current.point1);

--- a/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
+++ b/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
@@ -23,6 +23,7 @@ import { exceededDragThreshold } from "./utils/dragThreshold";
 import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
 import { resolveLineColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
+import { useDraggableRefs } from "./utils/useDraggableRefs";
 
 interface LineSegmentSVs extends DraggableGraphicalSVs {
     numericalEndpoints: [number, number][];
@@ -52,14 +53,12 @@ export default React.memo(function LineSegment(props: UseDoenetRendererProps) {
     let pointCoords = useRef<any>(null);
     let downOnPoint = useRef<number | null>(null);
 
-    let lastPositionsFromCore = useRef<[number, number][] | null>(null);
-    let fixed = useRef(false);
-    let fixLocation = useRef(false);
+    const {
+        lastPositionFromCore: lastPositionsFromCore,
+        fixed,
+        fixLocation,
+    } = useDraggableRefs<[number, number][]>(SVs, SVs.numericalEndpoints);
     let endpointsFixed = useRef(false);
-
-    lastPositionsFromCore.current = SVs.numericalEndpoints;
-    fixed.current = SVs.fixed;
-    fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
     endpointsFixed.current =
         !SVs.endpointsDraggable || SVs.fixed || SVs.fixLocation;
 

--- a/packages/doenetml/src/Viewer/renderers/point.tsx
+++ b/packages/doenetml/src/Viewer/renderers/point.tsx
@@ -23,6 +23,7 @@ import { exceededDragThreshold } from "./utils/dragThreshold";
 import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
 import { resolveMarkerColor } from "./utils/styleColors";
 import {
+    removeJXGEventHandlers,
     syncLabelStrokeColor,
     syncLayer,
     syncWithLabelToggle,
@@ -86,12 +87,7 @@ export default React.memo(function Point(props: UseDoenetRendererProps) {
         //On unmount
         return () => {
             if (pointJXG.current !== null && shadowPointJXG.current !== null) {
-                shadowPointJXG.current.off("drag");
-                shadowPointJXG.current.off("down");
-                shadowPointJXG.current.off("hit");
-                shadowPointJXG.current.off("up");
-                shadowPointJXG.current.off("keyfocusout");
-                shadowPointJXG.current.off("keydown");
+                removeJXGEventHandlers(shadowPointJXG.current);
                 board!.removeObject(pointJXG.current);
                 board!.removeObject(shadowPointJXG.current);
                 pointJXG.current = null;

--- a/packages/doenetml/src/Viewer/renderers/polygon.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polygon.tsx
@@ -13,6 +13,7 @@ import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
 import { resolveLineColor, resolveFillColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
+import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
 import {
     syncLabelStrokeColor,
     syncLayer,
@@ -65,13 +66,10 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
 
     useBoardPointerTracking(board, dragState);
 
-    React.useEffect(() => {
-        return () => {
-            if (polygonJXG.current) {
-                deletePolygonJXG();
-            }
-        };
-    }, []);
+    useJSXGraphCleanup({
+        objectRef: polygonJXG,
+        destroy: () => deletePolygonJXG(),
+    });
 
     function createPolygonJXG() {
         if (board === null) {

--- a/packages/doenetml/src/Viewer/renderers/polygon.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polygon.tsx
@@ -17,6 +17,7 @@ import {
     syncLayer,
     syncLineStrokeStyle,
 } from "./utils/jsxgraph";
+import { buildBaseAttributes } from "./utils/buildGraphicalAttributes";
 
 interface PolygonSVs extends DraggableGraphicalSVs {
     numVertices: number;
@@ -114,18 +115,18 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
         };
 
         let jsxPolygonAttributes: Record<string, any> = {
-            name: SVs.labelForGraph,
-            visible: !SVs.hidden,
-            withLabel: SVs.labelForGraph !== "",
-            fixed: fixed.current,
-            layer: 10 * SVs.layer + LINE_LAYER_OFFSET,
+            ...buildBaseAttributes({
+                SVs,
+                layerOffset: LINE_LAYER_OFFSET,
+                fixed: fixed.current,
+                fixLocation: fixLocation.current,
+            }),
 
             //specific to polygon
             fillColor,
             fillOpacity: SVs.selectedStyle.fillOpacity,
             highlightFillColor: fillColor,
             highlightFillOpacity: SVs.selectedStyle.fillOpacity * 0.5,
-            highlight: !fixLocation.current,
             vertices: jsxPointAttributes.current,
             borders: jsxBorderAttributes,
         };

--- a/packages/doenetml/src/Viewer/renderers/polygon.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polygon.tsx
@@ -288,7 +288,7 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
                 for (let j = 0; j < SVs.numVertices; j++) {
                     polygonJXG.current.vertices[j].coords.setCoordinates(
                         JXG.COORDS_BY_USER,
-                        [...lastPositionsFromCore.current![j]],
+                        [...lastPositionsFromCore.current[j]],
                     );
                 }
             } else {
@@ -308,7 +308,7 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
                 });
                 polygonJXG.current.vertices[i].coords.setCoordinates(
                     JXG.COORDS_BY_USER,
-                    [...lastPositionsFromCore.current![i]],
+                    [...lastPositionsFromCore.current[i]],
                 );
                 board.updateInfobox(polygonJXG.current.vertices[i]);
             }

--- a/packages/doenetml/src/Viewer/renderers/polygon.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polygon.tsx
@@ -15,6 +15,7 @@ import { styleToDash } from "./utils/styleToDash";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
 import {
+    removeJXGEventHandlers,
     syncLabelStrokeColor,
     syncLayer,
     syncLineStrokeStyle,
@@ -193,17 +194,12 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
     function initializePoints(polygon: JXGPolygon) {
         for (let i = 0; i < SVs.numVertices; i++) {
             let vertex = polygon.vertices[i];
-            vertex.off("drag");
+            removeJXGEventHandlers(vertex);
             vertex.on("drag", (e) => dragHandler(i, e));
-            vertex.off("up");
             vertex.on("up", () => upHandler(i));
-            vertex.off("keyfocusout");
             vertex.on("keyfocusout", () => keyFocusOutHandler(i));
-            vertex.off("keydown");
             vertex.on("keydown", (e) => keyDownHandler(i, e));
-            vertex.off("down");
             vertex.on("down", (e) => downHandler(i, e));
-            vertex.off("hit");
             vertex.on("hit", () => hitHandler());
         }
     }
@@ -520,12 +516,7 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
                     i >= SVs.numVertices;
                     i--
                 ) {
-                    polygonJXG.current.vertices[i].off("drag");
-                    polygonJXG.current.vertices[i].off("down");
-                    polygonJXG.current.vertices[i].off("hit");
-                    polygonJXG.current.vertices[i].off("up");
-                    polygonJXG.current.vertices[i].off("keyfocusout");
-                    polygonJXG.current.vertices[i].off("keydown");
+                    removeJXGEventHandlers(polygonJXG.current.vertices[i]);
                     polygonJXG.current.removePoints(
                         polygonJXG.current.vertices[i],
                     );

--- a/packages/doenetml/src/Viewer/renderers/polygon.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polygon.tsx
@@ -12,6 +12,7 @@ import { exceededDragThreshold } from "./utils/dragThreshold";
 import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
 import { resolveLineColor, resolveFillColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
+import { useDraggableRefs } from "./utils/useDraggableRefs";
 import {
     syncLabelStrokeColor,
     syncLayer,
@@ -49,15 +50,13 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
     let previousNumVertices = useRef<number | null>(null);
     let jsxPointAttributes = useRef<Record<string, any> | null>(null);
 
-    let lastPositionsFromCore = useRef<[number, number][] | null>(null);
-    let fixed = useRef(false);
-    let fixLocation = useRef(false);
+    const {
+        lastPositionFromCore: lastPositionsFromCore,
+        fixed,
+        fixLocation,
+    } = useDraggableRefs<[number, number][]>(SVs, SVs.numericalVertices);
     let verticesFixed = useRef(false);
     let vertexIndicesDraggable = useRef<number[]>([]);
-
-    lastPositionsFromCore.current = SVs.numericalVertices;
-    fixed.current = SVs.fixed;
-    fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
     verticesFixed.current =
         !SVs.verticesDraggable || SVs.fixed || SVs.fixLocation;
     vertexIndicesDraggable.current = SVs.vertexIndicesDraggable;

--- a/packages/doenetml/src/Viewer/renderers/polyline.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polyline.tsx
@@ -12,6 +12,7 @@ import { exceededDragThreshold } from "./utils/dragThreshold";
 import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
 import { resolveLineColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
+import { useDraggableRefs } from "./utils/useDraggableRefs";
 import {
     syncLabelStrokeColor,
     syncLayer,
@@ -48,15 +49,13 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
     let previousNumVertices = useRef<number | null>(null);
     let jsxPointAttributes = useRef<Record<string, any> | null>(null);
 
-    let lastPositionsFromCore = useRef<[number, number][] | null>(null);
-    let fixed = useRef(false);
-    let fixLocation = useRef(false);
+    const {
+        lastPositionFromCore: lastPositionsFromCore,
+        fixed,
+        fixLocation,
+    } = useDraggableRefs<[number, number][]>(SVs, SVs.numericalVertices);
     let verticesFixed = useRef(false);
     let vertexIndicesDraggable = useRef<number[]>([]);
-
-    lastPositionsFromCore.current = SVs.numericalVertices;
-    fixed.current = SVs.fixed;
-    fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
     verticesFixed.current =
         !SVs.verticesDraggable || SVs.fixed || SVs.fixLocation;
     vertexIndicesDraggable.current = SVs.vertexIndicesDraggable;

--- a/packages/doenetml/src/Viewer/renderers/polyline.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polyline.tsx
@@ -15,6 +15,7 @@ import { styleToDash } from "./utils/styleToDash";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
 import {
+    removeJXGEventHandlers,
     syncLabelStrokeColor,
     syncLayer,
     syncLineStrokeStyle,
@@ -196,12 +197,7 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
         if (!polylineJXG.current) {
             return;
         }
-        polylineJXG.current.off("drag");
-        polylineJXG.current.off("down");
-        polylineJXG.current.off("hit");
-        polylineJXG.current.off("up");
-        polylineJXG.current.off("keyfocusout");
-        polylineJXG.current.off("keydown");
+        removeJXGEventHandlers(polylineJXG.current);
         board?.removeObject(polylineJXG.current);
         polylineJXG.current = null;
 
@@ -209,12 +205,7 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
             for (let i = 0; i < SVs.numVertices; i++) {
                 let point = pointsJXG.current[i];
                 if (point) {
-                    point.off("drag");
-                    point.off("down");
-                    point.off("hit");
-                    point.off("up");
-                    point.off("keyfocusout");
-                    point.off("keydown");
+                    removeJXGEventHandlers(point);
                     board?.removeObject(point);
                 }
             }
@@ -548,12 +539,7 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
                 ) {
                     let pt = pointsJXG.current.pop();
                     if (pt) {
-                        pt.off("drag");
-                        pt.off("down");
-                        pt.off("hit");
-                        pt.off("up");
-                        pt.off("keyfocusout");
-                        pt.off("keydown");
+                        removeJXGEventHandlers(pt);
                         board?.removeObject(pt);
                     }
                 }

--- a/packages/doenetml/src/Viewer/renderers/polyline.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polyline.tsx
@@ -277,12 +277,12 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
                 for (let j = 0; j < SVs.numVertices; j++) {
                     pointsJXG.current[j].coords.setCoordinates(
                         JXG.COORDS_BY_USER,
-                        [...lastPositionsFromCore.current![j]],
+                        [...lastPositionsFromCore.current[j]],
                     );
                     polylineJXG.current.dataX[j] =
-                        lastPositionsFromCore.current![j][0] - shiftX;
+                        lastPositionsFromCore.current[j][0] - shiftX;
                     polylineJXG.current.dataY[j] =
-                        lastPositionsFromCore.current![j][1] - shiftY;
+                        lastPositionsFromCore.current[j][1] - shiftY;
                 }
             } else {
                 pointCoords.current = {};
@@ -300,7 +300,7 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
                     },
                 });
                 pointsJXG.current[i].coords.setCoordinates(JXG.COORDS_BY_USER, [
-                    ...lastPositionsFromCore.current![i],
+                    ...lastPositionsFromCore.current[i],
                 ]);
                 board.updateInfobox(pointsJXG.current[i]);
             }

--- a/packages/doenetml/src/Viewer/renderers/polyline.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polyline.tsx
@@ -13,6 +13,7 @@ import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
 import { resolveLineColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
+import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
 import {
     syncLabelStrokeColor,
     syncLayer,
@@ -64,13 +65,10 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
 
     useBoardPointerTracking(board, dragState);
 
-    React.useEffect(() => {
-        return () => {
-            if (polylineJXG.current) {
-                deletePolylineJXG();
-            }
-        };
-    }, []);
+    useJSXGraphCleanup({
+        objectRef: polylineJXG,
+        destroy: () => deletePolylineJXG(),
+    });
 
     function createPolylineJXG() {
         if (board === null) {

--- a/packages/doenetml/src/Viewer/renderers/polyline.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polyline.tsx
@@ -17,6 +17,7 @@ import {
     syncLayer,
     syncLineStrokeStyle,
 } from "./utils/jsxgraph";
+import { buildLineLikeAttributes } from "./utils/buildGraphicalAttributes";
 
 interface PolylineSVs extends DraggableGraphicalSVs {
     numVertices: number;
@@ -99,19 +100,14 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
 
         //things to be passed to JSXGraph as attributes
         let jsxPolylineAttributes: Record<string, any> = {
-            name: SVs.labelForGraph,
+            ...buildLineLikeAttributes({
+                SVs,
+                layerOffset: LINE_LAYER_OFFSET,
+                fixed: fixed.current,
+                fixLocation: fixLocation.current,
+                darkMode,
+            }),
             visible: !SVs.hidden && validCoords,
-            withLabel: SVs.labelForGraph !== "",
-            layer: 10 * SVs.layer + LINE_LAYER_OFFSET,
-            fixed: fixed.current,
-            strokeColor: lineColor,
-            strokeOpacity: SVs.selectedStyle.lineOpacity,
-            highlightStrokeColor: lineColor,
-            highlightStrokeOpacity: SVs.selectedStyle.lineOpacity * 0.5,
-            strokeWidth: SVs.selectedStyle.lineWidth,
-            highlightStrokeWidth: SVs.selectedStyle.lineWidth,
-            dash: styleToDash(SVs.selectedStyle.lineStyle),
-            highlight: !fixLocation.current,
             lineCap: "butt",
         };
 

--- a/packages/doenetml/src/Viewer/renderers/ray.tsx
+++ b/packages/doenetml/src/Viewer/renderers/ray.tsx
@@ -7,6 +7,7 @@ import { DocContext } from "../DocViewer";
 import {
     applyLineFamilyLabelPlacement,
     buildLineFamilyLabelAttributes,
+    removeJXGEventHandlers,
     stabilizeInitialLineFamilyLabelPlacement,
     syncLabelStrokeColor,
     syncLayer,
@@ -290,12 +291,7 @@ export default React.memo(function Ray(props: UseDoenetRendererProps) {
         if (!rayJXG.current) {
             return;
         }
-        rayJXG.current.off("drag");
-        rayJXG.current.off("down");
-        rayJXG.current.off("hit");
-        rayJXG.current.off("up");
-        rayJXG.current.off("keyfocusout");
-        rayJXG.current.off("keydown");
+        removeJXGEventHandlers(rayJXG.current);
         board?.removeObject(rayJXG.current);
         rayJXG.current = null;
     }

--- a/packages/doenetml/src/Viewer/renderers/ray.tsx
+++ b/packages/doenetml/src/Viewer/renderers/ray.tsx
@@ -23,6 +23,7 @@ import { exceededDragThreshold } from "./utils/dragThreshold";
 import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
 import { resolveLineColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
+import { useDraggableRefs } from "./utils/useDraggableRefs";
 
 interface RaySVs extends DraggableGraphicalSVs {
     numericalEndpoint: [number, number];
@@ -49,15 +50,13 @@ export default React.memo(function Ray(props: UseDoenetRendererProps) {
     let cancelInitialLabelPlacement = useRef<(() => void) | null>(null);
     let pointCoords = useRef<[number, number][] | null>(null);
 
-    let lastEndpointFromCore = useRef<[number, number] | null>(null);
+    const {
+        lastPositionFromCore: lastEndpointFromCore,
+        fixed,
+        fixLocation,
+    } = useDraggableRefs<[number, number]>(SVs, SVs.numericalEndpoint);
     let lastThroughpointFromCore = useRef<[number, number] | null>(null);
-    let fixed = useRef(false);
-    let fixLocation = useRef(false);
-
-    lastEndpointFromCore.current = SVs.numericalEndpoint;
     lastThroughpointFromCore.current = SVs.numericalThroughpoint;
-    fixed.current = SVs.fixed;
-    fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
 
     const { darkMode } = useContext(DocContext) || {};
 

--- a/packages/doenetml/src/Viewer/renderers/ray.tsx
+++ b/packages/doenetml/src/Viewer/renderers/ray.tsx
@@ -14,6 +14,7 @@ import {
     syncLineStrokeStyle,
     syncWithLabelToggle,
 } from "./utils/jsxgraph";
+import { buildLineLikeAttributes } from "./utils/buildGraphicalAttributes";
 import { JXGLine } from "./jsxgraph-distrib/types";
 import { DraggableGraphicalSVs } from "./utils/graphicalSVs";
 import { usePointerDragState } from "./utils/pointerDragState";
@@ -87,19 +88,13 @@ export default React.memo(function Ray(props: UseDoenetRendererProps) {
 
         //things to be passed to JSXGraph as attributes
         var jsxRayAttributes: Record<string, any> = {
-            name: SVs.labelForGraph,
-            visible: !SVs.hidden,
-            withLabel: SVs.labelForGraph !== "",
-            layer: 10 * SVs.layer + LINE_LAYER_OFFSET,
-            fixed: fixed.current,
-            strokeColor: lineColor,
-            strokeOpacity: SVs.selectedStyle.lineOpacity,
-            highlightStrokeColor: lineColor,
-            highlightStrokeOpacity: SVs.selectedStyle.lineOpacity * 0.5,
-            strokeWidth: SVs.selectedStyle.lineWidth,
-            highlightStrokeWidth: SVs.selectedStyle.lineWidth,
-            dash: styleToDash(SVs.selectedStyle.lineStyle),
-            highlight: !fixLocation.current,
+            ...buildLineLikeAttributes({
+                SVs,
+                layerOffset: LINE_LAYER_OFFSET,
+                fixed: fixed.current,
+                fixLocation: fixLocation.current,
+                darkMode,
+            }),
             straightFirst: false,
         };
 

--- a/packages/doenetml/src/Viewer/renderers/ray.tsx
+++ b/packages/doenetml/src/Viewer/renderers/ray.tsx
@@ -24,6 +24,7 @@ import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
 import { resolveLineColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
+import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
 
 interface RaySVs extends DraggableGraphicalSVs {
     numericalEndpoint: [number, number];
@@ -62,14 +63,11 @@ export default React.memo(function Ray(props: UseDoenetRendererProps) {
 
     useBoardPointerTracking(board, dragState);
 
-    React.useEffect(() => {
-        return () => {
-            cancelInitialLabelPlacement.current?.();
-            if (rayJXG.current !== null) {
-                deleteRayJXG();
-            }
-        };
-    }, []);
+    useJSXGraphCleanup({
+        objectRef: rayJXG,
+        destroy: () => deleteRayJXG(),
+        cancelLabelPlacementRef: cancelInitialLabelPlacement,
+    });
 
     function createRayJXG() {
         if (board === null) {

--- a/packages/doenetml/src/Viewer/renderers/utils/buildGraphicalAttributes.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/buildGraphicalAttributes.ts
@@ -31,6 +31,11 @@ export function buildBaseAttributes({
     };
 }
 
+type LineLikeSVs = Pick<
+    GraphicalSVs,
+    "labelForGraph" | "hidden" | "layer" | "selectedStyle"
+>;
+
 /**
  * Standard JSXgraph attribute object for stroke-only "line-family" elements
  * (line, lineSegment, ray, vector, polyline). Caller adds the `label`
@@ -44,7 +49,7 @@ export function buildLineLikeAttributes({
     darkMode,
     dashed,
 }: {
-    SVs: GraphicalSVs;
+    SVs: LineLikeSVs;
     layerOffset: number;
     fixed: boolean;
     fixLocation: boolean;
@@ -77,7 +82,7 @@ export function buildFilledShapeAttributes({
     darkMode,
     dashed,
 }: {
-    SVs: GraphicalSVs;
+    SVs: LineLikeSVs;
     layerOffset: number;
     fixed: boolean;
     fixLocation: boolean;

--- a/packages/doenetml/src/Viewer/renderers/utils/jsxgraph.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/jsxgraph.ts
@@ -868,3 +868,33 @@ export function syncLabelStrokeColor(
         ? lineColor
         : "var(--canvasText)";
 }
+
+/**
+ * Pointer/keyboard event names registered by line-family renderers (line,
+ * lineSegment, ray, vector, polyline, polygon, circle, and point's shadow
+ * point) on every draggable JSXgraph object. Centralized so adding a new
+ * event type is a one-place change.
+ */
+export const LINE_FAMILY_EVENTS = [
+    "drag",
+    "down",
+    "hit",
+    "up",
+    "keyfocusout",
+    "keydown",
+] as const;
+
+/**
+ * Deregister event handlers from a JSXgraph object. No-op if `obj` is
+ * null/undefined; defaults to `LINE_FAMILY_EVENTS` so the common case is a
+ * single argument.
+ */
+export function removeJXGEventHandlers(
+    obj: { off: (event: string) => void } | null | undefined,
+    events: readonly string[] = LINE_FAMILY_EVENTS,
+): void {
+    if (!obj) return;
+    for (const event of events) {
+        obj.off(event);
+    }
+}

--- a/packages/doenetml/src/Viewer/renderers/utils/useDraggableRefs.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useDraggableRefs.ts
@@ -1,0 +1,36 @@
+import { useRef, type MutableRefObject } from "react";
+import type { DraggableGraphicalSVs } from "./graphicalSVs";
+
+/**
+ * Bookkeeping refs that every draggable JSXgraph renderer needs.
+ *
+ * `fixed` and `fixLocation` mirror the SVs but are kept in refs so that
+ * event handlers (registered once at JXG-create time) read the current
+ * value rather than a stale closure capture.
+ *
+ * `lastPositionFromCore` is the renderer's source-of-truth coordinates
+ * received from the worker; drag handlers reset the JXG element back to
+ * this value after dispatching a transient move action.
+ *
+ * Renderers with additional draggable-related state (e.g. `switchable`,
+ * `endpointsFixed`, off-graph indicators) keep those refs local — this
+ * hook only owns the universal triple.
+ */
+export function useDraggableRefs<TPos>(
+    SVs: DraggableGraphicalSVs,
+    position: TPos,
+): {
+    lastPositionFromCore: MutableRefObject<TPos | null>;
+    fixed: MutableRefObject<boolean>;
+    fixLocation: MutableRefObject<boolean>;
+} {
+    const lastPositionFromCore = useRef<TPos | null>(null);
+    const fixed = useRef(false);
+    const fixLocation = useRef(false);
+
+    lastPositionFromCore.current = position;
+    fixed.current = SVs.fixed;
+    fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
+
+    return { lastPositionFromCore, fixed, fixLocation };
+}

--- a/packages/doenetml/src/Viewer/renderers/utils/useDraggableRefs.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useDraggableRefs.ts
@@ -20,11 +20,11 @@ export function useDraggableRefs<TPos>(
     SVs: DraggableGraphicalSVs,
     position: TPos,
 ): {
-    lastPositionFromCore: MutableRefObject<TPos | null>;
+    lastPositionFromCore: MutableRefObject<TPos>;
     fixed: MutableRefObject<boolean>;
     fixLocation: MutableRefObject<boolean>;
 } {
-    const lastPositionFromCore = useRef<TPos | null>(null);
+    const lastPositionFromCore = useRef(position);
     const fixed = useRef(false);
     const fixLocation = useRef(false);
 

--- a/packages/doenetml/src/Viewer/renderers/utils/useJSXGraphCleanup.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useJSXGraphCleanup.ts
@@ -5,17 +5,20 @@ import { useEffect, type MutableRefObject } from "react";
  * label-placement timers, then call the renderer's `destroy` if the primary
  * object ref is still populated.
  *
+ * Contract: `objectRef.current` must be `null` (not `undefined`) when empty —
+ * the hook treats anything else as a populated object and calls `destroy()`.
+ *
  * The empty-deps `useEffect` captures `destroy` from the first render. That
  * matches the pre-existing per-renderer pattern: `destroy` reads
  * `objectRef.current` (always live) and other live refs, so a stale closure
  * around the function itself is harmless.
  */
-export function useJSXGraphCleanup({
+export function useJSXGraphCleanup<T>({
     objectRef,
     destroy,
     cancelLabelPlacementRef,
 }: {
-    objectRef: MutableRefObject<unknown>;
+    objectRef: MutableRefObject<T | null>;
     destroy: () => void;
     cancelLabelPlacementRef?: MutableRefObject<(() => void) | null>;
 }): void {

--- a/packages/doenetml/src/Viewer/renderers/utils/useJSXGraphCleanup.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useJSXGraphCleanup.ts
@@ -1,0 +1,30 @@
+import { useEffect, type MutableRefObject } from "react";
+
+/**
+ * Run the standard JSXgraph teardown on unmount: cancel any pending initial
+ * label-placement timers, then call the renderer's `destroy` if the primary
+ * object ref is still populated.
+ *
+ * The empty-deps `useEffect` captures `destroy` from the first render. That
+ * matches the pre-existing per-renderer pattern: `destroy` reads
+ * `objectRef.current` (always live) and other live refs, so a stale closure
+ * around the function itself is harmless.
+ */
+export function useJSXGraphCleanup({
+    objectRef,
+    destroy,
+    cancelLabelPlacementRef,
+}: {
+    objectRef: MutableRefObject<unknown>;
+    destroy: () => void;
+    cancelLabelPlacementRef?: MutableRefObject<(() => void) | null>;
+}): void {
+    useEffect(() => {
+        return () => {
+            cancelLabelPlacementRef?.current?.();
+            if (objectRef.current !== null) {
+                destroy();
+            }
+        };
+    }, []);
+}

--- a/packages/doenetml/src/Viewer/renderers/vector.tsx
+++ b/packages/doenetml/src/Viewer/renderers/vector.tsx
@@ -491,11 +491,11 @@ export default React.memo(function Vector(props: UseDoenetRendererProps) {
 
             vectorJXG.current?.point1.coords.setCoordinates(
                 JXG.COORDS_BY_USER,
-                lastPositionsFromCore.current![0],
+                lastPositionsFromCore.current[0],
             );
             vectorJXG.current?.point2.coords.setCoordinates(
                 JXG.COORDS_BY_USER,
-                lastPositionsFromCore.current![1],
+                lastPositionsFromCore.current[1],
             );
             if (i === 0) {
                 board.updateInfobox(point1JXG.current);

--- a/packages/doenetml/src/Viewer/renderers/vector.tsx
+++ b/packages/doenetml/src/Viewer/renderers/vector.tsx
@@ -11,6 +11,7 @@ import { ChoiceInputInlineContext } from "./choiceInput";
 import {
     applyLineFamilyLabelPlacement,
     buildLineFamilyLabelAttributes,
+    removeJXGEventHandlers,
     stabilizeInitialLineFamilyLabelPlacement,
     syncLabelStrokeColor,
     syncLayer,
@@ -508,34 +509,19 @@ export default React.memo(function Vector(props: UseDoenetRendererProps) {
         cancelInitialLabelPlacement.current?.();
         cancelInitialLabelPlacement.current = null;
         if (vectorJXG.current) {
-            vectorJXG.current.off("drag");
-            vectorJXG.current.off("down");
-            vectorJXG.current.off("hit");
-            vectorJXG.current.off("up");
-            vectorJXG.current.off("keyfocusout");
-            vectorJXG.current.off("keydown");
+            removeJXGEventHandlers(vectorJXG.current);
             board?.removeObject(vectorJXG.current);
             vectorJXG.current = null;
         }
 
         if (point1JXG.current) {
-            point1JXG.current.off("drag");
-            point1JXG.current.off("down");
-            point1JXG.current.off("hit");
-            point1JXG.current.off("up");
-            point1JXG.current.off("keyfocusout");
-            point1JXG.current.off("keydown");
+            removeJXGEventHandlers(point1JXG.current);
             board?.removeObject(point1JXG.current);
             point1JXG.current = null;
         }
 
         if (point2JXG.current) {
-            point2JXG.current.off("drag");
-            point2JXG.current.off("down");
-            point2JXG.current.off("hit");
-            point2JXG.current.off("up");
-            point2JXG.current.off("keyfocusout");
-            point2JXG.current.off("keydown");
+            removeJXGEventHandlers(point2JXG.current);
             board?.removeObject(point2JXG.current);
             point2JXG.current = null;
         }

--- a/packages/doenetml/src/Viewer/renderers/vector.tsx
+++ b/packages/doenetml/src/Viewer/renderers/vector.tsx
@@ -25,6 +25,7 @@ import { exceededDragThreshold } from "./utils/dragThreshold";
 import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
 import { resolveLineColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
+import { useDraggableRefs } from "./utils/useDraggableRefs";
 
 interface VectorSVs extends DraggableGraphicalSVs {
     numericalEndpoints: [number, number][];
@@ -60,17 +61,13 @@ export default React.memo(function Vector(props: UseDoenetRendererProps) {
     let previousWithLabel = useRef<boolean | null>(null);
     let cancelInitialLabelPlacement = useRef<(() => void) | null>(null);
 
-    let lastPositionsFromCore = useRef<[number, number][]>(
-        SVs.numericalEndpoints,
-    );
-    let fixed = useRef(false);
-    let fixLocation = useRef(false);
+    const {
+        lastPositionFromCore: lastPositionsFromCore,
+        fixed,
+        fixLocation,
+    } = useDraggableRefs<[number, number][]>(SVs, SVs.numericalEndpoints);
     let headDraggable = useRef(true);
     let tailDraggable = useRef(true);
-
-    lastPositionsFromCore.current = SVs.numericalEndpoints;
-    fixed.current = SVs.fixed;
-    fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
     tailDraggable.current = SVs.tailDraggable && !SVs.fixed && !SVs.fixLocation;
     headDraggable.current = SVs.headDraggable && !SVs.fixed && !SVs.fixLocation;
 
@@ -496,11 +493,11 @@ export default React.memo(function Vector(props: UseDoenetRendererProps) {
 
             vectorJXG.current?.point1.coords.setCoordinates(
                 JXG.COORDS_BY_USER,
-                lastPositionsFromCore.current[0],
+                lastPositionsFromCore.current![0],
             );
             vectorJXG.current?.point2.coords.setCoordinates(
                 JXG.COORDS_BY_USER,
-                lastPositionsFromCore.current[1],
+                lastPositionsFromCore.current![1],
             );
             if (i === 0) {
                 board.updateInfobox(point1JXG.current);

--- a/packages/doenetml/src/Viewer/renderers/vector.tsx
+++ b/packages/doenetml/src/Viewer/renderers/vector.tsx
@@ -17,6 +17,7 @@ import {
     syncLineStrokeStyle,
     syncWithLabelToggle,
 } from "./utils/jsxgraph";
+import { buildLineLikeAttributes } from "./utils/buildGraphicalAttributes";
 import { DraggableGraphicalSVs } from "./utils/graphicalSVs";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
@@ -108,19 +109,13 @@ export default React.memo(function Vector(props: UseDoenetRendererProps) {
 
         //things to be passed to JSXGraph as attributes
         var jsxVectorAttributes: Record<string, any> = {
-            name: SVs.labelForGraph,
-            visible: !SVs.hidden,
-            withLabel: SVs.labelForGraph !== "",
-            fixed: fixed.current,
-            layer: 10 * SVs.layer + LINE_LAYER_OFFSET,
-            strokeColor: lineColor,
-            strokeOpacity: SVs.selectedStyle.lineOpacity,
-            highlightStrokeColor: lineColor,
-            highlightStrokeOpacity: SVs.selectedStyle.lineOpacity * 0.5,
-            strokeWidth: SVs.selectedStyle.lineWidth,
-            highlightStrokeWidth: SVs.selectedStyle.lineWidth,
-            dash: styleToDash(SVs.selectedStyle.lineStyle),
-            highlight: !fixLocation.current,
+            ...buildLineLikeAttributes({
+                SVs,
+                layerOffset: LINE_LAYER_OFFSET,
+                fixed: fixed.current,
+                fixLocation: fixLocation.current,
+                darkMode,
+            }),
             lastArrow: { type: 1, size: 3, highlightSize: 3 },
         };
 

--- a/packages/doenetml/src/Viewer/renderers/vector.tsx
+++ b/packages/doenetml/src/Viewer/renderers/vector.tsx
@@ -26,6 +26,7 @@ import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
 import { resolveLineColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
+import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
 
 interface VectorSVs extends DraggableGraphicalSVs {
     numericalEndpoints: [number, number][];
@@ -75,15 +76,11 @@ export default React.memo(function Vector(props: UseDoenetRendererProps) {
 
     useBoardPointerTracking(board, dragState);
 
-    React.useEffect(() => {
-        //On unmount
-        return () => {
-            cancelInitialLabelPlacement.current?.();
-            if (vectorJXG.current !== null) {
-                deleteVectorJXG();
-            }
-        };
-    }, []);
+    useJSXGraphCleanup({
+        objectRef: vectorJXG,
+        destroy: () => deleteVectorJXG(),
+        cancelLabelPlacementRef: cancelInitialLabelPlacement,
+    });
 
     function createVectorJXG() {
         if (board === null) {


### PR DESCRIPTION
## Summary

Follow-up dedup pass on the JSXgraph graphical renderers, layered on top of #1058. Net **−42 LOC** in renderers + 96 LOC of new shared helpers used across all of them. Each commit is independent and can be reviewed on its own.

## Commits

1. **\`969c1cf\` adopt buildLineLikeAttributes / buildFilledShapeAttributes** — the helpers in \`utils/buildGraphicalAttributes.ts\` existed but no renderer used them. Adopted across line, lineSegment, ray, vector, polyline, polygon, circle (with per-renderer overrides for divergent keys: ray's \`straightFirst\`, vector's \`lastArrow\`, polyline's \`lineCap\` and validCoords visibility, circle's conditional \`fillColor\`).
2. **\`7327611\` extract \`useDraggableRefs\` hook** — collapses the universal \`{ lastPositionFromCore, fixed, fixLocation }\` triple every draggable renderer maintains. Renderer-specific extras (\`switchable\`, \`endpointsFixed\`, head/tail draggable, off-graph indicators, etc.) stay local.
3. **\`41b6d2e\` extract \`useJSXGraphCleanup\` hook** — owns the unmount sequence: cancel any pending initial label-placement timer, then destroy the primary JXG object if still populated.
4. **\`527bf4e\` consolidate event-handler removal** — \`LINE_FAMILY_EVENTS\` constant + \`removeJXGEventHandlers\` helper. Replaces the standard 6-event \`.off()\` chain (drag/down/hit/up/keyfocusout/keydown) with a single helper call.
5. **\`3f9fbd3\` tighten dedup-pass helpers from review feedback** — drop dead \`const fillColor\` in \`createCircleJXG\`; make \`useJSXGraphCleanup\` generic over the ref type so callers' concrete JXG types are preserved; narrow \`buildLineLikeAttributes\` / \`buildFilledShapeAttributes\` from the full \`GraphicalSVs\` to a \`Pick\` of the keys they actually read.
6. **\`eeca06a\` eliminate null init in \`useDraggableRefs\`, drop \`!\` assertions** — initialize \`lastPositionFromCore\` with \`useRef(position)\` instead of \`useRef<TPos | null>(null)\`, narrowing the return type to \`MutableRefObject<TPos>\` and removing non-null assertions in all callers. Also drops a now-dead null-guard branch in \`circle.tsx\`.

## Skipped on purpose

- \`point.tsx\` for steps 2–3: it mutates \`lastPositionFromCore\` inside \`createPointJXG\` (off-graph indicator coords), which conflicts with the hook's per-render reassignment. Its unmount sequence also interleaves \`.off()\` and \`removeObject\` for two objects in a way that doesn't match the single-object cleanup hook. Step 4 (event helper) does apply to its shadow point.
- \`angle.tsx\`, \`cobwebPolyline.tsx\`, most of \`curve.tsx\`: divergent attribute shapes / event sets — adopting the helpers would require widening their APIs.

## What's left

A separate, larger refactor of the line-family **drag handlers** (\`down\`/\`drag\`/\`up\`/\`keydown\`/\`keyfocusout\`) is sketched in \`refactor-renderer-drag-handlers.md\` (locally — not in this PR). That's ~1000 LOC of remaining duplication but with higher behavioral risk; intentionally deferred to its own PR.

## Test plan

- [ ] \`tsc --noEmit\` clean (verified locally)
- [ ] \`npm run build -w @doenet/doenetml\` clean (verified locally)
- [ ] Cypress group runs covering graph renderers (\`test:e2e-group1\`–\`group5\`)
- [ ] Manual smoke: drag, click, keyboard-Enter, focus-out on each migrated renderer (line, lineSegment, ray, vector, polyline, polygon, circle)
- [ ] Mount-unmount loops to confirm no handler leaks (DevTools memory snapshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)