### PR TITLE
fix(ci): regenerate package-lock.json in changesets version PR

### DIFF
--- a/.github/workflows/changesets-version-pr.yml
+++ b/.github/workflows/changesets-version-pr.yml
@@ -34,6 +34,6 @@ jobs:
             - name: Create or update version PR
               uses: changesets/action@v1
               with:
-                  version: npm run version:changesets
+                  version: npm run version:changesets && npm install --package-lock-only
                   title: "chore: version packages"
                   commit: "chore: version packages"


### PR DESCRIPTION
## Summary

- Adds `npm install --package-lock-only` after `changeset version` in the changesets version PR workflow
- This keeps `package-lock.json` in sync when internal package versions are bumped, preventing lockfile drift

## Test plan

- [ ] Merge a changeset and confirm the resulting version PR includes `package-lock.json` updates alongside the `package.json` bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)