### PR TITLE
refactor(renderers): extract attachLineFamilyDragHandlers helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26835,7 +26835,7 @@
         },
         "packages/doenetml": {
             "name": "@doenet/doenetml",
-            "version": "0.7.15",
+            "version": "0.7.16",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
                 "dompurify": "^3.3.0"
@@ -26847,7 +26847,7 @@
         },
         "packages/doenetml-iframe": {
             "name": "@doenet/doenetml-iframe",
-            "version": "0.7.15",
+            "version": "0.7.16",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {},
             "peerDependencies": {
@@ -27403,7 +27403,7 @@
         },
         "packages/standalone": {
             "name": "@doenet/standalone",
-            "version": "0.7.15",
+            "version": "0.7.16",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },
@@ -27459,7 +27459,7 @@
         },
         "packages/v06-to-v07": {
             "name": "@doenet/v06-to-v07",
-            "version": "0.7.15",
+            "version": "0.7.16",
             "license": "AGPL-3.0-or-later",
             "devDependencies": {}
         },
@@ -27471,7 +27471,7 @@
         },
         "packages/vscode-extension": {
             "name": "@doenet/vscode-extension",
-            "version": "0.7.10",
+            "version": "0.7.16",
             "license": "AGPL",
             "devDependencies": {
                 "@types/vscode": "^1.99.0",
@@ -27488,7 +27488,7 @@
         },
         "packages/vscode-extension/extension": {
             "name": "doenet-vscode-extension",
-            "version": "0.7.10",
+            "version": "0.7.16",
             "license": "AGPL",
             "devDependencies": {
                 "@types/vscode": "^1.76.0",

--- a/packages/doenetml/src/Viewer/renderers/circle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/circle.tsx
@@ -21,8 +21,11 @@ import { JXGCircle, JXGPoint } from "./jsxgraph-distrib/types";
 import { DraggableGraphicalSVs } from "./utils/graphicalSVs";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
-import { exceededDragThreshold } from "./utils/dragThreshold";
 import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
+import {
+    DragCoordinationState,
+    attachLineFamilyDragHandlers,
+} from "./utils/lineFamilyDragHandlers";
 import {
     resolveLineColor,
     resolveFillColor,
@@ -61,14 +64,18 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
     let indicatorJXG = useRef<JXGPoint | null>(null);
 
     const dragState = usePointerDragState();
-    const { pointerAtDown, pointerIsDown, pointerMovedSinceDown, dragged } =
-        dragState;
     let centerAtDown = useRef<[number, number, number] | null>(null);
     let radiusAtDown = useRef<number | null>(null);
     let throughAnglesAtDown = useRef<[number, number] | null>(null);
     let previousWithLabel = useRef<boolean | null>(null);
     let previousPointLabelPosition = useRef<LabelPosition | null>(null);
     let centerCoords = useRef<[number, number] | null>(null);
+
+    // Tag layout: 0 = main circle disk, 1 = off-graph indicator point.
+    const dragCoordination: DragCoordinationState<number> = {
+        draggedTag: useRef<number | null>(null),
+        downOnTag: useRef<number | null>(null),
+    };
 
     const {
         lastPositionFromCore: lastCenterFromCore,
@@ -105,31 +112,6 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
             )
         ) {
             return null;
-        }
-
-        function dispatchMoveCircle(
-            args: Omit<
-                Record<string, any>,
-                "center" | "x" | "y" | "radius" | "throughAngles"
-            > = {},
-        ) {
-            if (
-                !centerCoords.current ||
-                !Number.isFinite(centerCoords.current[0]) ||
-                !Number.isFinite(centerCoords.current[1])
-            ) {
-                return;
-            }
-
-            callAction({
-                action: actions.moveCircle,
-                args: {
-                    center: centerCoords.current,
-                    radius: radiusAtDown.current,
-                    throughAngles: throughAnglesAtDown.current,
-                    ...args,
-                },
-            });
         }
 
         const lineColor = resolveLineColor(SVs.selectedStyle, darkMode);
@@ -248,230 +230,146 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
 
         indicatorJXG.current.isDraggable = !fixLocation.current;
 
-        circleJXG.current.on("drag", function (e) {
-            let viaPointer = e.type === "pointermove";
-
-            if (exceededDragThreshold(e, pointerAtDown.current)) {
-                dragged.current = true;
-            }
-
-            if (viaPointer && pointerAtDown.current && centerAtDown.current) {
-                // Compute from pointer delta rather than .X()/.Y() directly so
-                // the center doesn't snap back to an attractor on slow drags.
-                centerCoords.current = pointerEventToUserCoords(
-                    e,
-                    pointerAtDown.current,
-                    centerAtDown.current,
-                    board,
-                );
-            } else {
-                centerCoords.current = [
-                    circleJXG.current!.center.X(),
-                    circleJXG.current!.center.Y(),
-                ];
-            }
-
-            dispatchMoveCircle({
-                transient: true,
-                skippable: true,
-            });
-
-            circleJXG.current!.center.coords.setCoordinates(
-                JXG.COORDS_BY_USER,
-                [...lastCenterFromCore.current],
-            );
-        });
-
-        circleJXG.current.on("up", function (e) {
-            if (dragged.current) {
-                dispatchMoveCircle();
-            } else if (!pointerMovedSinceDown.current && !fixed.current) {
-                callAction({
-                    action: actions.circleClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                });
-            }
-            pointerIsDown.current = false;
-        });
-
-        circleJXG.current.on("keyfocusout", function (e) {
-            if (dragged.current) {
-                dispatchMoveCircle();
-                dragged.current = false;
-            }
-            pointerIsDown.current = false;
-        });
-
-        circleJXG.current.on("down", function (e) {
-            (document.activeElement as HTMLElement | null)?.blur();
-
-            dragged.current = false;
-            pointerAtDown.current = [e.x, e.y];
-            centerAtDown.current = [
-                ...circleJXG.current!.center.coords.scrCoords,
-            ];
-            radiusAtDown.current = circleJXG.current!.radius;
-            throughAnglesAtDown.current = [...throughAnglesFromCore.current!];
-            pointerIsDown.current = true;
-            pointerMovedSinceDown.current = false;
-            if (!fixed.current) {
-                callAction({
-                    action: actions.circleFocused,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                });
-            }
-        });
-
-        // hit is called by jsxgraph when focused in via keyboard
-        circleJXG.current.on("hit", function (e) {
-            dragged.current = false;
-            centerAtDown.current = [
-                ...circleJXG.current!.center.coords.scrCoords,
-            ];
-            radiusAtDown.current = circleJXG.current!.radius;
-            throughAnglesAtDown.current = [...throughAnglesFromCore.current!];
-            callAction({
-                action: actions.circleFocused,
-                args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-            });
-        });
-
-        circleJXG.current.on("keydown", function (e) {
-            if (e.key === "Enter") {
-                if (dragged.current) {
-                    dispatchMoveCircle();
-                    dragged.current = false;
-                }
-                callAction({
-                    action: actions.circleClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                });
-            }
-        });
-
-        indicatorJXG.current.on("drag", function (e) {
-            if (exceededDragThreshold(e, pointerAtDown.current)) {
-                dragged.current = true;
-            }
-
-            centerCoords.current = [
-                indicatorJXG.current!.X() +
-                    offGraphIndicatorOffsetAtDown.current[0],
-                indicatorJXG.current!.Y() +
-                    offGraphIndicatorOffsetAtDown.current[1],
-            ];
-
-            dispatchMoveCircle({
-                transient: true,
-                skippable: true,
-            });
-        });
-
-        indicatorJXG.current.on("up", function (e) {
-            if (dragged.current) {
-                dispatchMoveCircle();
-            } else if (!pointerMovedSinceDown.current && !fixed.current) {
-                callAction({
-                    action: actions.circleClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                });
-            }
-            pointerIsDown.current = false;
-        });
-
-        indicatorJXG.current.on("keyfocusout", function (e) {
-            if (dragged.current) {
-                dispatchMoveCircle();
-                dragged.current = false;
-            }
-            pointerIsDown.current = false;
-        });
-
-        indicatorJXG.current.on("down", function (e) {
-            (document.activeElement as HTMLElement | null)?.blur();
-
+        function buildCircleCommitArgs() {
             if (
-                !centerAtDown.current ||
-                !offGraphIndicatorOrientation.current ||
-                !radiusAtDown.current ||
-                !circleJXG.current
+                !centerCoords.current ||
+                !Number.isFinite(centerCoords.current[0]) ||
+                !Number.isFinite(centerCoords.current[1])
             ) {
-                return;
+                return null;
             }
-            dragged.current = false;
-            pointerAtDown.current = [e.x, e.y];
+            return {
+                center: centerCoords.current,
+                radius: radiusAtDown.current,
+                throughAngles: throughAnglesAtDown.current,
+            };
+        }
+
+        function captureCircleSnapshot() {
+            if (!circleJXG.current) {
+                return null;
+            }
             centerAtDown.current = [
                 ...circleJXG.current.center.coords.scrCoords,
             ];
             radiusAtDown.current = circleJXG.current.radius;
             throughAnglesAtDown.current = [...throughAnglesFromCore.current!];
+            return centerAtDown.current;
+        }
 
-            let { flippedX, flippedY } = getEffectiveBoundingBox(board);
-
-            let xSign = flippedX ? -1 : 1;
-            let ySign = flippedY ? -1 : 1;
-
-            if (
-                offGraphIndicatorOrientation.current[0] === 0 ||
-                offGraphIndicatorOrientation.current[1] === 0
-            ) {
-                offGraphIndicatorOffsetAtDown.current = [
-                    xSign *
-                        offGraphIndicatorOrientation.current[0] *
-                        radiusAtDown.current,
-                    ySign *
-                        offGraphIndicatorOrientation.current[1] *
-                        radiusAtDown.current,
-                ];
-            } else {
-                let sqrt2 = Math.sqrt(2);
-                offGraphIndicatorOffsetAtDown.current = [
-                    (xSign / sqrt2) *
-                        offGraphIndicatorOrientation.current[0] *
-                        radiusAtDown.current,
-                    (ySign / sqrt2) *
-                        offGraphIndicatorOrientation.current[1] *
-                        radiusAtDown.current,
-                ];
-            }
-
-            pointerIsDown.current = true;
-            pointerMovedSinceDown.current = false;
-            if (!fixed.current) {
-                callAction({
-                    action: actions.circleFocused,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                });
-            }
-        });
-
-        // hit is called by jsxgraph when focused in via keyboard
-        indicatorJXG.current.on("hit", function (e) {
-            dragged.current = false;
-            centerAtDown.current = [
-                ...circleJXG.current!.center.coords.scrCoords,
-            ];
-            radiusAtDown.current = circleJXG.current!.radius;
-            throughAnglesAtDown.current = [
-                ...throughAnglesFromCore.current!,
-            ] as [number, number];
-            callAction({
-                action: actions.circleFocused,
-                args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-            });
-        });
-
-        indicatorJXG.current.on("keydown", function (e) {
-            if (e.key === "Enter") {
-                if (dragged.current) {
-                    dispatchMoveCircle();
-                    dragged.current = false;
+        attachLineFamilyDragHandlers({
+            jxg: circleJXG.current,
+            tag: 0,
+            dragState,
+            coordination: dragCoordination,
+            componentIdx,
+            callAction,
+            fixedRef: fixed,
+            actions: {
+                move: actions.moveCircle,
+                focus: actions.circleFocused,
+                click: actions.circleClicked,
+            },
+            snapshot: captureCircleSnapshot,
+            snapshotRef: centerAtDown,
+            dispatchTransientBelowThreshold: true,
+            buildTransientMoveArgs: (e, snap) => {
+                let viaPointer = e.type === "pointermove";
+                if (viaPointer && dragState.pointerAtDown.current && snap) {
+                    // Compute from pointer delta rather than .X()/.Y() directly so
+                    // the center doesn't snap back to an attractor on slow drags.
+                    centerCoords.current = pointerEventToUserCoords(
+                        e,
+                        dragState.pointerAtDown.current,
+                        snap,
+                        board,
+                    );
+                } else {
+                    centerCoords.current = [
+                        circleJXG.current!.center.X(),
+                        circleJXG.current!.center.Y(),
+                    ];
                 }
-                callAction({
-                    action: actions.circleClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                });
-            }
+                const base = buildCircleCommitArgs();
+                if (!base) {
+                    return null;
+                }
+                return { ...base, transient: true, skippable: true };
+            },
+            buildCommitMoveArgs: () => buildCircleCommitArgs(),
+            onDragApplied: () => {
+                circleJXG.current!.center.coords.setCoordinates(
+                    JXG.COORDS_BY_USER,
+                    [...lastCenterFromCore.current],
+                );
+            },
+        });
+
+        attachLineFamilyDragHandlers({
+            jxg: indicatorJXG.current,
+            tag: 1,
+            dragState,
+            coordination: dragCoordination,
+            componentIdx,
+            callAction,
+            fixedRef: fixed,
+            actions: {
+                move: actions.moveCircle,
+                focus: actions.circleFocused,
+                click: actions.circleClicked,
+            },
+            snapshot: captureCircleSnapshot,
+            snapshotRef: centerAtDown,
+            dispatchTransientBelowThreshold: true,
+            buildTransientMoveArgs: () => {
+                centerCoords.current = [
+                    indicatorJXG.current!.X() +
+                        offGraphIndicatorOffsetAtDown.current[0],
+                    indicatorJXG.current!.Y() +
+                        offGraphIndicatorOffsetAtDown.current[1],
+                ];
+                const base = buildCircleCommitArgs();
+                if (!base) {
+                    return null;
+                }
+                return { ...base, transient: true, skippable: true };
+            },
+            buildCommitMoveArgs: () => buildCircleCommitArgs(),
+            onDownExtra: () => {
+                if (
+                    !offGraphIndicatorOrientation.current ||
+                    !radiusAtDown.current
+                ) {
+                    return;
+                }
+                let { flippedX, flippedY } = getEffectiveBoundingBox(board);
+                let xSign = flippedX ? -1 : 1;
+                let ySign = flippedY ? -1 : 1;
+
+                if (
+                    offGraphIndicatorOrientation.current[0] === 0 ||
+                    offGraphIndicatorOrientation.current[1] === 0
+                ) {
+                    offGraphIndicatorOffsetAtDown.current = [
+                        xSign *
+                            offGraphIndicatorOrientation.current[0] *
+                            radiusAtDown.current,
+                        ySign *
+                            offGraphIndicatorOrientation.current[1] *
+                            radiusAtDown.current,
+                    ];
+                } else {
+                    let sqrt2 = Math.sqrt(2);
+                    offGraphIndicatorOffsetAtDown.current = [
+                        (xSign / sqrt2) *
+                            offGraphIndicatorOrientation.current[0] *
+                            radiusAtDown.current,
+                        (ySign / sqrt2) *
+                            offGraphIndicatorOrientation.current[1] *
+                            radiusAtDown.current,
+                    ];
+                }
+            },
         });
 
         previousWithLabel.current = SVs.labelForGraph !== "";

--- a/packages/doenetml/src/Viewer/renderers/circle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/circle.tsx
@@ -64,7 +64,6 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
     let indicatorJXG = useRef<JXGPoint | null>(null);
 
     const dragState = usePointerDragState();
-    let centerAtDown = useRef<[number, number, number] | null>(null);
     let radiusAtDown = useRef<number | null>(null);
     let throughAnglesAtDown = useRef<[number, number] | null>(null);
     let previousWithLabel = useRef<boolean | null>(null);
@@ -245,16 +244,17 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
             };
         }
 
-        function captureCircleSnapshot() {
+        function captureCircleSnapshot(): [number, number, number] | null {
             if (!circleJXG.current) {
                 return null;
             }
-            centerAtDown.current = [
-                ...circleJXG.current.center.coords.scrCoords,
-            ];
             radiusAtDown.current = circleJXG.current.radius;
             throughAnglesAtDown.current = [...throughAnglesFromCore.current!];
-            return centerAtDown.current;
+            return [...circleJXG.current.center.coords.scrCoords] as [
+                number,
+                number,
+                number,
+            ];
         }
 
         attachLineFamilyDragHandlers({
@@ -271,7 +271,6 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
                 click: actions.circleClicked,
             },
             snapshot: captureCircleSnapshot,
-            snapshotRef: centerAtDown,
             dispatchTransientBelowThreshold: true,
             buildTransientMoveArgs: (e, snap) => {
                 let viaPointer = e.type === "pointermove";
@@ -319,7 +318,6 @@ export default React.memo(function Circle(props: UseDoenetRendererProps) {
                 click: actions.circleClicked,
             },
             snapshot: captureCircleSnapshot,
-            snapshotRef: centerAtDown,
             dispatchTransientBelowThreshold: true,
             buildTransientMoveArgs: () => {
                 centerCoords.current = [

--- a/packages/doenetml/src/Viewer/renderers/line.tsx
+++ b/packages/doenetml/src/Viewer/renderers/line.tsx
@@ -23,12 +23,15 @@ import { JXGLine } from "./jsxgraph-distrib/types";
 import { DraggableGraphicalSVs } from "./utils/graphicalSVs";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
-import { exceededDragThreshold } from "./utils/dragThreshold";
 import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
 import { resolveLineColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
+import {
+    DragCoordinationState,
+    attachLineFamilyDragHandlers,
+} from "./utils/lineFamilyDragHandlers";
 
 interface LineSVs extends DraggableGraphicalSVs {
     numericalPoints: [number, number][];
@@ -50,12 +53,15 @@ export default React.memo(function Line(props: UseDoenetRendererProps) {
     let lineJXG = useRef<JXGLine | null>(null);
 
     const dragState = usePointerDragState();
-    const { pointerAtDown, pointerIsDown, pointerMovedSinceDown, dragged } =
-        dragState;
     let pointsAtDown = useRef<[number[], number[]] | null>(null);
     let previousWithLabel = useRef<boolean | null>(null);
     let cancelInitialLabelPlacement = useRef<(() => void) | null>(null);
     let pointCoords = useRef<[number, number][] | null>(null);
+
+    const dragCoordination: DragCoordinationState<number> = {
+        draggedTag: useRef<number | null>(null),
+        downOnTag: useRef<number | null>(null),
+    };
 
     const {
         lastPositionFromCore: lastPositionsFromCore,
@@ -124,160 +130,75 @@ export default React.memo(function Line(props: UseDoenetRendererProps) {
 
         newLineJXG.isDraggable = !fixLocation.current;
 
-        newLineJXG.on("drag", function (e) {
-            if (exceededDragThreshold(e, pointerAtDown.current)) {
-                dragged.current = true;
-            }
+        function buildMoveArgs(): Record<string, any> {
+            return {
+                point1coords: pointCoords.current?.[0],
+                point2coords: pointCoords.current?.[1],
+            };
+        }
 
-            pointCoords.current = [];
-
-            if (
-                e.type === "pointermove" &&
-                pointerAtDown.current &&
-                pointsAtDown.current
-            ) {
-                // Compute from pointer delta rather than .X()/.Y() directly so
-                // points don't snap back to attractors on slow drags.
-                for (let i = 0; i < 2; i++) {
-                    pointCoords.current.push(
-                        pointerEventToUserCoords(
-                            e,
-                            pointerAtDown.current,
-                            pointsAtDown.current[i] as [number, number, number],
-                            board,
-                        ),
-                    );
+        attachLineFamilyDragHandlers({
+            jxg: newLineJXG,
+            tag: 0,
+            dragState,
+            coordination: dragCoordination,
+            componentIdx,
+            callAction,
+            fixedRef: fixed,
+            actions: {
+                move: actions.moveLine,
+                focus: actions.lineFocused,
+                click: actions.lineClicked,
+                clickPrelude: actions.switchLine,
+            },
+            clickPreludeGate: switchable,
+            snapshot: () =>
+                [
+                    [...newLineJXG.point1.coords.scrCoords],
+                    [...newLineJXG.point2.coords.scrCoords],
+                ] as [number[], number[]],
+            snapshotRef: pointsAtDown,
+            buildTransientMoveArgs: (e, snap) => {
+                const next: [number, number][] = [];
+                if (
+                    e.type === "pointermove" &&
+                    dragState.pointerAtDown.current &&
+                    snap
+                ) {
+                    // Compute from pointer delta rather than .X()/.Y() directly so
+                    // points don't snap back to attractors on slow drags.
+                    for (let i = 0; i < 2; i++) {
+                        next.push(
+                            pointerEventToUserCoords(
+                                e,
+                                dragState.pointerAtDown.current,
+                                snap[i] as [number, number, number],
+                                board,
+                            ),
+                        );
+                    }
+                } else {
+                    next.push([newLineJXG.point1.X(), newLineJXG.point1.Y()]);
+                    next.push([newLineJXG.point2.X(), newLineJXG.point2.Y()]);
                 }
-            } else {
-                pointCoords.current.push([
-                    newLineJXG.point1.X(),
-                    newLineJXG.point1.Y(),
-                ]);
-                pointCoords.current.push([
-                    newLineJXG.point2.X(),
-                    newLineJXG.point2.Y(),
-                ]);
-            }
-
-            callAction({
-                action: actions.moveLine,
-                args: {
-                    point1coords: pointCoords.current[0],
-                    point2coords: pointCoords.current[1],
+                pointCoords.current = next;
+                return {
+                    ...buildMoveArgs(),
                     transient: true,
                     skippable: true,
-                },
-            });
-
-            newLineJXG.point1.coords.setCoordinates(
-                JXG.COORDS_BY_USER,
-                lastPositionsFromCore.current[0],
-            );
-            newLineJXG.point2.coords.setCoordinates(
-                JXG.COORDS_BY_USER,
-                lastPositionsFromCore.current[1],
-            );
-        });
-
-        newLineJXG.on("up", function (e) {
-            if (dragged.current) {
-                callAction({
-                    action: actions.moveLine,
-                    args: {
-                        point1coords: pointCoords.current?.[0],
-                        point2coords: pointCoords.current?.[1],
-                    },
-                });
-            } else if (!pointerMovedSinceDown.current && !fixed.current) {
-                if (switchable.current) {
-                    callAction({
-                        action: actions.switchLine,
-                    });
-                    callAction({
-                        action: actions.lineClicked,
-                        args: { componentIdx },
-                    });
-                } else {
-                    callAction({
-                        action: actions.lineClicked,
-                        args: { componentIdx },
-                    });
-                }
-            }
-            pointerIsDown.current = false;
-        });
-
-        newLineJXG.on("keyfocusout", function (e) {
-            if (dragged.current) {
-                callAction({
-                    action: actions.moveLine,
-                    args: {
-                        point1coords: pointCoords.current?.[0],
-                        point2coords: pointCoords.current?.[1],
-                    },
-                });
-                dragged.current = false;
-            }
-        });
-
-        newLineJXG.on("down", function (e) {
-            (document.activeElement as HTMLElement | null)?.blur();
-
-            dragged.current = false;
-            pointerAtDown.current = [e.x, e.y];
-            pointsAtDown.current = [
-                [...newLineJXG.point1.coords.scrCoords],
-                [...newLineJXG.point2.coords.scrCoords],
-            ];
-            pointerIsDown.current = true;
-            pointerMovedSinceDown.current = false;
-            if (!fixed.current) {
-                callAction({
-                    action: actions.lineFocused,
-                    args: { componentIdx },
-                });
-            }
-        });
-
-        newLineJXG.on("hit", function (e) {
-            dragged.current = false;
-            pointsAtDown.current = [
-                [...newLineJXG.point1.coords.scrCoords],
-                [...newLineJXG.point2.coords.scrCoords],
-            ];
-            callAction({
-                action: actions.lineFocused,
-                args: { componentIdx },
-            });
-        });
-
-        newLineJXG.on("keydown", function (e) {
-            if (e.key === "Enter") {
-                if (dragged.current) {
-                    callAction({
-                        action: actions.moveLine,
-                        args: {
-                            point1coords: pointCoords.current?.[0],
-                            point2coords: pointCoords.current?.[1],
-                        },
-                    });
-                    dragged.current = false;
-                }
-                if (switchable.current) {
-                    callAction({
-                        action: actions.switchLine,
-                    });
-                    callAction({
-                        action: actions.lineClicked,
-                        args: { componentIdx },
-                    });
-                } else {
-                    callAction({
-                        action: actions.lineClicked,
-                        args: { componentIdx },
-                    });
-                }
-            }
+                };
+            },
+            buildCommitMoveArgs: () => buildMoveArgs(),
+            onDragApplied: () => {
+                newLineJXG.point1.coords.setCoordinates(
+                    JXG.COORDS_BY_USER,
+                    lastPositionsFromCore.current[0],
+                );
+                newLineJXG.point2.coords.setCoordinates(
+                    JXG.COORDS_BY_USER,
+                    lastPositionsFromCore.current[1],
+                );
+            },
         });
 
         lineJXG.current = newLineJXG;

--- a/packages/doenetml/src/Viewer/renderers/line.tsx
+++ b/packages/doenetml/src/Viewer/renderers/line.tsx
@@ -53,7 +53,6 @@ export default React.memo(function Line(props: UseDoenetRendererProps) {
     let lineJXG = useRef<JXGLine | null>(null);
 
     const dragState = usePointerDragState();
-    let pointsAtDown = useRef<[number[], number[]] | null>(null);
     let previousWithLabel = useRef<boolean | null>(null);
     let cancelInitialLabelPlacement = useRef<(() => void) | null>(null);
     let pointCoords = useRef<[number, number][] | null>(null);
@@ -157,7 +156,6 @@ export default React.memo(function Line(props: UseDoenetRendererProps) {
                     [...newLineJXG.point1.coords.scrCoords],
                     [...newLineJXG.point2.coords.scrCoords],
                 ] as [number[], number[]],
-            snapshotRef: pointsAtDown,
             buildTransientMoveArgs: (e, snap) => {
                 const next: [number, number][] = [];
                 if (

--- a/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
+++ b/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
@@ -20,12 +20,15 @@ import { JXGLine, JXGPoint } from "./jsxgraph-distrib/types";
 import { DraggableGraphicalSVs } from "./utils/graphicalSVs";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
-import { exceededDragThreshold } from "./utils/dragThreshold";
 import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
 import { resolveLineColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
+import {
+    DragCoordinationState,
+    attachLineFamilyDragHandlers,
+} from "./utils/lineFamilyDragHandlers";
 
 interface LineSegmentSVs extends DraggableGraphicalSVs {
     numericalEndpoints: [number, number][];
@@ -47,13 +50,15 @@ export default React.memo(function LineSegment(props: UseDoenetRendererProps) {
     let point2JXG = useRef<JXGPoint | null>(null);
 
     const dragState = usePointerDragState();
-    const { pointerAtDown, pointerIsDown, pointerMovedSinceDown } = dragState;
     let pointsAtDown = useRef<[number[], number[]] | null>(null);
-    let draggedPoint = useRef<number | null>(null);
     let previousWithLabel = useRef<boolean | null>(null);
     let cancelInitialLabelPlacement = useRef<(() => void) | null>(null);
     let pointCoords = useRef<any>(null);
-    let downOnPoint = useRef<number | null>(null);
+
+    const dragCoordination: DragCoordinationState<number> = {
+        draggedTag: useRef<number | null>(null),
+        downOnTag: useRef<number | null>(null),
+    };
 
     const {
         lastPositionFromCore: lastPositionsFromCore,
@@ -157,228 +162,144 @@ export default React.memo(function LineSegment(props: UseDoenetRendererProps) {
         lineSegmentJXG.current = newSegmentJXG;
         newSegmentJXG.isDraggable = !fixLocation.current;
 
-        newPoint1JXG.on("drag", (e) => onDragHandler(1, e));
-        newPoint2JXG.on("drag", (e) => onDragHandler(2, e));
-        newSegmentJXG.on("drag", (e) => onDragHandler(0, e));
+        const segmentBuildCommit = (): Record<string, any> | null => {
+            if (!pointCoords.current) {
+                return null;
+            }
+            return {
+                point1coords: pointCoords.current[0],
+                point2coords: pointCoords.current[1],
+            };
+        };
 
-        newPoint1JXG.on("up", () => {
-            if (draggedPoint.current === 1) {
-                callAction({
-                    action: actions.moveLineSegment,
-                    args: {
-                        point1coords: pointCoords.current,
-                    },
-                });
-            } else if (!pointerMovedSinceDown.current && !fixed.current) {
-                callAction({
-                    action: actions.lineSegmentClicked,
-                    args: { componentIdx },
-                });
-            }
-            downOnPoint.current = null;
-            pointerIsDown.current = false;
-        });
-        newPoint2JXG.on("up", () => {
-            if (draggedPoint.current === 2) {
-                callAction({
-                    action: actions.moveLineSegment,
-                    args: {
-                        point2coords: pointCoords.current,
-                    },
-                });
-            } else if (!pointerMovedSinceDown.current && !fixed.current) {
-                callAction({
-                    action: actions.lineSegmentClicked,
-                    args: { componentIdx },
-                });
-            }
-            downOnPoint.current = null;
-            pointerIsDown.current = false;
-        });
-        newSegmentJXG.on("up", function (e) {
-            if (draggedPoint.current === 0) {
-                callAction({
-                    action: actions.moveLineSegment,
-                    args: {
-                        point1coords: pointCoords.current[0],
-                        point2coords: pointCoords.current[1],
-                    },
-                });
-            } else if (
-                !pointerMovedSinceDown.current &&
-                downOnPoint.current === null &&
-                !fixed.current
-            ) {
-                // Note: counting on fact that up on line segment will trigger before up on points
-                callAction({
-                    action: actions.lineSegmentClicked,
-                    args: { componentIdx },
-                });
-            }
-            pointerIsDown.current = false;
-        });
-
-        newPoint1JXG.on("keyfocusout", () => {
-            if (draggedPoint.current === 1) {
-                callAction({
-                    action: actions.moveLineSegment,
-                    args: {
-                        point1coords: pointCoords.current,
-                    },
-                });
-            }
-            draggedPoint.current = null;
-        });
-        newPoint2JXG.on("keyfocusout", () => {
-            if (draggedPoint.current === 2) {
-                callAction({
-                    action: actions.moveLineSegment,
-                    args: {
-                        point2coords: pointCoords.current,
-                    },
-                });
-            }
-            draggedPoint.current = null;
-        });
-        newSegmentJXG.on("keyfocusout", function (e) {
-            if (draggedPoint.current === 0) {
-                callAction({
-                    action: actions.moveLineSegment,
-                    args: {
-                        point1coords: pointCoords.current[0],
-                        point2coords: pointCoords.current[1],
-                    },
-                });
-            }
-            draggedPoint.current = null;
-        });
-
-        newPoint1JXG.on("down", (e) => {
-            (document.activeElement as HTMLElement | null)?.blur();
-
-            draggedPoint.current = null;
-            pointerAtDown.current = [e.x, e.y];
-            downOnPoint.current = 1;
-            pointerIsDown.current = true;
-            pointerMovedSinceDown.current = false;
-            if (!endpointsFixed.current) {
-                callAction({
-                    action: actions.lineSegmentFocused,
-                    args: { componentIdx },
-                });
-            }
-        });
-        newPoint1JXG.on("hit", (e) => {
-            draggedPoint.current = null;
-            callAction({
-                action: actions.lineSegmentFocused,
-                args: { componentIdx },
-            });
-        });
-        newPoint2JXG.on("down", (e) => {
-            (document.activeElement as HTMLElement | null)?.blur();
-
-            draggedPoint.current = null;
-            pointerAtDown.current = [e.x, e.y];
-            downOnPoint.current = 2;
-            pointerIsDown.current = true;
-            pointerMovedSinceDown.current = false;
-            if (!endpointsFixed.current) {
-                callAction({
-                    action: actions.lineSegmentFocused,
-                    args: { componentIdx },
-                });
-            }
-        });
-        newPoint2JXG.on("hit", (e) => {
-            draggedPoint.current = null;
-            callAction({
-                action: actions.lineSegmentFocused,
-                args: { componentIdx },
-            });
-        });
-        newSegmentJXG.on("down", function (e) {
-            (document.activeElement as HTMLElement | null)?.blur();
-
-            draggedPoint.current = null;
-            pointerAtDown.current = [e.x, e.y];
-            pointsAtDown.current = [
-                [...point1JXG.current!.coords.scrCoords],
-                [...point2JXG.current!.coords.scrCoords],
-            ];
-            pointerIsDown.current = true;
-            pointerMovedSinceDown.current = false;
-
-            if (downOnPoint.current === null && !fixed.current) {
-                // Note: counting on fact that down on line segment itself will trigger after down on points
-                callAction({
-                    action: actions.lineSegmentFocused,
-                    args: { componentIdx },
-                });
-            }
-        });
-        newSegmentJXG.on("hit", (e) => {
-            draggedPoint.current = null;
-            callAction({
-                action: actions.lineSegmentFocused,
-                args: { componentIdx },
-            });
-        });
-
-        newPoint1JXG.on("keydown", function (e) {
-            if (e.key === "Enter") {
-                if (draggedPoint.current === 1) {
-                    callAction({
-                        action: actions.moveLineSegment,
-                        args: {
-                            point1coords: pointCoords.current,
-                        },
-                    });
+        attachLineFamilyDragHandlers({
+            jxg: newSegmentJXG,
+            tag: 0,
+            dragState,
+            coordination: dragCoordination,
+            componentIdx,
+            callAction,
+            fixedRef: fixed,
+            participatesInDownTag: false,
+            suppressClickWhenDownOnOtherTag: true,
+            suppressFocusOnDownWhenDownOnOtherTag: true,
+            actions: {
+                move: actions.moveLineSegment,
+                focus: actions.lineSegmentFocused,
+                click: actions.lineSegmentClicked,
+            },
+            snapshot: () =>
+                [
+                    [...point1JXG.current!.coords.scrCoords],
+                    [...point2JXG.current!.coords.scrCoords],
+                ] as [number[], number[]],
+            snapshotRef: pointsAtDown,
+            buildTransientMoveArgs: (e, snap) => {
+                const next: [number, number][] = [];
+                if (
+                    e.type === "pointermove" &&
+                    dragState.pointerAtDown.current &&
+                    snap
+                ) {
+                    // Compute from pointer delta rather than .X()/.Y() directly
+                    // so points don't snap back to attractors on slow drags.
+                    for (let j = 0; j < 2; j++) {
+                        next.push(
+                            pointerEventToUserCoords(
+                                e,
+                                dragState.pointerAtDown.current,
+                                snap[j] as [number, number, number],
+                                board,
+                            ),
+                        );
+                    }
+                } else {
+                    next.push([
+                        newSegmentJXG.point1.X(),
+                        newSegmentJXG.point1.Y(),
+                    ]);
+                    next.push([
+                        newSegmentJXG.point2.X(),
+                        newSegmentJXG.point2.Y(),
+                    ]);
                 }
-                draggedPoint.current = null;
-                callAction({
-                    action: actions.lineSegmentClicked,
-                    args: { componentIdx },
-                });
-            }
+                pointCoords.current = next;
+                return {
+                    point1coords: next[0],
+                    point2coords: next[1],
+                    transient: true,
+                    skippable: true,
+                };
+            },
+            buildCommitMoveArgs: () => segmentBuildCommit(),
+            onDragApplied: () => {
+                newSegmentJXG.point1.coords.setCoordinates(
+                    JXG.COORDS_BY_USER,
+                    lastPositionsFromCore.current[0],
+                );
+                newSegmentJXG.point2.coords.setCoordinates(
+                    JXG.COORDS_BY_USER,
+                    lastPositionsFromCore.current[1],
+                );
+            },
         });
 
-        newPoint2JXG.on("keydown", function (e) {
-            if (e.key === "Enter") {
-                if (draggedPoint.current === 2) {
-                    callAction({
-                        action: actions.moveLineSegment,
-                        args: {
-                            point2coords: pointCoords.current,
-                        },
-                    });
-                }
-                draggedPoint.current = null;
-                callAction({
-                    action: actions.lineSegmentClicked,
-                    args: { componentIdx },
-                });
-            }
-        });
+        function attachEndpointHandlers(
+            point: JXGPoint,
+            tagN: 1 | 2,
+            argKey: "point1coords" | "point2coords",
+        ) {
+            attachLineFamilyDragHandlers({
+                jxg: point,
+                tag: tagN,
+                dragState,
+                coordination: dragCoordination,
+                componentIdx,
+                callAction,
+                fixedRef: fixed,
+                shouldDispatchFocusOnDown: () => !endpointsFixed.current,
+                actions: {
+                    move: actions.moveLineSegment,
+                    focus: actions.lineSegmentFocused,
+                    click: actions.lineSegmentClicked,
+                },
+                snapshot: () => null,
+                snapshotRef: { current: null } as any,
+                buildTransientMoveArgs: () => {
+                    const coords: [number, number] = [point.X(), point.Y()];
+                    pointCoords.current = coords;
+                    return {
+                        [argKey]: coords,
+                        transient: true,
+                        skippable: true,
+                        sourceDetails: { endpoint: tagN },
+                    };
+                },
+                buildCommitMoveArgs: () => ({
+                    [argKey]: pointCoords.current,
+                }),
+                onDragApplied: () => {
+                    newSegmentJXG.point1.coords.setCoordinates(
+                        JXG.COORDS_BY_USER,
+                        lastPositionsFromCore.current[0],
+                    );
+                    newSegmentJXG.point2.coords.setCoordinates(
+                        JXG.COORDS_BY_USER,
+                        lastPositionsFromCore.current[1],
+                    );
+                    if (board) {
+                        board.updateInfobox(
+                            tagN === 1
+                                ? newSegmentJXG.point1
+                                : newSegmentJXG.point2,
+                        );
+                    }
+                },
+            });
+        }
 
-        newSegmentJXG.on("keydown", function (e) {
-            if (e.key === "Enter") {
-                if (draggedPoint.current === 0) {
-                    callAction({
-                        action: actions.moveLineSegment,
-                        args: {
-                            point1coords: pointCoords.current[0],
-                            point2coords: pointCoords.current[1],
-                        },
-                    });
-                }
-                draggedPoint.current = null;
-                callAction({
-                    action: actions.lineSegmentClicked,
-                    args: { componentIdx },
-                });
-            }
-        });
+        attachEndpointHandlers(newPoint1JXG, 1, "point1coords");
+        attachEndpointHandlers(newPoint2JXG, 2, "point2coords");
 
         cancelInitialLabelPlacement.current?.();
         cancelInitialLabelPlacement.current = null;
@@ -411,107 +332,6 @@ export default React.memo(function LineSegment(props: UseDoenetRendererProps) {
         previousWithLabel.current = SVs.labelForGraph !== "";
 
         return lineSegmentJXG.current;
-    }
-
-    function onDragHandler(
-        i: number,
-        e: { type: string; x: number; y: number },
-    ) {
-        if (lineSegmentJXG.current === null || board === null) {
-            return;
-        }
-
-        if (exceededDragThreshold(e, pointerAtDown.current)) {
-            draggedPoint.current = i;
-
-            if (i == 1) {
-                pointCoords.current = [
-                    lineSegmentJXG.current.point1.X(),
-                    lineSegmentJXG.current.point1.Y(),
-                ];
-                callAction({
-                    action: actions.moveLineSegment,
-                    args: {
-                        point1coords: pointCoords.current,
-                        transient: true,
-                        skippable: true,
-                        sourceDetails: { endpoint: i },
-                    },
-                });
-            } else if (i == 2) {
-                pointCoords.current = [
-                    lineSegmentJXG.current.point2.X(),
-                    lineSegmentJXG.current.point2.Y(),
-                ];
-                callAction({
-                    action: actions.moveLineSegment,
-                    args: {
-                        point2coords: pointCoords.current,
-                        transient: true,
-                        skippable: true,
-                        sourceDetails: { endpoint: i },
-                    },
-                });
-            } else {
-                pointCoords.current = [];
-
-                if (
-                    e.type === "pointermove" &&
-                    pointerAtDown.current &&
-                    pointsAtDown.current
-                ) {
-                    // Compute from pointer delta rather than .X()/.Y() directly
-                    // so points don't snap back to attractors on slow drags.
-                    for (let j = 0; j < 2; j++) {
-                        pointCoords.current.push(
-                            pointerEventToUserCoords(
-                                e,
-                                pointerAtDown.current,
-                                pointsAtDown.current[j] as [
-                                    number,
-                                    number,
-                                    number,
-                                ],
-                                board,
-                            ),
-                        );
-                    }
-                } else {
-                    pointCoords.current.push([
-                        lineSegmentJXG.current.point1.X(),
-                        lineSegmentJXG.current.point1.Y(),
-                    ]);
-                    pointCoords.current.push([
-                        lineSegmentJXG.current.point2.X(),
-                        lineSegmentJXG.current.point2.Y(),
-                    ]);
-                }
-
-                callAction({
-                    action: actions.moveLineSegment,
-                    args: {
-                        point1coords: pointCoords.current[0],
-                        point2coords: pointCoords.current[1],
-                        transient: true,
-                        skippable: true,
-                    },
-                });
-            }
-        }
-
-        lineSegmentJXG.current.point1.coords.setCoordinates(
-            JXG.COORDS_BY_USER,
-            lastPositionsFromCore.current[0],
-        );
-        lineSegmentJXG.current.point2.coords.setCoordinates(
-            JXG.COORDS_BY_USER,
-            lastPositionsFromCore.current[1],
-        );
-        if (i == 1) {
-            board.updateInfobox(lineSegmentJXG.current.point1);
-        } else if (i == 2) {
-            board.updateInfobox(lineSegmentJXG.current.point2);
-        }
     }
 
     function deleteLineSegmentJXG() {

--- a/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
+++ b/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
@@ -50,7 +50,6 @@ export default React.memo(function LineSegment(props: UseDoenetRendererProps) {
     let point2JXG = useRef<JXGPoint | null>(null);
 
     const dragState = usePointerDragState();
-    let pointsAtDown = useRef<[number[], number[]] | null>(null);
     let previousWithLabel = useRef<boolean | null>(null);
     let cancelInitialLabelPlacement = useRef<(() => void) | null>(null);
     let pointCoords = useRef<any>(null);
@@ -193,7 +192,6 @@ export default React.memo(function LineSegment(props: UseDoenetRendererProps) {
                     [...point1JXG.current!.coords.scrCoords],
                     [...point2JXG.current!.coords.scrCoords],
                 ] as [number[], number[]],
-            snapshotRef: pointsAtDown,
             buildTransientMoveArgs: (e, snap) => {
                 const next: [number, number][] = [];
                 if (
@@ -264,7 +262,6 @@ export default React.memo(function LineSegment(props: UseDoenetRendererProps) {
                     click: actions.lineSegmentClicked,
                 },
                 snapshot: () => null,
-                snapshotRef: { current: null } as any,
                 buildTransientMoveArgs: () => {
                     const coords: [number, number] = [point.X(), point.Y()];
                     pointCoords.current = coords;

--- a/packages/doenetml/src/Viewer/renderers/point.tsx
+++ b/packages/doenetml/src/Viewer/renderers/point.tsx
@@ -55,7 +55,6 @@ export default React.memo(function Point(props: UseDoenetRendererProps) {
     let shadowPointJXG = useRef<JXGPoint | null>(null);
 
     const dragState = usePointerDragState();
-    let pointAtDown = useRef<[number, number, number] | null>(null);
     let previousWithLabel = useRef<boolean | null>(null);
     let previousLabelPosition = useRef<LabelPosition | null>(null);
     let calculatedX = useRef<number | null>(null);
@@ -235,7 +234,6 @@ export default React.memo(function Point(props: UseDoenetRendererProps) {
                         number,
                     ]),
                 ] as [number, number, number],
-            snapshotRef: pointAtDown,
             dispatchTransientBelowThreshold: true,
             buildTransientMoveArgs: (e, snap) => {
                 let viaPointer = e.type === "pointermove";

--- a/packages/doenetml/src/Viewer/renderers/point.tsx
+++ b/packages/doenetml/src/Viewer/renderers/point.tsx
@@ -19,7 +19,6 @@ import { ChoiceInputInlineContext } from "./choiceInput";
 import { DraggableGraphicalSVs } from "./utils/graphicalSVs";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
-import { exceededDragThreshold } from "./utils/dragThreshold";
 import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
 import { resolveMarkerColor } from "./utils/styleColors";
 import {
@@ -28,6 +27,10 @@ import {
     syncLayer,
     syncWithLabelToggle,
 } from "./utils/jsxgraph";
+import {
+    DragCoordinationState,
+    attachLineFamilyDragHandlers,
+} from "./utils/lineFamilyDragHandlers";
 
 interface PointSVs extends DraggableGraphicalSVs {
     numericalXs: [number, number];
@@ -52,13 +55,16 @@ export default React.memo(function Point(props: UseDoenetRendererProps) {
     let shadowPointJXG = useRef<JXGPoint | null>(null);
 
     const dragState = usePointerDragState();
-    const { pointerAtDown, pointerIsDown, pointerMovedSinceDown, dragged } =
-        dragState;
     let pointAtDown = useRef<[number, number, number] | null>(null);
     let previousWithLabel = useRef<boolean | null>(null);
     let previousLabelPosition = useRef<LabelPosition | null>(null);
     let calculatedX = useRef<number | null>(null);
     let calculatedY = useRef<number | null>(null);
+
+    const dragCoordination: DragCoordinationState<number> = {
+        draggedTag: useRef<number | null>(null),
+        downOnTag: useRef<number | null>(null),
+    };
 
     let lastPositionFromCore = useRef<[number, number] | null>(null);
 
@@ -206,105 +212,33 @@ export default React.memo(function Point(props: UseDoenetRendererProps) {
             jsxPointAttributes,
         );
 
-        newShadowPointJXG.on("down", function (e: { x: number; y: number }) {
-            (document.activeElement as HTMLElement | null)?.blur();
-
-            pointerAtDown.current = [e.x, e.y];
-            pointAtDown.current = [
-                ...(newShadowPointJXG.coords.scrCoords as [
-                    number,
-                    number,
-                    number,
-                ]),
-            ];
-            dragged.current = false;
-            if (shadowPointJXG.current != null && pointJXG.current != null) {
-                shadowPointJXG.current.visProp.highlightfillopacity =
-                    pointJXG.current.visProp.fillopacity;
-                shadowPointJXG.current.visProp.highlightstrokeopacity =
-                    pointJXG.current.visProp.strokeopacity;
-            }
-            pointerIsDown.current = true;
-            pointerMovedSinceDown.current = false;
-
-            if (!fixed.current) {
-                callAction({
-                    action: actions.pointFocused,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                });
-            }
-        });
-
-        newShadowPointJXG.on("hit", function (e: unknown) {
-            dragged.current = false;
-            callAction({
-                action: actions.pointFocused,
-                args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-            });
-        });
-
-        newShadowPointJXG.on("up", function (e: unknown) {
-            if (dragged.current) {
-                callAction({
-                    action: actions.movePoint,
-                    args: {
-                        x: calculatedX.current,
-                        y: calculatedY.current,
-                    },
-                });
-                dragged.current = false;
-            } else if (!pointerMovedSinceDown.current && !fixed.current) {
-                if (switchable.current) {
-                    callAction({
-                        action: actions.switchPoint,
-                    });
-                    callAction({
-                        action: actions.pointClicked,
-                        args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                    });
-                } else {
-                    callAction({
-                        action: actions.pointClicked,
-                        args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                    });
-                }
-            }
-            pointerIsDown.current = false;
-
-            if (shadowPointJXG.current != null && pointJXG.current != null) {
-                shadowPointJXG.current.visProp.highlightfillopacity = 0;
-                shadowPointJXG.current.visProp.highlightstrokeopacity = 0;
-            }
-        });
-
-        newShadowPointJXG.on("hit", function (e: unknown) {
-            board.updateInfobox(pointJXG.current);
-        });
-
-        newShadowPointJXG.on("keyfocusout", function (e: unknown) {
-            if (dragged.current) {
-                callAction({
-                    action: actions.movePoint,
-                    args: {
-                        x: calculatedX.current,
-                        y: calculatedY.current,
-                    },
-                });
-                dragged.current = false;
-            }
-        });
-
-        newShadowPointJXG.on(
-            "drag",
-            function (e: { type: string; x: number; y: number }) {
+        attachLineFamilyDragHandlers({
+            jxg: newShadowPointJXG,
+            tag: 0,
+            dragState,
+            coordination: dragCoordination,
+            componentIdx,
+            callAction,
+            fixedRef: fixed,
+            actions: {
+                move: actions.movePoint,
+                focus: actions.pointFocused,
+                click: actions.pointClicked,
+                clickPrelude: actions.switchPoint,
+            },
+            clickPreludeGate: switchable,
+            snapshot: () =>
+                [
+                    ...(newShadowPointJXG.coords.scrCoords as [
+                        number,
+                        number,
+                        number,
+                    ]),
+                ] as [number, number, number],
+            snapshotRef: pointAtDown,
+            dispatchTransientBelowThreshold: true,
+            buildTransientMoveArgs: (e, snap) => {
                 let viaPointer = e.type === "pointermove";
-
-                if (
-                    pointAtDown.current != null &&
-                    exceededDragThreshold(e, pointerAtDown.current)
-                ) {
-                    dragged.current = true;
-                }
 
                 let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
 
@@ -328,11 +262,7 @@ export default React.memo(function Point(props: UseDoenetRendererProps) {
                 ymaxAdjusted -= yscale * 0.01;
                 yminAdjusted += yscale * 0.01;
 
-                if (
-                    viaPointer &&
-                    pointAtDown.current &&
-                    pointerAtDown.current
-                ) {
+                if (viaPointer && snap && dragState.pointerAtDown.current) {
                     // Compute from pointer delta rather than .X()/.Y() directly:
                     // .X()/.Y() are affected by setCoordinates calls in update(),
                     // so attractor/constraint dependencies can shift them on
@@ -341,8 +271,8 @@ export default React.memo(function Point(props: UseDoenetRendererProps) {
                     [calculatedX.current, calculatedY.current] =
                         pointerEventToUserCoords(
                             e,
-                            pointerAtDown.current,
-                            pointAtDown.current,
+                            dragState.pointerAtDown.current,
+                            snap,
                             board,
                         );
                 } else {
@@ -359,16 +289,6 @@ export default React.memo(function Point(props: UseDoenetRendererProps) {
                     Math.max(yminAdjusted, calculatedY.current || 0),
                 );
 
-                callAction({
-                    action: actions.movePoint,
-                    args: {
-                        x: calculatedX.current,
-                        y: calculatedY.current,
-                        transient: true,
-                        skippable: true,
-                    },
-                });
-
                 let shadowX = Math.min(
                     xmaxAdjusted,
                     Math.max(xminAdjusted, newShadowPointJXG.X()),
@@ -382,42 +302,47 @@ export default React.memo(function Point(props: UseDoenetRendererProps) {
                     shadowY,
                 ]);
 
+                return {
+                    x: calculatedX.current,
+                    y: calculatedY.current,
+                    transient: true,
+                    skippable: true,
+                };
+            },
+            buildCommitMoveArgs: () => ({
+                x: calculatedX.current,
+                y: calculatedY.current,
+            }),
+            onDragApplied: () => {
                 newPointJXG.coords.setCoordinates(
                     JXG.COORDS_BY_USER,
                     lastPositionFromCore.current,
                 );
                 board.updateInfobox(newPointJXG);
             },
-        );
-
-        newShadowPointJXG.on("keydown", function (e) {
-            if (e.key === "Enter") {
-                if (dragged.current) {
-                    callAction({
-                        action: actions.movePoint,
-                        args: {
-                            x: calculatedX.current,
-                            y: calculatedY.current,
-                        },
-                    });
-                    dragged.current = false;
+            onDownExtra: () => {
+                if (
+                    shadowPointJXG.current != null &&
+                    pointJXG.current != null
+                ) {
+                    shadowPointJXG.current.visProp.highlightfillopacity =
+                        pointJXG.current.visProp.fillopacity;
+                    shadowPointJXG.current.visProp.highlightstrokeopacity =
+                        pointJXG.current.visProp.strokeopacity;
                 }
-
-                if (switchable.current) {
-                    callAction({
-                        action: actions.switchPoint,
-                    });
-                    callAction({
-                        action: actions.pointClicked,
-                        args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                    });
-                } else {
-                    callAction({
-                        action: actions.pointClicked,
-                        args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                    });
+            },
+            onUpExtra: () => {
+                if (
+                    shadowPointJXG.current != null &&
+                    pointJXG.current != null
+                ) {
+                    shadowPointJXG.current.visProp.highlightfillopacity = 0;
+                    shadowPointJXG.current.visProp.highlightstrokeopacity = 0;
                 }
-            }
+            },
+            onHitExtra: () => {
+                board.updateInfobox(pointJXG.current!);
+            },
         });
 
         pointJXG.current = newPointJXG;
@@ -511,7 +436,7 @@ export default React.memo(function Point(props: UseDoenetRendererProps) {
             let y = lastPositionFromCore.current?.[1];
 
             pointJXG.current.coords.setCoordinates(JXG.COORDS_BY_USER, [x, y]);
-            if (!dragged.current) {
+            if (dragCoordination.draggedTag.current === null) {
                 shadowPointJXG.current?.coords.setCoordinates(
                     JXG.COORDS_BY_USER,
                     [x, y],

--- a/packages/doenetml/src/Viewer/renderers/polygon.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polygon.tsx
@@ -8,12 +8,15 @@ import { JXGPolygon, JXGPoint } from "./jsxgraph-distrib/types";
 import { DraggableGraphicalSVs } from "./utils/graphicalSVs";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
-import { exceededDragThreshold } from "./utils/dragThreshold";
 import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
 import { resolveLineColor, resolveFillColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
+import {
+    DragCoordinationState,
+    attachLineFamilyDragHandlers,
+} from "./utils/lineFamilyDragHandlers";
 import {
     removeJXGEventHandlers,
     syncLabelStrokeColor,
@@ -44,13 +47,16 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
     let pointsJXG = useRef<JXGPoint[]>([]);
 
     let pointCoords = useRef<any>(null);
-    let draggedPoint = useRef<number | null>(null);
-    let downOnPoint = useRef<number | null>(null);
     const dragState = usePointerDragState();
-    const { pointerAtDown, pointerIsDown, pointerMovedSinceDown } = dragState;
     let pointsAtDown = useRef<number[][] | null>(null);
     let previousNumVertices = useRef<number | null>(null);
     let jsxPointAttributes = useRef<Record<string, any> | null>(null);
+
+    // Tag layout: -1 = polygon body; 0..N-1 = vertex at that index.
+    const dragCoordination: DragCoordinationState<number> = {
+        draggedTag: useRef<number | null>(null),
+        downOnTag: useRef<number | null>(null),
+    };
 
     const {
         lastPositionFromCore: lastPositionsFromCore,
@@ -169,13 +175,7 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
 
         initializePoints(newPolygonJXG);
 
-        newPolygonJXG.on("drag", (e) => dragHandler(-1, e));
-        newPolygonJXG.on("up", () => upHandler(-1));
-        newPolygonJXG.on("keyfocusout", () => keyFocusOutHandler(-1));
-        newPolygonJXG.on("keydown", (e) => keyDownHandler(-1, e));
-
-        newPolygonJXG.on("down", (e) => downHandler(-1, e));
-        newPolygonJXG.on("hit", () => hitHandler());
+        attachPolygonBodyDragHandlers(newPolygonJXG);
 
         newPolygonJXG.on("over", () => {
             highlightVertices();
@@ -195,13 +195,150 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
         for (let i = 0; i < SVs.numVertices; i++) {
             let vertex = polygon.vertices[i];
             removeJXGEventHandlers(vertex);
-            vertex.on("drag", (e) => dragHandler(i, e));
-            vertex.on("up", () => upHandler(i));
-            vertex.on("keyfocusout", () => keyFocusOutHandler(i));
-            vertex.on("keydown", (e) => keyDownHandler(i, e));
-            vertex.on("down", (e) => downHandler(i, e));
-            vertex.on("hit", () => hitHandler());
+            attachPolygonVertexDragHandlers(vertex, i);
         }
+    }
+
+    function attachPolygonBodyDragHandlers(polygon: JXGPolygon) {
+        attachLineFamilyDragHandlers({
+            jxg: polygon,
+            tag: -1,
+            dragState,
+            coordination: dragCoordination,
+            componentIdx,
+            callAction,
+            fixedRef: fixed,
+            participatesInDownTag: false,
+            suppressClickWhenDownOnOtherTag: true,
+            suppressFocusOnDownWhenDownOnOtherTag: true,
+            actions: {
+                move: actions.movePolygon,
+                focus: actions.polygonFocused,
+                click: actions.polygonClicked,
+            },
+            snapshot: () =>
+                polygon.vertices.map(
+                    (x) => [...x.coords.scrCoords] as number[],
+                ),
+            snapshotRef: pointsAtDown,
+            buildTransientMoveArgs: (e, snap) => {
+                if (!polygonJXG.current || !board) {
+                    return null;
+                }
+                const next: [number, number][] = [];
+                if (
+                    e.type === "pointermove" &&
+                    dragState.pointerAtDown.current &&
+                    snap
+                ) {
+                    // Compute from pointer delta rather than .X()/.Y() directly
+                    // so points don't snap back to attractors on slow drags.
+                    for (let j = 0; j < polygon.vertices.length - 1; j++) {
+                        next.push(
+                            pointerEventToUserCoords(
+                                e,
+                                dragState.pointerAtDown.current,
+                                snap[j] as [number, number, number],
+                                board,
+                            ),
+                        );
+                    }
+                } else {
+                    for (let j = 0; j < polygon.vertices.length - 1; j++) {
+                        const v = polygon.vertices[j];
+                        next.push([v.X(), v.Y()]);
+                    }
+                }
+                pointCoords.current = next;
+                return {
+                    pointCoords: next,
+                    transient: true,
+                    skippable: true,
+                };
+            },
+            buildCommitMoveArgs: () =>
+                pointCoords.current
+                    ? { pointCoords: pointCoords.current }
+                    : null,
+            onDragApplied: () => {
+                if (
+                    !polygonJXG.current ||
+                    dragCoordination.draggedTag.current !== -1
+                ) {
+                    return;
+                }
+                for (let j = 0; j < SVs.numVertices; j++) {
+                    polygon.vertices[j].coords.setCoordinates(
+                        JXG.COORDS_BY_USER,
+                        [...lastPositionsFromCore.current[j]],
+                    );
+                }
+            },
+            onHitExtra: () => highlightVertices(),
+            onKeyFocusOutExtra: () => unHighlightVertices(),
+        });
+    }
+
+    function attachPolygonVertexDragHandlers(vertex: JXGPoint, i: number) {
+        attachLineFamilyDragHandlers({
+            jxg: vertex,
+            tag: i,
+            dragState,
+            coordination: dragCoordination,
+            componentIdx,
+            callAction,
+            fixedRef: fixed,
+            shouldDispatchFocusOnDown: () => !verticesFixed.current,
+            actions: {
+                move: actions.movePolygon,
+                focus: actions.polygonFocused,
+                click: actions.polygonClicked,
+            },
+            snapshot: () => null,
+            snapshotRef: { current: null } as any,
+            buildTransientMoveArgs: () => {
+                const map: Record<number, [number, number]> = {};
+                map[i] = [vertex.X(), vertex.Y()];
+                pointCoords.current = map;
+                return {
+                    pointCoords: map,
+                    transient: true,
+                    skippable: true,
+                    sourceDetails: { vertex: i },
+                };
+            },
+            buildCommitMoveArgs: (_, variant) => {
+                if (!pointCoords.current) {
+                    return null;
+                }
+                if (variant === "up") {
+                    return {
+                        pointCoords: pointCoords.current,
+                        sourceDetails: { vertex: i },
+                    };
+                }
+                return {
+                    pointCoords: pointCoords.current,
+                    sourceInformation: { vertex: i },
+                };
+            },
+            onDragApplied: () => {
+                if (
+                    !polygonJXG.current ||
+                    !board ||
+                    dragCoordination.draggedTag.current !== i
+                ) {
+                    return;
+                }
+                polygonJXG.current.vertices[i].coords.setCoordinates(
+                    JXG.COORDS_BY_USER,
+                    [...lastPositionsFromCore.current[i]],
+                );
+                board.updateInfobox(polygonJXG.current.vertices[i]);
+            },
+            onHitExtra: () => highlightVertices(),
+            onKeyFocusOutExtra: () => unHighlightVertices(),
+        });
     }
 
     function deletePolygonJXG() {
@@ -228,219 +365,6 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
             board?.removeObject(pt);
         }
         pointsJXG.current = [];
-    }
-
-    function dragHandler(i: number, e: { type: string; x: number; y: number }) {
-        if (!polygonJXG.current || board === null) {
-            return;
-        }
-        if (exceededDragThreshold(e, pointerAtDown.current)) {
-            draggedPoint.current = i;
-
-            if (i === -1) {
-                pointCoords.current = [];
-
-                if (
-                    e.type === "pointermove" &&
-                    pointerAtDown.current &&
-                    pointsAtDown.current
-                ) {
-                    // Compute from pointer delta rather than .X()/.Y() directly
-                    // so points don't snap back to attractors on slow drags.
-                    for (
-                        let j = 0;
-                        j < polygonJXG.current.vertices.length - 1;
-                        j++
-                    ) {
-                        pointCoords.current.push(
-                            pointerEventToUserCoords(
-                                e,
-                                pointerAtDown.current,
-                                pointsAtDown.current[j] as [
-                                    number,
-                                    number,
-                                    number,
-                                ],
-                                board,
-                            ),
-                        );
-                    }
-                } else {
-                    for (
-                        let j = 0;
-                        j < polygonJXG.current.vertices.length - 1;
-                        j++
-                    ) {
-                        let vertex = polygonJXG.current.vertices[j];
-                        pointCoords.current.push([vertex.X(), vertex.Y()]);
-                    }
-                }
-
-                callAction({
-                    action: actions.movePolygon,
-                    args: {
-                        pointCoords: pointCoords.current,
-                        transient: true,
-                        skippable: true,
-                    },
-                });
-
-                for (let j = 0; j < SVs.numVertices; j++) {
-                    polygonJXG.current.vertices[j].coords.setCoordinates(
-                        JXG.COORDS_BY_USER,
-                        [...lastPositionsFromCore.current[j]],
-                    );
-                }
-            } else {
-                pointCoords.current = {};
-                pointCoords.current[i] = [
-                    polygonJXG.current.vertices[i].X(),
-                    polygonJXG.current.vertices[i].Y(),
-                ];
-                callAction({
-                    action: actions.movePolygon,
-                    args: {
-                        pointCoords: pointCoords.current,
-                        transient: true,
-                        skippable: true,
-                        sourceDetails: { vertex: i },
-                    },
-                });
-                polygonJXG.current.vertices[i].coords.setCoordinates(
-                    JXG.COORDS_BY_USER,
-                    [...lastPositionsFromCore.current[i]],
-                );
-                board.updateInfobox(polygonJXG.current.vertices[i]);
-            }
-        }
-    }
-
-    function downHandler(i: number, e: { x: number; y: number; type: string }) {
-        (document.activeElement as HTMLElement | null)?.blur();
-
-        draggedPoint.current = null;
-        pointerAtDown.current = [e.x, e.y];
-
-        if (i === -1) {
-            if (downOnPoint.current === null && !fixed.current) {
-                // Note: counting on fact that down on polygon itself will trigger after down on points
-                callAction({
-                    action: actions.polygonFocused,
-                    args: { componentIdx },
-                });
-            }
-            pointsAtDown.current = polygonJXG.current!.vertices.map(
-                (x) => [...x.coords.scrCoords] as number[],
-            );
-        } else {
-            if (!verticesFixed.current) {
-                callAction({
-                    action: actions.polygonFocused,
-                    args: { componentIdx },
-                });
-            }
-            downOnPoint.current = i;
-        }
-
-        pointerIsDown.current = true;
-        pointerMovedSinceDown.current = false;
-    }
-
-    function hitHandler() {
-        highlightVertices();
-        draggedPoint.current = null;
-        callAction({
-            action: actions.polygonFocused,
-            args: { componentIdx },
-        });
-    }
-
-    function upHandler(i: number) {
-        if (draggedPoint.current === i) {
-            if (i === -1) {
-                callAction({
-                    action: actions.movePolygon,
-                    args: {
-                        pointCoords: pointCoords.current,
-                    },
-                });
-            } else {
-                callAction({
-                    action: actions.movePolygon,
-                    args: {
-                        pointCoords: pointCoords.current,
-                        sourceDetails: { vertex: i },
-                    },
-                });
-            }
-        } else if (
-            !pointerMovedSinceDown.current &&
-            (downOnPoint.current === null || i !== -1) &&
-            !fixed.current
-        ) {
-            // Note: counting on fact that up on polygon itself (i===-1) will trigger before up on points
-            callAction({
-                action: actions.polygonClicked,
-                args: { componentIdx },
-            });
-        }
-
-        if (i !== -1) {
-            downOnPoint.current = null;
-        }
-
-        pointerIsDown.current = false;
-    }
-
-    function keyFocusOutHandler(i: number) {
-        unHighlightVertices();
-        if (draggedPoint.current === i) {
-            if (i === -1) {
-                callAction({
-                    action: actions.movePolygon,
-                    args: {
-                        pointCoords: pointCoords.current,
-                    },
-                });
-            } else {
-                callAction({
-                    action: actions.movePolygon,
-                    args: {
-                        pointCoords: pointCoords.current,
-                        sourceInformation: { vertex: i },
-                    },
-                });
-            }
-        }
-        draggedPoint.current = null;
-    }
-
-    function keyDownHandler(i: number, e: { key: string }) {
-        if (e.key === "Enter") {
-            if (draggedPoint.current === i) {
-                if (i === -1) {
-                    callAction({
-                        action: actions.movePolygon,
-                        args: {
-                            pointCoords: pointCoords.current,
-                        },
-                    });
-                } else {
-                    callAction({
-                        action: actions.movePolygon,
-                        args: {
-                            pointCoords: pointCoords.current,
-                            sourceInformation: { vertex: i },
-                        },
-                    });
-                }
-            }
-            draggedPoint.current = null;
-            callAction({
-                action: actions.polygonClicked,
-                args: { componentIdx },
-            });
-        }
     }
 
     function highlightVertices() {

--- a/packages/doenetml/src/Viewer/renderers/polygon.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polygon.tsx
@@ -48,7 +48,6 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
 
     let pointCoords = useRef<any>(null);
     const dragState = usePointerDragState();
-    let pointsAtDown = useRef<number[][] | null>(null);
     let previousNumVertices = useRef<number | null>(null);
     let jsxPointAttributes = useRef<Record<string, any> | null>(null);
 
@@ -220,7 +219,6 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
                 polygon.vertices.map(
                     (x) => [...x.coords.scrCoords] as number[],
                 ),
-            snapshotRef: pointsAtDown,
             buildTransientMoveArgs: (e, snap) => {
                 if (!polygonJXG.current || !board) {
                     return null;
@@ -295,7 +293,6 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
                 click: actions.polygonClicked,
             },
             snapshot: () => null,
-            snapshotRef: { current: null } as any,
             buildTransientMoveArgs: () => {
                 const map: Record<number, [number, number]> = {};
                 map[i] = [vertex.X(), vertex.Y()];
@@ -348,16 +345,10 @@ export default React.memo(function Polygon(props: UseDoenetRendererProps) {
         for (let i = 0; i < SVs.numVertices; i++) {
             let vertex = polygonJXG.current.vertices[i];
             if (vertex) {
-                vertex.off("drag");
-                vertex.off("up");
-                vertex.off("down");
-                vertex.off("hit");
+                removeJXGEventHandlers(vertex);
             }
         }
-        polygonJXG.current.off("drag");
-        polygonJXG.current.off("up");
-        polygonJXG.current.off("down");
-        polygonJXG.current.off("hit");
+        removeJXGEventHandlers(polygonJXG.current);
         board?.removeObject(polygonJXG.current);
         polygonJXG.current = null;
 

--- a/packages/doenetml/src/Viewer/renderers/polyline.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polyline.tsx
@@ -47,7 +47,6 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
 
     let pointCoords = useRef<any>(null);
     const dragState = usePointerDragState();
-    let pointsAtDown = useRef<number[][] | null>(null);
     let previousNumVertices = useRef<number | null>(null);
     let jsxPointAttributes = useRef<Record<string, any> | null>(null);
 
@@ -208,7 +207,6 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
             },
             snapshot: () =>
                 polyline.points!.map((x) => [...x.scrCoords] as number[]),
-            snapshotRef: pointsAtDown,
             buildTransientMoveArgs: (e, snap) => {
                 if (!polylineJXG.current || !board) {
                     return null;
@@ -298,7 +296,6 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
                 click: actions.polylineClicked,
             },
             snapshot: () => null,
-            snapshotRef: { current: null } as any,
             buildTransientMoveArgs: () => {
                 const map: Record<number, [number, number]> = {};
                 map[i] = [vertex.X(), vertex.Y()];

--- a/packages/doenetml/src/Viewer/renderers/polyline.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polyline.tsx
@@ -8,12 +8,15 @@ import { JXGCurve, JXGPoint } from "./jsxgraph-distrib/types";
 import { DraggableGraphicalSVs } from "./utils/graphicalSVs";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
-import { exceededDragThreshold } from "./utils/dragThreshold";
 import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
 import { resolveLineColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
+import {
+    DragCoordinationState,
+    attachLineFamilyDragHandlers,
+} from "./utils/lineFamilyDragHandlers";
 import {
     removeJXGEventHandlers,
     syncLabelStrokeColor,
@@ -43,13 +46,16 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
     let pointsJXG = useRef<JXGPoint[] | null>(null);
 
     let pointCoords = useRef<any>(null);
-    let draggedPoint = useRef<number | null>(null);
-    let downOnPoint = useRef<number | null>(null);
     const dragState = usePointerDragState();
-    const { pointerAtDown, pointerIsDown, pointerMovedSinceDown } = dragState;
     let pointsAtDown = useRef<number[][] | null>(null);
     let previousNumVertices = useRef<number | null>(null);
     let jsxPointAttributes = useRef<Record<string, any> | null>(null);
+
+    // Tag layout: -1 = polyline body; 0..N-1 = vertex at that index.
+    const dragCoordination: DragCoordinationState<number> = {
+        draggedTag: useRef<number | null>(null),
+        downOnTag: useRef<number | null>(null),
+    };
 
     const {
         lastPositionFromCore: lastPositionsFromCore,
@@ -167,20 +173,10 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
         newPolylineJXG.isDraggable = !fixLocation.current;
 
         for (let i = 0; i < SVs.numVertices; i++) {
-            pointsJXG.current[i].on("drag", (e) => dragHandler(i, e));
-            pointsJXG.current[i].on("up", () => upHandler(i));
-            pointsJXG.current[i].on("keyfocusout", () => keyFocusOutHandler(i));
-            pointsJXG.current[i].on("keydown", (e) => keyDownHandler(i, e));
-            pointsJXG.current[i].on("down", (e) => downHandler(i, e));
-            pointsJXG.current[i].on("hit", () => hitHandler());
+            attachVertexDragHandlers(pointsJXG.current[i], i);
         }
 
-        newPolylineJXG.on("drag", (e) => dragHandler(-1, e));
-        newPolylineJXG.on("up", () => upHandler(-1));
-        newPolylineJXG.on("keyfocusout", () => keyFocusOutHandler(-1));
-        newPolylineJXG.on("keydown", (e) => keyDownHandler(-1, e));
-        newPolylineJXG.on("down", (e) => downHandler(-1, e));
-        newPolylineJXG.on("hit", () => hitHandler());
+        attachPolylineBodyDragHandlers(newPolylineJXG);
         newPolylineJXG.on("over", () => {
             highlightVertices();
         });
@@ -191,6 +187,162 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
         previousNumVertices.current = SVs.numVertices;
 
         return newPolylineJXG;
+    }
+
+    function attachPolylineBodyDragHandlers(polyline: JXGCurve) {
+        attachLineFamilyDragHandlers({
+            jxg: polyline,
+            tag: -1,
+            dragState,
+            coordination: dragCoordination,
+            componentIdx,
+            callAction,
+            fixedRef: fixed,
+            participatesInDownTag: false,
+            suppressClickWhenDownOnOtherTag: true,
+            suppressFocusOnDownWhenDownOnOtherTag: true,
+            actions: {
+                move: actions.movePolyline,
+                focus: actions.polylineFocused,
+                click: actions.polylineClicked,
+            },
+            snapshot: () =>
+                polyline.points!.map((x) => [...x.scrCoords] as number[]),
+            snapshotRef: pointsAtDown,
+            buildTransientMoveArgs: (e, snap) => {
+                if (!polylineJXG.current || !board) {
+                    return null;
+                }
+                polyline.updateTransformMatrix?.();
+                let shiftX = polyline.transformMat![1][0];
+                let shiftY = polyline.transformMat![2][0];
+                const next: [number, number][] = [];
+                if (
+                    e.type === "pointermove" &&
+                    dragState.pointerAtDown.current &&
+                    snap
+                ) {
+                    // Compute from pointer delta rather than .X()/.Y() directly
+                    // so points don't snap back to attractors on slow drags.
+                    for (let j = 0; j < polyline.points!.length; j++) {
+                        next.push(
+                            pointerEventToUserCoords(
+                                e,
+                                dragState.pointerAtDown.current,
+                                snap[j] as [number, number, number],
+                                board,
+                            ),
+                        );
+                    }
+                } else {
+                    for (let j = 0; j < polyline.points!.length; j++) {
+                        next.push([
+                            polyline.dataX[j] + shiftX,
+                            polyline.dataY[j] + shiftY,
+                        ]);
+                    }
+                }
+                pointCoords.current = next;
+                return {
+                    pointCoords: next,
+                    transient: true,
+                    skippable: true,
+                };
+            },
+            buildCommitMoveArgs: () =>
+                pointCoords.current
+                    ? { pointCoords: pointCoords.current }
+                    : null,
+            onDragApplied: () => {
+                // Polyline keeps the reset gated on threshold (matches the
+                // pre-helper behavior — sub-threshold drags are left alone
+                // because the transformMat shift hasn't been refreshed).
+                if (
+                    !polylineJXG.current ||
+                    !pointsJXG.current ||
+                    dragCoordination.draggedTag.current !== -1
+                ) {
+                    return;
+                }
+                let shiftX = polyline.transformMat![1][0];
+                let shiftY = polyline.transformMat![2][0];
+                for (let j = 0; j < SVs.numVertices; j++) {
+                    pointsJXG.current[j].coords.setCoordinates(
+                        JXG.COORDS_BY_USER,
+                        [...lastPositionsFromCore.current[j]],
+                    );
+                    polyline.dataX[j] =
+                        lastPositionsFromCore.current[j][0] - shiftX;
+                    polyline.dataY[j] =
+                        lastPositionsFromCore.current[j][1] - shiftY;
+                }
+            },
+            onHitExtra: () => highlightVertices(),
+            onKeyFocusOutExtra: () => unHighlightVertices(),
+        });
+    }
+
+    function attachVertexDragHandlers(vertex: JXGPoint, i: number) {
+        attachLineFamilyDragHandlers({
+            jxg: vertex,
+            tag: i,
+            dragState,
+            coordination: dragCoordination,
+            componentIdx,
+            callAction,
+            fixedRef: fixed,
+            shouldDispatchFocusOnDown: () => !verticesFixed.current,
+            actions: {
+                move: actions.movePolyline,
+                focus: actions.polylineFocused,
+                click: actions.polylineClicked,
+            },
+            snapshot: () => null,
+            snapshotRef: { current: null } as any,
+            buildTransientMoveArgs: () => {
+                const map: Record<number, [number, number]> = {};
+                map[i] = [vertex.X(), vertex.Y()];
+                pointCoords.current = map;
+                return {
+                    pointCoords: map,
+                    transient: true,
+                    skippable: true,
+                    sourceDetails: { vertex: i },
+                };
+            },
+            buildCommitMoveArgs: (_, variant) => {
+                if (!pointCoords.current) {
+                    return null;
+                }
+                if (variant === "up") {
+                    return {
+                        pointCoords: pointCoords.current,
+                        sourceDetails: { vertex: i },
+                    };
+                }
+                // keyfocusout / keyEnter use sourceInformation, matching
+                // the pre-helper polyline behavior.
+                return {
+                    pointCoords: pointCoords.current,
+                    sourceInformation: { vertex: i },
+                };
+            },
+            onDragApplied: () => {
+                if (
+                    !pointsJXG.current ||
+                    !board ||
+                    dragCoordination.draggedTag.current !== i
+                ) {
+                    return;
+                }
+                pointsJXG.current[i].coords.setCoordinates(JXG.COORDS_BY_USER, [
+                    ...lastPositionsFromCore.current[i],
+                ]);
+                board.updateInfobox(pointsJXG.current[i]);
+            },
+            onHitExtra: () => highlightVertices(),
+            onKeyFocusOutExtra: () => unHighlightVertices(),
+        });
     }
 
     function deletePolylineJXG() {
@@ -211,228 +363,6 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
             }
         }
         pointsJXG.current = null;
-    }
-
-    function dragHandler(i: number, e: { type: string; x: number; y: number }) {
-        if (!polylineJXG.current || !pointsJXG.current || board === null) {
-            return;
-        }
-        if (exceededDragThreshold(e, pointerAtDown.current)) {
-            draggedPoint.current = i;
-
-            if (i === -1) {
-                polylineJXG.current.updateTransformMatrix?.();
-                let shiftX = polylineJXG.current.transformMat![1][0];
-                let shiftY = polylineJXG.current.transformMat![2][0];
-
-                pointCoords.current = [];
-
-                if (
-                    e.type === "pointermove" &&
-                    pointerAtDown.current &&
-                    pointsAtDown.current
-                ) {
-                    // Compute from pointer delta rather than .X()/.Y() directly
-                    // so points don't snap back to attractors on slow drags.
-                    for (
-                        let j = 0;
-                        j < polylineJXG.current.points!.length;
-                        j++
-                    ) {
-                        pointCoords.current.push(
-                            pointerEventToUserCoords(
-                                e,
-                                pointerAtDown.current,
-                                pointsAtDown.current[j] as [
-                                    number,
-                                    number,
-                                    number,
-                                ],
-                                board,
-                            ),
-                        );
-                    }
-                } else {
-                    for (
-                        let j = 0;
-                        j < polylineJXG.current.points!.length;
-                        j++
-                    ) {
-                        pointCoords.current.push([
-                            polylineJXG.current.dataX[j] + shiftX,
-                            polylineJXG.current.dataY[j] + shiftY,
-                        ]);
-                    }
-                }
-
-                callAction({
-                    action: actions.movePolyline,
-                    args: {
-                        pointCoords: pointCoords.current,
-                        transient: true,
-                        skippable: true,
-                    },
-                });
-
-                for (let j = 0; j < SVs.numVertices; j++) {
-                    pointsJXG.current[j].coords.setCoordinates(
-                        JXG.COORDS_BY_USER,
-                        [...lastPositionsFromCore.current[j]],
-                    );
-                    polylineJXG.current.dataX[j] =
-                        lastPositionsFromCore.current[j][0] - shiftX;
-                    polylineJXG.current.dataY[j] =
-                        lastPositionsFromCore.current[j][1] - shiftY;
-                }
-            } else {
-                pointCoords.current = {};
-                pointCoords.current[i] = [
-                    pointsJXG.current[i].X(),
-                    pointsJXG.current[i].Y(),
-                ];
-                callAction({
-                    action: actions.movePolyline,
-                    args: {
-                        pointCoords: pointCoords.current,
-                        transient: true,
-                        skippable: true,
-                        sourceDetails: { vertex: i },
-                    },
-                });
-                pointsJXG.current[i].coords.setCoordinates(JXG.COORDS_BY_USER, [
-                    ...lastPositionsFromCore.current[i],
-                ]);
-                board.updateInfobox(pointsJXG.current[i]);
-            }
-        }
-    }
-
-    function downHandler(i: number, e: { x: number; y: number; type: string }) {
-        (document.activeElement as HTMLElement | null)?.blur();
-
-        draggedPoint.current = null;
-        pointerAtDown.current = [e.x, e.y];
-
-        if (i === -1) {
-            if (downOnPoint.current === null && !fixed.current) {
-                // Note: counting on fact that down on polyline itself will trigger after down on points
-                callAction({
-                    action: actions.polylineFocused,
-                    args: { componentIdx },
-                });
-            }
-            pointsAtDown.current = polylineJXG.current!.points!.map(
-                (x) => [...x.scrCoords] as number[],
-            );
-        } else {
-            if (!verticesFixed.current) {
-                callAction({
-                    action: actions.polylineFocused,
-                    args: { componentIdx },
-                });
-            }
-            downOnPoint.current = i;
-        }
-
-        pointerIsDown.current = true;
-        pointerMovedSinceDown.current = false;
-    }
-
-    function hitHandler() {
-        highlightVertices();
-        draggedPoint.current = null;
-        callAction({
-            action: actions.polylineFocused,
-            args: { componentIdx },
-        });
-    }
-
-    function upHandler(i: number) {
-        if (draggedPoint.current === i) {
-            if (i === -1) {
-                callAction({
-                    action: actions.movePolyline,
-                    args: {
-                        pointCoords: pointCoords.current,
-                    },
-                });
-            } else {
-                callAction({
-                    action: actions.movePolyline,
-                    args: {
-                        pointCoords: pointCoords.current,
-                        sourceDetails: { vertex: i },
-                    },
-                });
-            }
-        } else if (
-            !pointerMovedSinceDown.current &&
-            (downOnPoint.current === null || i !== -1) &&
-            !fixed.current
-        ) {
-            // Note: counting on fact that up on polyline itself (i===-1) will trigger before up on points
-            callAction({
-                action: actions.polylineClicked,
-                args: { componentIdx },
-            });
-        }
-
-        if (i !== -1) {
-            downOnPoint.current = null;
-        }
-
-        pointerIsDown.current = false;
-    }
-
-    function keyFocusOutHandler(i: number) {
-        unHighlightVertices();
-        if (draggedPoint.current === i) {
-            if (i === -1) {
-                callAction({
-                    action: actions.movePolyline,
-                    args: {
-                        pointCoords: pointCoords.current,
-                    },
-                });
-            } else {
-                callAction({
-                    action: actions.movePolyline,
-                    args: {
-                        pointCoords: pointCoords.current,
-                        sourceInformation: { vertex: i },
-                    },
-                });
-            }
-        }
-        draggedPoint.current = null;
-    }
-
-    function keyDownHandler(i: number, e: { key: string }) {
-        if (e.key === "Enter") {
-            if (draggedPoint.current === i) {
-                if (i === -1) {
-                    callAction({
-                        action: actions.movePolyline,
-                        args: {
-                            pointCoords: pointCoords.current,
-                        },
-                    });
-                } else {
-                    callAction({
-                        action: actions.movePolyline,
-                        args: {
-                            pointCoords: pointCoords.current,
-                            sourceInformation: { vertex: i },
-                        },
-                    });
-                }
-            }
-            draggedPoint.current = null;
-            callAction({
-                action: actions.polylineClicked,
-                args: { componentIdx },
-            });
-        }
     }
 
     function highlightVertices() {
@@ -517,16 +447,7 @@ export default React.memo(function Polyline(props: UseDoenetRendererProps) {
                     );
                     polylineJXG.current.dataX.length = SVs.numVertices;
 
-                    pointsJXG.current[i].on("drag", (e) => dragHandler(i, e));
-                    pointsJXG.current[i].on("up", () => upHandler(i));
-                    pointsJXG.current[i].on("down", (e) => downHandler(i, e));
-                    pointsJXG.current[i].on("hit", () => hitHandler());
-                    pointsJXG.current[i].on("keyfocusout", () =>
-                        keyFocusOutHandler(i),
-                    );
-                    pointsJXG.current[i].on("keydown", (e) =>
-                        keyDownHandler(i, e),
-                    );
+                    attachVertexDragHandlers(pointsJXG.current[i], i);
                 }
             } else if (
                 previousNumVertices.current !== null &&

--- a/packages/doenetml/src/Viewer/renderers/ray.tsx
+++ b/packages/doenetml/src/Viewer/renderers/ray.tsx
@@ -47,7 +47,6 @@ export default React.memo(function Ray(props: UseDoenetRendererProps) {
     let rayJXG = useRef<JXGLine | null>(null);
 
     const dragState = usePointerDragState();
-    let pointsAtDown = useRef<[number[], number[]] | null>(null);
 
     const dragCoordination: DragCoordinationState<number> = {
         draggedTag: useRef<number | null>(null),
@@ -143,7 +142,6 @@ export default React.memo(function Ray(props: UseDoenetRendererProps) {
                     [...newRayJXG.point1.coords.scrCoords],
                     [...newRayJXG.point2.coords.scrCoords],
                 ] as [number[], number[]],
-            snapshotRef: pointsAtDown,
             buildTransientMoveArgs: (e, snap) => {
                 const next: [number, number][] = [];
                 if (

--- a/packages/doenetml/src/Viewer/renderers/ray.tsx
+++ b/packages/doenetml/src/Viewer/renderers/ray.tsx
@@ -20,12 +20,15 @@ import { JXGLine } from "./jsxgraph-distrib/types";
 import { DraggableGraphicalSVs } from "./utils/graphicalSVs";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
-import { exceededDragThreshold } from "./utils/dragThreshold";
 import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
 import { resolveLineColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
+import {
+    DragCoordinationState,
+    attachLineFamilyDragHandlers,
+} from "./utils/lineFamilyDragHandlers";
 
 interface RaySVs extends DraggableGraphicalSVs {
     numericalEndpoint: [number, number];
@@ -44,9 +47,12 @@ export default React.memo(function Ray(props: UseDoenetRendererProps) {
     let rayJXG = useRef<JXGLine | null>(null);
 
     const dragState = usePointerDragState();
-    const { pointerAtDown, pointerIsDown, pointerMovedSinceDown, dragged } =
-        dragState;
     let pointsAtDown = useRef<[number[], number[]] | null>(null);
+
+    const dragCoordination: DragCoordinationState<number> = {
+        draggedTag: useRef<number | null>(null),
+        downOnTag: useRef<number | null>(null),
+    };
 
     let previousWithLabel = useRef<boolean | null>(null);
     let cancelInitialLabelPlacement = useRef<(() => void) | null>(null);
@@ -119,141 +125,81 @@ export default React.memo(function Ray(props: UseDoenetRendererProps) {
         );
         newRayJXG.isDraggable = !fixLocation.current;
 
-        newRayJXG.on("drag", function (e) {
-            if (exceededDragThreshold(e, pointerAtDown.current)) {
-                dragged.current = true;
-
-                pointCoords.current = [];
-
+        attachLineFamilyDragHandlers({
+            jxg: newRayJXG,
+            tag: 0,
+            dragState,
+            coordination: dragCoordination,
+            componentIdx,
+            callAction,
+            fixedRef: fixed,
+            actions: {
+                move: actions.moveRay,
+                focus: actions.rayFocused,
+                click: actions.rayClicked,
+            },
+            snapshot: () =>
+                [
+                    [...newRayJXG.point1.coords.scrCoords],
+                    [...newRayJXG.point2.coords.scrCoords],
+                ] as [number[], number[]],
+            snapshotRef: pointsAtDown,
+            buildTransientMoveArgs: (e, snap) => {
+                const next: [number, number][] = [];
                 if (
                     e.type === "pointermove" &&
-                    pointerAtDown.current &&
-                    pointsAtDown.current
+                    dragState.pointerAtDown.current &&
+                    snap
                 ) {
                     // Compute from pointer delta rather than .X()/.Y() directly
                     // so points don't snap back to attractors on slow drags.
                     for (let i = 0; i < 2; i++) {
-                        pointCoords.current.push(
+                        next.push(
                             pointerEventToUserCoords(
                                 e,
-                                pointerAtDown.current,
-                                pointsAtDown.current[i] as [
-                                    number,
-                                    number,
-                                    number,
-                                ],
+                                dragState.pointerAtDown.current,
+                                snap[i] as [number, number, number],
                                 board,
                             ),
                         );
                     }
                 } else {
-                    pointCoords.current.push([
-                        newRayJXG.point1.X(),
-                        newRayJXG.point1.Y(),
-                    ]);
-                    pointCoords.current.push([
-                        newRayJXG.point2.X(),
-                        newRayJXG.point2.Y(),
-                    ]);
+                    next.push([newRayJXG.point1.X(), newRayJXG.point1.Y()]);
+                    next.push([newRayJXG.point2.X(), newRayJXG.point2.Y()]);
                 }
-
-                callAction({
-                    action: actions.moveRay,
-                    args: {
-                        endpointcoords: pointCoords.current[0],
-                        throughcoords: pointCoords.current[1],
-                        transient: true,
-                        skippable: true,
-                    },
-                });
-            }
-
-            newRayJXG.point1.coords.setCoordinates(
-                JXG.COORDS_BY_USER,
-                lastEndpointFromCore.current,
-            );
-            newRayJXG.point2.coords.setCoordinates(
-                JXG.COORDS_BY_USER,
-                lastThroughpointFromCore.current,
-            );
-        });
-
-        newRayJXG.on("up", function (e) {
-            if (dragged.current) {
-                callAction({
-                    action: actions.moveRay,
-                    args: {
+                pointCoords.current = next;
+                return {
+                    endpointcoords: next[0],
+                    throughcoords: next[1],
+                    transient: true,
+                    skippable: true,
+                };
+            },
+            buildCommitMoveArgs: (_, variant) => {
+                if (variant === "up") {
+                    return {
                         endpointcoords: pointCoords.current?.[0],
                         throughcoords: pointCoords.current?.[1],
-                    },
-                });
-            } else if (!pointerMovedSinceDown.current && !fixed.current) {
-                callAction({
-                    action: actions.rayClicked,
-                    args: { componentIdx },
-                });
-            }
-            pointerIsDown.current = false;
-        });
-
-        newRayJXG.on("keyfocusout", function (e) {
-            if (dragged.current) {
-                callAction({
-                    action: actions.moveRay,
-                    args: {
-                        point1coords: pointCoords.current?.[0],
-                        point2coords: pointCoords.current?.[1],
-                    },
-                });
-                dragged.current = false;
-            }
-        });
-
-        newRayJXG.on("down", function (e) {
-            (document.activeElement as HTMLElement | null)?.blur();
-
-            dragged.current = false;
-            pointerAtDown.current = [e.x, e.y];
-            pointsAtDown.current = [
-                [...newRayJXG.point1.coords.scrCoords],
-                [...newRayJXG.point2.coords.scrCoords],
-            ];
-            pointerIsDown.current = true;
-            pointerMovedSinceDown.current = false;
-            if (!fixed.current) {
-                callAction({
-                    action: actions.rayFocused,
-                    args: { componentIdx },
-                });
-            }
-        });
-
-        newRayJXG.on("hit", function (e) {
-            dragged.current = false;
-            callAction({
-                action: actions.rayFocused,
-                args: { componentIdx },
-            });
-        });
-
-        newRayJXG.on("keydown", function (e) {
-            if (e.key === "Enter") {
-                if (dragged.current) {
-                    callAction({
-                        action: actions.moveRay,
-                        args: {
-                            point1coords: pointCoords.current?.[0],
-                            point2coords: pointCoords.current?.[1],
-                        },
-                    });
-                    dragged.current = false;
+                    };
                 }
-
-                callAction({
-                    action: actions.rayClicked,
-                    args: { componentIdx },
-                });
-            }
+                // keyEnter / keyFocusOut: preserve existing arg names — moveRay
+                // ignores point1coords/point2coords, so the dispatch is currently
+                // a no-op. Left intact pending a separate behavior fix.
+                return {
+                    point1coords: pointCoords.current?.[0],
+                    point2coords: pointCoords.current?.[1],
+                };
+            },
+            onDragApplied: () => {
+                newRayJXG.point1.coords.setCoordinates(
+                    JXG.COORDS_BY_USER,
+                    lastEndpointFromCore.current,
+                );
+                newRayJXG.point2.coords.setCoordinates(
+                    JXG.COORDS_BY_USER,
+                    lastThroughpointFromCore.current,
+                );
+            },
         });
 
         rayJXG.current = newRayJXG;

--- a/packages/doenetml/src/Viewer/renderers/utils/jsxgraph.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/jsxgraph.ts
@@ -1,6 +1,6 @@
 import me from "math-expressions";
 import { cesc } from "@doenet/utils";
-import type { MutableRefObject } from "react";
+import type { RefObject } from "react";
 import { JXGBoard, JXGElement } from "../jsxgraph-distrib/types";
 
 type AxisJXG = JXGElement & {
@@ -13,7 +13,7 @@ type AxisJXG = JXGElement & {
     getLabelAnchor?: () => { scrCoords?: number[] };
 };
 
-type AxisRef = MutableRefObject<AxisJXG | null | undefined>;
+type AxisRef = RefObject<AxisJXG | null | undefined>;
 
 /**
  * Minimal structural shape for the line-like objects these helpers touch.
@@ -111,7 +111,7 @@ export function createYAxis({
     theBoard: JXGBoard;
     SVs: Record<string, any>;
     yaxisRef: AxisRef;
-    previousYaxisWithLabelRef: MutableRefObject<boolean>;
+    previousYaxisWithLabelRef: RefObject<boolean>;
 }): void {
     const yaxisOptions: Record<string, any> = { highlight: false, fixed: true };
     if (SVs.yLabel) {
@@ -208,7 +208,7 @@ export function createXAxis({
     theBoard: JXGBoard;
     SVs: Record<string, any>;
     xaxisRef: AxisRef;
-    previousXaxisWithLabelRef: MutableRefObject<boolean>;
+    previousXaxisWithLabelRef: RefObject<boolean>;
 }): void {
     const xaxisOptions: Record<string, any> = { highlight: false, fixed: true };
     if (SVs.xLabel) {
@@ -845,7 +845,7 @@ export function syncLineStrokeStyle(
 export function syncWithLabelToggle(
     obj: SyncableJXG,
     labelForGraph: string,
-    previousWithLabelRef: MutableRefObject<boolean | null>,
+    previousWithLabelRef: RefObject<boolean | null>,
 ): boolean {
     const withlabel = labelForGraph !== "";
     if (withlabel !== previousWithLabelRef.current) {

--- a/packages/doenetml/src/Viewer/renderers/utils/lineFamilyDragHandlers.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/lineFamilyDragHandlers.ts
@@ -1,4 +1,4 @@
-import type { MutableRefObject } from "react";
+import type { RefObject } from "react";
 import { JXGElement, JXGEvent } from "../jsxgraph-distrib/types";
 import { exceededDragThreshold } from "./dragThreshold";
 import { PointerDragState } from "./pointerDragState";
@@ -20,8 +20,8 @@ export type CallActionFn = (params: {
  * coordination semantics.
  */
 export interface DragCoordinationState<TTag = number> {
-    draggedTag: MutableRefObject<TTag | null>;
-    downOnTag: MutableRefObject<TTag | null>;
+    draggedTag: RefObject<TTag | null>;
+    downOnTag: RefObject<TTag | null>;
 }
 
 export type CommitVariant = "up" | "keyEnter" | "keyFocusOut";
@@ -42,7 +42,7 @@ export interface AttachDragHandlersConfig<TTag, TSnapshot> {
     callAction: CallActionFn;
 
     /** Whether the whole component is "fixed" (no clicks, no focus). */
-    fixedRef: MutableRefObject<boolean>;
+    fixedRef: RefObject<boolean>;
     /**
      * Optional override for whether `down` should fire `actions.focus`. Used
      * by lineSegment endpoints (gated on `endpointsFixed`, not on `fixed`).
@@ -67,12 +67,12 @@ export interface AttachDragHandlersConfig<TTag, TSnapshot> {
      * whenever `actions.clickPrelude` is set. Pass a ref reading
      * `switchable && !fixed` to mirror the line/point pattern.
      */
-    clickPreludeGate?: MutableRefObject<boolean>;
+    clickPreludeGate?: RefObject<boolean>;
 
     /** Captures any state needed at `down` (e.g., scrCoords snapshot). */
     snapshot: () => TSnapshot;
     /** Where the most recent `snapshot()` result is stored. */
-    snapshotRef: MutableRefObject<TSnapshot | null>;
+    snapshotRef: RefObject<TSnapshot | null>;
 
     /**
      * Build the args for the transient (in-flight) `move` dispatch. Return

--- a/packages/doenetml/src/Viewer/renderers/utils/lineFamilyDragHandlers.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/lineFamilyDragHandlers.ts
@@ -150,11 +150,6 @@ export interface AttachDragHandlersConfig<TTag, TSnapshot> {
     onHitExtra?: () => void;
     /** Extra logic at the start of `keyfocusout` (before commit/clear). */
     onKeyFocusOutExtra?: () => void;
-    /** Extra logic at the start of `keydown` Enter (before commit). */
-    onKeyDownEnterExtra?: () => void;
-
-    /** Additional `jxg.on(name, handler)` registrations (e.g., over/out). */
-    extraEvents?: Record<string, (e: any) => void>;
 }
 
 /**
@@ -198,8 +193,6 @@ export function attachLineFamilyDragHandlers<TTag, TSnapshot>(
         onUpExtra,
         onHitExtra,
         onKeyFocusOutExtra,
-        onKeyDownEnterExtra,
-        extraEvents,
     } = config;
 
     const focusArgs = { componentIdx };
@@ -323,17 +316,10 @@ export function attachLineFamilyDragHandlers<TTag, TSnapshot>(
         if (e.key !== "Enter") {
             return;
         }
-        onKeyDownEnterExtra?.();
         if (coordination.draggedTag.current === tag) {
             dispatchCommit("keyEnter");
             coordination.draggedTag.current = null;
         }
         dispatchClick();
     });
-
-    if (extraEvents) {
-        for (const [name, handler] of Object.entries(extraEvents)) {
-            jxg.on(name, handler);
-        }
-    }
 }

--- a/packages/doenetml/src/Viewer/renderers/utils/lineFamilyDragHandlers.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/lineFamilyDragHandlers.ts
@@ -1,0 +1,339 @@
+import type { MutableRefObject } from "react";
+import { JXGElement, JXGEvent } from "../jsxgraph-distrib/types";
+import { exceededDragThreshold } from "./dragThreshold";
+import { PointerDragState } from "./pointerDragState";
+
+export type CallActionFn = (params: {
+    action: any;
+    args?: Record<string, any>;
+}) => void;
+
+/**
+ * Coordination state shared between every draggable target of one renderer.
+ *
+ * - `draggedTag` is the tag of the target that exceeded the drag threshold
+ *   on the current pointer interaction (or `null` when no drag is active).
+ * - `downOnTag` is the tag of the target that received `down` most recently
+ *   on the current pointer interaction (or `null` when no `down` is active).
+ *
+ * Single-object renderers can pass `tag = 0` and ignore the multi-object
+ * coordination semantics.
+ */
+export interface DragCoordinationState<TTag = number> {
+    draggedTag: MutableRefObject<TTag | null>;
+    downOnTag: MutableRefObject<TTag | null>;
+}
+
+export type CommitVariant = "up" | "keyEnter" | "keyFocusOut";
+
+type MoveArgs = Record<string, any>;
+
+export interface AttachDragHandlersConfig<TTag, TSnapshot> {
+    /** The JSXgraph object to bind handlers to. */
+    jxg: JXGElement;
+    /** Identifier for this target within a multi-object renderer. */
+    tag: TTag;
+    /** Pointer state shared with `useBoardPointerTracking`. */
+    dragState: PointerDragState;
+    /** Multi-object coordination state. */
+    coordination: DragCoordinationState<TTag>;
+
+    componentIdx: number;
+    callAction: CallActionFn;
+
+    /** Whether the whole component is "fixed" (no clicks, no focus). */
+    fixedRef: MutableRefObject<boolean>;
+    /**
+     * Optional override for whether `down` should fire `actions.focus`. Used
+     * by lineSegment endpoints (gated on `endpointsFixed`, not on `fixed`).
+     * Returns `true` to allow focus dispatch. When omitted, the gate is
+     * `!fixedRef.current`.
+     */
+    shouldDispatchFocusOnDown?: () => boolean;
+
+    actions: {
+        move?: any;
+        focus?: any;
+        click?: any;
+        /**
+         * Optional second action dispatched immediately before `click`. Used
+         * by line/point's `switchable` flag. Evaluated at click time, so the
+         * caller can pass a ref to gate dispatch dynamically.
+         */
+        clickPrelude?: any;
+    };
+    /**
+     * Gate for `actions.clickPrelude` evaluated at click time. Default: dispatch
+     * whenever `actions.clickPrelude` is set. Pass a ref reading
+     * `switchable && !fixed` to mirror the line/point pattern.
+     */
+    clickPreludeGate?: MutableRefObject<boolean>;
+
+    /** Captures any state needed at `down` (e.g., scrCoords snapshot). */
+    snapshot: () => TSnapshot;
+    /** Where the most recent `snapshot()` result is stored. */
+    snapshotRef: MutableRefObject<TSnapshot | null>;
+
+    /**
+     * Build the args for the transient (in-flight) `move` dispatch. Return
+     * `null` to skip dispatching. Receives whatever the most recent
+     * `snapshot()` produced (may be `null` if the target needs no snapshot).
+     */
+    buildTransientMoveArgs: (
+        e: { type: string; x: number; y: number },
+        snapshot: TSnapshot | null,
+    ) => MoveArgs | null;
+
+    /**
+     * If true, `buildTransientMoveArgs` is called and the move action is
+     * dispatched on every `drag` event, including sub-threshold ones. Used
+     * by point.tsx, whose visible point's bounding-box clamping and shadow
+     * sync need to run on every drag tick. Default `false` — only dispatch
+     * after the drag threshold has been crossed.
+     */
+    dispatchTransientBelowThreshold?: boolean;
+
+    /**
+     * Build the args for the commit `move` dispatch (released a drag). The
+     * `commitVariant` lets the caller emit slightly different shapes per
+     * trigger — e.g., polyline uses `sourceInformation` (not `sourceDetails`)
+     * on keyfocusout/keyEnter commits.
+     */
+    buildCommitMoveArgs: (
+        snapshot: TSnapshot | null,
+        commitVariant: CommitVariant,
+    ) => MoveArgs | null;
+
+    /**
+     * Called on every `drag` event with the snapshot taken at `down`.
+     * Typically resets JXG state back to `lastPositionFromCore` so the
+     * worker stays the source of truth — see ray/line/circle/etc. for the
+     * unconditional pattern. Renderers that should reset only after a
+     * threshold-crossing dispatch (polyline/polygon) can guard with
+     * `if (coordination.draggedTag.current !== tag) return`.
+     */
+    onDragApplied?: (
+        snapshot: TSnapshot | null,
+        e: { type: string; x: number; y: number },
+    ) => void;
+
+    /**
+     * Suppress the click dispatch when a sibling target's `down` fired
+     * before this one's `up`. Used by lineSegment / vector / polyline /
+     * polygon "container" objects whose `up` fires before per-vertex `up`.
+     */
+    suppressClickWhenDownOnOtherTag?: boolean;
+
+    /**
+     * Suppress the focus-on-down dispatch when a sibling target's `down`
+     * fired earlier in the same pointer interaction. Used by lineSegment /
+     * polyline / polygon containers (whose `down` fires after the child's
+     * `down`); vector leaves it false because its container always fires
+     * `vectorFocused` regardless of which sub-target the user grabbed.
+     */
+    suppressFocusOnDownWhenDownOnOtherTag?: boolean;
+
+    /**
+     * Whether this target's `down` should write its tag into `downOnTag`.
+     * Children of a container set it (default `true`); containers leave it
+     * alone (`false`) so the child's tag remains visible to the container's
+     * `up` for click suppression. Containers also rely on the child's `up`
+     * clearing the slot.
+     */
+    participatesInDownTag?: boolean;
+
+    /** Extra setup at the end of `down` (e.g., circle indicator offsets). */
+    onDownExtra?: (e: { x: number; y: number }) => void;
+    /** Extra teardown at the end of `up`. */
+    onUpExtra?: () => void;
+    /** Extra logic in `hit` after the standard focus dispatch. */
+    onHitExtra?: () => void;
+    /** Extra logic at the start of `keyfocusout` (before commit/clear). */
+    onKeyFocusOutExtra?: () => void;
+    /** Extra logic at the start of `keydown` Enter (before commit). */
+    onKeyDownEnterExtra?: () => void;
+
+    /** Additional `jxg.on(name, handler)` registrations (e.g., over/out). */
+    extraEvents?: Record<string, (e: any) => void>;
+}
+
+/**
+ * Register the standard line-family drag handler set on a JSXgraph object.
+ *
+ * Handles the full state machine — pointerdown capture, drag-threshold
+ * detection, transient move dispatch, drag-coords reset, click/commit
+ * disambiguation on up, keyboard Enter as click, keyfocusout commit — that
+ * every draggable line-family renderer needs. Per-renderer payload shapes
+ * and snapshot semantics are supplied via the `snapshot` / `buildMoveArgs`
+ * callbacks; cross-object coordination is supplied via the
+ * `coordination` refs.
+ *
+ * Returns nothing; handlers are detached by the existing
+ * `removeJXGEventHandlers` flow when the renderer rebuilds the JXG element.
+ */
+export function attachLineFamilyDragHandlers<TTag, TSnapshot>(
+    config: AttachDragHandlersConfig<TTag, TSnapshot>,
+): void {
+    const {
+        jxg,
+        tag,
+        dragState,
+        coordination,
+        componentIdx,
+        callAction,
+        fixedRef,
+        shouldDispatchFocusOnDown,
+        actions,
+        snapshot,
+        snapshotRef,
+        buildTransientMoveArgs,
+        buildCommitMoveArgs,
+        dispatchTransientBelowThreshold,
+        onDragApplied,
+        suppressClickWhenDownOnOtherTag,
+        suppressFocusOnDownWhenDownOnOtherTag,
+        participatesInDownTag = true,
+        clickPreludeGate,
+        onDownExtra,
+        onUpExtra,
+        onHitExtra,
+        onKeyFocusOutExtra,
+        onKeyDownEnterExtra,
+        extraEvents,
+    } = config;
+
+    const focusArgs = { componentIdx };
+
+    function dispatchFocus() {
+        if (actions.focus) {
+            callAction({ action: actions.focus, args: focusArgs });
+        }
+    }
+
+    function dispatchClick() {
+        if (!actions.click) {
+            return;
+        }
+        const preludeOk = clickPreludeGate ? clickPreludeGate.current : true;
+        if (actions.clickPrelude && preludeOk) {
+            callAction({ action: actions.clickPrelude });
+        }
+        callAction({ action: actions.click, args: focusArgs });
+    }
+
+    function dispatchCommit(variant: CommitVariant) {
+        if (!actions.move) {
+            return;
+        }
+        const args = buildCommitMoveArgs(snapshotRef.current, variant);
+        if (!args) {
+            return;
+        }
+        callAction({ action: actions.move, args });
+    }
+
+    jxg.on("down", function (e: JXGEvent) {
+        (document.activeElement as HTMLElement | null)?.blur();
+
+        coordination.draggedTag.current = null;
+        dragState.pointerAtDown.current = [e.x, e.y];
+        if (participatesInDownTag) {
+            coordination.downOnTag.current = tag;
+        }
+
+        snapshotRef.current = snapshot();
+
+        dragState.pointerIsDown.current = true;
+        dragState.pointerMovedSinceDown.current = false;
+
+        const focusGate = shouldDispatchFocusOnDown
+            ? shouldDispatchFocusOnDown()
+            : !fixedRef.current;
+        const focusSuppressed =
+            suppressFocusOnDownWhenDownOnOtherTag &&
+            coordination.downOnTag.current !== null &&
+            coordination.downOnTag.current !== tag;
+        if (focusGate && !focusSuppressed) {
+            dispatchFocus();
+        }
+
+        onDownExtra?.(e);
+    });
+
+    jxg.on("hit", function (_e: JXGEvent) {
+        coordination.draggedTag.current = null;
+        // Some renderers (line, circle) re-snapshot on `hit` so a keyboard
+        // focus refreshes the captured position. Cheap to do unconditionally.
+        snapshotRef.current = snapshot();
+        dispatchFocus();
+        onHitExtra?.();
+    });
+
+    jxg.on("drag", function (e: JXGEvent) {
+        const aboveThreshold = exceededDragThreshold(
+            e,
+            dragState.pointerAtDown.current,
+        );
+
+        if (aboveThreshold) {
+            coordination.draggedTag.current = tag;
+        }
+
+        if (aboveThreshold || dispatchTransientBelowThreshold) {
+            const args = buildTransientMoveArgs(e, snapshotRef.current);
+            if (args && actions.move) {
+                callAction({ action: actions.move, args });
+            }
+        }
+
+        onDragApplied?.(snapshotRef.current, e);
+    });
+
+    jxg.on("up", function (_e: JXGEvent) {
+        if (coordination.draggedTag.current === tag) {
+            dispatchCommit("up");
+        } else if (
+            !dragState.pointerMovedSinceDown.current &&
+            !fixedRef.current &&
+            !(
+                suppressClickWhenDownOnOtherTag &&
+                coordination.downOnTag.current !== null &&
+                coordination.downOnTag.current !== tag
+            )
+        ) {
+            dispatchClick();
+        }
+
+        if (coordination.downOnTag.current === tag) {
+            coordination.downOnTag.current = null;
+        }
+        dragState.pointerIsDown.current = false;
+        onUpExtra?.();
+    });
+
+    jxg.on("keyfocusout", function (_e: JXGEvent) {
+        onKeyFocusOutExtra?.();
+        if (coordination.draggedTag.current === tag) {
+            dispatchCommit("keyFocusOut");
+        }
+        coordination.draggedTag.current = null;
+    });
+
+    jxg.on("keydown", function (e: JXGEvent) {
+        if (e.key !== "Enter") {
+            return;
+        }
+        onKeyDownEnterExtra?.();
+        if (coordination.draggedTag.current === tag) {
+            dispatchCommit("keyEnter");
+            coordination.draggedTag.current = null;
+        }
+        dispatchClick();
+    });
+
+    if (extraEvents) {
+        for (const [name, handler] of Object.entries(extraEvents)) {
+            jxg.on(name, handler);
+        }
+    }
+}

--- a/packages/doenetml/src/Viewer/renderers/utils/lineFamilyDragHandlers.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/lineFamilyDragHandlers.ts
@@ -285,6 +285,7 @@ export function attachLineFamilyDragHandlers<TTag, TSnapshot>(
     jxg.on("up", function (_e: JXGEvent) {
         if (coordination.draggedTag.current === tag) {
             dispatchCommit("up");
+            coordination.draggedTag.current = null;
         } else if (
             !dragState.pointerMovedSinceDown.current &&
             !fixedRef.current &&

--- a/packages/doenetml/src/Viewer/renderers/utils/lineFamilyDragHandlers.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/lineFamilyDragHandlers.ts
@@ -69,10 +69,12 @@ export interface AttachDragHandlersConfig<TTag, TSnapshot> {
      */
     clickPreludeGate?: RefObject<boolean>;
 
-    /** Captures any state needed at `down` (e.g., scrCoords snapshot). */
+    /**
+     * Captures any state needed at `down` (e.g., scrCoords snapshot). The
+     * helper stores the most recent result internally and forwards it to
+     * `buildTransientMoveArgs` / `buildCommitMoveArgs` / `onDragApplied`.
+     */
     snapshot: () => TSnapshot;
-    /** Where the most recent `snapshot()` result is stored. */
-    snapshotRef: RefObject<TSnapshot | null>;
 
     /**
      * Build the args for the transient (in-flight) `move` dispatch. Return
@@ -180,7 +182,6 @@ export function attachLineFamilyDragHandlers<TTag, TSnapshot>(
         shouldDispatchFocusOnDown,
         actions,
         snapshot,
-        snapshotRef,
         buildTransientMoveArgs,
         buildCommitMoveArgs,
         dispatchTransientBelowThreshold,
@@ -196,6 +197,7 @@ export function attachLineFamilyDragHandlers<TTag, TSnapshot>(
     } = config;
 
     const focusArgs = { componentIdx };
+    let currentSnapshot: TSnapshot | null = null;
 
     function dispatchFocus() {
         if (actions.focus) {
@@ -218,7 +220,7 @@ export function attachLineFamilyDragHandlers<TTag, TSnapshot>(
         if (!actions.move) {
             return;
         }
-        const args = buildCommitMoveArgs(snapshotRef.current, variant);
+        const args = buildCommitMoveArgs(currentSnapshot, variant);
         if (!args) {
             return;
         }
@@ -234,7 +236,7 @@ export function attachLineFamilyDragHandlers<TTag, TSnapshot>(
             coordination.downOnTag.current = tag;
         }
 
-        snapshotRef.current = snapshot();
+        currentSnapshot = snapshot();
 
         dragState.pointerIsDown.current = true;
         dragState.pointerMovedSinceDown.current = false;
@@ -257,7 +259,7 @@ export function attachLineFamilyDragHandlers<TTag, TSnapshot>(
         coordination.draggedTag.current = null;
         // Some renderers (line, circle) re-snapshot on `hit` so a keyboard
         // focus refreshes the captured position. Cheap to do unconditionally.
-        snapshotRef.current = snapshot();
+        currentSnapshot = snapshot();
         dispatchFocus();
         onHitExtra?.();
     });
@@ -273,13 +275,13 @@ export function attachLineFamilyDragHandlers<TTag, TSnapshot>(
         }
 
         if (aboveThreshold || dispatchTransientBelowThreshold) {
-            const args = buildTransientMoveArgs(e, snapshotRef.current);
+            const args = buildTransientMoveArgs(e, currentSnapshot);
             if (args && actions.move) {
                 callAction({ action: actions.move, args });
             }
         }
 
-        onDragApplied?.(snapshotRef.current, e);
+        onDragApplied?.(currentSnapshot, e);
     });
 
     jxg.on("up", function (_e: JXGEvent) {

--- a/packages/doenetml/src/Viewer/renderers/utils/pointerDragState.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/pointerDragState.ts
@@ -14,10 +14,10 @@ import { useMemo, useRef } from "react";
  *   event as a click or as the end of a drag.
  */
 export interface PointerDragState {
-    pointerAtDown: React.MutableRefObject<[number, number] | null>;
-    pointerIsDown: React.MutableRefObject<boolean>;
-    pointerMovedSinceDown: React.MutableRefObject<boolean>;
-    dragged: React.MutableRefObject<boolean>;
+    pointerAtDown: React.RefObject<[number, number] | null>;
+    pointerIsDown: React.RefObject<boolean>;
+    pointerMovedSinceDown: React.RefObject<boolean>;
+    dragged: React.RefObject<boolean>;
 }
 
 export function usePointerDragState(): PointerDragState {

--- a/packages/doenetml/src/Viewer/renderers/utils/useDraggableRefs.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useDraggableRefs.ts
@@ -1,4 +1,4 @@
-import { useRef, type MutableRefObject } from "react";
+import { useRef, type RefObject } from "react";
 import type { DraggableGraphicalSVs } from "./graphicalSVs";
 
 /**
@@ -20,9 +20,9 @@ export function useDraggableRefs<TPos>(
     SVs: DraggableGraphicalSVs,
     position: TPos,
 ): {
-    lastPositionFromCore: MutableRefObject<TPos>;
-    fixed: MutableRefObject<boolean>;
-    fixLocation: MutableRefObject<boolean>;
+    lastPositionFromCore: RefObject<TPos>;
+    fixed: RefObject<boolean>;
+    fixLocation: RefObject<boolean>;
 } {
     const lastPositionFromCore = useRef(position);
     const fixed = useRef(false);

--- a/packages/doenetml/src/Viewer/renderers/utils/useJSXGraphCleanup.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useJSXGraphCleanup.ts
@@ -1,4 +1,4 @@
-import { useEffect, type MutableRefObject } from "react";
+import { useEffect, type RefObject } from "react";
 
 /**
  * Run the standard JSXgraph teardown on unmount: cancel any pending initial
@@ -18,9 +18,9 @@ export function useJSXGraphCleanup<T>({
     destroy,
     cancelLabelPlacementRef,
 }: {
-    objectRef: MutableRefObject<T | null>;
+    objectRef: RefObject<T | null>;
     destroy: () => void;
-    cancelLabelPlacementRef?: MutableRefObject<(() => void) | null>;
+    cancelLabelPlacementRef?: RefObject<(() => void) | null>;
 }): void {
     useEffect(() => {
         return () => {

--- a/packages/doenetml/src/Viewer/renderers/vector.tsx
+++ b/packages/doenetml/src/Viewer/renderers/vector.tsx
@@ -247,7 +247,12 @@ export default React.memo(function Vector(props: UseDoenetRendererProps) {
                 headcoords: headcoords.current,
                 tailcoords: tailcoords.current,
             }),
-            onDragApplied: applyDragReset,
+            onDragApplied: () => {
+                if (dragCoordination.draggedTag.current !== 0) {
+                    return;
+                }
+                applyDragReset();
+            },
         });
 
         function attachVectorEndpointHandlers(
@@ -286,6 +291,9 @@ export default React.memo(function Vector(props: UseDoenetRendererProps) {
                     [argKey]: coordsRef.current,
                 }),
                 onDragApplied: () => {
+                    if (dragCoordination.draggedTag.current !== tagN) {
+                        return;
+                    }
                     applyDragReset();
                     if (board) {
                         board.updateInfobox(point);

--- a/packages/doenetml/src/Viewer/renderers/vector.tsx
+++ b/packages/doenetml/src/Viewer/renderers/vector.tsx
@@ -22,12 +22,15 @@ import { buildLineLikeAttributes } from "./utils/buildGraphicalAttributes";
 import { DraggableGraphicalSVs } from "./utils/graphicalSVs";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
-import { exceededDragThreshold } from "./utils/dragThreshold";
 import { pointerEventToUserCoords } from "./utils/pointerToBoardCoords";
 import { resolveLineColor } from "./utils/styleColors";
 import { styleToDash } from "./utils/styleToDash";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
+import {
+    DragCoordinationState,
+    attachLineFamilyDragHandlers,
+} from "./utils/lineFamilyDragHandlers";
 
 interface VectorSVs extends DraggableGraphicalSVs {
     numericalEndpoints: [number, number][];
@@ -52,13 +55,14 @@ export default React.memo(function Vector(props: UseDoenetRendererProps) {
     let point2JXG = useRef<JXGPoint | null>(null);
 
     const dragState = usePointerDragState();
-    const { pointerAtDown, pointerIsDown, pointerMovedSinceDown } = dragState;
     let pointsAtDown = useRef<[number[], number[]] | null>(null);
-    let headBeingDragged = useRef(false);
-    let tailBeingDragged = useRef(false);
-    let downOnPoint = useRef<number | null>(null);
     let headcoords = useRef<number[] | null>(null);
     let tailcoords = useRef<number[] | null>(null);
+
+    const dragCoordination: DragCoordinationState<number> = {
+        draggedTag: useRef<number | null>(null),
+        downOnTag: useRef<number | null>(null),
+    };
 
     let previousWithLabel = useRef<boolean | null>(null);
     let cancelInitialLabelPlacement = useRef<(() => void) | null>(null);
@@ -171,237 +175,139 @@ export default React.memo(function Vector(props: UseDoenetRendererProps) {
         cancelInitialLabelPlacement.current?.();
         cancelInitialLabelPlacement.current = null;
 
-        newPoint1JXG.on("drag", (e: { x: number; y: number; type: string }) =>
-            onDragHandler(e, 0),
-        );
-        newPoint2JXG.on("drag", (e: { x: number; y: number; type: string }) =>
-            onDragHandler(e, 1),
-        );
-        newVectorJXG.on("drag", (e: { x: number; y: number; type: string }) =>
-            onDragHandler(e, -1),
-        );
+        // Tag layout: 0 = vector body, 1 = tail (point1), 2 = head (point2).
 
-        newPoint1JXG.on("up", (e: unknown) => {
-            if (!headBeingDragged.current && tailBeingDragged.current) {
-                callAction({
-                    action: actions.moveVector,
-                    args: { tailcoords: tailcoords.current },
-                });
-            } else if (!pointerMovedSinceDown.current && !fixed.current) {
-                callAction({
-                    action: actions.vectorClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                });
-            }
-            downOnPoint.current = null;
-            pointerIsDown.current = false;
-        });
-        newPoint2JXG.on("up", (e: unknown) => {
-            if (headBeingDragged.current && !tailBeingDragged.current) {
-                callAction({
-                    action: actions.moveVector,
-                    args: { headcoords: headcoords.current },
-                });
-            } else if (!pointerMovedSinceDown.current && !fixed.current) {
-                callAction({
-                    action: actions.vectorClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                });
-            }
-            downOnPoint.current = null;
-            pointerIsDown.current = false;
-        });
-        newVectorJXG.on("up", (e: unknown) => {
-            if (headBeingDragged.current && tailBeingDragged.current) {
-                callAction({
-                    action: actions.moveVector,
-                    args: {
-                        headcoords: headcoords.current,
-                        tailcoords: tailcoords.current,
-                    },
-                });
-            } else if (
-                !pointerMovedSinceDown.current &&
-                downOnPoint.current === null &&
-                !fixed.current
-            ) {
-                // Note: counting on fact that up on vector will trigger before up on points
-                callAction({
-                    action: actions.vectorClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                });
-            }
-            pointerIsDown.current = false;
-        });
+        function applyDragReset() {
+            vectorJXG.current?.point1.coords.setCoordinates(
+                JXG.COORDS_BY_USER,
+                lastPositionsFromCore.current[0],
+            );
+            vectorJXG.current?.point2.coords.setCoordinates(
+                JXG.COORDS_BY_USER,
+                lastPositionsFromCore.current[1],
+            );
+        }
 
-        newPoint1JXG.on("keyfocusout", (e: unknown) => {
-            if (!headBeingDragged.current && tailBeingDragged.current) {
-                callAction({
-                    action: actions.moveVector,
-                    args: { tailcoords: tailcoords.current },
-                });
-            }
-            headBeingDragged.current = false;
-            tailBeingDragged.current = false;
-        });
-        newPoint2JXG.on("keyfocusout", (e: unknown) => {
-            if (headBeingDragged.current && !tailBeingDragged.current) {
-                callAction({
-                    action: actions.moveVector,
-                    args: { headcoords: headcoords.current },
-                });
-            }
-            headBeingDragged.current = false;
-            tailBeingDragged.current = false;
-        });
-        newVectorJXG.on("keyfocusout", (e: unknown) => {
-            if (headBeingDragged.current && tailBeingDragged.current) {
-                callAction({
-                    action: actions.moveVector,
-                    args: {
-                        headcoords: headcoords.current,
-                        tailcoords: tailcoords.current,
-                    },
-                });
-            }
-            headBeingDragged.current = false;
-            tailBeingDragged.current = false;
-        });
-
-        newPoint1JXG.on("down", function (e) {
-            (document.activeElement as HTMLElement | null)?.blur();
-
-            headBeingDragged.current = false;
-            tailBeingDragged.current = false;
-            pointerAtDown.current = [e.x, e.y];
-            downOnPoint.current = 1;
-            pointerIsDown.current = true;
-            pointerMovedSinceDown.current = false;
-            if (tailDraggable.current) {
-                callAction({
-                    action: actions.vectorFocused,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                });
-            }
-        });
-
-        newPoint1JXG.on("hit", function (e) {
-            headBeingDragged.current = false;
-            tailBeingDragged.current = false;
-            callAction({
-                action: actions.vectorFocused,
-                args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-            });
-        });
-
-        newPoint2JXG.on("down", function (e) {
-            (document.activeElement as HTMLElement | null)?.blur();
-
-            headBeingDragged.current = false;
-            tailBeingDragged.current = false;
-            pointerAtDown.current = [e.x, e.y];
-            downOnPoint.current = 2;
-            pointerIsDown.current = true;
-            pointerMovedSinceDown.current = false;
-            if (headDraggable.current) {
-                callAction({
-                    action: actions.vectorFocused,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                });
-            }
-        });
-
-        newPoint2JXG.on("hit", function (e) {
-            headBeingDragged.current = false;
-            tailBeingDragged.current = false;
-            callAction({
-                action: actions.vectorFocused,
-                args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-            });
-        });
-
-        // if drag vector, need to keep track of original point positions
-        // so that they won't get stuck in an attractor
-        newVectorJXG.on("down", function (e) {
-            (document.activeElement as HTMLElement | null)?.blur();
-
-            headBeingDragged.current = false;
-            tailBeingDragged.current = false;
-            pointerAtDown.current = [e.x, e.y];
-            pointsAtDown.current = [
-                [...newVectorJXG.point1.coords.scrCoords],
-                [...newVectorJXG.point2.coords.scrCoords],
-            ];
-            pointerIsDown.current = true;
-            pointerMovedSinceDown.current = false;
-            if (!fixed.current) {
-                callAction({
-                    action: actions.vectorFocused,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                });
-            }
-        });
-
-        newVectorJXG.on("hit", function (e: unknown) {
-            headBeingDragged.current = false;
-            tailBeingDragged.current = false;
-            callAction({
-                action: actions.vectorFocused,
-                args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-            });
-        });
-
-        newPoint1JXG.on("keydown", (e) => {
-            if (e.key === "Enter") {
-                if (!headBeingDragged.current && tailBeingDragged.current) {
-                    callAction({
-                        action: actions.moveVector,
-                        args: { tailcoords: tailcoords.current },
-                    });
+        attachLineFamilyDragHandlers({
+            jxg: newVectorJXG,
+            tag: 0,
+            dragState,
+            coordination: dragCoordination,
+            componentIdx,
+            callAction,
+            fixedRef: fixed,
+            participatesInDownTag: false,
+            suppressClickWhenDownOnOtherTag: true,
+            // vector body's `down` always dispatches focus, regardless of
+            // whether a child got down first (matches existing behavior).
+            actions: {
+                move: actions.moveVector,
+                focus: actions.vectorFocused,
+                click: actions.vectorClicked,
+            },
+            snapshot: () =>
+                [
+                    [...newVectorJXG.point1.coords.scrCoords],
+                    [...newVectorJXG.point2.coords.scrCoords],
+                ] as [number[], number[]],
+            snapshotRef: pointsAtDown,
+            buildTransientMoveArgs: (e, snap) => {
+                const viaPointer = e.type === "pointermove";
+                if (viaPointer && dragState.pointerAtDown.current && snap) {
+                    tailcoords.current = pointerEventToUserCoords(
+                        e,
+                        dragState.pointerAtDown.current,
+                        snap[0] as [number, number, number],
+                        board,
+                    );
+                    headcoords.current = pointerEventToUserCoords(
+                        e,
+                        dragState.pointerAtDown.current,
+                        snap[1] as [number, number, number],
+                        board,
+                    );
+                } else {
+                    tailcoords.current = [
+                        newVectorJXG.point1.X(),
+                        newVectorJXG.point1.Y(),
+                    ];
+                    headcoords.current = [
+                        newVectorJXG.point2.X(),
+                        newVectorJXG.point2.Y(),
+                    ];
                 }
-                headBeingDragged.current = false;
-                tailBeingDragged.current = false;
-                callAction({
-                    action: actions.vectorClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                });
-            }
+                return {
+                    headcoords: headcoords.current,
+                    tailcoords: tailcoords.current,
+                    transient: true,
+                    skippable: true,
+                };
+            },
+            buildCommitMoveArgs: () => ({
+                headcoords: headcoords.current,
+                tailcoords: tailcoords.current,
+            }),
+            onDragApplied: applyDragReset,
         });
-        newPoint2JXG.on("keydown", (e) => {
-            if (e.key === "Enter") {
-                if (headBeingDragged.current && !tailBeingDragged.current) {
-                    callAction({
-                        action: actions.moveVector,
-                        args: { headcoords: headcoords.current },
-                    });
-                }
-                headBeingDragged.current = false;
-                tailBeingDragged.current = false;
-                callAction({
-                    action: actions.vectorClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                });
-            }
-        });
-        newVectorJXG.on("keydown", (e) => {
-            if (e.key === "Enter") {
-                if (headBeingDragged.current && tailBeingDragged.current) {
-                    callAction({
-                        action: actions.moveVector,
-                        args: {
-                            headcoords: headcoords.current,
-                            tailcoords: tailcoords.current,
-                        },
-                    });
-                }
-                headBeingDragged.current = false;
-                tailBeingDragged.current = false;
-                callAction({
-                    action: actions.vectorClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                });
-            }
-        });
+
+        function attachVectorEndpointHandlers(
+            point: JXGPoint,
+            tagN: 1 | 2,
+            argKey: "tailcoords" | "headcoords",
+            coordsRef: typeof tailcoords,
+            isDraggable: typeof tailDraggable,
+        ) {
+            attachLineFamilyDragHandlers({
+                jxg: point,
+                tag: tagN,
+                dragState,
+                coordination: dragCoordination,
+                componentIdx,
+                callAction,
+                fixedRef: fixed,
+                shouldDispatchFocusOnDown: () => isDraggable.current,
+                actions: {
+                    move: actions.moveVector,
+                    focus: actions.vectorFocused,
+                    click: actions.vectorClicked,
+                },
+                snapshot: () => null,
+                snapshotRef: { current: null } as any,
+                buildTransientMoveArgs: () => {
+                    coordsRef.current = [point.X(), point.Y()];
+                    return {
+                        [argKey]: coordsRef.current,
+                        transient: true,
+                        skippable: true,
+                        sourceDetails: { vertex: tagN - 1 },
+                    };
+                },
+                buildCommitMoveArgs: () => ({
+                    [argKey]: coordsRef.current,
+                }),
+                onDragApplied: () => {
+                    applyDragReset();
+                    if (board) {
+                        board.updateInfobox(point);
+                    }
+                },
+            });
+        }
+
+        attachVectorEndpointHandlers(
+            newPoint1JXG,
+            1,
+            "tailcoords",
+            tailcoords,
+            tailDraggable,
+        );
+        attachVectorEndpointHandlers(
+            newPoint2JXG,
+            2,
+            "headcoords",
+            headcoords,
+            headDraggable,
+        );
 
         vectorJXG.current = newVectorJXG;
         point1JXG.current = newPoint1JXG;
@@ -434,77 +340,6 @@ export default React.memo(function Vector(props: UseDoenetRendererProps) {
         previousWithLabel.current = SVs.labelForGraph !== "";
     }
 
-    function onDragHandler(
-        e: { x: number; y: number; type: string },
-        i: number,
-    ) {
-        if (vectorJXG.current === null || board === null) {
-            return;
-        }
-
-        if (exceededDragThreshold(e, pointerAtDown.current)) {
-            if (i === 0) {
-                tailBeingDragged.current = true;
-            } else if (i === 1) {
-                headBeingDragged.current = true;
-            } else {
-                headBeingDragged.current = true;
-                tailBeingDragged.current = true;
-            }
-
-            let instructions: Record<string, any> = {
-                transient: true,
-                skippable: true,
-            };
-
-            if (headBeingDragged.current) {
-                if (i === -1) {
-                    headcoords.current = calculatePointPosition(e, 1);
-                } else {
-                    headcoords.current = [
-                        vectorJXG.current.point2.X(),
-                        vectorJXG.current.point2.Y(),
-                    ];
-                }
-                instructions.headcoords = headcoords.current;
-            }
-            if (tailBeingDragged.current) {
-                if (i === -1) {
-                    tailcoords.current = calculatePointPosition(e, 0);
-                } else {
-                    tailcoords.current = [
-                        vectorJXG.current.point1.X(),
-                        vectorJXG.current.point1.Y(),
-                    ];
-                }
-                instructions.tailcoords = tailcoords.current;
-            }
-
-            if (i === 0 || i === 1) {
-                instructions.sourceDetails = { vertex: i };
-            }
-
-            callAction({
-                action: actions.moveVector,
-                args: instructions,
-            });
-
-            vectorJXG.current?.point1.coords.setCoordinates(
-                JXG.COORDS_BY_USER,
-                lastPositionsFromCore.current[0],
-            );
-            vectorJXG.current?.point2.coords.setCoordinates(
-                JXG.COORDS_BY_USER,
-                lastPositionsFromCore.current[1],
-            );
-            if (i === 0) {
-                board.updateInfobox(point1JXG.current);
-            } else if (i === 1) {
-                board.updateInfobox(point2JXG.current);
-            }
-        }
-    }
-
     function deleteVectorJXG() {
         cancelInitialLabelPlacement.current?.();
         cancelInitialLabelPlacement.current = null;
@@ -525,34 +360,6 @@ export default React.memo(function Vector(props: UseDoenetRendererProps) {
             board?.removeObject(point2JXG.current);
             point2JXG.current = null;
         }
-    }
-
-    function calculatePointPosition(
-        e: { x: number; y: number; type: string },
-        i: number,
-    ): number[] | null {
-        let viaPointer = e.type === "pointermove";
-
-        if (board === null || vectorJXG.current === null) {
-            return null;
-        }
-
-        if (
-            viaPointer &&
-            pointsAtDown.current !== null &&
-            pointerAtDown.current !== null
-        ) {
-            return pointerEventToUserCoords(
-                e,
-                pointerAtDown.current,
-                pointsAtDown.current[i] as [number, number, number],
-                board,
-            );
-        }
-        if (i == 0) {
-            return [vectorJXG.current.point1.X(), vectorJXG.current.point1.Y()];
-        }
-        return [vectorJXG.current.point2.X(), vectorJXG.current.point2.Y()];
     }
 
     if (board) {

--- a/packages/doenetml/src/Viewer/renderers/vector.tsx
+++ b/packages/doenetml/src/Viewer/renderers/vector.tsx
@@ -55,7 +55,6 @@ export default React.memo(function Vector(props: UseDoenetRendererProps) {
     let point2JXG = useRef<JXGPoint | null>(null);
 
     const dragState = usePointerDragState();
-    let pointsAtDown = useRef<[number[], number[]] | null>(null);
     let headcoords = useRef<number[] | null>(null);
     let tailcoords = useRef<number[] | null>(null);
 
@@ -210,7 +209,6 @@ export default React.memo(function Vector(props: UseDoenetRendererProps) {
                     [...newVectorJXG.point1.coords.scrCoords],
                     [...newVectorJXG.point2.coords.scrCoords],
                 ] as [number[], number[]],
-            snapshotRef: pointsAtDown,
             buildTransientMoveArgs: (e, snap) => {
                 const viaPointer = e.type === "pointermove";
                 if (viaPointer && dragState.pointerAtDown.current && snap) {
@@ -277,7 +275,6 @@ export default React.memo(function Vector(props: UseDoenetRendererProps) {
                     click: actions.vectorClicked,
                 },
                 snapshot: () => null,
-                snapshotRef: { current: null } as any,
                 buildTransientMoveArgs: () => {
                     coordsRef.current = [point.X(), point.Y()];
                     return {

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -37,7 +37,7 @@ type DoenetMLFlagsSubset = Partial<DoenetMLFlags>;
  * for processing events from the virtual keyboard.
  */
 export const FocusedMathInputContext = React.createContext<
-    React.MutableRefObject<HTMLElement | null>
+    React.RefObject<HTMLElement | null>
 >({ current: null });
 
 /**


### PR DESCRIPTION
## Summary

Consolidate the `down`/`drag`/`up`/`keyfocusout`/`keydown`/`hit` state machine duplicated across the 8 draggable line-family renderers (line, lineSegment, ray, vector, polyline, polygon, point, circle).

- New `attachLineFamilyDragHandlers` helper at `packages/doenetml/src/Viewer/renderers/utils/lineFamilyDragHandlers.ts`. Takes a typed config (snapshot, transient/commit move-args builders, drag-applied reset). Per-renderer action payload shapes are supplied via the builders; the helper handles the threshold check, dispatch, click vs. commit disambiguation, and JXG state reset.
- Multi-object renderers (lineSegment, vector, polyline, polygon, plus circle's two objects) thread parent/child interaction via a `DragCoordinationState` ref pair (`draggedTag`, `downOnTag`). Container objects opt in via `participatesInDownTag: false` + `suppressClickWhenDownOnOtherTag` (and, for the lineSegment/polyline/polygon cases that also gate focus-on-down on `downOnTag`, `suppressFocusOnDownWhenDownOnOtherTag`).
- Switchable click decoration (line, point) is supported via `actions.clickPrelude` + a `clickPreludeGate` ref evaluated at click time so the gate stays in sync with the latest SV value.
- Point and circle dispatch transient move actions on every drag event (their pre-helper behavior); covered by `dispatchTransientBelowThreshold: true`. Other renderers gate dispatch on the threshold as before.

Net: ~500 LOC removed from the 8 renderers; one shared 339-LOC helper added.

Stacked on #1059 (now merged).

## Follow-up PRs

The migration preserved existing behavior verbatim. A couple of pre-existing quirks stand out as worth a separate behavior-change PR:

- **ray.tsx keyEnter / keyFocusOut commit dispatches the wrong arg names.** The pre-helper code emits `{ point1coords, point2coords }` for keyboard-driven commits, but `moveRay` reads `endpointcoords` / `throughcoords` — so a keyboard drag commit on a ray is currently a silent no-op. Preserved as-is in `buildCommitMoveArgs` (with a code comment); fix should standardize on the correct arg names. Trivial diff once the e2e baseline is recaptured.
- **polyline / polygon emit `sourceDetails` on transient + `up`-commit dispatches, but `sourceInformation` on keyboard commits.** Preserved verbatim via the `commitVariant` switch. Worth picking one name (likely `sourceDetails`, since the other renderers and the worker's own routing all use it) and converging in a follow-up.
- **Sub-threshold drags should be completely ignored across the entire line family.** The ideal: a sub-threshold drag produces *no* observable effect anywhere — the renderer pins the JXG geometry to `lastPositionFromCore`, no `board.updateInfobox` call, no transient action dispatch to core, no state-flag mutation. After the regression patch in this PR, vector now gates `onDragApplied` on `draggedTag === tag` (matching pre-helper); polyline / polygon already gated internally. **line / lineSegment / ray / circle still run their `onDragApplied` coord-reset on every drag tick, including sub-threshold ones.** The threshold gate should move into `attachLineFamilyDragHandlers` itself — `onDragApplied` should fire only when `coordination.draggedTag.current === tag` by default — so every line-family renderer inherits sub-threshold isolation by construction and the next renderer added can't forget. Drop polyline/polygon's internal `if (draggedTag !== tag) return` guards and vector's inline gate as part of the same change. Recapture e2e baselines for line / lineSegment / ray / circle (likely visually invisible, but worth confirming).
- **Unit tests for `attachLineFamilyDragHandlers`.** The helper has a wide config surface (`participatesInDownTag`, `suppressClickWhenDownOnOtherTag`, `suppressFocusOnDownWhenDownOnOtherTag`, `dispatchTransientBelowThreshold`, `clickPreludeGate`, `shouldDispatchFocusOnDown`, commit-variant routing). A small unit-test suite over a stub JXG element would cover the flag matrix and serve as insurance against regressions when adding a 9th renderer or new knob.
- **Tighten action types in `AttachDragHandlersConfig['actions']`.** Currently typed `any`; a typo'd action name compiles. Replace with the real action type (or a discriminated union) once a shared type is available.

## Test plan
- [x] `npm run test:e2e` for `tagSpecific/{line,linesegment,ray,vector,polyline,polygon,point,circle}.cy.js` and the `graph` group
- [x] Manual: drag, click, keyboard-Enter, keyboard-focusout on each renderer
- [ ] Manual: pointer-up *outside* the JXG board still finalizes the drag (`useBoardPointerTracking` integration)
- [x] Manual: switchable line + switchable point click swaps endpoints
- [x] Manual: point off-graph indicator drag still works through the shadow point
- [x] Manual: circle off-graph indicator drag changes only `center`, leaves `radius`/`throughAngles` unchanged
- [x] Manual: polyline/polygon vertex highlight on hover/keyboard focus still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)