### PR TITLE
fix(editor-viewer): fire diagnosticsSummaryCallback once per diagnostics update

### DIFF
--- a/.changeset/diagnostics-summary-callback-per-update.md
+++ b/.changeset/diagnostics-summary-callback-per-update.md
@@ -1,0 +1,9 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Fix `diagnosticsSummaryCallback` in `DoenetEditor` to fire once per diagnostics update, including when the counts are unchanged. Previously the effect was keyed off a memoized counts object, so a viewer re-run that produced the same counts would silently skip the callback. Inline callbacks are now tracked through a ref so they don't refire the effect on every parent render, and `initialDiagnostics` defaults to a stable reference so unrelated parent re-renders don't refire downstream memos and effects.

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -185,7 +185,26 @@ export function EditorViewer({
     const diagnosticsSummaryCallbackRef = useRef(diagnosticsSummaryCallback);
     useEffect(() => {
         diagnosticsSummaryCallbackRef.current = diagnosticsSummaryCallback;
+    }, [diagnosticsSummaryCallback]);
+
+    // Keep the latest counts available to the effect below without making them
+    // dependencies — `initialDiagnostics` defaults to a fresh `[]` per render and
+    // would otherwise refire the effect on every parent re-render (and could
+    // re-introduce a render loop if a consumer stores the summary in state).
+    const latestCountsRef = useRef<DiagnosticsSummary>({
+        warningsCount,
+        errorsCount,
+        infosCount,
+        accessibilityLevel1Count,
+        accessibilityLevel2Count,
     });
+    latestCountsRef.current = {
+        warningsCount,
+        errorsCount,
+        infosCount,
+        accessibilityLevel1Count,
+        accessibilityLevel2Count,
+    };
 
     useEffect(() => {
         // On initial load of the editor, don't call `diagnosticsSummaryCallback`
@@ -196,16 +215,8 @@ export function EditorViewer({
             return;
         }
 
-        diagnosticsSummaryCallbackRef.current?.({
-            warningsCount,
-            errorsCount,
-            infosCount,
-            accessibilityLevel1Count,
-            accessibilityLevel2Count,
-        });
-        // Fire once per `diagnostics`/`initialDiagnostics` change rather than per
-        // count change — the consumer should treat this as an event, not a memoized value.
-    }, [diagnostics, initialDiagnostics, receivedDiagnosticsFromViewer]);
+        diagnosticsSummaryCallbackRef.current?.(latestCountsRef.current);
+    }, [diagnostics, receivedDiagnosticsFromViewer]);
 
     const [responses, setResponses] = useState<
         {

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -179,28 +179,13 @@ export function EditorViewer({
         [initialDiagnostics, diagnostics],
     );
 
-    /**
-     * Memoize the diagnosticsSummary object so its reference is stable when
-     * diagnostic counts don't change. This prevents unnecessary re-invocations
-     * of the effect callback and avoids potential render loops if a consumer
-     * stores this object in React state and passes an inline callback.
-     */
-    const diagnosticsSummary = useMemo(
-        () => ({
-            warningsCount,
-            errorsCount,
-            infosCount,
-            accessibilityLevel1Count,
-            accessibilityLevel2Count,
-        }),
-        [
-            warningsCount,
-            errorsCount,
-            infosCount,
-            accessibilityLevel1Count,
-            accessibilityLevel2Count,
-        ],
-    );
+    // Hold the latest `diagnosticsSummaryCallback` in a ref so inline callbacks
+    // (whose identity changes every parent render) don't retrigger the effect below
+    // and cause unbounded recursion when the consumer stores the summary in state.
+    const diagnosticsSummaryCallbackRef = useRef(diagnosticsSummaryCallback);
+    useEffect(() => {
+        diagnosticsSummaryCallbackRef.current = diagnosticsSummaryCallback;
+    });
 
     useEffect(() => {
         // On initial load of the editor, don't call `diagnosticsSummaryCallback`
@@ -211,12 +196,16 @@ export function EditorViewer({
             return;
         }
 
-        diagnosticsSummaryCallback?.(diagnosticsSummary);
-    }, [
-        diagnosticsSummary,
-        receivedDiagnosticsFromViewer,
-        diagnosticsSummaryCallback,
-    ]);
+        diagnosticsSummaryCallbackRef.current?.({
+            warningsCount,
+            errorsCount,
+            infosCount,
+            accessibilityLevel1Count,
+            accessibilityLevel2Count,
+        });
+        // Fire once per `diagnostics`/`initialDiagnostics` change rather than per
+        // count change — the consumer should treat this as an event, not a memoized value.
+    }, [diagnostics, initialDiagnostics, receivedDiagnosticsFromViewer]);
 
     const [responses, setResponses] = useState<
         {

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -30,6 +30,11 @@ import {
     toAdditionalDiagnosticsForLsp,
 } from "./diagnostics";
 
+// Module-level constant so the default for `initialDiagnostics` is referentially
+// stable across renders. A parameter default `= []` would create a fresh array
+// each render, refiring every effect/memo that depends on `initialDiagnostics`.
+const EMPTY_INITIAL_DIAGNOSTICS: DiagnosticRecord[] = [];
+
 /**
  * Combined DoenetML editor/viewer shell with diagnostics, responses, formatting, and variants.
  */
@@ -55,7 +60,7 @@ export function EditorViewer({
     showDiagnostics = true,
     showResponses = true,
     border = "1px solid",
-    initialDiagnostics = [],
+    initialDiagnostics = EMPTY_INITIAL_DIAGNOSTICS,
     fetchExternalDoenetML,
 }: {
     doenetML: string;
@@ -187,25 +192,6 @@ export function EditorViewer({
         diagnosticsSummaryCallbackRef.current = diagnosticsSummaryCallback;
     }, [diagnosticsSummaryCallback]);
 
-    // Keep the latest counts available to the effect below without making them
-    // dependencies — `initialDiagnostics` defaults to a fresh `[]` per render and
-    // would otherwise refire the effect on every parent re-render (and could
-    // re-introduce a render loop if a consumer stores the summary in state).
-    const latestCountsRef = useRef<DiagnosticsSummary>({
-        warningsCount,
-        errorsCount,
-        infosCount,
-        accessibilityLevel1Count,
-        accessibilityLevel2Count,
-    });
-    latestCountsRef.current = {
-        warningsCount,
-        errorsCount,
-        infosCount,
-        accessibilityLevel1Count,
-        accessibilityLevel2Count,
-    };
-
     useEffect(() => {
         // On initial load of the editor, don't call `diagnosticsSummaryCallback`
         // until the viewer has sent diagnostics so avoid sending just the initial diagnostics.
@@ -215,8 +201,16 @@ export function EditorViewer({
             return;
         }
 
-        diagnosticsSummaryCallbackRef.current?.(latestCountsRef.current);
-    }, [diagnostics, receivedDiagnosticsFromViewer]);
+        diagnosticsSummaryCallbackRef.current?.({
+            warningsCount,
+            errorsCount,
+            infosCount,
+            accessibilityLevel1Count,
+            accessibilityLevel2Count,
+        });
+        // Fire once per `diagnostics`/`initialDiagnostics` change rather than per
+        // count change — the consumer should treat this as an event, not a memoized value.
+    }, [diagnostics, initialDiagnostics, receivedDiagnosticsFromViewer]);
 
     const [responses, setResponses] = useState<
         {

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -1,6 +1,12 @@
 import "./DoenetML.css";
 import seedrandom from "seedrandom";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
 import { DocViewer } from "./Viewer/DocViewer";
 import { MathJaxContext } from "better-react-mathjax";
 import { mathjaxConfig, isErrorRecord, isWarningRecord } from "@doenet/utils";
@@ -27,6 +33,11 @@ export { defaultFlags } from "./flags";
 
 let warnedShowErrorsWarningsDeprecation = false;
 let warnedInitialErrorsWarningsDeprecation = false;
+
+// Module-level constant so the default for `initialDiagnostics` is referentially
+// stable across renders (a parameter default `= []` would create a fresh array
+// each render, refiring every memo/effect downstream that depends on it).
+const EMPTY_INITIAL_DIAGNOSTICS: DiagnosticRecord[] = [];
 
 export const version: string = DOENETML_VERSION;
 
@@ -332,7 +343,7 @@ export function DoenetEditor({
     showErrorsWarnings,
     showResponses = true,
     border = "1px solid",
-    initialDiagnostics = [],
+    initialDiagnostics = EMPTY_INITIAL_DIAGNOSTICS,
     initialErrors,
     initialWarnings,
     fetchExternalDoenetML,
@@ -393,11 +404,18 @@ export function DoenetEditor({
         );
     }
 
-    const normalizedInitialDiagnostics = [
-        ...initialDiagnostics,
-        ...(initialErrors ?? []),
-        ...(initialWarnings ?? []),
-    ];
+    // Memoized so the array reference is stable across re-renders unless one
+    // of the inputs actually changes. Without this, every re-render of
+    // `DoenetEditor` would hand `EditorViewer` a fresh array, refiring its
+    // diagnostics-summary effect on every parent render.
+    const normalizedInitialDiagnostics = useMemo(
+        () => [
+            ...initialDiagnostics,
+            ...(initialErrors ?? []),
+            ...(initialWarnings ?? []),
+        ],
+        [initialDiagnostics, initialErrors, initialWarnings],
+    );
 
     useEffect(() => {
         // Add a YouTube iframe api to the document header if it doesn't exist

--- a/packages/test-cypress/cypress/e2e/EditorViewer/editorViewerAccessibilityReport.cy.js
+++ b/packages/test-cypress/cypress/e2e/EditorViewer/editorViewerAccessibilityReport.cy.js
@@ -193,6 +193,20 @@ describe(
                     calls[1].accessibilityLevel1Count,
                 );
             });
+
+            // Toggling an unrelated parent control re-renders CypressTest (and
+            // thus EditorViewer) without changing diagnostics. The callback
+            // must not fire — guards against `initialDiagnostics`'s default
+            // `[]` (or an inline-callback identity) refiring the effect.
+            cy.get("#testRunner_toggleControls").click();
+            cy.get("#testRunner_darkMode").click();
+            cy.get("#testRunner_darkMode").click();
+            cy.get("#testRunner_toggleControls").click();
+            cy.wait(200);
+            cy.window().should((win) => {
+                const calls = win.returnDiagnosticsSummaryCallbackCalls();
+                expect(calls).to.have.length(3);
+            });
         });
 
         it("displays accessibility report with WCAG AA Violations section", () => {

--- a/packages/test-cypress/cypress/e2e/EditorViewer/editorViewerAccessibilityReport.cy.js
+++ b/packages/test-cypress/cypress/e2e/EditorViewer/editorViewerAccessibilityReport.cy.js
@@ -155,6 +155,46 @@ describe(
             });
         });
 
+        it("diagnosticsSummaryCallback fires on each diagnostics update, including when counts are unchanged", () => {
+            postDoenetML(`<textInput /><text name="t">hello</text>`);
+
+            cy.get("#t").should("contain.text", "hello");
+
+            // First call: textInput without a label is one level-1 violation.
+            cy.window().should((win) => {
+                const calls = win.returnDiagnosticsSummaryCallbackCalls();
+                expect(calls).to.have.length(1);
+                expect(calls[0].accessibilityLevel1Count).to.eq(1);
+            });
+
+            // Type at the end of the editor and force a viewer update.
+            cy.get(".cm-content").click().type("{ctrl+end}abc", { delay: 10 });
+            cy.get('[data-test="Viewer Update Button"]').click();
+
+            // Second call: same accessibility counts, but the callback must
+            // still fire because diagnostics were re-emitted by the viewer.
+            cy.window().should((win) => {
+                const calls = win.returnDiagnosticsSummaryCallbackCalls();
+                expect(calls).to.have.length(2);
+                expect(calls[1].accessibilityLevel1Count).to.eq(1);
+            });
+
+            // Add a second unlabeled input and update again.
+            cy.get(".cm-content")
+                .click()
+                .type("{ctrl+end}<mathInput />", { delay: 10 });
+            cy.get('[data-test="Viewer Update Button"]').click();
+
+            // Third call: a new violation, so the count goes up.
+            cy.window().should((win) => {
+                const calls = win.returnDiagnosticsSummaryCallbackCalls();
+                expect(calls).to.have.length(3);
+                expect(calls[2].accessibilityLevel1Count).to.be.greaterThan(
+                    calls[1].accessibilityLevel1Count,
+                );
+            });
+        });
+
         it("displays accessibility report with WCAG AA Violations section", () => {
             postDoenetML(`
 <styleDefinition styleNumber="102" textColor="#ff9900" />

--- a/packages/test-cypress/src/CypressTest.tsx
+++ b/packages/test-cypress/src/CypressTest.tsx
@@ -111,6 +111,7 @@ export function CypressTest() {
         testSettings.includeVariantSelector,
     );
     const diagnosticsSummaryRef = useRef<Record<string, number> | null>(null);
+    const diagnosticsSummaryCallsRef = useRef<Record<string, number>[]>([]);
 
     useEffect(() => {
         (window as any).returnDiagnosticsSummaryCallbackValue = (): Record<
@@ -119,14 +120,22 @@ export function CypressTest() {
         > | null => {
             return diagnosticsSummaryRef.current;
         };
+        (window as any).returnDiagnosticsSummaryCallbackCalls = (): Record<
+            string,
+            number
+        >[] => {
+            return diagnosticsSummaryCallsRef.current;
+        };
         return () => {
             delete (window as any).returnDiagnosticsSummaryCallbackValue;
+            delete (window as any).returnDiagnosticsSummaryCallbackCalls;
         };
     }, []);
 
-    // Reset diagnosticsSummaryRef when new DoenetML is posted to avoid stale values
+    // Reset diagnostics tracking when new DoenetML is posted to avoid stale values
     useEffect(() => {
         diagnosticsSummaryRef.current = null;
+        diagnosticsSummaryCallsRef.current = [];
     }, [doenetMLstring]);
 
     const solutionDisplayMode = "button";
@@ -598,6 +607,10 @@ export function CypressTest() {
                     nextDiagnosticsSummary: Record<string, number>,
                 ) => {
                     diagnosticsSummaryRef.current = nextDiagnosticsSummary;
+                    diagnosticsSummaryCallsRef.current = [
+                        ...diagnosticsSummaryCallsRef.current,
+                        nextDiagnosticsSummary,
+                    ];
                 }}
             />
         );

--- a/packages/test-cypress/src/CypressTest.tsx
+++ b/packages/test-cypress/src/CypressTest.tsx
@@ -124,7 +124,7 @@ export function CypressTest() {
             string,
             number
         >[] => {
-            return diagnosticsSummaryCallsRef.current;
+            return diagnosticsSummaryCallsRef.current.slice();
         };
         return () => {
             delete (window as any).returnDiagnosticsSummaryCallbackValue;
@@ -607,10 +607,9 @@ export function CypressTest() {
                     nextDiagnosticsSummary: Record<string, number>,
                 ) => {
                     diagnosticsSummaryRef.current = nextDiagnosticsSummary;
-                    diagnosticsSummaryCallsRef.current = [
-                        ...diagnosticsSummaryCallsRef.current,
+                    diagnosticsSummaryCallsRef.current.push(
                         nextDiagnosticsSummary,
-                    ];
+                    );
                 }}
             />
         );


### PR DESCRIPTION
## Summary
- The effect that calls `diagnosticsSummaryCallback` previously depended on a memoized `diagnosticsSummary`, so when `diagnostics` changed but the counts stayed the same (e.g., after a viewer re-run with no new violations) the callback was silently skipped.
- Now the effect depends on `diagnostics`/`initialDiagnostics` directly, so it fires once per actual diagnostics update. The memoized `diagnosticsSummary` was removed since it's no longer load-bearing.
- The original reason for the memo was an infinite-recursion loop in Cypress when consumers passed an inline callback — that is now blocked by storing `diagnosticsSummaryCallback` in a ref, so the effect doesn't react to callback identity changes.

## Test plan
- [x] New cypress test `diagnosticsSummaryCallback fires on each diagnostics update, including when counts are unchanged` posts `<textInput /><text name="t">hello</text>`, verifies one call with `accessibilityLevel1Count: 1`, then types into the editor and clicks the Viewer Update button to verify a second call with the same count, then appends `<mathInput />` and updates again to verify a third call with a higher count.
- [x] Full `editorViewerAccessibilityReport.cy.js` spec passes locally (16/16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)