### PR TITLE
refactor(renderers): migrate remaining renderers to typed SVs (PR A of 2)

### DIFF
--- a/packages/doenetml/src/Viewer/renderers/GraphFrame.tsx
+++ b/packages/doenetml/src/Viewer/renderers/GraphFrame.tsx
@@ -1,7 +1,20 @@
-// @ts-nocheck
 import React from "react";
 import { sizeToCSS } from "./utils/css";
 import { DescriptionAsDetails, DescriptionPopover } from "./utils/Description";
+import { GraphSVs } from "./graph";
+
+interface GraphFrameProps {
+    id: string;
+    SVs: GraphSVs;
+    isPrefigureRenderer: boolean;
+    containerRef: React.RefObject<HTMLDivElement | null>;
+    descriptionChild: React.ReactNode | false;
+    hasInteractiveControls: boolean;
+    suppressTopMargin?: boolean;
+    children:
+        | React.ReactNode
+        | ((surfaceStyle: React.CSSProperties) => React.ReactNode);
+}
 
 /**
  * Shared frame for graph-style renderers.
@@ -19,7 +32,7 @@ export default function GraphFrame({
     hasInteractiveControls,
     suppressTopMargin = false,
     children,
-}) {
+}: GraphFrameProps) {
     const contentStyle: React.CSSProperties = {
         width: sizeToCSS(SVs.width),
         aspectRatio: String(SVs.aspectRatio),

--- a/packages/doenetml/src/Viewer/renderers/JSXGraphRenderer.tsx
+++ b/packages/doenetml/src/Viewer/renderers/JSXGraphRenderer.tsx
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState, Context } from "react";
 // @ts-ignore
 import JXG from "jsxgraph";
 import {
@@ -8,6 +7,20 @@ import {
     createYAxis,
 } from "./utils/jsxgraph";
 import useJSXGraphBoardSync from "./utils/useJSXGraphBoardSync";
+import { JXGBoard } from "./jsxgraph-distrib/types";
+import { GraphSVs } from "./graph";
+import { CallActionArgs, RendererAction } from "../useDoenetRenderer";
+
+interface JSXGraphRendererProps {
+    id: string;
+    SVs: GraphSVs;
+    children: React.ReactNode;
+    ignoreUpdate: boolean;
+    actions: Record<string, RendererAction>;
+    callAction: (argObj: CallActionArgs) => void;
+    BoardContext: Context<JXGBoard | null>;
+    surfaceStyle: React.CSSProperties;
+}
 
 export default function JSXGraphRenderer({
     id,
@@ -18,21 +31,24 @@ export default function JSXGraphRenderer({
     callAction,
     BoardContext,
     surfaceStyle,
-}) {
-    const [board, setBoard] = useState(null);
+}: JSXGraphRendererProps) {
+    const [board, setBoard] = useState<JXGBoard | null>(null);
 
-    const previousDimensions = useRef(null);
-    const previousBoundingbox = useRef(null);
-    const xaxis = useRef(null);
-    const yaxis = useRef(null);
-    const settingBoundingBox = useRef(false);
-    const boardJustInitialized = useRef(false);
+    const previousDimensions = useRef<{
+        width: number;
+        aspectRatio: string | number;
+    } | null>(null);
+    const previousBoundingbox = useRef<number[] | null>(null);
+    const xaxis = useRef<any>(null);
+    const yaxis = useRef<any>(null);
+    const settingBoundingBox = useRef<boolean>(false);
+    const boardJustInitialized = useRef<boolean>(false);
 
-    const previousShowNavigation = useRef(false);
-    const previousXaxisWithLabel = useRef(null);
-    const previousYaxisWithLabel = useRef(null);
+    const previousShowNavigation = useRef<boolean>(false);
+    const previousXaxisWithLabel = useRef<boolean>(false);
+    const previousYaxisWithLabel = useRef<boolean>(false);
 
-    const showNavigation = SVs.showNavigation && !SVs.fixAxes;
+    const showNavigation = Boolean(SVs.showNavigation && !SVs.fixAxes);
 
     useEffect(() => {
         const boundingbox = [SVs.xMin, SVs.yMax, SVs.xMax, SVs.yMin];
@@ -49,7 +65,7 @@ export default function JSXGraphRenderer({
             JXG.Options.grid.gridY = SVs.grid[1];
         }
 
-        const newBoard = window.JXG.JSXGraph.initBoard(id, {
+        const newBoard: JXGBoard = (window as any).JXG.JSXGraph.initBoard(id, {
             boundingbox,
             axis: false,
             showCopyright: false,
@@ -59,7 +75,7 @@ export default function JSXGraphRenderer({
             grid: haveFixedGrid,
         });
 
-        newBoard.itemsRenderedLowQuality = {};
+        (newBoard as any).itemsRenderedLowQuality = {};
 
         newBoard.on("boundingbox", () => {
             if (!settingBoundingBox.current) {
@@ -68,8 +84,8 @@ export default function JSXGraphRenderer({
 
                 const xscale = Math.abs(xMax - xMin);
                 const yscale = Math.abs(yMax - yMin);
-                const diffs = newBoundingbox.map((v, i) =>
-                    Math.abs(v - previousBoundingbox.current[i]),
+                const diffs = newBoundingbox.map((v: number, i: number) =>
+                    Math.abs(v - previousBoundingbox.current![i]),
                 );
                 if (
                     Math.max(
@@ -92,7 +108,7 @@ export default function JSXGraphRenderer({
         setBoard(newBoard);
 
         previousDimensions.current = {
-            width: parseFloat(surfaceStyle.width),
+            width: parseFloat(surfaceStyle.width as string),
             aspectRatio: SVs.aspectRatio,
         };
 
@@ -117,34 +133,40 @@ export default function JSXGraphRenderer({
         boardJustInitialized.current = true;
         previousShowNavigation.current = showNavigation;
 
-        function keyFocusOutListener(evt) {
-            const id_node = evt.target.id;
+        function keyFocusOutListener(evt: FocusEvent) {
+            const id_node = (evt.target as HTMLElement).id;
             if (id_node === "") {
                 return false;
             }
 
             const el_id = id_node.replace(id + "_", "");
-            const el = newBoard.select(el_id);
+            const el = (newBoard as any).select(el_id);
             el.triggerEventHandlers?.(["keyfocusout"], [evt]);
         }
 
-        newBoard.containerObj.addEventListener("focusout", keyFocusOutListener);
+        (newBoard as any).containerObj.addEventListener(
+            "focusout",
+            keyFocusOutListener,
+        );
 
-        function keyDownListener(evt) {
-            const id_node = evt.target.id;
+        function keyDownListener(evt: KeyboardEvent) {
+            const id_node = (evt.target as HTMLElement).id;
             if (id_node === "") {
                 return false;
             }
 
             const el_id = id_node.replace(id + "_", "");
-            const el = newBoard.select(el_id);
+            const el = (newBoard as any).select(el_id);
             el.triggerEventHandlers?.(["keydown"], [evt]);
         }
 
-        newBoard.containerObj.addEventListener("keydown", keyDownListener);
+        (newBoard as any).containerObj.addEventListener(
+            "keydown",
+            keyDownListener,
+        );
 
         return () => {
-            const container = newBoard.containerObj;
+            const container = (newBoard as any).containerObj;
             container?.removeEventListener("focusout", keyFocusOutListener);
             container?.removeEventListener("keydown", keyDownListener);
             newBoard.off("boundingbox");

--- a/packages/doenetml/src/Viewer/renderers/_error.tsx
+++ b/packages/doenetml/src/Viewer/renderers/_error.tsx
@@ -3,8 +3,15 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 
+interface ErrorSVs {
+    hidden: boolean;
+    showMessage: boolean;
+    rangeMessage?: string;
+    message: string;
+}
+
 export default React.memo(function Error(props: UseDoenetRendererProps) {
-    let { id, SVs, children } = useDoenetRenderer(props);
+    let { id, SVs, children } = useDoenetRenderer<ErrorSVs>(props);
 
     let displayedMessage = null;
 

--- a/packages/doenetml/src/Viewer/renderers/alert.tsx
+++ b/packages/doenetml/src/Viewer/renderers/alert.tsx
@@ -4,8 +4,14 @@ import useDoenetRenderer, {
 } from "../useDoenetRenderer";
 import { addCommasForCompositeRanges } from "./utils/composites";
 
+interface AlertSVs {
+    [key: string]: any;
+    hidden: boolean;
+    _compositeReplacementActiveRange?: any;
+}
+
 export default React.memo(function Alert(props: UseDoenetRendererProps) {
-    let { id, SVs, children } = useDoenetRenderer(props);
+    let { id, SVs, children } = useDoenetRenderer<AlertSVs>(props);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/answer.tsx
+++ b/packages/doenetml/src/Viewer/renderers/answer.tsx
@@ -12,6 +12,20 @@ import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
 import { MathJax } from "better-react-mathjax";
 import { DescriptionPopover } from "./utils/Description";
 
+interface AnswerSVs {
+    [key: string]: any;
+    hidden: boolean;
+    inline: boolean;
+    label: string;
+    labelHasLatex: boolean;
+    justSubmitted: boolean;
+    forceFullCheckWorkButton: boolean;
+    forceSmallCheckWorkButton: boolean;
+    haveBlockInputChild: boolean;
+    inputChildIndices: any;
+    descriptionChildInd: any;
+}
+
 export default React.memo(function Answer(props: UseDoenetRendererProps) {
     let {
         componentIdx,
@@ -23,7 +37,7 @@ export default React.memo(function Answer(props: UseDoenetRendererProps) {
         children,
         flags,
         callAction,
-    } = useDoenetRenderer(props);
+    } = useDoenetRenderer<AnswerSVs>(props);
 
     const { showAnswerResponseButton, answerResponseCounts } =
         useContext(DocContext) || {};
@@ -42,7 +56,7 @@ export default React.memo(function Answer(props: UseDoenetRendererProps) {
         justSubmitted: SVs.justSubmitted,
     });
 
-    let label = SVs.label;
+    let label: React.ReactNode = SVs.label;
     if (SVs.labelHasLatex) {
         label = (
             <MathJax hideUntilTypeset={"first"} inline dynamic>

--- a/packages/doenetml/src/Viewer/renderers/asList.tsx
+++ b/packages/doenetml/src/Viewer/renderers/asList.tsx
@@ -3,8 +3,12 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 
+interface AsListSVs {
+    hidden: boolean;
+}
+
 export default React.memo(function AsList(props: UseDoenetRendererProps) {
-    let { id, SVs, children } = useDoenetRenderer(props);
+    let { id, SVs, children } = useDoenetRenderer<AsListSVs>(props);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/blockQuote.tsx
+++ b/packages/doenetml/src/Viewer/renderers/blockQuote.tsx
@@ -13,7 +13,8 @@ interface BlockQuoteSVs {
 }
 
 export default React.memo(function Container(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer<BlockQuoteSVs>(props);
+    let { id, SVs, children, actions, callAction } =
+        useDoenetRenderer<BlockQuoteSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/blockQuote.tsx
+++ b/packages/doenetml/src/Viewer/renderers/blockQuote.tsx
@@ -5,8 +5,15 @@ import useDoenetRenderer, {
 import { addCommasForCompositeRanges } from "./utils/composites";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 
+interface BlockQuoteSVs {
+    [key: string]: any;
+    hidden: boolean;
+    _compositeReplacementActiveRange?: any;
+    renderInlineForListItem: boolean;
+}
+
 export default React.memo(function Container(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer(props);
+    let { id, SVs, children, actions, callAction } = useDoenetRenderer<BlockQuoteSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/boolean.tsx
+++ b/packages/doenetml/src/Viewer/renderers/boolean.tsx
@@ -3,8 +3,14 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 
+interface BooleanSVs {
+    [key: string]: any;
+    hidden: boolean;
+    text: string;
+}
+
 export default React.memo(function Boolean(props: UseDoenetRendererProps) {
-    let { id, SVs } = useDoenetRenderer(props, false);
+    let { id, SVs } = useDoenetRenderer<BooleanSVs>(props, false);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/booleanInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/booleanInput.tsx
@@ -19,9 +19,28 @@ import {
 import { DescriptionPopover } from "./utils/Description";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
 
+interface BooleanInputSVs {
+    [key: string]: any;
+    hidden: boolean;
+    disabled: boolean;
+    value: boolean;
+    asToggleButton: boolean;
+    label: string;
+    labelHasLatex: boolean;
+    labelPosition?: string;
+    fixed: boolean;
+    fixLocation: boolean;
+    draggable: boolean;
+    anchor: any;
+    positionFromAnchor: any;
+    forceFullCheckWorkButton: boolean;
+    justSubmitted: boolean;
+    shortDescription?: string;
+}
+
 export default React.memo(function BooleanInput(props: UseDoenetRendererProps) {
     let { id, SVs, children, actions, ignoreUpdate, callAction } =
-        useDoenetRenderer(props);
+        useDoenetRenderer<BooleanInputSVs>(props);
 
     // @ts-ignore
     BooleanInput.baseStateVariable = "value";
@@ -32,10 +51,10 @@ export default React.memo(function BooleanInput(props: UseDoenetRendererProps) {
     const [rendererValue, setRendererValue] = useState(SVs.value);
 
     // add ref, because event handler called from jsxgraph doesn't get new value
-    let rendererValueRef = useRef(null);
+    let rendererValueRef = useRef<boolean | null>(null);
     rendererValueRef.current = rendererValue;
 
-    let valueWhenSetState = useRef(null);
+    let valueWhenSetState = useRef<boolean | null>(null);
 
     let inputJXG = useRef<JXGObject | null>(null);
     let anchorPointJXG = useRef<JXGObject | null>(null);
@@ -497,7 +516,7 @@ export default React.memo(function BooleanInput(props: UseDoenetRendererProps) {
     );
 
     let input;
-    let label = SVs.label;
+    let label: React.ReactNode = SVs.label;
     if (SVs.labelHasLatex) {
         label = (
             <MathJax hideUntilTypeset={"first"} inline dynamic>
@@ -535,7 +554,7 @@ export default React.memo(function BooleanInput(props: UseDoenetRendererProps) {
                 onClick={onChangeHandler}
                 onFocus={() => onFocusChanged(true)}
                 onBlur={() => onFocusChanged(false)}
-                value={label}
+                value={label as any}
                 disabled={disabled}
                 ariaLabel={shortDescription}
             />

--- a/packages/doenetml/src/Viewer/renderers/br.tsx
+++ b/packages/doenetml/src/Viewer/renderers/br.tsx
@@ -3,8 +3,12 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 
+interface BrSVs {
+    hidden: boolean;
+}
+
 export default React.memo(function Br(props: UseDoenetRendererProps) {
-    let { id, SVs } = useDoenetRenderer(props);
+    let { id, SVs } = useDoenetRenderer<BrSVs>(props);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/button.tsx
+++ b/packages/doenetml/src/Viewer/renderers/button.tsx
@@ -11,11 +11,30 @@ import {
 } from "./utils/graph";
 import { cesc } from "@doenet/utils";
 import { JXGEvent, JXGObject } from "./jsxgraph-distrib/types";
+import { SelectedStyle } from "./utils/graphicalSVs";
+
+interface ButtonSVs {
+    [key: string]: any;
+    hidden: boolean;
+    disabled: boolean;
+    fixed: boolean;
+    fixLocation: boolean;
+    draggable: boolean;
+    anchor: any;
+    positionFromAnchor: any;
+    label: string;
+    labelHasLatex: boolean;
+    clickAction: any;
+    selectedStyle: SelectedStyle;
+}
 
 export default React.memo(function ButtonComponent(
     props: UseDoenetRendererProps,
 ) {
-    let { id, SVs, actions, callAction } = useDoenetRenderer(props, false);
+    let { id, SVs, actions, callAction } = useDoenetRenderer<ButtonSVs>(
+        props,
+        false,
+    );
 
     // @ts-ignore
     ButtonComponent.ignoreActionsWithoutCore = (actionName) =>
@@ -45,7 +64,7 @@ export default React.memo(function ButtonComponent(
 
     let label = SVs.label ? SVs.label : "Button";
 
-    let fillColor: string = SVs.selectedStyle.highContrastColor;
+    let fillColor: string = SVs.selectedStyle.highContrastColor ?? "";
 
     useEffect(() => {
         //On unmount

--- a/packages/doenetml/src/Viewer/renderers/c.tsx
+++ b/packages/doenetml/src/Viewer/renderers/c.tsx
@@ -4,8 +4,14 @@ import useDoenetRenderer, {
 } from "../useDoenetRenderer";
 import { addCommasForCompositeRanges } from "./utils/composites";
 
+interface CSVs {
+    [key: string]: any;
+    hidden: boolean;
+    _compositeReplacementActiveRange?: any;
+}
+
 export default React.memo(function C(props: UseDoenetRendererProps) {
-    let { id, SVs, children } = useDoenetRenderer(props);
+    let { id, SVs, children } = useDoenetRenderer<CSVs>(props);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/cell.tsx
+++ b/packages/doenetml/src/Viewer/renderers/cell.tsx
@@ -4,8 +4,20 @@ import useDoenetRenderer, {
 } from "../useDoenetRenderer";
 import { addCommasForCompositeRanges } from "./utils/composites";
 
+interface CellSVs {
+    [key: string]: any;
+    hidden: boolean;
+    _compositeReplacementActiveRange?: any;
+    bottom?: any;
+    colSpan: number;
+    halign?: any;
+    inHeader: boolean;
+    right?: any;
+    text: string;
+}
+
 export default React.memo(function Cell(props: UseDoenetRendererProps) {
-    let { id, SVs, children } = useDoenetRenderer(props);
+    let { id, SVs, children } = useDoenetRenderer<CellSVs>(props);
 
     if (SVs.hidden) {
         return null;
@@ -52,7 +64,7 @@ export default React.memo(function Cell(props: UseDoenetRendererProps) {
         });
     }
 
-    let content = children;
+    let content: React.ReactNode[] | string = children;
 
     if (content.length === 0) {
         content = SVs.text;

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -37,9 +37,33 @@ export const ChoiceInputInlineContext = createContext<{
     inOption: boolean;
 }>({ isHidden: false, inOption: false });
 
+interface ChoiceInputSVs {
+    [key: string]: any;
+    hidden: boolean;
+    disabled: boolean;
+    inline: boolean;
+    label: string;
+    labelHasLatex: boolean;
+    labelPosition: string;
+    justSubmitted: boolean;
+    forceFullCheckWorkButton: boolean;
+    forceSmallCheckWorkButton: boolean;
+    colorCorrectness: boolean;
+    choiceChildIndices: any;
+    choiceOrder: any;
+    choicesDisabled: any;
+    choicesHidden: any;
+    descriptionChildInd: any;
+    externalLabelRendererIds: any;
+    immediateValue: any;
+    placeHolder: any;
+    renderInlineForListItem: boolean;
+    selectedIndices: any;
+}
+
 export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
     let { id, SVs, actions, children, ignoreUpdate, callAction } =
-        useDoenetRenderer(props);
+        useDoenetRenderer<ChoiceInputSVs>(props);
 
     // @ts-ignore
     ChoiceInput.baseStateVariable = "selectedIndices";
@@ -149,7 +173,7 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
 
     let disabled = SVs.disabled;
 
-    let label = SVs.label;
+    let label: React.ReactNode = SVs.label;
     const hasLabel =
         typeof SVs.label === "string" ? SVs.label.trim() !== "" : !!SVs.label;
     const labelId = `${id}-label`;

--- a/packages/doenetml/src/Viewer/renderers/codeEditor.tsx
+++ b/packages/doenetml/src/Viewer/renderers/codeEditor.tsx
@@ -7,9 +7,21 @@ import { sizeToCSS } from "./utils/css";
 import { useInView } from "framer-motion";
 import { EditorViewer } from "../../EditorViewer/EditorViewer";
 
+interface CodeEditorSVs {
+    [key: string]: any;
+    hidden: boolean;
+    readOnly: boolean;
+    showFormatter: boolean;
+    showResults: boolean;
+    resultsLocation: any;
+    immediateValue: string;
+    width: any;
+    height: any;
+}
+
 export default React.memo(function CodeEditor(props: UseDoenetRendererProps) {
     let { id, SVs, actions, ignoreUpdate, callAction, fetchExternalDoenetML } =
-        useDoenetRenderer(props) as any;
+        useDoenetRenderer<CodeEditorSVs>(props) as any;
 
     // @ts-ignore
     CodeEditor.baseStateVariable = "immediateValue";

--- a/packages/doenetml/src/Viewer/renderers/containerBlock.tsx
+++ b/packages/doenetml/src/Viewer/renderers/containerBlock.tsx
@@ -10,8 +10,16 @@ import {
 } from "./utils/checkWork";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
 
+interface ContainerBlockSVs {
+    [key: string]: any;
+    hidden: boolean;
+    _compositeReplacementActiveRange?: any;
+    justSubmitted: boolean;
+    renderInlineForListItem: boolean;
+}
+
 export default React.memo(function Container(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer(props);
+    let { id, SVs, children, actions, callAction } = useDoenetRenderer<ContainerBlockSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/containerBlock.tsx
+++ b/packages/doenetml/src/Viewer/renderers/containerBlock.tsx
@@ -19,7 +19,8 @@ interface ContainerBlockSVs {
 }
 
 export default React.memo(function Container(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer<ContainerBlockSVs>(props);
+    let { id, SVs, children, actions, callAction } =
+        useDoenetRenderer<ContainerBlockSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/containerInline.tsx
+++ b/packages/doenetml/src/Viewer/renderers/containerInline.tsx
@@ -9,10 +9,17 @@ import {
 } from "./utils/checkWork";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
 
+interface ContainerInlineSVs {
+    [key: string]: any;
+    hidden: boolean;
+    _compositeReplacementActiveRange?: any;
+    justSubmitted: boolean;
+}
+
 export default React.memo(function ContainerInline(
     props: UseDoenetRendererProps,
 ) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer(props);
+    let { id, SVs, children, actions, callAction } = useDoenetRenderer<ContainerInlineSVs>(props);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/containerInline.tsx
+++ b/packages/doenetml/src/Viewer/renderers/containerInline.tsx
@@ -19,7 +19,8 @@ interface ContainerInlineSVs {
 export default React.memo(function ContainerInline(
     props: UseDoenetRendererProps,
 ) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer<ContainerInlineSVs>(props);
+    let { id, SVs, children, actions, callAction } =
+        useDoenetRenderer<ContainerInlineSVs>(props);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/ellipsis.tsx
+++ b/packages/doenetml/src/Viewer/renderers/ellipsis.tsx
@@ -3,8 +3,12 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 
+interface EllipsisSVs {
+    hidden: boolean;
+}
+
 export default React.memo(function Ellipsis(props: UseDoenetRendererProps) {
-    let { id, SVs } = useDoenetRenderer(props);
+    let { id, SVs } = useDoenetRenderer<EllipsisSVs>(props);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/em.tsx
+++ b/packages/doenetml/src/Viewer/renderers/em.tsx
@@ -4,8 +4,14 @@ import useDoenetRenderer, {
 } from "../useDoenetRenderer";
 import { addCommasForCompositeRanges } from "./utils/composites";
 
+interface EmSVs {
+    [key: string]: any;
+    hidden: boolean;
+    _compositeReplacementActiveRange?: any;
+}
+
 export default React.memo(function Em(props: UseDoenetRendererProps) {
-    let { id, SVs, children } = useDoenetRenderer(props);
+    let { id, SVs, children } = useDoenetRenderer<EmSVs>(props);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/embed.tsx
+++ b/packages/doenetml/src/Viewer/renderers/embed.tsx
@@ -1,13 +1,25 @@
-// @ts-nocheck
 import React, { useEffect, useRef } from "react";
-import useDoenetRenderer from "../useDoenetRenderer";
+import useDoenetRenderer, {
+    UseDoenetRendererProps,
+} from "../useDoenetRenderer";
 import { sizeToCSS } from "./utils/css";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 
-export default React.memo(function Figure(props) {
-    let { id, SVs, actions, callAction } = useDoenetRenderer(props);
+declare const MathJax: any;
 
-    const ref = useRef(null);
+interface EmbedSVs {
+    [key: string]: any;
+    hidden: boolean;
+    width?: { size: string; isAbsolute: boolean };
+    height?: { size: string; isAbsolute: boolean };
+    geogebra?: string;
+    encodedGeogebraContent?: string;
+}
+
+export default React.memo(function Figure(props: UseDoenetRendererProps) {
+    let { id, SVs, actions, callAction } = useDoenetRenderer<EmbedSVs>(props);
+
+    const ref = useRef<HTMLDivElement | null>(null);
 
     useRecordVisibilityChanges(ref, callAction, actions);
 
@@ -35,7 +47,7 @@ export default React.memo(function Figure(props) {
                     enableShiftDragZoom: true,
                     enableRightClick: true,
                     showToolBarHelp: false,
-                    ggbBase64: doenetSvData.encodedGeogebraContent.trim(),
+                    ggbBase64: doenetSvData.encodedGeogebraContent!.trim(),
                     language: "en",
                     country: "US",
                     isPreloader: false,
@@ -48,7 +60,7 @@ export default React.memo(function Figure(props) {
                     canary: false,
                     allowUpscale: false,
                 };
-                let applet = new window.GGBApplet(parameters, true);
+                let applet = new (window as any).GGBApplet(parameters, true);
                 applet.setHTML5Codebase("/geogebra/HTML5/5.0/web/", "true");
                 applet.inject("container_" + cIdx, "preferhtml5");
             });

--- a/packages/doenetml/src/Viewer/renderers/embed.tsx
+++ b/packages/doenetml/src/Viewer/renderers/embed.tsx
@@ -16,7 +16,7 @@ interface EmbedSVs {
     encodedGeogebraContent?: string;
 }
 
-export default React.memo(function Figure(props: UseDoenetRendererProps) {
+export default React.memo(function Embed(props: UseDoenetRendererProps) {
     let { id, SVs, actions, callAction } = useDoenetRenderer<EmbedSVs>(props);
 
     const ref = useRef<HTMLDivElement | null>(null);

--- a/packages/doenetml/src/Viewer/renderers/feedback.tsx
+++ b/packages/doenetml/src/Viewer/renderers/feedback.tsx
@@ -16,7 +16,8 @@ interface FeedbackSVs {
 }
 
 export default React.memo(function Feedback(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer<FeedbackSVs>(props);
+    let { id, SVs, children, actions, callAction } =
+        useDoenetRenderer<FeedbackSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/feedback.tsx
+++ b/packages/doenetml/src/Viewer/renderers/feedback.tsx
@@ -8,8 +8,15 @@ import { useRecordVisibilityChanges } from "../../utils/visibility";
 import { addCommasForCompositeRanges } from "./utils/composites";
 import "./feedback.css";
 
+interface FeedbackSVs {
+    [key: string]: any;
+    hidden: boolean;
+    _compositeReplacementActiveRange?: any;
+    feedbackText: string;
+}
+
 export default React.memo(function Feedback(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer(props);
+    let { id, SVs, children, actions, callAction } = useDoenetRenderer<FeedbackSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/figure.tsx
+++ b/packages/doenetml/src/Viewer/renderers/figure.tsx
@@ -5,8 +5,16 @@ import useDoenetRenderer, {
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 import Measure from "react-measure";
 
+interface FigureSVs {
+    [key: string]: any;
+    hidden: boolean;
+    captionChildName?: any;
+    figureName: string;
+    suppressFigureNameInCaption: boolean;
+}
+
 export default React.memo(function Figure(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer(props);
+    let { id, SVs, children, actions, callAction } = useDoenetRenderer<FigureSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/figure.tsx
+++ b/packages/doenetml/src/Viewer/renderers/figure.tsx
@@ -14,7 +14,8 @@ interface FigureSVs {
 }
 
 export default React.memo(function Figure(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer<FigureSVs>(props);
+    let { id, SVs, children, actions, callAction } =
+        useDoenetRenderer<FigureSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/footnote.tsx
+++ b/packages/doenetml/src/Viewer/renderers/footnote.tsx
@@ -9,8 +9,15 @@ import {
     Button,
 } from "@ariakit/react";
 
+interface FootnoteSVs {
+    [key: string]: any;
+    hidden: boolean;
+    footnoteTag: string;
+    text: string;
+}
+
 export default React.memo(function Footnote(props: UseDoenetRendererProps) {
-    let { id, SVs } = useDoenetRenderer(props, false);
+    let { id, SVs } = useDoenetRenderer<FootnoteSVs>(props, false);
     let [isVisible, setIsVisible] = useState(false);
 
     if (SVs.hidden) {

--- a/packages/doenetml/src/Viewer/renderers/graph.tsx
+++ b/packages/doenetml/src/Viewer/renderers/graph.tsx
@@ -1,6 +1,7 @@
-// @ts-nocheck
 import React, { useEffect, useRef, useState, createContext } from "react";
-import useDoenetRenderer from "../useDoenetRenderer";
+import useDoenetRenderer, {
+    UseDoenetRendererProps,
+} from "../useDoenetRenderer";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 import { JXGBoard } from "./jsxgraph-distrib/types";
 import Prefigure from "./prefigure";
@@ -10,6 +11,44 @@ import JSXGraphRenderer from "./JSXGraphRenderer";
 import { normalizeGraphControlsMode } from "./graphControls/model";
 
 export const BoardContext = createContext<JXGBoard | null>(null);
+
+/**
+ * State variables read by the Graph renderer trio (graph.tsx, GraphFrame.tsx,
+ * JSXGraphRenderer.tsx) plus the inline children (Prefigure,
+ * GraphControlsRoot, axis helpers, useJSXGraphBoardSync). The index signature
+ * keeps it open for the many additional fields consumed by helpers that
+ * accept `Record<string, any>`.
+ */
+export interface GraphSVs {
+    [key: string]: any;
+    hidden: boolean;
+    haveGraphParent: boolean;
+    descriptionChildInd: number;
+    addControls: string;
+    graphicalDescendantsForControls: any[];
+    controlsPosition?: string;
+    renderInlineForListItem?: boolean;
+    effectiveRenderer?: string;
+    renderer?: string;
+    width: { size: string; isAbsolute: boolean };
+    aspectRatio: string | number;
+    displayMode: string;
+    horizontalAlign?: string;
+    showBorder: boolean;
+    shortDescription?: string;
+    decorative: boolean;
+    showNavigation?: boolean;
+    fixAxes?: boolean;
+    xMin: number;
+    yMax: number;
+    xMax: number;
+    yMin: number;
+    grid?: unknown;
+    displayXAxis?: boolean;
+    displayYAxis?: boolean;
+    prefigureXML: string | null;
+    hasAuthorAnnotations: boolean;
+}
 
 type ControlsPosition = "bottom" | "left" | "right" | "top";
 
@@ -34,16 +73,17 @@ function normalizeControlsPosition(value: unknown): ControlsPosition {
     return "left";
 }
 
-export default React.memo(function Graph(props) {
+export default React.memo(function Graph(props: UseDoenetRendererProps) {
     let { id, SVs, children, ignoreUpdate, actions, callAction } =
-        useDoenetRenderer(props);
+        useDoenetRenderer<GraphSVs>(props);
 
+    // @ts-ignore
     Graph.baseStateVariable = "boundingbox";
 
     const graphRenderer = SVs.effectiveRenderer ?? SVs.renderer;
     const isPrefigureRenderer = graphRenderer === "prefigure";
 
-    const containerRef = useRef(null);
+    const containerRef = useRef<HTMLDivElement | null>(null);
     const [availableWidth, setAvailableWidth] = useState<number | null>(null);
 
     useRecordVisibilityChanges(
@@ -66,13 +106,13 @@ export default React.memo(function Graph(props) {
     }, []);
 
     useEffect(() => {
-        const container = containerRef.current as HTMLDivElement | null;
+        const container = containerRef.current;
         if (!container) {
             return;
         }
 
         function updateContainerWidth() {
-            setAvailableWidth(container.clientWidth);
+            setAvailableWidth(container!.clientWidth);
         }
 
         updateContainerWidth();

--- a/packages/doenetml/src/Viewer/renderers/hint.tsx
+++ b/packages/doenetml/src/Viewer/renderers/hint.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React, { useRef } from "react";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
@@ -11,8 +10,18 @@ import { useRecordVisibilityChanges } from "../../utils/visibility";
 import { addCommasForCompositeRanges } from "./utils/composites";
 import "./hint.css";
 
+interface HintSVs {
+    [key: string]: any;
+    showHints: boolean;
+    open: boolean;
+    title: string;
+    titleChildName?: string;
+    _compositeReplacementActiveRange?: any;
+}
+
 export default React.memo(function Hint(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer(props);
+    let { id, SVs, children, actions, callAction } =
+        useDoenetRenderer<HintSVs>(props);
 
     const ref = useRef(null);
 
@@ -31,11 +40,8 @@ export default React.memo(function Hint(props: UseDoenetRendererProps) {
         for (let [ind, child] of children.entries()) {
             //child might be null or a string
             if (
-                child &&
-                typeof child === "object" &&
-                "props" in child &&
-                child?.props?.componentInstructions.componentIdx ===
-                    SVs.titleChildName
+                (child as any)?.props?.componentInstructions?.componentIdx ===
+                SVs.titleChildName
             ) {
                 title = children[ind];
                 children.splice(ind, 1); // remove title

--- a/packages/doenetml/src/Viewer/renderers/hr.tsx
+++ b/packages/doenetml/src/Viewer/renderers/hr.tsx
@@ -3,8 +3,12 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 
+interface HrSVs {
+    hidden: boolean;
+}
+
 export default React.memo(function Hr(props: UseDoenetRendererProps) {
-    let { id, SVs } = useDoenetRenderer(props);
+    let { id, SVs } = useDoenetRenderer<HrSVs>(props);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/image.tsx
+++ b/packages/doenetml/src/Viewer/renderers/image.tsx
@@ -324,6 +324,15 @@ export default React.memo(function Image(props: UseDoenetRendererProps) {
                 yMax - 0.01 * (yMax - yMin) - currentOffset.current![1];
 
             if (viaPointer) {
+                // the reason we calculate point position with this algorithm,
+                // rather than using .X() and .Y() directly
+                // is that attributes .X() and .Y() are affected by the
+                // .setCoordinates function called in update().
+                // Due to this dependence, the location of .X() and .Y()
+                // can be affected by constraints of objects that the points depends on,
+                // leading to a different location on up than on drag
+                // (as dragging uses the mouse location)
+                // TODO: find an example where need this this additional complexity
                 var o = board.origin.scrCoords;
 
                 calculatedX.current =
@@ -472,6 +481,8 @@ export default React.memo(function Image(props: UseDoenetRendererProps) {
                 imageJXG.current.visPropCalc["visible"] = visible;
 
                 if (actuallyChangedVisibility) {
+                    // this function is incredibly slow, so don't run it if not necessary
+                    // TODO: figure out how to make label disappear right away so don't need to run this function
                     imageJXG.current.setAttribute({ visible });
                 }
             } else {

--- a/packages/doenetml/src/Viewer/renderers/image.tsx
+++ b/packages/doenetml/src/Viewer/renderers/image.tsx
@@ -1,53 +1,94 @@
-// @ts-nocheck
 import React, { useEffect, useState, useContext, useRef } from "react";
 import { BoardContext, IMAGE_LAYER_OFFSET } from "./graph";
-import useDoenetRenderer from "../useDoenetRenderer";
+import useDoenetRenderer, {
+    UseDoenetRendererProps,
+} from "../useDoenetRenderer";
 import { sizeToCSS } from "./utils/css";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 import me from "math-expressions";
 import { POINTER_DRAG_THRESHOLD } from "./utils/graph";
 import { DescriptionAsDetails, DescriptionPopover } from "./utils/Description";
 import { getNonInlineMediaLayoutStyles } from "./utils/nonInlineMediaLayout";
+import { JXGElement, JXGEvent, JXGPoint } from "./jsxgraph-distrib/types";
 
-export default React.memo(function Image(props) {
+interface ImageSVs {
+    hidden: boolean;
+    layer: number;
+    fixed: boolean;
+    fixLocation: boolean;
+    draggable: boolean;
+    anchor: any;
+    positionFromAnchor: any;
+    cid?: string;
+    source: string;
+    widthForGraph?: { size: number };
+    aspectRatio?: number;
+    rotate: number;
+    width: { size: string; isAbsolute: boolean };
+    displayMode: string;
+    horizontalAlign?: string;
+    decorative?: boolean;
+    shortDescription?: string;
+    renderInlineForListItem?: boolean;
+}
+
+type JXGImage = JXGElement & {
+    X(): number;
+    Y(): number;
+    W(): number;
+    H(): number;
+    relativeCoords?: {
+        usrCoords: [number, number, number];
+        setCoordinates: Function;
+    };
+    setSize(width: number, height: number): void;
+};
+
+type JXGTransform = JXGElement & {
+    bindTo(target: JXGElement): void;
+    setMatrix(board: any, type: string, params: any[]): void;
+};
+
+export default React.memo(function Image(props: UseDoenetRendererProps) {
     let { componentIdx, id, SVs, children, actions, callAction } =
-        useDoenetRenderer(props, false);
-    let [url, setUrl] = useState(null);
+        useDoenetRenderer<ImageSVs>(props, false);
+    let [url, setUrl] = useState<string | null>(null);
 
+    // @ts-ignore
     Image.ignoreActionsWithoutCore = () => true;
 
-    let imageJXG = useRef(null);
-    let anchorPointJXG = useRef(null);
+    let imageJXG = useRef<JXGImage | null>(null);
+    let anchorPointJXG = useRef<JXGPoint | null>(null);
 
     const board = useContext(BoardContext);
 
-    let pointerAtDown = useRef(null);
-    let pointAtDown = useRef(null);
-    let pointerIsDown = useRef(false);
-    let pointerMovedSinceDown = useRef(false);
-    let dragged = useRef(false);
+    let pointerAtDown = useRef<[number, number] | null>(null);
+    let pointAtDown = useRef<number[] | null>(null);
+    let pointerIsDown = useRef<boolean>(false);
+    let pointerMovedSinceDown = useRef<boolean>(false);
+    let dragged = useRef<boolean>(false);
 
-    let calculatedX = useRef(null);
-    let calculatedY = useRef(null);
+    let calculatedX = useRef<number | null>(null);
+    let calculatedY = useRef<number | null>(null);
 
-    let lastPositionFromCore = useRef(null);
-    let previousPositionFromAnchor = useRef(null);
-    let currentSize = useRef(null);
+    let lastPositionFromCore = useRef<number[] | null>(null);
+    let previousPositionFromAnchor = useRef<any>(null);
+    let currentSize = useRef<[number, number] | null>(null);
 
-    let currentOffset = useRef(null);
+    let currentOffset = useRef<[number, number] | null>(null);
 
-    let rotationTransform = useRef(null);
-    let lastRotate = useRef(SVs.rotate);
+    let rotationTransform = useRef<JXGTransform | null>(null);
+    let lastRotate = useRef<number>(SVs.rotate);
 
-    let fixed = useRef(false);
-    let fixLocation = useRef(false);
+    let fixed = useRef<boolean>(false);
+    let fixLocation = useRef<boolean>(false);
 
     fixed.current = SVs.fixed;
     fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
 
     const urlOrSource = (SVs.cid ? url : SVs.source) || "";
 
-    const ref = useRef(null);
+    const ref = useRef<HTMLDivElement | null>(null);
 
     useRecordVisibilityChanges(ref, callAction, actions);
 
@@ -83,20 +124,20 @@ export default React.memo(function Image(props) {
         }
 
         //things to be passed to JSXGraph as attributes
-        let jsxImageAttributes = {
+        let jsxImageAttributes: Record<string, any> = {
             visible: !SVs.hidden,
             fixed: fixed.current,
             layer: 10 * SVs.layer + IMAGE_LAYER_OFFSET,
             highlight: !fixLocation.current,
         };
 
-        let newAnchorPointJXG;
+        let newAnchorPointJXG: JXGPoint;
 
         try {
             let anchor = me.fromAst(SVs.anchor);
             let anchorCoords = [
-                anchor.get_component(0).evaluate_to_constant(),
-                anchor.get_component(1).evaluate_to_constant(),
+                anchor.get_component(0).evaluate_to_constant() ?? NaN,
+                anchor.get_component(1).evaluate_to_constant() ?? NaN,
             ];
 
             if (!Number.isFinite(anchorCoords[0])) {
@@ -110,12 +151,12 @@ export default React.memo(function Image(props) {
 
             newAnchorPointJXG = board.create("point", anchorCoords, {
                 visible: false,
-            });
+            }) as JXGPoint;
         } catch (e) {
             jsxImageAttributes["visible"] = false;
             newAnchorPointJXG = board.create("point", [0, 0], {
                 visible: false,
-            });
+            }) as JXGPoint;
         }
 
         jsxImageAttributes.anchor = newAnchorPointJXG;
@@ -127,7 +168,7 @@ export default React.memo(function Image(props) {
             height = 0;
         }
 
-        let offset;
+        let offset: [number, number];
         if (SVs.positionFromAnchor === "center") {
             offset = [-width / 2, -height / 2];
         } else if (SVs.positionFromAnchor === "lowerleft") {
@@ -154,7 +195,7 @@ export default React.memo(function Image(props) {
             "image",
             [urlOrSource, offset, [width, height]],
             jsxImageAttributes,
-        );
+        ) as JXGImage;
 
         newImageJXG.isDraggable = !fixLocation.current;
 
@@ -171,7 +212,7 @@ export default React.memo(function Image(props) {
                 },
             ],
             { type: "translate" },
-        );
+        ) as JXGTransform;
         var tOffInverse = board.create(
             "transform",
             [
@@ -183,8 +224,10 @@ export default React.memo(function Image(props) {
                 },
             ],
             { type: "translate" },
-        );
-        var tRot = board.create("transform", [SVs.rotate], { type: "rotate" });
+        ) as JXGTransform;
+        var tRot = board.create("transform", [SVs.rotate], {
+            type: "rotate",
+        }) as JXGTransform;
 
         tOff.bindTo(newImageJXG); // Shift image to origin
         tRot.bindTo(newImageJXG); // Rotate
@@ -193,7 +236,7 @@ export default React.memo(function Image(props) {
         rotationTransform.current = tRot;
         lastRotate.current = SVs.rotate;
 
-        newImageJXG.on("down", function (e) {
+        newImageJXG.on("down", function (e: JXGEvent) {
             (document.activeElement as HTMLElement | null)?.blur();
 
             pointerAtDown.current = [e.x, e.y];
@@ -204,21 +247,21 @@ export default React.memo(function Image(props) {
             if (!fixed.current) {
                 callAction({
                     action: actions.imageFocused,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
+                    args: { componentIdx },
                 });
             }
         });
 
-        newImageJXG.on("hit", function (e) {
+        newImageJXG.on("hit", function (e: JXGEvent) {
             pointAtDown.current = [...newAnchorPointJXG.coords.scrCoords];
             dragged.current = false;
             callAction({
                 action: actions.imageFocused,
-                args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
+                args: { componentIdx },
             });
         });
 
-        newImageJXG.on("up", function (e) {
+        newImageJXG.on("up", function (e: JXGEvent) {
             if (dragged.current) {
                 callAction({
                     action: actions.moveImage,
@@ -231,13 +274,13 @@ export default React.memo(function Image(props) {
             } else if (!pointerMovedSinceDown.current && !fixed.current) {
                 callAction({
                     action: actions.imageClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
+                    args: { componentIdx },
                 });
             }
             pointerIsDown.current = false;
         });
 
-        newImageJXG.on("keyfocusout", function (e) {
+        newImageJXG.on("keyfocusout", function (e: JXGEvent) {
             if (dragged.current) {
                 callAction({
                     action: actions.moveImage,
@@ -250,15 +293,15 @@ export default React.memo(function Image(props) {
             }
         });
 
-        newImageJXG.on("drag", function (e) {
+        newImageJXG.on("drag", function (e: JXGEvent) {
             let viaPointer = e.type === "pointermove";
 
             //Protect against very small unintended drags
             if (
                 !viaPointer ||
-                Math.abs(e.x - pointerAtDown.current[0]) >
+                Math.abs(e.x - pointerAtDown.current![0]) >
                     POINTER_DRAG_THRESHOLD ||
-                Math.abs(e.y - pointerAtDown.current[1]) >
+                Math.abs(e.y - pointerAtDown.current![1]) >
                     POINTER_DRAG_THRESHOLD
             ) {
                 dragged.current = true;
@@ -268,53 +311,43 @@ export default React.memo(function Image(props) {
             let xminAdjusted =
                 xMin +
                 0.01 * (xMax - xMin) -
-                currentOffset.current[0] -
-                currentSize.current[0];
+                currentOffset.current![0] -
+                currentSize.current![0];
             let xmaxAdjusted =
-                xMax - 0.01 * (xMax - xMin) - currentOffset.current[0];
+                xMax - 0.01 * (xMax - xMin) - currentOffset.current![0];
             let yminAdjusted =
                 yMin +
                 0.01 * (yMax - yMin) -
-                currentOffset.current[1] -
-                currentSize.current[1];
+                currentOffset.current![1] -
+                currentSize.current![1];
             let ymaxAdjusted =
-                yMax - 0.01 * (yMax - yMin) - currentOffset.current[1];
+                yMax - 0.01 * (yMax - yMin) - currentOffset.current![1];
 
             if (viaPointer) {
-                // the reason we calculate point position with this algorithm,
-                // rather than using .X() and .Y() directly
-                // is that attributes .X() and .Y() are affected by the
-                // .setCoordinates function called in update().
-                // Due to this dependence, the location of .X() and .Y()
-                // can be affected by constraints of objects that the points depends on,
-                // leading to a different location on up than on drag
-                // (as dragging uses the mouse location)
-                // TODO: find an example where need this this additional complexity
-
                 var o = board.origin.scrCoords;
 
                 calculatedX.current =
-                    (pointAtDown.current[1] +
+                    (pointAtDown.current![1] +
                         e.x -
-                        pointerAtDown.current[0] -
+                        pointerAtDown.current![0] -
                         o[1]) /
                     board.unitX;
 
                 calculatedY.current =
                     (o[2] -
-                        (pointAtDown.current[2] +
+                        (pointAtDown.current![2] +
                             e.y -
-                            pointerAtDown.current[1])) /
+                            pointerAtDown.current![1])) /
                     board.unitY;
             } else {
                 calculatedX.current =
                     newAnchorPointJXG.X() +
-                    newImageJXG.relativeCoords.usrCoords[1] -
-                    currentOffset.current[0];
+                    newImageJXG.relativeCoords!.usrCoords[1] -
+                    currentOffset.current![0];
                 calculatedY.current =
                     newAnchorPointJXG.Y() +
-                    newImageJXG.relativeCoords.usrCoords[2] -
-                    currentOffset.current[1];
+                    newImageJXG.relativeCoords!.usrCoords[2] -
+                    currentOffset.current![1];
             }
 
             calculatedX.current = Math.min(
@@ -336,7 +369,7 @@ export default React.memo(function Image(props) {
                 },
             });
 
-            newImageJXG.relativeCoords.setCoordinates(
+            newImageJXG.relativeCoords!.setCoordinates(
                 JXG.COORDS_BY_USER,
                 currentOffset.current,
             );
@@ -346,7 +379,7 @@ export default React.memo(function Image(props) {
             );
         });
 
-        newImageJXG.on("keydown", function (e) {
+        newImageJXG.on("keydown", function (e: JXGEvent) {
             if (e.key === "Enter") {
                 if (dragged.current) {
                     callAction({
@@ -360,7 +393,7 @@ export default React.memo(function Image(props) {
                 }
                 callAction({
                     action: actions.imageClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
+                    args: { componentIdx },
                 });
             }
         });
@@ -374,13 +407,13 @@ export default React.memo(function Image(props) {
         imageJXG.current.fullUpdate();
     }
 
-    function boardMoveHandler(e) {
+    function boardMoveHandler(e: JXGEvent) {
         if (pointerIsDown.current) {
             //Protect against very small unintended move
             if (
-                Math.abs(e.x - pointerAtDown.current[0]) >
+                Math.abs(e.x - pointerAtDown.current![0]) >
                     POINTER_DRAG_THRESHOLD ||
-                Math.abs(e.y - pointerAtDown.current[1]) >
+                Math.abs(e.y - pointerAtDown.current![1]) >
                     POINTER_DRAG_THRESHOLD
             ) {
                 pointerMovedSinceDown.current = true;
@@ -389,6 +422,7 @@ export default React.memo(function Image(props) {
     }
 
     function deleteImageJXG() {
+        if (!imageJXG.current) return;
         imageJXG.current.off("drag");
         imageJXG.current.off("down");
         imageJXG.current.off("hit");
@@ -400,12 +434,12 @@ export default React.memo(function Image(props) {
     }
 
     if (board) {
-        let anchorCoords;
+        let anchorCoords: number[];
         try {
             let anchor = me.fromAst(SVs.anchor);
             anchorCoords = [
-                anchor.get_component(0).evaluate_to_constant(),
-                anchor.get_component(1).evaluate_to_constant(),
+                anchor.get_component(0).evaluate_to_constant() ?? NaN,
+                anchor.get_component(1).evaluate_to_constant() ?? NaN,
             ];
         } catch (e) {
             anchorCoords = [NaN, NaN];
@@ -419,7 +453,7 @@ export default React.memo(function Image(props) {
             }
             createImageJXG();
         } else {
-            anchorPointJXG.current.coords.setCoordinates(
+            anchorPointJXG.current!.coords.setCoordinates(
                 JXG.COORDS_BY_USER,
                 anchorCoords,
             );
@@ -438,8 +472,6 @@ export default React.memo(function Image(props) {
                 imageJXG.current.visPropCalc["visible"] = visible;
 
                 if (actuallyChangedVisibility) {
-                    // this function is incredibly slow, so don't run it if not necessary
-                    // TODO: figure out how to make label disappear right away so don't need to run this function
                     imageJXG.current.setAttribute({ visible });
                 }
             } else {
@@ -468,8 +500,8 @@ export default React.memo(function Image(props) {
             }
 
             let sizeChanged =
-                width !== currentSize.current[0] ||
-                height !== currentSize.current[1];
+                width !== currentSize.current![0] ||
+                height !== currentSize.current![1];
 
             if (sizeChanged) {
                 imageJXG.current.setSize(width, height);
@@ -477,7 +509,7 @@ export default React.memo(function Image(props) {
             }
 
             if (SVs.rotate != lastRotate.current) {
-                rotationTransform.current.setMatrix(board, "rotate", [
+                rotationTransform.current!.setMatrix(board, "rotate", [
                     SVs.rotate,
                 ]);
                 lastRotate.current = SVs.rotate;
@@ -487,7 +519,7 @@ export default React.memo(function Image(props) {
                 SVs.positionFromAnchor !== previousPositionFromAnchor.current ||
                 sizeChanged
             ) {
-                let offset;
+                let offset: [number, number];
                 if (SVs.positionFromAnchor === "center") {
                     offset = [-width / 2, -height / 2];
                 } else if (SVs.positionFromAnchor === "lowerleft") {
@@ -509,7 +541,7 @@ export default React.memo(function Image(props) {
                     offset = [-width, -height / 2];
                 }
 
-                imageJXG.current.relativeCoords.setCoordinates(
+                imageJXG.current.relativeCoords!.setCoordinates(
                     JXG.COORDS_BY_USER,
                     offset,
                 );
@@ -518,15 +550,15 @@ export default React.memo(function Image(props) {
                 currentOffset.current = offset;
                 imageJXG.current.fullUpdate();
             } else {
-                imageJXG.current.relativeCoords.setCoordinates(
+                imageJXG.current.relativeCoords!.setCoordinates(
                     JXG.COORDS_BY_USER,
                     currentOffset.current,
                 );
                 imageJXG.current.update();
             }
 
-            anchorPointJXG.current.needsUpdate = true;
-            anchorPointJXG.current.update();
+            anchorPointJXG.current!.needsUpdate = true;
+            anchorPointJXG.current!.update();
             board.updateRenderer();
         }
 
@@ -537,10 +569,10 @@ export default React.memo(function Image(props) {
 
     if (SVs.hidden) return null;
 
-    let outerStyle = {};
-    let innerStyle = {};
-    let mediaContainerStyle = {};
-    let mediaColumnStyle = {};
+    let outerStyle: React.CSSProperties = {};
+    let innerStyle: React.CSSProperties = {};
+    let mediaContainerStyle: React.CSSProperties = {};
+    let mediaColumnStyle: React.CSSProperties = {};
 
     if (SVs.displayMode === "inline") {
         outerStyle = {
@@ -560,12 +592,12 @@ export default React.memo(function Image(props) {
             }));
     }
 
-    let imageStyle = {
+    let imageStyle: React.CSSProperties = {
         maxWidth: "100%",
         width: sizeToCSS(SVs.width),
     };
 
-    if (SVs.aspectRatio > 0) {
+    if ((SVs.aspectRatio ?? 0) > 0) {
         imageStyle.aspectRatio = String(SVs.aspectRatio);
     }
 

--- a/packages/doenetml/src/Viewer/renderers/label.tsx
+++ b/packages/doenetml/src/Viewer/renderers/label.tsx
@@ -173,7 +173,7 @@ export default React.memo(function Label(props: UseDoenetRendererProps) {
             if (!fixed.current) {
                 callAction({
                     action: actions.labelFocused,
-                    args: { componentIdx },
+                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
                 });
             }
         });
@@ -183,7 +183,7 @@ export default React.memo(function Label(props: UseDoenetRendererProps) {
             dragged.current = false;
             callAction({
                 action: actions.labelFocused,
-                args: { componentIdx },
+                args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
             });
         });
 
@@ -200,7 +200,7 @@ export default React.memo(function Label(props: UseDoenetRendererProps) {
             } else if (!pointerMovedSinceDown.current && !fixed.current) {
                 callAction({
                     action: actions.labelClicked,
-                    args: { componentIdx },
+                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
                 });
             }
             pointerIsDown.current = false;
@@ -259,6 +259,15 @@ export default React.memo(function Label(props: UseDoenetRendererProps) {
             let ymaxAdjusted = yMax - 0.04 * (yMax - yMin) - offsety;
 
             if (viaPointer) {
+                // the reason we calculate point position with this algorithm,
+                // rather than using .X() and .Y() directly
+                // is that attributes .X() and .Y() are affected by the
+                // .setCoordinates function called in update().
+                // Due to this dependence, the location of .X() and .Y()
+                // can be affected by constraints of objects that the points depends on,
+                // leading to a different location on up than on drag
+                // (as dragging uses the mouse location)
+                // TODO: find an example where need this this additional complexity
                 var o = board.origin.scrCoords;
 
                 calculatedX.current =
@@ -326,7 +335,7 @@ export default React.memo(function Label(props: UseDoenetRendererProps) {
                 }
                 callAction({
                     action: actions.labelClicked,
-                    args: { componentIdx },
+                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
                 });
             }
         });
@@ -416,6 +425,8 @@ export default React.memo(function Label(props: UseDoenetRendererProps) {
                 labelJXG.current.visPropCalc["visible"] = visible;
 
                 if (actuallyChangedVisibility) {
+                    // this function is incredibly slow, so don't run it if not necessary
+                    // TODO: figure out how to make label disappear right away so don't need to run this function
                     labelJXG.current.setAttribute({ visible });
                 }
             } else {

--- a/packages/doenetml/src/Viewer/renderers/label.tsx
+++ b/packages/doenetml/src/Viewer/renderers/label.tsx
@@ -173,7 +173,7 @@ export default React.memo(function Label(props: UseDoenetRendererProps) {
             if (!fixed.current) {
                 callAction({
                     action: actions.labelFocused,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
+                    args: { componentIdx },
                 });
             }
         });
@@ -183,7 +183,7 @@ export default React.memo(function Label(props: UseDoenetRendererProps) {
             dragged.current = false;
             callAction({
                 action: actions.labelFocused,
-                args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
+                args: { componentIdx },
             });
         });
 
@@ -200,7 +200,7 @@ export default React.memo(function Label(props: UseDoenetRendererProps) {
             } else if (!pointerMovedSinceDown.current && !fixed.current) {
                 callAction({
                     action: actions.labelClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
+                    args: { componentIdx },
                 });
             }
             pointerIsDown.current = false;
@@ -335,7 +335,7 @@ export default React.memo(function Label(props: UseDoenetRendererProps) {
                 }
                 callAction({
                     action: actions.labelClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
+                    args: { componentIdx },
                 });
             }
         });

--- a/packages/doenetml/src/Viewer/renderers/label.tsx
+++ b/packages/doenetml/src/Viewer/renderers/label.tsx
@@ -1,7 +1,8 @@
-// @ts-nocheck
 import React, { useContext, useEffect, useRef } from "react";
 import { BoardContext, TEXT_LAYER_OFFSET } from "./graph";
-import useDoenetRenderer from "../useDoenetRenderer";
+import useDoenetRenderer, {
+    UseDoenetRendererProps,
+} from "../useDoenetRenderer";
 import { MathJax } from "better-react-mathjax";
 import me from "math-expressions";
 import { textRendererStyle } from "@doenet/utils";
@@ -11,34 +12,52 @@ import {
 } from "./utils/graph";
 import { DocContext } from "../DocViewer";
 import { ChoiceInputInlineContext } from "./choiceInput";
+import { JXGEvent, JXGPoint, JXGText } from "./jsxgraph-distrib/types";
+import { SelectedStyle } from "./utils/graphicalSVs";
 
-export default React.memo(function Label(props) {
-    let { componentIdx, id, SVs, children, actions, callAction } =
-        useDoenetRenderer(props);
+interface LabelSVs {
+    hidden: boolean;
+    layer: number;
+    fixed: boolean;
+    fixLocation: boolean;
+    draggable: boolean;
+    anchor: any;
+    positionFromAnchor: any;
+    value: string;
+    hasLatex: boolean;
+    forTargetRendererId?: string;
+    forTargetIsGroup?: boolean;
+    selectedStyle: SelectedStyle;
+}
 
+export default React.memo(function Label(props: UseDoenetRendererProps) {
+    let { componentIdx, id, SVs, actions, callAction } =
+        useDoenetRenderer<LabelSVs>(props);
+
+    // @ts-ignore
     Label.ignoreActionsWithoutCore = () => true;
 
-    let labelJXG = useRef(null);
-    let anchorPointJXG = useRef(null);
-    let anchorRel = useRef(null);
+    let labelJXG = useRef<JXGText | null>(null);
+    let anchorPointJXG = useRef<JXGPoint | null>(null);
+    let anchorRel = useRef<[string, string] | null>(null);
 
     const board = useContext(BoardContext);
     const choiceInputInlineContext = useContext(ChoiceInputInlineContext);
 
-    let pointerAtDown = useRef(null);
-    let pointAtDown = useRef(null);
-    let pointerIsDown = useRef(false);
-    let pointerMovedSinceDown = useRef(false);
-    let dragged = useRef(false);
+    let pointerAtDown = useRef<[number, number] | null>(null);
+    let pointAtDown = useRef<number[] | null>(null);
+    let pointerIsDown = useRef<boolean>(false);
+    let pointerMovedSinceDown = useRef<boolean>(false);
+    let dragged = useRef<boolean>(false);
 
-    let calculatedX = useRef(null);
-    let calculatedY = useRef(null);
+    let calculatedX = useRef<number | null>(null);
+    let calculatedY = useRef<number | null>(null);
 
-    let lastPositionFromCore = useRef(null);
-    let previousPositionFromAnchor = useRef(null);
+    let lastPositionFromCore = useRef<number[] | null>(null);
+    let previousPositionFromAnchor = useRef<any>(null);
 
-    let fixed = useRef(false);
-    let fixLocation = useRef(false);
+    let fixed = useRef<boolean>(false);
+    let fixLocation = useRef<boolean>(false);
 
     fixed.current = SVs.fixed;
     fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
@@ -84,7 +103,7 @@ export default React.memo(function Label(props) {
         }
 
         //things to be passed to JSXGraph as attributes
-        let jsxLabelAttributes = {
+        let jsxLabelAttributes: Record<string, any> = {
             visible: !SVs.hidden,
             fixed: fixed.current,
             layer: 10 * SVs.layer + TEXT_LAYER_OFFSET,
@@ -99,13 +118,13 @@ export default React.memo(function Label(props) {
             parse: false,
         };
 
-        let newAnchorPointJXG;
+        let newAnchorPointJXG: JXGPoint;
 
         try {
             let anchor = me.fromAst(SVs.anchor);
             let anchorCoords = [
-                anchor.get_component(0).evaluate_to_constant(),
-                anchor.get_component(1).evaluate_to_constant(),
+                anchor.get_component(0).evaluate_to_constant() ?? NaN,
+                anchor.get_component(1).evaluate_to_constant() ?? NaN,
             ];
 
             if (!Number.isFinite(anchorCoords[0])) {
@@ -119,12 +138,12 @@ export default React.memo(function Label(props) {
 
             newAnchorPointJXG = board.create("point", anchorCoords, {
                 visible: false,
-            });
+            }) as JXGPoint;
         } catch (e) {
             jsxLabelAttributes["visible"] = false;
             newAnchorPointJXG = board.create("point", [0, 0], {
                 visible: false,
-            });
+            }) as JXGPoint;
         }
 
         jsxLabelAttributes.anchor = newAnchorPointJXG;
@@ -134,16 +153,16 @@ export default React.memo(function Label(props) {
         );
         jsxLabelAttributes.anchorx = anchorx;
         jsxLabelAttributes.anchory = anchory;
-        anchorRel.current = [anchorx, anchory];
+        anchorRel.current = [anchorx as string, anchory as string];
 
         let newLabelJXG = board.create(
             "text",
             [0, 0, SVs.value],
             jsxLabelAttributes,
-        );
+        ) as JXGText;
         newLabelJXG.isDraggable = !fixLocation.current;
 
-        newLabelJXG.on("down", function (e) {
+        newLabelJXG.on("down", function (e: JXGEvent) {
             (document.activeElement as HTMLElement | null)?.blur();
 
             pointerAtDown.current = [e.x, e.y];
@@ -154,21 +173,21 @@ export default React.memo(function Label(props) {
             if (!fixed.current) {
                 callAction({
                     action: actions.labelFocused,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
+                    args: { componentIdx },
                 });
             }
         });
 
-        newLabelJXG.on("hit", function (e) {
+        newLabelJXG.on("hit", function (e: JXGEvent) {
             pointAtDown.current = [...newAnchorPointJXG.coords.scrCoords];
             dragged.current = false;
             callAction({
                 action: actions.labelFocused,
-                args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
+                args: { componentIdx },
             });
         });
 
-        newLabelJXG.on("up", function (e) {
+        newLabelJXG.on("up", function (e: JXGEvent) {
             if (dragged.current) {
                 callAction({
                     action: actions.moveLabel,
@@ -181,13 +200,13 @@ export default React.memo(function Label(props) {
             } else if (!pointerMovedSinceDown.current && !fixed.current) {
                 callAction({
                     action: actions.labelClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
+                    args: { componentIdx },
                 });
             }
             pointerIsDown.current = false;
         });
 
-        newLabelJXG.on("keyfocusout", function (e) {
+        newLabelJXG.on("keyfocusout", function (e: JXGEvent) {
             if (dragged.current) {
                 callAction({
                     action: actions.moveLabel,
@@ -200,26 +219,26 @@ export default React.memo(function Label(props) {
             }
         });
 
-        newLabelJXG.on("drag", function (e) {
+        newLabelJXG.on("drag", function (e: JXGEvent) {
             let viaPointer = e.type === "pointermove";
 
             //Protect against very small unintended drags
             if (
                 !viaPointer ||
-                Math.abs(e.x - pointerAtDown.current[0]) >
+                Math.abs(e.x - pointerAtDown.current![0]) >
                     POINTER_DRAG_THRESHOLD ||
-                Math.abs(e.y - pointerAtDown.current[1]) >
+                Math.abs(e.y - pointerAtDown.current![1]) >
                     POINTER_DRAG_THRESHOLD
             ) {
                 dragged.current = true;
             }
 
             let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
-            let width = newLabelJXG.size[0] / board.unitX;
-            let height = newLabelJXG.size[1] / board.unitY;
+            let width = newLabelJXG.size![0] / board.unitX;
+            let height = newLabelJXG.size![1] / board.unitY;
 
-            let anchorx = anchorRel.current[0];
-            let anchory = anchorRel.current[1];
+            let anchorx = anchorRel.current![0];
+            let anchory = anchorRel.current![1];
 
             let offsetx = 0;
             if (anchorx === "middle") {
@@ -240,37 +259,28 @@ export default React.memo(function Label(props) {
             let ymaxAdjusted = yMax - 0.04 * (yMax - yMin) - offsety;
 
             if (viaPointer) {
-                // the reason we calculate point position with this algorithm,
-                // rather than using .X() and .Y() directly
-                // is that attributes .X() and .Y() are affected by the
-                // .setCoordinates function called in update().
-                // Due to this dependence, the location of .X() and .Y()
-                // can be affected by constraints of objects that the points depends on,
-                // leading to a different location on up than on drag
-                // (as dragging uses the mouse location)
-                // TODO: find an example where need this this additional complexity
                 var o = board.origin.scrCoords;
 
                 calculatedX.current =
-                    (pointAtDown.current[1] +
+                    (pointAtDown.current![1] +
                         e.x -
-                        pointerAtDown.current[0] -
+                        pointerAtDown.current![0] -
                         o[1]) /
                     board.unitX;
 
                 calculatedY.current =
                     (o[2] -
-                        (pointAtDown.current[2] +
+                        (pointAtDown.current![2] +
                             e.y -
-                            pointerAtDown.current[1])) /
+                            pointerAtDown.current![1])) /
                     board.unitY;
             } else {
                 calculatedX.current =
                     newAnchorPointJXG.X() +
-                    newLabelJXG.relativeCoords.usrCoords[1];
+                    newLabelJXG.relativeCoords!.usrCoords[1];
                 calculatedY.current =
                     newAnchorPointJXG.Y() +
-                    newLabelJXG.relativeCoords.usrCoords[2];
+                    newLabelJXG.relativeCoords!.usrCoords[2];
             }
 
             calculatedX.current = Math.min(
@@ -292,7 +302,7 @@ export default React.memo(function Label(props) {
                 },
             });
 
-            newLabelJXG.relativeCoords.setCoordinates(
+            newLabelJXG.relativeCoords!.setCoordinates(
                 JXG.COORDS_BY_USER,
                 [0, 0],
             );
@@ -302,7 +312,7 @@ export default React.memo(function Label(props) {
             );
         });
 
-        newLabelJXG.on("keydown", function (e) {
+        newLabelJXG.on("keydown", function (e: JXGEvent) {
             if (e.key === "Enter") {
                 if (dragged.current) {
                     callAction({
@@ -316,7 +326,7 @@ export default React.memo(function Label(props) {
                 }
                 callAction({
                     action: actions.labelClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
+                    args: { componentIdx },
                 });
             }
         });
@@ -340,13 +350,13 @@ export default React.memo(function Label(props) {
         }
     }
 
-    function boardMoveHandler(e) {
+    function boardMoveHandler(e: JXGEvent) {
         if (pointerIsDown.current) {
             //Protect against very small unintended move
             if (
-                Math.abs(e.x - pointerAtDown.current[0]) >
+                Math.abs(e.x - pointerAtDown.current![0]) >
                     POINTER_DRAG_THRESHOLD ||
-                Math.abs(e.y - pointerAtDown.current[1]) >
+                Math.abs(e.y - pointerAtDown.current![1]) >
                     POINTER_DRAG_THRESHOLD
             ) {
                 pointerMovedSinceDown.current = true;
@@ -355,6 +365,7 @@ export default React.memo(function Label(props) {
     }
 
     function deleteLabelJXG() {
+        if (!labelJXG.current) return;
         labelJXG.current.off("drag");
         labelJXG.current.off("down");
         labelJXG.current.off("hit");
@@ -366,12 +377,12 @@ export default React.memo(function Label(props) {
     }
 
     if (board) {
-        let anchorCoords;
+        let anchorCoords: number[];
         try {
             let anchor = me.fromAst(SVs.anchor);
             anchorCoords = [
-                anchor.get_component(0).evaluate_to_constant(),
-                anchor.get_component(1).evaluate_to_constant(),
+                anchor.get_component(0).evaluate_to_constant() ?? NaN,
+                anchor.get_component(1).evaluate_to_constant() ?? NaN,
             ];
         } catch (e) {
             anchorCoords = [NaN, NaN];
@@ -382,11 +393,11 @@ export default React.memo(function Label(props) {
         if (labelJXG.current === null) {
             createLabelJXG();
         } else {
-            labelJXG.current.relativeCoords.setCoordinates(
+            labelJXG.current.relativeCoords!.setCoordinates(
                 JXG.COORDS_BY_USER,
                 [0, 0],
             );
-            anchorPointJXG.current.coords.setCoordinates(
+            anchorPointJXG.current!.coords.setCoordinates(
                 JXG.COORDS_BY_USER,
                 anchorCoords,
             );
@@ -405,8 +416,6 @@ export default React.memo(function Label(props) {
                 labelJXG.current.visPropCalc["visible"] = visible;
 
                 if (actuallyChangedVisibility) {
-                    // this function is incredibly slow, so don't run it if not necessary
-                    // TODO: figure out how to make label disappear right away so don't need to run this function
                     labelJXG.current.setAttribute({ visible });
                 }
             } else {
@@ -437,8 +446,8 @@ export default React.memo(function Label(props) {
             }
 
             if (labelJXG.current.visProp.strokecolor !== textColor) {
-                labelJXG.current.visProp.strokecolor = textColor;
-                labelJXG.current.visProp.highlightstrokecolor = textColor;
+                labelJXG.current.visProp.strokecolor = textColor!;
+                labelJXG.current.visProp.highlightstrokecolor = textColor!;
             }
             if (labelJXG.current.visProp.cssstyle !== cssStyle) {
                 labelJXG.current.visProp.cssstyle = cssStyle;
@@ -457,15 +466,15 @@ export default React.memo(function Label(props) {
                 );
                 labelJXG.current.visProp.anchorx = anchorx;
                 labelJXG.current.visProp.anchory = anchory;
-                anchorRel.current = [anchorx, anchory];
+                anchorRel.current = [anchorx as string, anchory as string];
                 previousPositionFromAnchor.current = SVs.positionFromAnchor;
                 labelJXG.current.fullUpdate();
             } else {
                 labelJXG.current.update();
             }
 
-            anchorPointJXG.current.needsUpdate = true;
-            anchorPointJXG.current.update();
+            anchorPointJXG.current!.needsUpdate = true;
+            anchorPointJXG.current!.update();
             board.updateRenderer();
         }
 
@@ -479,10 +488,10 @@ export default React.memo(function Label(props) {
     }
 
     const style = !choiceInputInlineContext.inOption
-        ? textRendererStyle(darkMode, SVs.selectedStyle)
+        ? textRendererStyle(darkMode ?? "light", SVs.selectedStyle)
         : undefined;
 
-    let label = SVs.value;
+    let label: React.ReactNode = SVs.value;
 
     if (SVs.hasLatex) {
         label = (

--- a/packages/doenetml/src/Viewer/renderers/legend.tsx
+++ b/packages/doenetml/src/Viewer/renderers/legend.tsx
@@ -11,6 +11,7 @@ import {
     JXGPolygon,
     JXGText,
 } from "./jsxgraph-distrib/types";
+import { styleToDash } from "./utils/styleToDash";
 
 declare const MathJax: any;
 
@@ -340,18 +341,6 @@ export default React.memo(function Legend(props: UseDoenetRendererProps) {
         </>
     );
 });
-
-function styleToDash(style: string | undefined): number {
-    if (style === "dashed") {
-        return 2;
-    } else if (style === "solid") {
-        return 0;
-    } else if (style === "dotted") {
-        return 1;
-    } else {
-        return 0;
-    }
-}
 
 function normalizeStyle(style: string | undefined): string | undefined {
     if (style === "triangle") {

--- a/packages/doenetml/src/Viewer/renderers/legend.tsx
+++ b/packages/doenetml/src/Viewer/renderers/legend.tsx
@@ -1,20 +1,61 @@
-// @ts-nocheck
 import React, { useContext, useEffect, useRef } from "react";
-import useDoenetRenderer from "../useDoenetRenderer";
+import useDoenetRenderer, {
+    UseDoenetRendererProps,
+} from "../useDoenetRenderer";
 import { BoardContext } from "./graph";
 import { deepCompare } from "@doenet/utils";
+import {
+    JXGElement,
+    JXGLine,
+    JXGPoint,
+    JXGPolygon,
+    JXGText,
+} from "./jsxgraph-distrib/types";
 
-export default React.memo(function Legend(props) {
-    let { id, SVs } = useDoenetRenderer(props);
+declare const MathJax: any;
+
+interface LegendElement {
+    label?: { hasLatex: boolean; value: string };
+    swatchType: "marker" | "rectangle" | "line";
+    markerColor?: string;
+    markerStyle?: string;
+    markerSize?: number;
+    lineColor?: string;
+    lineWidth?: number;
+    lineStyle?: string;
+    lineOpacity?: number;
+    fillColor?: string;
+    fillOpacity?: number;
+    filled?: boolean;
+}
+
+interface GraphLimits {
+    xMin: number;
+    xMax: number;
+    yMin: number;
+    yMax: number;
+}
+
+interface LegendSVs {
+    hidden: boolean;
+    graphLimits: GraphLimits;
+    position: string;
+    legendElements: LegendElement[];
+}
+
+type Swatch = JXGPoint | JXGPolygon | JXGLine | JXGElement;
+
+export default React.memo(function Legend(props: UseDoenetRendererProps) {
+    let { id, SVs } = useDoenetRenderer<LegendSVs>(props);
 
     const board = useContext(BoardContext);
 
-    let swatches = useRef([]);
-    let labels = useRef([]);
+    let swatches = useRef<Swatch[]>([]);
+    let labels = useRef<JXGText[]>([]);
 
-    let previousElements = useRef(null);
-    let previousPosition = useRef(null);
-    let previousLimits = useRef(null);
+    let previousElements = useRef<LegendElement[] | null>(null);
+    let previousPosition = useRef<string | null>(null);
+    let previousLimits = useRef<GraphLimits | null>(null);
 
     useEffect(() => {
         //On unmount
@@ -24,6 +65,9 @@ export default React.memo(function Legend(props) {
     }, []);
 
     function createLegend() {
+        if (board === null) {
+            return;
+        }
         let { xMin, xMax, yMin, yMax } = SVs.graphLimits;
 
         let legendDy = (yMax - yMin) * 0.06;
@@ -32,7 +76,7 @@ export default React.memo(function Legend(props) {
 
         let legendX = xMin + (xMax - xMin) * 0.05;
 
-        let legendY;
+        let legendY: number;
 
         if (SVs.position.slice(0, 5) === "upper") {
             legendY = yMin + (yMax - yMin) * 0.95;
@@ -58,7 +102,7 @@ export default React.memo(function Legend(props) {
             if (element.label) {
                 let y = legendY - ind * legendDy;
 
-                let textAttrs = {
+                let textAttrs: Record<string, any> = {
                     fixed: true,
                     highlight: false,
                 };
@@ -77,7 +121,7 @@ export default React.memo(function Legend(props) {
                         element.label.value,
                     ],
                     textAttrs,
-                );
+                ) as JXGText;
 
                 labels.current.push(txt);
 
@@ -97,7 +141,7 @@ export default React.memo(function Legend(props) {
         for (let [ind, element] of SVs.legendElements.entries()) {
             let y = legendY - ind * legendDy;
             if (element.swatchType === "marker") {
-                let pointStyle = {
+                let pointStyle: Record<string, any> = {
                     fillColor: element.markerColor,
                     fillOpacity: element.lineOpacity,
                     strokeColor: "none",
@@ -112,10 +156,10 @@ export default React.memo(function Legend(props) {
                     "point",
                     [legendX + legendLineLength / 2, y],
                     pointStyle,
-                );
+                ) as JXGPoint;
                 swatches.current.push(point);
             } else if (element.swatchType === "rectangle") {
-                let rectangleStyle = {
+                let rectangleStyle: Record<string, any> = {
                     fillColor: element.filled ? element.fillColor : "none",
                     fillOpacity: element.fillOpacity,
                     fixed: true,
@@ -140,10 +184,10 @@ export default React.memo(function Legend(props) {
                         [legendX, y - legendDy / 4],
                     ],
                     rectangleStyle,
-                );
+                ) as JXGPolygon;
                 swatches.current.push(seg);
             } else {
-                let lineStyle = {
+                let lineStyle: Record<string, any> = {
                     strokeColor: element.lineColor,
                     strokeWidth: element.lineWidth,
                     strokeOpacity: element.lineOpacity,
@@ -158,7 +202,7 @@ export default React.memo(function Legend(props) {
                         [legendX + legendLineLength, y],
                     ],
                     lineStyle,
-                );
+                ) as JXGLine;
                 swatches.current.push(seg);
             }
             if (atRight && element.label) {
@@ -179,7 +223,7 @@ export default React.memo(function Legend(props) {
                     );
                 }
 
-                maxTextWidth /= board.unitX;
+                maxTextWidth /= board!.unitX;
 
                 legendX = Math.max(
                     legendX,
@@ -189,49 +233,51 @@ export default React.memo(function Legend(props) {
                 for (let [ind, swatch] of swatches.current.entries()) {
                     let y = legendY - ind * legendDy;
                     if (swatch.elType === "point") {
-                        swatch.coords.setCoordinates(JXG.COORDS_BY_USER, [
-                            legendX + legendLineLength / 2,
-                            y,
-                        ]);
+                        (swatch as JXGPoint).coords.setCoordinates(
+                            JXG.COORDS_BY_USER,
+                            [legendX + legendLineLength / 2, y],
+                        );
                         swatch.needsUpdate = true;
                         swatch.update();
                     } else if (swatch.elType === "polygon") {
-                        swatch.vertices[0].coords.setCoordinates(
+                        const polygon = swatch as JXGPolygon;
+                        polygon.vertices[0].coords.setCoordinates(
                             JXG.COORDS_BY_USER,
                             [legendX, y + legendDy / 4],
                         );
-                        swatch.vertices[1].coords.setCoordinates(
+                        polygon.vertices[1].coords.setCoordinates(
                             JXG.COORDS_BY_USER,
                             [legendX + legendLineLength, y + legendDy / 4],
                         );
-                        swatch.vertices[2].coords.setCoordinates(
+                        polygon.vertices[2].coords.setCoordinates(
                             JXG.COORDS_BY_USER,
                             [legendX + legendLineLength, y - legendDy / 4],
                         );
-                        swatch.vertices[3].coords.setCoordinates(
+                        polygon.vertices[3].coords.setCoordinates(
                             JXG.COORDS_BY_USER,
                             [legendX, y - legendDy / 4],
                         );
 
                         for (let i = 0; i < 4; i++) {
-                            swatch.vertices[i].needsUpdate = true;
-                            swatch.vertices[i].update();
-                            swatch.borders[i].needsUpdate = true;
-                            swatch.borders[i].update();
+                            polygon.vertices[i].needsUpdate = true;
+                            polygon.vertices[i].update();
+                            polygon.borders[i].needsUpdate = true;
+                            polygon.borders[i].update();
                         }
-                        swatch.needsUpdate = true;
-                        swatch.update();
+                        polygon.needsUpdate = true;
+                        polygon.update();
                     } else {
-                        swatch.point1.coords.setCoordinates(
-                            JXG.COORDS_BY_USER,
-                            [legendX, y],
-                        );
-                        swatch.point2.coords.setCoordinates(
-                            JXG.COORDS_BY_USER,
-                            [legendX + legendLineLength, y],
-                        );
-                        swatch.needsUpdate = true;
-                        swatch.update();
+                        const line = swatch as JXGLine;
+                        line.point1.coords.setCoordinates(JXG.COORDS_BY_USER, [
+                            legendX,
+                            y,
+                        ]);
+                        line.point2.coords.setCoordinates(JXG.COORDS_BY_USER, [
+                            legendX + legendLineLength,
+                            y,
+                        ]);
+                        line.needsUpdate = true;
+                        line.update();
                     }
 
                     if (labels.current[ind]) {
@@ -244,7 +290,7 @@ export default React.memo(function Legend(props) {
                     }
                 }
 
-                board.updateRenderer();
+                board!.updateRenderer();
             });
         }
     }
@@ -295,7 +341,7 @@ export default React.memo(function Legend(props) {
     );
 });
 
-function styleToDash(style) {
+function styleToDash(style: string | undefined): number {
     if (style === "dashed") {
         return 2;
     } else if (style === "solid") {
@@ -307,7 +353,7 @@ function styleToDash(style) {
     }
 }
 
-function normalizeStyle(style) {
+function normalizeStyle(style: string | undefined): string | undefined {
     if (style === "triangle") {
         return "triangleup";
     } else {

--- a/packages/doenetml/src/Viewer/renderers/list.tsx
+++ b/packages/doenetml/src/Viewer/renderers/list.tsx
@@ -22,7 +22,8 @@ interface ListSVs {
 }
 
 export default React.memo(function List(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer<ListSVs>(props);
+    let { id, SVs, children, actions, callAction } =
+        useDoenetRenderer<ListSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/list.tsx
+++ b/packages/doenetml/src/Viewer/renderers/list.tsx
@@ -10,8 +10,19 @@ import {
 } from "./utils/checkWork";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
 
+interface ListSVs {
+    [key: string]: any;
+    hidden: boolean;
+    _compositeReplacementActiveRange?: any;
+    item?: any;
+    justSubmitted: boolean;
+    level: number;
+    marker: string;
+    numbered: boolean;
+}
+
 export default React.memo(function List(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer(props);
+    let { id, SVs, children, actions, callAction } = useDoenetRenderer<ListSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/lq.tsx
+++ b/packages/doenetml/src/Viewer/renderers/lq.tsx
@@ -3,8 +3,12 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 
+interface LqSVs {
+    hidden: boolean;
+}
+
 export default React.memo(function Lq(props: UseDoenetRendererProps) {
-    let { SVs } = useDoenetRenderer(props, false);
+    let { SVs } = useDoenetRenderer<LqSVs>(props, false);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/lsq.tsx
+++ b/packages/doenetml/src/Viewer/renderers/lsq.tsx
@@ -3,8 +3,12 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 
+interface LsqSVs {
+    hidden: boolean;
+}
+
 export default React.memo(function Lsq(props: UseDoenetRendererProps) {
-    let { SVs } = useDoenetRenderer(props, false);
+    let { SVs } = useDoenetRenderer<LsqSVs>(props, false);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/math.tsx
+++ b/packages/doenetml/src/Viewer/renderers/math.tsx
@@ -13,12 +13,29 @@ import {
 import { DocContext } from "../DocViewer";
 import { JXGEvent, JXGObject } from "./jsxgraph-distrib/types";
 import { ChoiceInputInlineContext } from "./choiceInput";
+import { SelectedStyle } from "./utils/graphicalSVs";
+
+interface MathSVs {
+    [key: string]: any;
+    hidden: boolean;
+    layer: number;
+    fixed: boolean;
+    fixLocation: boolean;
+    draggable: boolean;
+    anchor: any;
+    positionFromAnchor: any;
+    latex: string;
+    renderMode?: string;
+    equationTag?: string;
+    mrowChildRendererIds?: string[];
+    selectedStyle: SelectedStyle;
+}
 
 export default React.memo(function MathComponent(
     props: UseDoenetRendererProps,
 ) {
     let { componentIdx, id, SVs, actions, sourceOfUpdate, callAction } =
-        useDoenetRenderer(props);
+        useDoenetRenderer<MathSVs>(props);
 
     // @ts-ignore
     MathComponent.ignoreActionsWithoutCore = () => true;
@@ -493,8 +510,8 @@ export default React.memo(function MathComponent(
             }
 
             if (mathJXG.current.visProp.strokecolor !== textColor) {
-                mathJXG.current.visProp.strokecolor = textColor;
-                mathJXG.current.visProp.highlightstrokecolor = textColor;
+                mathJXG.current.visProp.strokecolor = textColor!;
+                mathJXG.current.visProp.highlightstrokecolor = textColor!;
             }
             if (mathJXG.current.visProp.cssstyle !== cssStyle) {
                 mathJXG.current.visProp.cssstyle = cssStyle;

--- a/packages/doenetml/src/Viewer/renderers/mathInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.tsx
@@ -342,9 +342,29 @@ function getBlurTransitionContext({
     };
 }
 
+interface MathInputSVs {
+    [key: string]: any;
+    hidden: boolean;
+    disabled: boolean;
+    label: string;
+    labelHasLatex: boolean;
+    labelPosition: string;
+    justSubmitted: boolean;
+    forceFullCheckWorkButton: boolean;
+    colorCorrectness: boolean;
+    errorMessageRawRenderer: any;
+    externalLabelRendererIds: any;
+    immediateValueLatex: string;
+    minWidth: any;
+    rawRendererValue: any;
+    shortDescription: string;
+    showCheckWork: boolean;
+    showPreview: boolean;
+}
+
 export default function MathInput(props: UseDoenetRendererProps) {
     let { id, SVs, children, actions, ignoreUpdate, callAction } =
-        useDoenetRenderer(props);
+        useDoenetRenderer<MathInputSVs>(props);
 
     // @ts-ignore
     MathInput.baseStateVariable = "rawRendererValue";
@@ -609,7 +629,7 @@ export default function MathInput(props: UseDoenetRendererProps) {
         isPending,
     );
 
-    let label = SVs.label;
+    let label: React.ReactNode = SVs.label;
     const inputKey = `${id}_input`;
     const hasLabel =
         typeof SVs.label === "string" ? SVs.label.trim() !== "" : !!SVs.label;

--- a/packages/doenetml/src/Viewer/renderers/matrixInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/matrixInput.tsx
@@ -1,6 +1,7 @@
-// @ts-nocheck
 import React, { useContext, useRef } from "react";
-import useDoenetRenderer from "../useDoenetRenderer";
+import useDoenetRenderer, {
+    UseDoenetRendererProps,
+} from "../useDoenetRenderer";
 // import me from 'math-expressions';
 import { ActionButton } from "@doenet/ui-components";
 import { ActionButtonGroup } from "@doenet/ui-components";
@@ -15,8 +16,26 @@ import {
 import { DescriptionPopover } from "./utils/Description";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
 
-export default React.memo(function MatrixInput(props) {
-    let { id, SVs, actions, children, callAction } = useDoenetRenderer(props);
+interface MatrixInputSVs {
+    [key: string]: any;
+    hidden: boolean;
+    disabled: boolean;
+    label: string;
+    labelHasLatex: boolean;
+    labelPosition?: string;
+    showSizeControls: boolean;
+    numRows: number;
+    numColumns: number;
+    forceFullCheckWorkButton: boolean;
+    justSubmitted: boolean;
+    shortDescription?: string;
+    descriptionChildInd?: number;
+    externalLabelRendererIds?: string[];
+}
+
+export default React.memo(function MatrixInput(props: UseDoenetRendererProps) {
+    let { id, SVs, actions, children, callAction } =
+        useDoenetRenderer<MatrixInputSVs>(props);
 
     // need to use a ref for validation state as handlePressEnter
     // does not update to current values
@@ -145,7 +164,7 @@ export default React.memo(function MatrixInput(props) {
         );
     }
 
-    let label = SVs.label;
+    let label: React.ReactNode = SVs.label;
     const hasLabel =
         typeof SVs.label === "string" ? SVs.label.trim() !== "" : !!SVs.label;
     const labelId = `${id}-label`;
@@ -167,7 +186,9 @@ export default React.memo(function MatrixInput(props) {
         .join(" ");
 
     const descriptionChild =
-        SVs.descriptionChildInd !== -1 && children[SVs.descriptionChildInd];
+        SVs.descriptionChildInd !== undefined &&
+        SVs.descriptionChildInd !== -1 &&
+        children[SVs.descriptionChildInd];
 
     let descriptionId: string | undefined = undefined;
     let description: React.ReactNode | null = null;

--- a/packages/doenetml/src/Viewer/renderers/mdash.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mdash.tsx
@@ -7,7 +7,7 @@ interface MdashSVs {
     hidden: boolean;
 }
 
-export default React.memo(function Ndash(props: UseDoenetRendererProps) {
+export default React.memo(function Mdash(props: UseDoenetRendererProps) {
     let { SVs } = useDoenetRenderer<MdashSVs>(props, false);
 
     if (SVs.hidden) {

--- a/packages/doenetml/src/Viewer/renderers/mdash.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mdash.tsx
@@ -3,8 +3,12 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 
+interface MdashSVs {
+    hidden: boolean;
+}
+
 export default React.memo(function Ndash(props: UseDoenetRendererProps) {
-    let { SVs } = useDoenetRenderer(props, false);
+    let { SVs } = useDoenetRenderer<MdashSVs>(props, false);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/nbsp.tsx
+++ b/packages/doenetml/src/Viewer/renderers/nbsp.tsx
@@ -3,8 +3,12 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 
+interface NbspSVs {
+    hidden: boolean;
+}
+
 export default React.memo(function Nbsp(props: UseDoenetRendererProps) {
-    let { SVs } = useDoenetRenderer(props, false);
+    let { SVs } = useDoenetRenderer<NbspSVs>(props, false);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/ndash.tsx
+++ b/packages/doenetml/src/Viewer/renderers/ndash.tsx
@@ -3,8 +3,12 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 
+interface NdashSVs {
+    hidden: boolean;
+}
+
 export default React.memo(function Ndash(props: UseDoenetRendererProps) {
-    let { SVs } = useDoenetRenderer(props);
+    let { SVs } = useDoenetRenderer<NdashSVs>(props);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/number.tsx
+++ b/packages/doenetml/src/Viewer/renderers/number.tsx
@@ -484,7 +484,7 @@ export default React.memo(function NumberComponent(
     }
 
     let number = SVs.text;
-    if ((SVs as any).renderAsMath) {
+    if (SVs.renderAsMath) {
         number = "\\(" + number + "\\)";
     }
 

--- a/packages/doenetml/src/Viewer/renderers/number.tsx
+++ b/packages/doenetml/src/Viewer/renderers/number.tsx
@@ -1,9 +1,10 @@
-// @ts-nocheck
 import { MathJax } from "better-react-mathjax";
 
 import React, { useContext, useEffect, useRef } from "react";
 import { BoardContext, TEXT_LAYER_OFFSET } from "./graph";
-import useDoenetRenderer from "../useDoenetRenderer";
+import useDoenetRenderer, {
+    UseDoenetRendererProps,
+} from "../useDoenetRenderer";
 import me from "math-expressions";
 import { textRendererStyle } from "@doenet/utils";
 import {
@@ -12,34 +13,52 @@ import {
 } from "./utils/graph";
 import { DocContext } from "../DocViewer";
 import { ChoiceInputInlineContext } from "./choiceInput";
+import { JXGEvent, JXGPoint, JXGText } from "./jsxgraph-distrib/types";
+import { SelectedStyle } from "./utils/graphicalSVs";
 
-export default React.memo(function NumberComponent(props) {
-    let { componentIdx, id, SVs, actions, sourceOfUpdate, callAction } =
-        useDoenetRenderer(props);
+interface NumberSVs {
+    hidden: boolean;
+    layer: number;
+    fixed: boolean;
+    fixLocation: boolean;
+    draggable: boolean;
+    anchor: any;
+    positionFromAnchor: any;
+    text: string;
+    renderAsMath: boolean;
+    selectedStyle: SelectedStyle;
+}
 
+export default React.memo(function NumberComponent(
+    props: UseDoenetRendererProps,
+) {
+    let { componentIdx, id, SVs, actions, callAction } =
+        useDoenetRenderer<NumberSVs>(props);
+
+    // @ts-ignore
     NumberComponent.ignoreActionsWithoutCore = () => true;
 
-    let numberJXG = useRef(null);
-    let anchorPointJXG = useRef(null);
-    let anchorRel = useRef(null);
+    let numberJXG = useRef<JXGText | null>(null);
+    let anchorPointJXG = useRef<JXGPoint | null>(null);
+    let anchorRel = useRef<[string, string] | null>(null);
 
     const board = useContext(BoardContext);
     const choiceInputInlineContext = useContext(ChoiceInputInlineContext);
 
-    let pointerAtDown = useRef(false);
-    let pointAtDown = useRef(false);
-    let pointerIsDown = useRef(false);
-    let pointerMovedSinceDown = useRef(false);
-    let dragged = useRef(false);
+    let pointerAtDown = useRef<[number, number] | null>(null);
+    let pointAtDown = useRef<number[] | null>(null);
+    let pointerIsDown = useRef<boolean>(false);
+    let pointerMovedSinceDown = useRef<boolean>(false);
+    let dragged = useRef<boolean>(false);
 
-    let calculatedX = useRef(null);
-    let calculatedY = useRef(null);
+    let calculatedX = useRef<number | null>(null);
+    let calculatedY = useRef<number | null>(null);
 
-    let lastPositionFromCore = useRef(null);
-    let previousPositionFromAnchor = useRef(null);
+    let lastPositionFromCore = useRef<number[] | null>(null);
+    let previousPositionFromAnchor = useRef<any>(null);
 
-    let fixed = useRef(false);
-    let fixLocation = useRef(false);
+    let fixed = useRef<boolean>(false);
+    let fixLocation = useRef<boolean>(false);
 
     fixed.current = SVs.fixed;
     fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
@@ -85,7 +104,7 @@ export default React.memo(function NumberComponent(props) {
         }
 
         //things to be passed to JSXGraph as attributes
-        let jsxNumberAttributes = {
+        let jsxNumberAttributes: Record<string, any> = {
             visible: !SVs.hidden,
             fixed: fixed.current,
             layer: 10 * SVs.layer + TEXT_LAYER_OFFSET,
@@ -99,7 +118,7 @@ export default React.memo(function NumberComponent(props) {
             parse: false,
         };
 
-        let newAnchorPointJXG;
+        let newAnchorPointJXG: JXGPoint;
 
         try {
             let anchor = me.fromAst(SVs.anchor);
@@ -118,12 +137,12 @@ export default React.memo(function NumberComponent(props) {
 
             newAnchorPointJXG = board.create("point", anchorCoords, {
                 visible: false,
-            });
+            }) as JXGPoint;
         } catch (e) {
             jsxNumberAttributes["visible"] = false;
             newAnchorPointJXG = board.create("point", [0, 0], {
                 visible: false,
-            });
+            }) as JXGPoint;
         }
 
         jsxNumberAttributes.anchor = newAnchorPointJXG;
@@ -133,16 +152,16 @@ export default React.memo(function NumberComponent(props) {
         );
         jsxNumberAttributes.anchorx = anchorx;
         jsxNumberAttributes.anchory = anchory;
-        anchorRel.current = [anchorx, anchory];
+        anchorRel.current = [anchorx as string, anchory as string];
 
         let newNumberJXG = board.create(
             "text",
             [0, 0, SVs.text],
             jsxNumberAttributes,
-        );
+        ) as JXGText;
         newNumberJXG.isDraggable = !fixLocation.current;
 
-        newNumberJXG.on("down", function (e) {
+        newNumberJXG.on("down", function (e: JXGEvent) {
             (document.activeElement as HTMLElement | null)?.blur();
 
             pointerAtDown.current = [e.x, e.y];
@@ -153,21 +172,21 @@ export default React.memo(function NumberComponent(props) {
             if (!fixed.current) {
                 callAction({
                     action: actions.numberFocused,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
+                    args: { componentIdx },
                 });
             }
         });
 
-        newNumberJXG.on("hit", function (e) {
+        newNumberJXG.on("hit", function (e: JXGEvent) {
             pointAtDown.current = [...newAnchorPointJXG.coords.scrCoords];
             dragged.current = false;
             callAction({
                 action: actions.numberFocused,
-                args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
+                args: { componentIdx },
             });
         });
 
-        newNumberJXG.on("up", function (e) {
+        newNumberJXG.on("up", function (e: JXGEvent) {
             if (dragged.current) {
                 callAction({
                     action: actions.moveNumber,
@@ -180,13 +199,13 @@ export default React.memo(function NumberComponent(props) {
             } else if (!pointerMovedSinceDown.current && !fixed.current) {
                 callAction({
                     action: actions.numberClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
+                    args: { componentIdx },
                 });
             }
             pointerIsDown.current = false;
         });
 
-        newNumberJXG.on("keyfocusout", function (e) {
+        newNumberJXG.on("keyfocusout", function (e: JXGEvent) {
             if (dragged.current) {
                 callAction({
                     action: actions.moveNumber,
@@ -199,26 +218,26 @@ export default React.memo(function NumberComponent(props) {
             }
         });
 
-        newNumberJXG.on("drag", function (e) {
+        newNumberJXG.on("drag", function (e: JXGEvent) {
             let viaPointer = e.type === "pointermove";
 
             //Protect against very small unintended drags
             if (
                 !viaPointer ||
-                Math.abs(e.x - pointerAtDown.current[0]) >
+                Math.abs(e.x - pointerAtDown.current![0]) >
                     POINTER_DRAG_THRESHOLD ||
-                Math.abs(e.y - pointerAtDown.current[1]) >
+                Math.abs(e.y - pointerAtDown.current![1]) >
                     POINTER_DRAG_THRESHOLD
             ) {
                 dragged.current = true;
             }
 
             let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
-            let width = newNumberJXG.size[0] / board.unitX;
-            let height = newNumberJXG.size[1] / board.unitY;
+            let width = newNumberJXG.size![0] / board.unitX;
+            let height = newNumberJXG.size![1] / board.unitY;
 
-            let anchorx = anchorRel.current[0];
-            let anchory = anchorRel.current[1];
+            let anchorx = anchorRel.current![0];
+            let anchory = anchorRel.current![1];
 
             let offsetx = 0;
             if (anchorx === "middle") {
@@ -251,25 +270,25 @@ export default React.memo(function NumberComponent(props) {
                 var o = board.origin.scrCoords;
 
                 calculatedX.current =
-                    (pointAtDown.current[1] +
+                    (pointAtDown.current![1] +
                         e.x -
-                        pointerAtDown.current[0] -
+                        pointerAtDown.current![0] -
                         o[1]) /
                     board.unitX;
 
                 calculatedY.current =
                     (o[2] -
-                        (pointAtDown.current[2] +
+                        (pointAtDown.current![2] +
                             e.y -
-                            pointerAtDown.current[1])) /
+                            pointerAtDown.current![1])) /
                     board.unitY;
             } else {
                 calculatedX.current =
                     newAnchorPointJXG.X() +
-                    newNumberJXG.relativeCoords.usrCoords[1];
+                    newNumberJXG.relativeCoords!.usrCoords[1];
                 calculatedY.current =
                     newAnchorPointJXG.Y() +
-                    newNumberJXG.relativeCoords.usrCoords[2];
+                    newNumberJXG.relativeCoords!.usrCoords[2];
             }
 
             calculatedX.current = Math.min(
@@ -291,7 +310,7 @@ export default React.memo(function NumberComponent(props) {
                 },
             });
 
-            newNumberJXG.relativeCoords.setCoordinates(
+            newNumberJXG.relativeCoords!.setCoordinates(
                 JXG.COORDS_BY_USER,
                 [0, 0],
             );
@@ -301,7 +320,7 @@ export default React.memo(function NumberComponent(props) {
             );
         });
 
-        newNumberJXG.on("keydown", function (e) {
+        newNumberJXG.on("keydown", function (e: JXGEvent) {
             if (e.key === "Enter") {
                 if (dragged.current) {
                     callAction({
@@ -315,7 +334,7 @@ export default React.memo(function NumberComponent(props) {
                 }
                 callAction({
                     action: actions.numberClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
+                    args: { componentIdx },
                 });
             }
         });
@@ -325,13 +344,13 @@ export default React.memo(function NumberComponent(props) {
         previousPositionFromAnchor.current = SVs.positionFromAnchor;
     }
 
-    function boardMoveHandler(e) {
+    function boardMoveHandler(e: JXGEvent) {
         if (pointerIsDown.current) {
             //Protect against very small unintended move
             if (
-                Math.abs(e.x - pointerAtDown.current[0]) >
+                Math.abs(e.x - pointerAtDown.current![0]) >
                     POINTER_DRAG_THRESHOLD ||
-                Math.abs(e.y - pointerAtDown.current[1]) >
+                Math.abs(e.y - pointerAtDown.current![1]) >
                     POINTER_DRAG_THRESHOLD
             ) {
                 pointerMovedSinceDown.current = true;
@@ -340,6 +359,7 @@ export default React.memo(function NumberComponent(props) {
     }
 
     function deleteNumberJXG() {
+        if (!numberJXG.current) return;
         numberJXG.current.off("drag");
         numberJXG.current.off("down");
         numberJXG.current.off("hit");
@@ -351,12 +371,12 @@ export default React.memo(function NumberComponent(props) {
     }
 
     if (board) {
-        let anchorCoords;
+        let anchorCoords: number[];
         try {
             let anchor = me.fromAst(SVs.anchor);
             anchorCoords = [
-                anchor.get_component(0).evaluate_to_constant(),
-                anchor.get_component(1).evaluate_to_constant(),
+                anchor.get_component(0).evaluate_to_constant() ?? NaN,
+                anchor.get_component(1).evaluate_to_constant() ?? NaN,
             ];
         } catch (e) {
             anchorCoords = [NaN, NaN];
@@ -367,11 +387,11 @@ export default React.memo(function NumberComponent(props) {
         if (numberJXG.current === null) {
             createNumberJXG();
         } else {
-            numberJXG.current.relativeCoords.setCoordinates(
+            numberJXG.current.relativeCoords!.setCoordinates(
                 JXG.COORDS_BY_USER,
                 [0, 0],
             );
-            anchorPointJXG.current.coords.setCoordinates(
+            anchorPointJXG.current!.coords.setCoordinates(
                 JXG.COORDS_BY_USER,
                 anchorCoords,
             );
@@ -422,8 +442,8 @@ export default React.memo(function NumberComponent(props) {
             }
 
             if (numberJXG.current.visProp.strokecolor !== textColor) {
-                numberJXG.current.visProp.strokecolor = textColor;
-                numberJXG.current.visProp.highlightstrokecolor = textColor;
+                numberJXG.current.visProp.strokecolor = textColor!;
+                numberJXG.current.visProp.highlightstrokecolor = textColor!;
             }
             if (numberJXG.current.visProp.cssstyle !== cssStyle) {
                 numberJXG.current.visProp.cssstyle = cssStyle;
@@ -442,15 +462,15 @@ export default React.memo(function NumberComponent(props) {
                 );
                 numberJXG.current.visProp.anchorx = anchorx;
                 numberJXG.current.visProp.anchory = anchory;
-                anchorRel.current = [anchorx, anchory];
+                anchorRel.current = [anchorx as string, anchory as string];
                 previousPositionFromAnchor.current = SVs.positionFromAnchor;
                 numberJXG.current.fullUpdate();
             } else {
                 numberJXG.current.update();
             }
 
-            anchorPointJXG.current.needsUpdate = true;
-            anchorPointJXG.current.update();
+            anchorPointJXG.current!.needsUpdate = true;
+            anchorPointJXG.current!.update();
             board.updateRenderer();
         }
 
@@ -464,12 +484,12 @@ export default React.memo(function NumberComponent(props) {
     }
 
     let number = SVs.text;
-    if (SVs.renderAsMath) {
+    if ((SVs as any).renderAsMath) {
         number = "\\(" + number + "\\)";
     }
 
     const style = !choiceInputInlineContext.inOption
-        ? textRendererStyle(darkMode, SVs.selectedStyle)
+        ? textRendererStyle(darkMode ?? "light", SVs.selectedStyle)
         : undefined;
 
     return (

--- a/packages/doenetml/src/Viewer/renderers/orbitalDiagram.tsx
+++ b/packages/doenetml/src/Viewer/renderers/orbitalDiagram.tsx
@@ -1,19 +1,34 @@
-// @ts-nocheck
-import React, { createRef, useRef } from "react";
-import useDoenetRenderer from "../useDoenetRenderer";
+import React, { useRef } from "react";
+import useDoenetRenderer, {
+    UseDoenetRendererProps,
+} from "../useDoenetRenderer";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
+
+interface OrbitalRowData {
+    orbitalText: string;
+    boxes: string[];
+}
+
+interface OrbitalDiagramSVs {
+    [key: string]: any;
+    hidden: boolean;
+    fixed: boolean;
+    value: OrbitalRowData[];
+}
 
 // border: ${(props) => (props.alert ? '2px solid #C1292E' : '2px solid black')};
 
-export default React.memo(function orbitalDiagram(props) {
-    let { id, SVs, actions, callAction } = useDoenetRenderer(props);
-    // console.log("orbitalDiagramInput SVs ", SVs);
+export default React.memo(function orbitalDiagram(
+    props: UseDoenetRendererProps,
+) {
+    let { id, SVs, actions, callAction } =
+        useDoenetRenderer<OrbitalDiagramSVs>(props);
 
     // use ref for fixed so changed value appears in callbacks
-    let fixed = createRef(SVs.fixed);
+    let fixed = useRef<boolean>(SVs.fixed);
     fixed.current = SVs.fixed;
 
-    const ref = useRef(null);
+    const ref = useRef<HTMLDivElement | null>(null);
 
     useRecordVisibilityChanges(ref, callAction, actions);
 
@@ -25,7 +40,7 @@ export default React.memo(function orbitalDiagram(props) {
 
     let rowsJSX = [];
     for (let [index, row] of Object.entries(rows)) {
-        let rowNumber = rows.length - index - 1;
+        let rowNumber = rows.length - Number(index) - 1;
         rowsJSX.push(
             <OrbitalRow
                 key={`OrbitalRow${rowNumber}`}
@@ -49,6 +64,11 @@ const OrbitalRow = React.memo(function OrbitalRow({
     orbitalText,
     boxes,
     name,
+}: {
+    rowNumber: number;
+    orbitalText: string;
+    boxes: string[];
+    name: string;
 }) {
     let rowStyle = {
         width: "800px",
@@ -79,7 +99,7 @@ const OrbitalRow = React.memo(function OrbitalRow({
         <div
             key={`OrbitalRow${rowNumber}`}
             id={`OrbitalRow${rowNumber}${name}`}
-            tabIndex="-1"
+            tabIndex={-1}
             style={rowStyle}
         >
             {/* <span style={{marginRight:"2px"}}>row {rowNumber + 1}</span> */}
@@ -97,6 +117,10 @@ const OrbitalText = React.memo(function OrbitalText({
     rowNumber,
     orbitalText,
     name,
+}: {
+    rowNumber: number;
+    orbitalText: string;
+    name: string;
 }) {
     return (
         <div
@@ -107,8 +131,7 @@ const OrbitalText = React.memo(function OrbitalText({
                 width: "40px",
                 backgroundColor: "white",
             }}
-            type="text"
-            size="4"
+            {...({ type: "text", size: "4" } as any)}
         >
             {orbitalText}
         </div>
@@ -120,6 +143,11 @@ const OrbitalBox = React.memo(function OrbitalBox({
     arrows = "",
     rowNumber,
     name,
+}: {
+    boxNum: string | number;
+    arrows?: string;
+    rowNumber: number;
+    name: string;
 }) {
     const firstUp = (
         <polyline
@@ -204,7 +232,7 @@ const OrbitalBox = React.memo(function OrbitalBox({
         <svg
             key={`orbitalbox${boxNum}`}
             id={`orbitalbox${name}${rowNumber}-${boxNum}`}
-            tabIndex="-1"
+            tabIndex={-1}
             width={boxWidth}
             height="40"
             style={{ margin: "2px" }}

--- a/packages/doenetml/src/Viewer/renderers/orbitalDiagram.tsx
+++ b/packages/doenetml/src/Viewer/renderers/orbitalDiagram.tsx
@@ -131,7 +131,6 @@ const OrbitalText = React.memo(function OrbitalText({
                 width: "40px",
                 backgroundColor: "white",
             }}
-            {...({ type: "text", size: "4" } as any)}
         >
             {orbitalText}
         </div>

--- a/packages/doenetml/src/Viewer/renderers/orbitalDiagramInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/orbitalDiagramInput.tsx
@@ -1,25 +1,44 @@
-// @ts-nocheck
-import React, { createRef, useRef } from "react";
-import useDoenetRenderer from "../useDoenetRenderer";
-import { Button } from "@doenet/ui-components";
+import React, { useRef } from "react";
+import useDoenetRenderer, {
+    UseDoenetRendererProps,
+} from "../useDoenetRenderer";
+import { Button as ButtonUntyped } from "@doenet/ui-components";
+const Button = ButtonUntyped as any;
 import { useRecordVisibilityChanges } from "../../utils/visibility";
+
+interface OrbitalRowData {
+    orbitalText: string;
+    boxes: string[];
+}
+
+interface OrbitalDiagramInputSVs {
+    [key: string]: any;
+    hidden: boolean;
+    fixed: boolean;
+    rows: OrbitalRowData[];
+    selectedRowIndex: number;
+    selectedBoxIndex: number;
+}
 
 // border: ${(props) => (props.alert ? '2px solid #C1292E' : '2px solid black')};
 
-export default React.memo(function orbitalDiagramInput(props) {
-    let { id, SVs, actions, callAction } = useDoenetRenderer(props);
-    // console.log("orbitalDiagramInput SVs ", SVs);
+export default React.memo(function orbitalDiagramInput(
+    props: UseDoenetRendererProps,
+) {
+    let { id, SVs, actions, callAction } =
+        useDoenetRenderer<OrbitalDiagramInputSVs>(props);
 
     let selectedRowIndex0 = SVs.selectedRowIndex - 1;
     let selectedBoxIndex0 = SVs.selectedBoxIndex - 1;
 
+    // @ts-ignore
     orbitalDiagramInput.ignoreActionsWithoutCore = () => true;
 
     // use ref for fixed so changed value appears in callbacks
-    let fixed = createRef(SVs.fixed);
+    let fixed = useRef<boolean>(SVs.fixed);
     fixed.current = SVs.fixed;
 
-    const ref = useRef(null);
+    const ref = useRef<HTMLDivElement | null>(null);
 
     useRecordVisibilityChanges(ref, callAction, actions);
 
@@ -27,7 +46,7 @@ export default React.memo(function orbitalDiagramInput(props) {
         return null;
     }
 
-    function setSelectedRow(index) {
+    function setSelectedRow(index: number | string) {
         if (!fixed.current) {
             callAction({
                 action: actions.selectRow,
@@ -36,7 +55,7 @@ export default React.memo(function orbitalDiagramInput(props) {
         }
     }
 
-    function setSelectedBox(index, rowNum) {
+    function setSelectedBox(index: number | string, rowNum?: number | string) {
         if (!fixed.current) {
             if (rowNum !== undefined) {
                 callAction({
@@ -51,7 +70,7 @@ export default React.memo(function orbitalDiagramInput(props) {
         }
     }
 
-    function updateRowText(newValue) {
+    function updateRowText(newValue: string) {
         if (!fixed.current) {
             callAction({
                 action: actions.updateRowText,
@@ -60,22 +79,21 @@ export default React.memo(function orbitalDiagramInput(props) {
         }
     }
 
-    function deselect(e) {
+    function deselect(e: React.FocusEvent) {
+        const relatedId = (e.relatedTarget as HTMLElement | null)?.id;
         if (
-            e.relatedTarget?.id !== `orbitaladdrow${id}` &&
-            e.relatedTarget?.id !== `orbitalremoverow${id}` &&
-            e.relatedTarget?.id !== `orbitaladdbox${id}` &&
-            e.relatedTarget?.id !== `orbitaladduparrow${id}` &&
-            e.relatedTarget?.id !== `orbitaladddownarrow${id}` &&
-            e.relatedTarget?.id !== `orbitalremovearrow${id}` &&
-            e.relatedTarget?.id !== `orbitalremovebox${id}`
+            relatedId !== `orbitaladdrow${id}` &&
+            relatedId !== `orbitalremoverow${id}` &&
+            relatedId !== `orbitaladdbox${id}` &&
+            relatedId !== `orbitaladduparrow${id}` &&
+            relatedId !== `orbitaladddownarrow${id}` &&
+            relatedId !== `orbitalremovearrow${id}` &&
+            relatedId !== `orbitalremovebox${id}`
         ) {
             if (
-                e.relatedTarget?.id !==
-                    `OrbitalText${selectedRowIndex0}${id}` &&
-                e.relatedTarget?.id !== `OrbitalRow${selectedRowIndex0}${id}` &&
-                e.relatedTarget?.id.substring(0, 10 + id.length) !==
-                    `orbitalbox${id}`
+                relatedId !== `OrbitalText${selectedRowIndex0}${id}` &&
+                relatedId !== `OrbitalRow${selectedRowIndex0}${id}` &&
+                relatedId?.substring(0, 10 + id.length) !== `orbitalbox${id}`
             ) {
                 setSelectedRow(-1);
             }
@@ -85,7 +103,7 @@ export default React.memo(function orbitalDiagramInput(props) {
 
     let rowsJSX = [];
     for (let [index, row] of Object.entries(SVs.rows)) {
-        let rowNumber = SVs.rows.length - index - 1;
+        let rowNumber = SVs.rows.length - Number(index) - 1;
         rowsJSX.push(
             <OrbitalRow
                 key={`OrbitalRow${rowNumber}`}
@@ -111,7 +129,7 @@ export default React.memo(function orbitalDiagramInput(props) {
                 <div style={{ display: "inline-block", marginRight: "4px" }}>
                     <Button
                         id={`orbitaladdrow${id}`}
-                        onBlur={(e) => {
+                        onBlur={(e: React.FocusEvent) => {
                             deselect(e);
                         }}
                         onClick={() => {
@@ -137,7 +155,7 @@ export default React.memo(function orbitalDiagramInput(props) {
                 <div style={{ display: "inline-block", marginRight: "4px" }}>
                     <Button
                         id={`orbitaladdbox${id}`}
-                        onBlur={(e) => {
+                        onBlur={(e: React.FocusEvent) => {
                             deselect(e);
                         }}
                         onClick={() => {
@@ -152,7 +170,7 @@ export default React.memo(function orbitalDiagramInput(props) {
                 <div style={{ display: "inline-block", marginRight: "4px" }}>
                     <Button
                         id={`orbitalremovebox${id}`}
-                        onBlur={(e) => {
+                        onBlur={(e: React.FocusEvent) => {
                             deselect(e);
                         }}
                         onClick={() => {
@@ -167,7 +185,7 @@ export default React.memo(function orbitalDiagramInput(props) {
                 <div style={{ display: "inline-block", marginRight: "4px" }}>
                     <Button
                         id={`orbitaladduparrow${id}`}
-                        onBlur={(e) => {
+                        onBlur={(e: React.FocusEvent) => {
                             deselect(e);
                         }}
                         onClick={() => {
@@ -182,7 +200,7 @@ export default React.memo(function orbitalDiagramInput(props) {
                 <div style={{ display: "inline-block", marginRight: "4px" }}>
                     <Button
                         id={`orbitaladddownarrow${id}`}
-                        onBlur={(e) => {
+                        onBlur={(e: React.FocusEvent) => {
                             deselect(e);
                         }}
                         onClick={() => {
@@ -197,7 +215,7 @@ export default React.memo(function orbitalDiagramInput(props) {
                 <div style={{ display: "inline-block", marginRight: "4px" }}>
                     <Button
                         id={`orbitalremovearrow${id}`}
-                        onBlur={(e) => {
+                        onBlur={(e: React.FocusEvent) => {
                             deselect(e);
                         }}
                         onClick={() => {
@@ -230,8 +248,19 @@ const OrbitalRow = React.memo(function OrbitalRow({
     setSelectedBox,
     deselect,
     name,
+}: {
+    rowNumber: number;
+    updateRowText: (newValue: string) => void;
+    selectedRow: number;
+    setSelectedRow: (index: number | string) => void;
+    orbitalText: string;
+    boxes: string[];
+    selectedBox: number;
+    setSelectedBox: (index: number | string, rowNum?: number | string) => void;
+    deselect: (e: React.FocusEvent) => void;
+    name: string;
 }) {
-    let rowStyle = {
+    let rowStyle: React.CSSProperties = {
         width: "800px",
         height: "44px",
         display: "flex",
@@ -251,7 +280,7 @@ const OrbitalRow = React.memo(function OrbitalRow({
     for (let [index, code] of Object.entries(boxes)) {
         let isSelected = false;
         // console.log("selectedBox === index",selectedBox,index,selectedBox === index,selectedBox == index)
-        if (selectedRow == rowNumber && selectedBox == index) {
+        if (selectedRow == rowNumber && String(selectedBox) === index) {
             isSelected = true;
         }
         boxesJSX.push(
@@ -271,13 +300,13 @@ const OrbitalRow = React.memo(function OrbitalRow({
         <div
             key={`OrbitalRow${rowNumber}`}
             id={`OrbitalRow${rowNumber}${name}`}
-            tabIndex="-1"
+            tabIndex={-1}
             onClick={() => {
                 if (selectedRow !== rowNumber) {
                     setSelectedRow(rowNumber);
                 }
             }}
-            onBlur={(e) => {
+            onBlur={(e: React.FocusEvent) => {
                 deselect(e);
             }}
             style={rowStyle}
@@ -299,13 +328,18 @@ const OrbitalText = React.memo(function OrbitalText({
     updateRowText,
     orbitalText,
     name,
+}: {
+    rowNumber: number;
+    updateRowText: (newValue: string) => void;
+    orbitalText: string;
+    name: string;
 }) {
     return (
         <input
             id={`OrbitalText${rowNumber}${name}`}
             style={{ marginRight: "4px", height: "14px" }}
             type="text"
-            size="4"
+            size={4}
             value={orbitalText}
             onChange={(e) => {
                 let newValue = e.target.value;
@@ -323,6 +357,13 @@ const OrbitalBox = React.memo(function OrbitalBox({
     isSelected,
     rowNumber,
     name,
+}: {
+    boxNum: string | number;
+    arrows?: string;
+    setSelectedBox: (index: number | string, rowNum?: number | string) => void;
+    isSelected: boolean;
+    rowNumber: number;
+    name: string;
 }) {
     const firstUp = (
         <polyline
@@ -411,7 +452,7 @@ const OrbitalBox = React.memo(function OrbitalBox({
         <svg
             key={`orbitalbox${boxNum}`}
             id={`orbitalbox${name}${rowNumber}-${boxNum}`}
-            tabIndex="-1"
+            tabIndex={-1}
             onClick={(e) => {
                 setSelectedBox(boxNum, rowNumber);
                 e.stopPropagation();

--- a/packages/doenetml/src/Viewer/renderers/p.tsx
+++ b/packages/doenetml/src/Viewer/renderers/p.tsx
@@ -20,7 +20,8 @@ interface PSVs {
 }
 
 export default React.memo(function P(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer<PSVs>(props);
+    let { id, SVs, children, actions, callAction } =
+        useDoenetRenderer<PSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/p.tsx
+++ b/packages/doenetml/src/Viewer/renderers/p.tsx
@@ -11,8 +11,16 @@ import {
 } from "./utils/checkWork";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
 
+interface PSVs {
+    [key: string]: any;
+    hidden: boolean;
+    _compositeReplacementActiveRange?: any;
+    justSubmitted: boolean;
+    renderInlineForListItem: boolean;
+}
+
 export default React.memo(function P(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer(props);
+    let { id, SVs, children, actions, callAction } = useDoenetRenderer<PSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/paginatorControls.tsx
+++ b/packages/doenetml/src/Viewer/renderers/paginatorControls.tsx
@@ -4,10 +4,21 @@ import useDoenetRenderer, {
 } from "../useDoenetRenderer";
 import { Button } from "@doenet/ui-components";
 
+interface PaginatorControlsSVs {
+    [key: string]: any;
+    hidden: boolean;
+    currentPage: number;
+    disabledDirectly: boolean;
+    nextLabel: string;
+    numPages: number;
+    pageLabel: string;
+    previousLabel: string;
+}
+
 export default React.memo(function PaginatorControls(
     props: UseDoenetRendererProps,
 ) {
-    let { id, SVs, actions, callAction } = useDoenetRenderer(props, false);
+    let { id, SVs, actions, callAction } = useDoenetRenderer<PaginatorControlsSVs>(props, false);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/paginatorControls.tsx
+++ b/packages/doenetml/src/Viewer/renderers/paginatorControls.tsx
@@ -18,7 +18,8 @@ interface PaginatorControlsSVs {
 export default React.memo(function PaginatorControls(
     props: UseDoenetRendererProps,
 ) {
-    let { id, SVs, actions, callAction } = useDoenetRenderer<PaginatorControlsSVs>(props, false);
+    let { id, SVs, actions, callAction } =
+        useDoenetRenderer<PaginatorControlsSVs>(props, false);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/pegboard.tsx
+++ b/packages/doenetml/src/Viewer/renderers/pegboard.tsx
@@ -1,32 +1,43 @@
-// @ts-nocheck
-import React, { useContext, useEffect, useState, useRef } from "react";
-import useDoenetRenderer from "../useDoenetRenderer";
+import React, { useContext, useEffect, useRef } from "react";
+import useDoenetRenderer, {
+    UseDoenetRendererProps,
+} from "../useDoenetRenderer";
 import { BASE_LAYER_OFFSET, BoardContext } from "./graph";
 import me from "math-expressions";
+import { JXGPoint } from "./jsxgraph-distrib/types";
 
-export default React.memo(function Pegboard(props) {
-    let { id, SVs, actions, sourceOfUpdate, callAction } =
-        useDoenetRenderer(props);
+interface PegboardSVs {
+    hidden: boolean;
+    layer: number;
+    dx: number;
+    dy: number;
+    xoffset: number;
+    yoffset: number;
+}
 
+export default React.memo(function Pegboard(props: UseDoenetRendererProps) {
+    let { SVs } = useDoenetRenderer<PegboardSVs>(props);
+
+    // @ts-ignore
     Pegboard.ignoreActionsWithoutCore = () => true;
 
     const board = useContext(BoardContext);
 
-    let pegboardJXG = useRef(null);
+    let pegboardJXG = useRef<JXGPoint[][] | null>(null);
 
-    let previousBounds = useRef(null);
+    let previousBounds = useRef<[number, number, number, number] | null>(null);
 
-    let dx = useRef(null);
-    let dy = useRef(null);
-    let xoffset = useRef(null);
-    let yoffset = useRef(null);
+    let dx = useRef<number>(SVs.dx);
+    let dy = useRef<number>(SVs.dy);
+    let xoffset = useRef<number>(SVs.xoffset);
+    let yoffset = useRef<number>(SVs.yoffset);
 
     dx.current = SVs.dx;
     dy.current = SVs.dy;
     xoffset.current = SVs.xoffset;
     yoffset.current = SVs.yoffset;
 
-    let jsxPointAttributes = useRef({
+    let jsxPointAttributes = useRef<Record<string, any>>({
         visible: !SVs.hidden,
         fixed: true,
         withlabel: false,
@@ -75,18 +86,18 @@ export default React.memo(function Pegboard(props) {
             Number.isFinite(minYind) &&
             Number.isFinite(maxYind)
         ) {
-            let pegs = [];
+            let pegs: JXGPoint[][] = [];
 
             for (let yind = minYind; yind <= maxYind; yind++) {
                 let y = yind * SVs.dy + SVs.yoffset;
-                let row = [];
+                let row: JXGPoint[] = [];
                 for (let xind = minXind; xind <= maxXind; xind++) {
                     row.push(
                         board.create(
                             "point",
                             [xind * SVs.dx + SVs.xoffset, y],
                             jsxPointAttributes.current,
-                        ),
+                        ) as JXGPoint,
                     );
                 }
                 pegs.push(row);
@@ -110,7 +121,7 @@ export default React.memo(function Pegboard(props) {
             let maxYind = me.math.round(Math.max(yind1, yind2) - 1);
 
             let [prevXmin, prevXmax, prevYmin, prevYmax] =
-                previousBounds.current;
+                previousBounds.current!;
 
             if (
                 minXind !== prevXmin ||
@@ -135,7 +146,12 @@ export default React.memo(function Pegboard(props) {
         pegboardJXG.current = null;
     }
 
-    function recalculatePegboard(minXind, maxXind, minYind, maxYind) {
+    function recalculatePegboard(
+        minXind: number,
+        maxXind: number,
+        minYind: number,
+        maxYind: number,
+    ) {
         if (pegboardJXG.current === null) {
             return createPegboardJXG();
         }
@@ -149,7 +165,7 @@ export default React.memo(function Pegboard(props) {
             return deletePegboardJXG();
         }
 
-        let [prevXmin, prevXmax, prevYmin, prevYmax] = previousBounds.current;
+        let [prevXmin, prevXmax, prevYmin, prevYmax] = previousBounds.current!;
 
         let numRows = maxYind - minYind + 1;
         let prevNrows = prevYmax - prevYmin + 1;
@@ -171,17 +187,19 @@ export default React.memo(function Pegboard(props) {
             if (prevNcols > numColumns) {
                 for (let j = numColumns; j < prevNcols; j++) {
                     let point = row.pop();
-                    board?.removeObject(point);
+                    if (point) {
+                        board?.removeObject(point);
+                    }
                 }
             } else if (prevNcols < numColumns) {
                 for (let j = prevNcols; j < numColumns; j++) {
                     let x = (j + minXind) * dx.current + xoffset.current;
                     row.push(
-                        board.create(
+                        board!.create(
                             "point",
                             [x, y],
                             jsxPointAttributes.current,
-                        ),
+                        ) as JXGPoint,
                     );
                 }
             }
@@ -190,23 +208,27 @@ export default React.memo(function Pegboard(props) {
         if (prevNrows > numRows) {
             for (let i = numRows; i < prevNrows; i++) {
                 let row = pegboardJXG.current.pop();
-                for (let j = 0; j < prevNcols; j++) {
-                    let point = row.pop();
-                    board?.removeObject(point);
+                if (row) {
+                    for (let j = 0; j < prevNcols; j++) {
+                        let point = row.pop();
+                        if (point) {
+                            board?.removeObject(point);
+                        }
+                    }
                 }
             }
         } else if (prevNrows < numRows) {
             for (let i = prevNrows; i < numRows; i++) {
-                let row = [];
+                let row: JXGPoint[] = [];
                 let y = (i + minYind) * dy.current + yoffset.current;
                 for (let j = 0; j < numColumns; j++) {
                     let x = (j + minXind) * dx.current + xoffset.current;
                     row.push(
-                        board.create(
+                        board!.create(
                             "point",
                             [x, y],
                             jsxPointAttributes.current,
-                        ),
+                        ) as JXGPoint,
                     );
                 }
                 pegboardJXG.current.push(row);
@@ -215,7 +237,7 @@ export default React.memo(function Pegboard(props) {
 
         previousBounds.current = [minXind, maxXind, minYind, maxYind];
 
-        board.updateRenderer();
+        board!.updateRenderer();
     }
 
     if (board) {
@@ -237,13 +259,13 @@ export default React.memo(function Pegboard(props) {
 
             recalculatePegboard(minXind, maxXind, minYind, maxYind);
 
-            let firstPeg = pegboardJXG.current[0]?.[0];
+            let firstPeg = pegboardJXG.current?.[0]?.[0];
             if (firstPeg) {
                 let layer = 10 * SVs.layer + BASE_LAYER_OFFSET;
                 let layerChanged = firstPeg.visProp.layer !== layer;
 
                 if (layerChanged) {
-                    for (let row of pegboardJXG.current) {
+                    for (let row of pegboardJXG.current!) {
                         for (let peg of row) {
                             peg.setAttribute({ layer });
                         }

--- a/packages/doenetml/src/Viewer/renderers/pre.tsx
+++ b/packages/doenetml/src/Viewer/renderers/pre.tsx
@@ -15,7 +15,8 @@ interface PreSVs {
 }
 
 export default React.memo(function Pre(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer<PreSVs>(props);
+    let { id, SVs, children, actions, callAction } =
+        useDoenetRenderer<PreSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/pre.tsx
+++ b/packages/doenetml/src/Viewer/renderers/pre.tsx
@@ -6,8 +6,16 @@ import { useRecordVisibilityChanges } from "../../utils/visibility";
 import { addCommasForCompositeRanges } from "./utils/composites";
 import { getBlockMarginWithOptionalTopSuppression } from "./utils/nonInlineMediaLayout";
 
+interface PreSVs {
+    [key: string]: any;
+    hidden: boolean;
+    _compositeReplacementActiveRange?: any;
+    displayDoenetMLIndices?: any;
+    renderInlineForListItem: boolean;
+}
+
 export default React.memo(function Pre(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer(props);
+    let { id, SVs, children, actions, callAction } = useDoenetRenderer<PreSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/pretzel.tsx
+++ b/packages/doenetml/src/Viewer/renderers/pretzel.tsx
@@ -12,6 +12,14 @@ import {
 } from "./utils/checkWork";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
 
+interface PretzelSVs {
+    [key: string]: any;
+    hidden: boolean;
+    justSubmitted: boolean;
+    maxNumColumns: number;
+    numProblems: number;
+}
+
 export default React.memo(function Pretzel(props: UseDoenetRendererProps) {
     let {
         componentIdx,
@@ -23,7 +31,7 @@ export default React.memo(function Pretzel(props: UseDoenetRendererProps) {
         actions,
         callAction,
         flags,
-    } = useDoenetRenderer(props);
+    } = useDoenetRenderer<PretzelSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/q.tsx
+++ b/packages/doenetml/src/Viewer/renderers/q.tsx
@@ -11,7 +11,12 @@ interface QSVs {
 }
 
 export default React.memo(function Q(props: UseDoenetRendererProps) {
-    let { componentIdx: name, id, SVs, children } = useDoenetRenderer<QSVs>(props);
+    let {
+        componentIdx: name,
+        id,
+        SVs,
+        children,
+    } = useDoenetRenderer<QSVs>(props);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/q.tsx
+++ b/packages/doenetml/src/Viewer/renderers/q.tsx
@@ -4,8 +4,14 @@ import useDoenetRenderer, {
 } from "../useDoenetRenderer";
 import { addCommasForCompositeRanges } from "./utils/composites";
 
+interface QSVs {
+    [key: string]: any;
+    hidden: boolean;
+    _compositeReplacementActiveRange?: any;
+}
+
 export default React.memo(function Q(props: UseDoenetRendererProps) {
-    let { componentIdx: name, id, SVs, children } = useDoenetRenderer(props);
+    let { componentIdx: name, id, SVs, children } = useDoenetRenderer<QSVs>(props);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/ref.tsx
+++ b/packages/doenetml/src/Viewer/renderers/ref.tsx
@@ -5,8 +5,21 @@ import useDoenetRenderer, {
 } from "../useDoenetRenderer";
 import "./ref.css";
 
+interface RefSVs {
+    [key: string]: any;
+    hidden: boolean;
+    activityId: string;
+    activityUrlPostfix: string;
+    createButton: boolean;
+    disabled: boolean;
+    linkText: string;
+    targetRendererId?: number;
+    url: string;
+}
+
 export default React.memo(function Ref(props: UseDoenetRendererProps) {
-    const { id, SVs, children, requestScrollTo } = useDoenetRenderer(props);
+    const { id, SVs, children, requestScrollTo } =
+        useDoenetRenderer<RefSVs>(props);
 
     const { doenetViewerUrl } = useContext(DocContext) || {};
 
@@ -46,7 +59,7 @@ export default React.memo(function Ref(props: UseDoenetRendererProps) {
         return null;
     }
 
-    let linkContent = children;
+    let linkContent: React.ReactNode[] | string = children;
     if (children.length === 0) {
         linkContent = SVs.linkText;
     }

--- a/packages/doenetml/src/Viewer/renderers/regionBetweenCurveXAxis.tsx
+++ b/packages/doenetml/src/Viewer/renderers/regionBetweenCurveXAxis.tsx
@@ -1,19 +1,36 @@
-// @ts-nocheck
-import React, { useContext, useEffect, useState, useRef } from "react";
-import useDoenetRenderer from "../useDoenetRenderer";
+import React, { useContext, useEffect, useRef } from "react";
+import useDoenetRenderer, {
+    UseDoenetRendererProps,
+} from "../useDoenetRenderer";
 import { BoardContext, LINE_LAYER_OFFSET } from "./graph";
 import { createFunctionFromDefinition } from "@doenet/utils";
 import { DocContext } from "../DocViewer";
+import { GraphicalSVs } from "./utils/graphicalSVs";
+import { JXGCurve, JXGElement, JXGPoint } from "./jsxgraph-distrib/types";
 
-export default React.memo(function RegionBetweenCurveXAxis(props) {
-    let { id, SVs } = useDoenetRenderer(props);
+interface RegionBetweenCurveXAxisSVs extends GraphicalSVs {
+    haveFunction: boolean;
+    boundaryValues: number[];
+    fDefinition: any;
+}
 
+type JXGIntegral = JXGElement & {
+    curveLeft: JXGPoint;
+    curveRight: JXGPoint;
+};
+
+export default React.memo(function RegionBetweenCurveXAxis(
+    props: UseDoenetRendererProps,
+) {
+    let { id, SVs } = useDoenetRenderer<RegionBetweenCurveXAxisSVs>(props);
+
+    // @ts-ignore
     RegionBetweenCurveXAxis.ignoreActionsWithoutCore = () => true;
 
     const board = useContext(BoardContext);
 
-    let curveJXG = useRef(null);
-    let integralJXG = useRef(null);
+    let curveJXG = useRef<JXGCurve | null>(null);
+    let integralJXG = useRef<JXGIntegral | null>(null);
 
     const { darkMode } = useContext(DocContext) || {};
 
@@ -27,7 +44,10 @@ export default React.memo(function RegionBetweenCurveXAxis(props) {
         };
     }, []);
 
-    function createRegion() {
+    function createRegion(): JXGIntegral | null {
+        if (board === null) {
+            return null;
+        }
         if (
             !SVs.haveFunction ||
             SVs.boundaryValues.length !== 2 ||
@@ -47,7 +67,7 @@ export default React.memo(function RegionBetweenCurveXAxis(props) {
 
         // TODO: either change behavior or change how label is specified
 
-        let jsxAttributes = {
+        let jsxAttributes: Record<string, any> = {
             name: SVs.labelForGraph,
             visible: !SVs.hidden,
             withLabel: SVs.labelForGraph !== "",
@@ -68,13 +88,15 @@ export default React.memo(function RegionBetweenCurveXAxis(props) {
         };
 
         let f = createFunctionFromDefinition(SVs.fDefinition);
-        curveJXG.current = board.create("functiongraph", f, { visible: false });
+        curveJXG.current = board.create("functiongraph", f, {
+            visible: false,
+        }) as JXGCurve;
 
         return board.create(
             "integral",
             [SVs.boundaryValues, curveJXG.current],
             jsxAttributes,
-        );
+        ) as JXGIntegral;
     }
 
     function deleteRegion() {
@@ -82,8 +104,10 @@ export default React.memo(function RegionBetweenCurveXAxis(props) {
             board?.removeObject(integralJXG.current);
             integralJXG.current = null;
 
-            board?.removeObject(curveJXG.current);
-            curveJXG.current = null;
+            if (curveJXG.current) {
+                board?.removeObject(curveJXG.current);
+                curveJXG.current = null;
+            }
         }
     }
 
@@ -99,7 +123,9 @@ export default React.memo(function RegionBetweenCurveXAxis(props) {
         } else {
             let f = createFunctionFromDefinition(SVs.fDefinition);
 
-            curveJXG.current.Y = f;
+            if (curveJXG.current) {
+                (curveJXG.current as any).Y = f;
+            }
             // Since not drawing curve, do we need to update it?
             // curveJXG.current.needsUpdate = true;
             // curveJXG.current.updateCurve();
@@ -108,7 +134,7 @@ export default React.memo(function RegionBetweenCurveXAxis(props) {
             integralJXG.current.visPropCalc["visible"] = !SVs.hidden;
 
             let [x1, x2] = SVs.boundaryValues;
-            let [y1, y2] = SVs.boundaryValues.map(f);
+            let [y1, y2] = SVs.boundaryValues.map(f as (n: number) => number);
             integralJXG.current.curveLeft.coords.setCoordinates(
                 JXG.COORDS_BY_USER,
                 [x1, y1],

--- a/packages/doenetml/src/Viewer/renderers/regionBetweenCurves.tsx
+++ b/packages/doenetml/src/Viewer/renderers/regionBetweenCurves.tsx
@@ -1,22 +1,37 @@
-// @ts-nocheck
-import React, { useContext, useEffect, useState, useRef } from "react";
-import useDoenetRenderer from "../useDoenetRenderer";
+import React, { useContext, useEffect, useRef } from "react";
+import useDoenetRenderer, {
+    UseDoenetRendererProps,
+} from "../useDoenetRenderer";
 import { BoardContext, LINE_LAYER_OFFSET } from "./graph";
 import { createFunctionFromDefinition } from "@doenet/utils";
 import { DocContext } from "../DocViewer";
+import { GraphicalSVs } from "./utils/graphicalSVs";
+import { JXGCurve } from "./jsxgraph-distrib/types";
+import { styleToDash } from "./utils/styleToDash";
 
-export default React.memo(function RegionBetweenCurves(props) {
-    let { id, SVs } = useDoenetRenderer(props);
+interface RegionBetweenCurvesSVs extends GraphicalSVs {
+    haveFunctions: boolean;
+    boundaryValues: number[];
+    fDefinitions: any[];
+    dashed: boolean;
+    flipFunctions: boolean;
+}
 
+export default React.memo(function RegionBetweenCurves(
+    props: UseDoenetRendererProps,
+) {
+    let { id, SVs } = useDoenetRenderer<RegionBetweenCurvesSVs>(props);
+
+    // @ts-ignore
     RegionBetweenCurves.ignoreActionsWithoutCore = () => true;
 
     const board = useContext(BoardContext);
 
-    let curve1JXG = useRef(null);
-    let curve2JXG = useRef(null);
-    let regionJXG = useRef(null);
-    let left = useRef(null);
-    let right = useRef(null);
+    let curve1JXG = useRef<JXGCurve | null>(null);
+    let curve2JXG = useRef<JXGCurve | null>(null);
+    let regionJXG = useRef<JXGCurve | null>(null);
+    let left = useRef<number | null>(null);
+    let right = useRef<number | null>(null);
 
     const { darkMode } = useContext(DocContext) || {};
 
@@ -27,7 +42,10 @@ export default React.memo(function RegionBetweenCurves(props) {
         };
     }, []);
 
-    function createRegion() {
+    function createRegion(): JXGCurve | null {
+        if (board === null) {
+            return null;
+        }
         if (
             !SVs.haveFunctions ||
             SVs.boundaryValues.length !== 2 ||
@@ -36,7 +54,7 @@ export default React.memo(function RegionBetweenCurves(props) {
             return null;
         }
 
-        [left.current, right.current] = SVs.boundaryValues.toSorted(
+        [left.current, right.current] = [...SVs.boundaryValues].sort(
             (a, b) => a - b,
         );
 
@@ -50,7 +68,7 @@ export default React.memo(function RegionBetweenCurves(props) {
                 ? SVs.selectedStyle.fillColorDarkMode
                 : SVs.selectedStyle.fillColor;
 
-        let jsxAttributes = {
+        let jsxAttributes: Record<string, any> = {
             name: SVs.labelForGraph,
             visible: !SVs.hidden,
             withLabel: SVs.labelForGraph !== "",
@@ -75,58 +93,54 @@ export default React.memo(function RegionBetweenCurves(props) {
         let f2 = createFunctionFromDefinition(SVs.fDefinitions[1]);
         curve1JXG.current = board.create("functiongraph", f1, {
             visible: false,
-        });
+        }) as JXGCurve;
         curve2JXG.current = board.create("functiongraph", f2, {
             visible: false,
-        });
+        }) as JXGCurve;
 
         // based on https://jsfiddle.net/migerh/u95pL/
         // as described in https://groups.google.com/g/jsxgraph/c/umlhu6CkGD0
-        var region = board.create("curve", [[], []], jsxAttributes);
+        var region = board.create("curve", [[], []], jsxAttributes) as JXGCurve;
 
-        region.updateDataArray = function () {
+        (region as any).updateDataArray = function (this: JXGCurve) {
             // start and end
-            var x, y;
+            var x: number[], y: number[];
 
-            const c1 = curve1JXG.current;
-            const c2 = curve2JXG.current;
+            const c1 = curve1JXG.current!;
+            const c2 = curve2JXG.current!;
+            const leftVal = left.current!;
+            const rightVal = right.current!;
 
-            x = [left.current];
-            y = [c1.Y(left.current)];
+            x = [leftVal];
+            y = [c1.Y!(leftVal)];
 
             // go through c1 forwards, push all of c1's data points into the data array for region
-            for (let pt of c1.points) {
-                if (
-                    left.current <= pt.usrCoords[1] &&
-                    pt.usrCoords[1] <= right.current
-                ) {
+            for (let pt of c1.points!) {
+                if (leftVal <= pt.usrCoords[1] && pt.usrCoords[1] <= rightVal) {
                     x.push(pt.usrCoords[1]);
                     y.push(pt.usrCoords[2]);
                 }
             }
-            x.push(right.current);
-            y.push(c1.Y(right.current));
+            x.push(rightVal);
+            y.push(c1.Y!(rightVal));
 
-            x.push(right.current);
-            y.push(c2.Y(right.current));
+            x.push(rightVal);
+            y.push(c2.Y!(rightVal));
 
             // walk backwards through c2
-            for (let pt of c2.points.toReversed()) {
-                if (
-                    left.current <= pt.usrCoords[1] &&
-                    pt.usrCoords[1] <= right.current
-                ) {
+            for (let pt of [...c2.points!].reverse()) {
+                if (leftVal <= pt.usrCoords[1] && pt.usrCoords[1] <= rightVal) {
                     x.push(pt.usrCoords[1]);
                     y.push(pt.usrCoords[2]);
                 }
             }
 
-            x.push(left.current);
-            y.push(c2.Y(left.current));
+            x.push(leftVal);
+            y.push(c2.Y!(leftVal));
 
             // close the curve
-            x.push(left.current);
-            y.push(c1.Y(left.current));
+            x.push(leftVal);
+            y.push(c1.Y!(leftVal));
 
             if (SVs.flipFunctions) {
                 this.dataX = y;
@@ -145,10 +159,14 @@ export default React.memo(function RegionBetweenCurves(props) {
             board?.removeObject(regionJXG.current);
             regionJXG.current = null;
 
-            board?.removeObject(curve1JXG.current);
-            curve1JXG.current = null;
-            board?.removeObject(curve2JXG.current);
-            curve2JXG.current = null;
+            if (curve1JXG.current) {
+                board?.removeObject(curve1JXG.current);
+                curve1JXG.current = null;
+            }
+            if (curve2JXG.current) {
+                board?.removeObject(curve2JXG.current);
+                curve2JXG.current = null;
+            }
         }
     }
 
@@ -165,13 +183,17 @@ export default React.memo(function RegionBetweenCurves(props) {
             let f1 = createFunctionFromDefinition(SVs.fDefinitions[0]);
             let f2 = createFunctionFromDefinition(SVs.fDefinitions[1]);
 
-            curve1JXG.current.Y = f1;
-            curve2JXG.current.Y = f2;
+            if (curve1JXG.current) {
+                (curve1JXG.current as any).Y = f1;
+            }
+            if (curve2JXG.current) {
+                (curve2JXG.current as any).Y = f2;
+            }
 
             regionJXG.current.visProp["visible"] = !SVs.hidden;
             regionJXG.current.visPropCalc["visible"] = !SVs.hidden;
 
-            [left.current, right.current] = SVs.boundaryValues.toSorted(
+            [left.current, right.current] = [...SVs.boundaryValues].sort(
                 (a, b) => a - b,
             );
 
@@ -247,22 +269,10 @@ export default React.memo(function RegionBetweenCurves(props) {
         return null;
     }
 
-    // don't think we want to return anything if not in board
+    // don't return anything if not in board
     return (
         <>
             <span id={id} />
         </>
     );
 });
-
-function styleToDash(style, dash) {
-    if (style === "dashed" || dash) {
-        return 2;
-    } else if (style === "solid") {
-        return 0;
-    } else if (style === "dotted") {
-        return 1;
-    } else {
-        return 0;
-    }
-}

--- a/packages/doenetml/src/Viewer/renderers/row.tsx
+++ b/packages/doenetml/src/Viewer/renderers/row.tsx
@@ -3,8 +3,15 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 
+interface RowSVs {
+    [key: string]: any;
+    hidden: boolean;
+    left?: any;
+    valign?: any;
+}
+
 export default React.memo(function Row(props: UseDoenetRendererProps) {
-    let { id, SVs, children } = useDoenetRenderer(props);
+    let { id, SVs, children } = useDoenetRenderer<RowSVs>(props);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/rq.tsx
+++ b/packages/doenetml/src/Viewer/renderers/rq.tsx
@@ -3,8 +3,12 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 
+interface RqSVs {
+    hidden: boolean;
+}
+
 export default React.memo(function Rq(props: UseDoenetRendererProps) {
-    let { SVs } = useDoenetRenderer(props, false);
+    let { SVs } = useDoenetRenderer<RqSVs>(props, false);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/rsq.tsx
+++ b/packages/doenetml/src/Viewer/renderers/rsq.tsx
@@ -3,8 +3,12 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 
+interface RsqSVs {
+    hidden: boolean;
+}
+
 export default React.memo(function Rsq(props: UseDoenetRendererProps) {
-    let { SVs } = useDoenetRenderer(props, false);
+    let { SVs } = useDoenetRenderer<RsqSVs>(props, false);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/section.tsx
+++ b/packages/doenetml/src/Viewer/renderers/section.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React, { useRef, useEffect } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -10,7 +9,9 @@ import {
 import { faCaretRight as twirlIsClosed } from "@fortawesome/free-solid-svg-icons";
 import { faCaretDown as twirlIsOpen } from "@fortawesome/free-solid-svg-icons";
 
-import useDoenetRenderer from "../useDoenetRenderer";
+import useDoenetRenderer, {
+    UseDoenetRendererProps,
+} from "../useDoenetRenderer";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 import { addCommasForCompositeRanges } from "./utils/composites";
 import {
@@ -20,8 +21,29 @@ import {
 import { cesc } from "@doenet/utils";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
 
-export default React.memo(function Section(props) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer(props);
+interface SectionSVs {
+    [key: string]: any;
+    hidden: boolean;
+    rendered: boolean;
+    isListItem: boolean;
+    boxed: boolean;
+    collapsible: boolean;
+    open: boolean;
+    title: string;
+    titleChildName?: string;
+    titleColor?: string;
+    titlePrefix?: string;
+    sectionNumber?: string;
+    level: number;
+    containerTag: string;
+    justSubmitted: boolean;
+    firstChildListItemAlignment?: string;
+    firstVisibleChildAdjustedForListItem?: any;
+}
+
+export default React.memo(function Section(props: UseDoenetRendererProps) {
+    let { id, SVs, children, actions, callAction } =
+        useDoenetRenderer<SectionSVs>(props);
 
     // List item styling constants
     // When a section is rendered as a list item (SVs.isListItem), the section number
@@ -41,7 +63,7 @@ export default React.memo(function Section(props) {
     const hasTitle = !!SVs.titleChildName || (!!SVs.title && !SVs.isListItem);
 
     // Declare heading variable early (assigned later in the component)
-    let heading = null;
+    let heading: React.ReactNode = null;
 
     const hasAdjustedFirstChildForListItem =
         SVs.firstVisibleChildAdjustedForListItem;
@@ -75,8 +97,10 @@ export default React.memo(function Section(props) {
     };
 
     // Helper function to create heading box styles for boxed sections
-    const getHeadingBoxStyle = (isCollapsible: boolean) => {
-        const baseStyle = {
+    const getHeadingBoxStyle = (
+        isCollapsible: boolean,
+    ): React.CSSProperties => {
+        const baseStyle: React.CSSProperties = {
             padding: BOX_PADDING,
             backgroundColor: SVs.titleColor,
             borderTopLeftRadius: "var(--mainBorderRadius)",
@@ -284,7 +308,7 @@ export default React.memo(function Section(props) {
         for (let [ind, child] of children.entries()) {
             //child might be null or a string
             if (
-                child?.props?.componentInstructions.componentIdx ===
+                (child as any)?.props?.componentInstructions.componentIdx ===
                 SVs.titleChildName
             ) {
                 title = children[ind];
@@ -419,7 +443,7 @@ export default React.memo(function Section(props) {
         while (
             startInd < children.length &&
             typeof children[startInd] === "string" &&
-            children[startInd].trim() === ""
+            (children[startInd] as string).trim() === ""
         ) {
             startInd++;
         }
@@ -489,7 +513,7 @@ export default React.memo(function Section(props) {
                 <div
                     className={headingBoxClassName}
                     style={headingBoxStyle}
-                    tabIndex="0"
+                    tabIndex={0}
                     onKeyPress={(e) => {
                         if (e.key === "Enter") {
                             callAction({
@@ -564,7 +588,7 @@ export default React.memo(function Section(props) {
 
     // Render non-boxed list-item sections with hanging section numbers
     if (SVs.isListItem && !SVs.collapsible && !SVs.boxed) {
-        const containerStyle = {
+        const containerStyle: React.CSSProperties = {
             margin: "12px 0",
             position: "relative",
             marginLeft: LIST_ITEM_INDENT,

--- a/packages/doenetml/src/Viewer/renderers/sideBySide.tsx
+++ b/packages/doenetml/src/Viewer/renderers/sideBySide.tsx
@@ -31,7 +31,8 @@ interface SideBySideSVs {
 }
 
 export default React.memo(function sideBySide(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer<SideBySideSVs>(props);
+    let { id, SVs, children, actions, callAction } =
+        useDoenetRenderer<SideBySideSVs>(props);
     const ref = useRef(null);
 
     useRecordVisibilityChanges(ref, callAction, actions);

--- a/packages/doenetml/src/Viewer/renderers/sideBySide.tsx
+++ b/packages/doenetml/src/Viewer/renderers/sideBySide.tsx
@@ -20,8 +20,18 @@ function isRenderablePanelChild(child: unknown): child is React.ReactElement {
     return typeof child === "object" && "key" in child;
 }
 
+interface SideBySideSVs {
+    [key: string]: any;
+    hidden: boolean;
+    gapWidth?: any;
+    listItemInlineAlignment?: any;
+    margins?: any;
+    numPanels: number;
+    widths?: any;
+}
+
 export default React.memo(function sideBySide(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer(props);
+    let { id, SVs, children, actions, callAction } = useDoenetRenderer<SideBySideSVs>(props);
     const ref = useRef(null);
 
     useRecordVisibilityChanges(ref, callAction, actions);

--- a/packages/doenetml/src/Viewer/renderers/slider.tsx
+++ b/packages/doenetml/src/Viewer/renderers/slider.tsx
@@ -170,9 +170,31 @@ function generateTextLabels(
     }
 }
 
+interface SliderSVs {
+    [key: string]: any;
+    hidden: boolean;
+    disabled: boolean;
+    label: string;
+    labelHasLatex: boolean;
+    firstItem: any;
+    from: any;
+    index: number;
+    items: any;
+    lastItem: any;
+    numItems: number;
+    rotateTickLabels: boolean;
+    showControls: boolean;
+    showTicks: boolean;
+    showValue: boolean;
+    step: any;
+    type: string;
+    valueForDisplay: any;
+    width: any;
+}
+
 export default React.memo(function Slider(props: UseDoenetRendererProps) {
     let { id, SVs, actions, ignoreUpdate, rendererName, callAction } =
-        useDoenetRenderer(props);
+        useDoenetRenderer<SliderSVs>(props);
 
     // @ts-ignore
     Slider.baseStateVariable = "index";

--- a/packages/doenetml/src/Viewer/renderers/solution.tsx
+++ b/packages/doenetml/src/Viewer/renderers/solution.tsx
@@ -8,8 +8,19 @@ import { useRecordVisibilityChanges } from "../../utils/visibility";
 import { addCommasForCompositeRanges } from "./utils/composites";
 import "./solution.css";
 
+interface SolutionSVs {
+    [key: string]: any;
+    hidden: boolean;
+    _compositeReplacementActiveRange?: any;
+    canBeClosed: boolean;
+    message: string;
+    open: boolean;
+    rendered: boolean;
+    sectionName: string;
+}
+
 export default React.memo(function Solution(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer(props);
+    let { id, SVs, children, actions, callAction } = useDoenetRenderer<SolutionSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/solution.tsx
+++ b/packages/doenetml/src/Viewer/renderers/solution.tsx
@@ -20,7 +20,8 @@ interface SolutionSVs {
 }
 
 export default React.memo(function Solution(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer<SolutionSVs>(props);
+    let { id, SVs, children, actions, callAction } =
+        useDoenetRenderer<SolutionSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/spreadsheet.tsx
+++ b/packages/doenetml/src/Viewer/renderers/spreadsheet.tsx
@@ -1,20 +1,42 @@
-// @ts-nocheck
 import React, { useRef } from "react";
-import useDoenetRenderer from "../useDoenetRenderer";
+import useDoenetRenderer, {
+    UseDoenetRendererProps,
+} from "../useDoenetRenderer";
+// @ts-ignore
 import { HotTable } from "@handsontable/react";
 import { HyperFormula } from "hyperformula";
 import "handsontable/dist/handsontable.full.css";
 import { sizeToCSS } from "./utils/css";
+// @ts-ignore
 import { registerAllModules } from "handsontable/registry";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 import { getBlockMarginWithOptionalTopSuppression } from "./utils/nonInlineMediaLayout";
 
+interface SpreadsheetSVs {
+    [key: string]: any;
+    hidden: boolean;
+    disabled: boolean;
+    cells: any[][];
+    columnHeaders: string[] | boolean;
+    rowHeaders: string[] | boolean;
+    width: { size: string; isAbsolute: boolean };
+    height: { size: string; isAbsolute: boolean };
+    fixedRowsTop: number;
+    fixedColumnsLeft: number;
+    hiddenColumns: number[];
+    hiddenRows: number[];
+    renderInlineForListItem?: boolean;
+}
+
 registerAllModules();
 
-export default React.memo(function SpreadsheetRenderer(props) {
-    let { id, SVs, actions, callAction } = useDoenetRenderer(props);
+export default React.memo(function SpreadsheetRenderer(
+    props: UseDoenetRendererProps,
+) {
+    let { id, SVs, actions, callAction } =
+        useDoenetRenderer<SpreadsheetSVs>(props);
 
-    const ref = useRef(null);
+    const ref = useRef<HTMLDivElement | null>(null);
 
     useRecordVisibilityChanges(ref, callAction, actions);
 
@@ -27,7 +49,7 @@ export default React.memo(function SpreadsheetRenderer(props) {
             id={id}
             style={{
                 margin: getBlockMarginWithOptionalTopSuppression({
-                    suppressTopMargin: SVs.renderInlineForListItem,
+                    suppressTopMargin: !!SVs.renderInlineForListItem,
                 }),
             }}
             ref={ref}
@@ -36,12 +58,12 @@ export default React.memo(function SpreadsheetRenderer(props) {
                 // style={{ borderRadius:"var(--mainBorderRadius)", border:"var(--mainBorder)" }}
                 licenseKey="non-commercial-and-evaluation"
                 data={SVs.cells.map((x) => [...x])}
-                colHeaders={SVs.columnHeaders}
-                rowHeaders={SVs.rowHeaders}
+                colHeaders={SVs.columnHeaders as any}
+                rowHeaders={SVs.rowHeaders as any}
                 width={sizeToCSS(SVs.width)}
                 height={sizeToCSS(SVs.height)}
                 // beforeChange={this.actions.onChange}
-                afterChange={(changes, source) =>
+                afterChange={(changes: any, source: any) =>
                     callAction({
                         action: actions.onChange,
                         args: { changes, source },

--- a/packages/doenetml/src/Viewer/renderers/sq.tsx
+++ b/packages/doenetml/src/Viewer/renderers/sq.tsx
@@ -4,8 +4,14 @@ import useDoenetRenderer, {
 } from "../useDoenetRenderer";
 import { addCommasForCompositeRanges } from "./utils/composites";
 
+interface SqSVs {
+    [key: string]: any;
+    hidden: boolean;
+    _compositeReplacementActiveRange?: any;
+}
+
 export default React.memo(function Sq(props: UseDoenetRendererProps) {
-    let { id, SVs, children } = useDoenetRenderer(props);
+    let { id, SVs, children } = useDoenetRenderer<SqSVs>(props);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/subsetOfRealsInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/subsetOfRealsInput.tsx
@@ -1,20 +1,46 @@
-// @ts-nocheck
 import React, { useRef, useState } from "react";
-import useDoenetRenderer from "../useDoenetRenderer";
+import useDoenetRenderer, {
+    UseDoenetRendererProps,
+} from "../useDoenetRenderer";
 import { ActionButton } from "@doenet/ui-components";
 import { ActionButtonGroup } from "@doenet/ui-components";
-import { ToggleButton } from "@doenet/ui-components";
-import { ToggleButtonGroup } from "@doenet/ui-components";
+import { ToggleButton as ToggleButtonUntyped } from "@doenet/ui-components";
+import { ToggleButtonGroup as ToggleButtonGroupUntyped } from "@doenet/ui-components";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 import "./subsetOfRealsInput.css";
 
-export default React.memo(function subsetOfReals(props) {
-    let { id, SVs, actions, callAction } = useDoenetRenderer(props, false);
-    let [mode, setMode] = useState("add remove points");
-    let bounds = useRef(null);
-    let pointGrabbed = useRef(null);
+const ToggleButton = ToggleButtonUntyped as any;
+const ToggleButtonGroup = ToggleButtonGroupUntyped as any;
 
-    const ref = useRef(null);
+interface PointDisplayed {
+    value: number;
+    inSubset: boolean;
+}
+
+interface IntervalDisplayed {
+    left: number;
+    right: number;
+    inSubset: boolean;
+}
+
+interface SubsetOfRealsInputSVs {
+    [key: string]: any;
+    hidden: boolean;
+    fixed: boolean;
+    pointsDisplayed: PointDisplayed[];
+    intervalsDisplayed: IntervalDisplayed[];
+}
+
+export default React.memo(function subsetOfReals(
+    props: UseDoenetRendererProps,
+) {
+    let { id, SVs, actions, callAction } =
+        useDoenetRenderer<SubsetOfRealsInputSVs>(props, false);
+    let [mode, setMode] = useState("add remove points");
+    let bounds = useRef<HTMLDivElement | null>(null);
+    let pointGrabbed = useRef<number | null>(null);
+
+    const ref = useRef<HTMLDivElement | null>(null);
 
     useRecordVisibilityChanges(ref, callAction, actions);
 
@@ -22,7 +48,7 @@ export default React.memo(function subsetOfReals(props) {
         return null;
     }
 
-    function handleTogglePoints(val) {
+    function handleTogglePoints(val: number) {
         // setTogglePoints(val);
         if (val === 0) {
             setMode("add remove points");
@@ -98,7 +124,7 @@ export default React.memo(function subsetOfReals(props) {
                 x={x}
                 y="66"
                 textAnchor="middle"
-                class="text-no-select"
+                className="text-no-select"
             >
                 {number}
             </text>,
@@ -191,7 +217,7 @@ export default React.memo(function subsetOfReals(props) {
         );
     }
 
-    function xValueToXPosition(xValue) {
+    function xValueToXPosition(xValue: number) {
         // let minValue = -10;
         // let maxValue = 10;
         // Shift to positive numbers
@@ -207,7 +233,7 @@ export default React.memo(function subsetOfReals(props) {
         return position;
     }
 
-    function xPositionToXValue(xPosition) {
+    function xPositionToXValue(xPosition: number) {
         let relativeX = xPosition - firstHashXPosition;
         let shiftAmount = 10;
         let intervalValueWidth = 1;
@@ -217,8 +243,8 @@ export default React.memo(function subsetOfReals(props) {
         return value;
     }
 
-    async function handleInput(e, inputState) {
-        let mouseLeft = e.clientX - bounds.current.offsetLeft;
+    async function handleInput(e: React.MouseEvent, inputState: string) {
+        let mouseLeft = e.clientX - (bounds.current?.offsetLeft ?? 0);
         let xPosition = xPositionToXValue(mouseLeft);
         let pointHitTolerance = 0.2;
 

--- a/packages/doenetml/src/Viewer/renderers/summaryStatistics.tsx
+++ b/packages/doenetml/src/Viewer/renderers/summaryStatistics.tsx
@@ -5,8 +5,17 @@ import useDoenetRenderer, {
 import { sizeToCSS } from "./utils/css";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 
+interface SummaryStatisticsSVs {
+    [key: string]: any;
+    hidden: boolean;
+    columnName: string;
+    height?: any;
+    summaryStatistics?: any;
+    width?: any;
+}
+
 export default React.memo(function Tabular(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer(props);
+    let { id, SVs, children, actions, callAction } = useDoenetRenderer<SummaryStatisticsSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/summaryStatistics.tsx
+++ b/packages/doenetml/src/Viewer/renderers/summaryStatistics.tsx
@@ -15,7 +15,8 @@ interface SummaryStatisticsSVs {
 }
 
 export default React.memo(function Tabular(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer<SummaryStatisticsSVs>(props);
+    let { id, SVs, children, actions, callAction } =
+        useDoenetRenderer<SummaryStatisticsSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/summaryStatistics.tsx
+++ b/packages/doenetml/src/Viewer/renderers/summaryStatistics.tsx
@@ -14,7 +14,9 @@ interface SummaryStatisticsSVs {
     width?: any;
 }
 
-export default React.memo(function Tabular(props: UseDoenetRendererProps) {
+export default React.memo(function SummaryStatistics(
+    props: UseDoenetRendererProps,
+) {
     let { id, SVs, children, actions, callAction } =
         useDoenetRenderer<SummaryStatisticsSVs>(props);
 

--- a/packages/doenetml/src/Viewer/renderers/table.tsx
+++ b/packages/doenetml/src/Viewer/renderers/table.tsx
@@ -4,8 +4,17 @@ import useDoenetRenderer, {
 } from "../useDoenetRenderer";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 
+interface TableSVs {
+    [key: string]: any;
+    hidden: boolean;
+    suppressTableNameInTitle: boolean;
+    tableName: string;
+    title: string;
+    titleChildName: string;
+}
+
 export default React.memo(function Table(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer(props);
+    let { id, SVs, children, actions, callAction } = useDoenetRenderer<TableSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/table.tsx
+++ b/packages/doenetml/src/Viewer/renderers/table.tsx
@@ -14,7 +14,8 @@ interface TableSVs {
 }
 
 export default React.memo(function Table(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer<TableSVs>(props);
+    let { id, SVs, children, actions, callAction } =
+        useDoenetRenderer<TableSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/tabular.tsx
+++ b/packages/doenetml/src/Viewer/renderers/tabular.tsx
@@ -6,8 +6,17 @@ import { sizeToCSS } from "./utils/css";
 import { getBlockMarginWithOptionalTopSuppression } from "./utils/nonInlineMediaLayout";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 
+interface TabularSVs {
+    [key: string]: any;
+    hidden: boolean;
+    renderInlineForListItem: boolean;
+    width?: any;
+    height?: any;
+    top?: any;
+}
+
 export default React.memo(function Tabular(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer(props);
+    let { id, SVs, children, actions, callAction } = useDoenetRenderer<TabularSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/tabular.tsx
+++ b/packages/doenetml/src/Viewer/renderers/tabular.tsx
@@ -16,7 +16,8 @@ interface TabularSVs {
 }
 
 export default React.memo(function Tabular(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer<TabularSVs>(props);
+    let { id, SVs, children, actions, callAction } =
+        useDoenetRenderer<TabularSVs>(props);
 
     const ref = useRef(null);
 

--- a/packages/doenetml/src/Viewer/renderers/tag.tsx
+++ b/packages/doenetml/src/Viewer/renderers/tag.tsx
@@ -3,8 +3,15 @@ import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 
+interface TagSVs {
+    [key: string]: any;
+    hidden: boolean;
+    closing: boolean;
+    selfClosed: boolean;
+}
+
 export default React.memo(function Tag(props: UseDoenetRendererProps) {
-    let { id, SVs, children } = useDoenetRenderer(props);
+    let { id, SVs, children } = useDoenetRenderer<TagSVs>(props);
 
     if (SVs.hidden) {
         return null;

--- a/packages/doenetml/src/Viewer/renderers/text.tsx
+++ b/packages/doenetml/src/Viewer/renderers/text.tsx
@@ -1,7 +1,8 @@
-// @ts-nocheck
 import React, { useContext, useEffect, useRef } from "react";
 import { BoardContext, TEXT_LAYER_OFFSET } from "./graph";
-import useDoenetRenderer from "../useDoenetRenderer";
+import useDoenetRenderer, {
+    UseDoenetRendererProps,
+} from "../useDoenetRenderer";
 import me from "math-expressions";
 import { textRendererStyle } from "@doenet/utils";
 import {
@@ -10,34 +11,49 @@ import {
 } from "./utils/graph";
 import { DocContext } from "../DocViewer";
 import { ChoiceInputInlineContext } from "./choiceInput";
+import { JXGEvent, JXGPoint, JXGText } from "./jsxgraph-distrib/types";
+import { SelectedStyle } from "./utils/graphicalSVs";
 
-export default React.memo(function Text(props) {
-    let { componentIdx, id, SVs, actions, sourceOfUpdate, callAction } =
-        useDoenetRenderer(props);
+interface TextSVs {
+    hidden: boolean;
+    layer: number;
+    fixed: boolean;
+    fixLocation: boolean;
+    draggable: boolean;
+    anchor: any;
+    positionFromAnchor: any;
+    text: string;
+    selectedStyle: SelectedStyle;
+}
 
+export default React.memo(function Text(props: UseDoenetRendererProps) {
+    let { componentIdx, id, SVs, actions, callAction } =
+        useDoenetRenderer<TextSVs>(props);
+
+    // @ts-ignore
     Text.ignoreActionsWithoutCore = () => true;
 
-    let textJXG = useRef(null);
-    let anchorPointJXG = useRef(null);
-    let anchorRel = useRef(null);
+    let textJXG = useRef<JXGText | null>(null);
+    let anchorPointJXG = useRef<JXGPoint | null>(null);
+    let anchorRel = useRef<[string, string] | null>(null);
 
     const board = useContext(BoardContext);
     const choiceInputInlineContext = useContext(ChoiceInputInlineContext);
 
-    let pointerAtDown = useRef(null);
-    let pointAtDown = useRef(null);
-    let pointerIsDown = useRef(false);
-    let pointerMovedSinceDown = useRef(false);
-    let dragged = useRef(false);
+    let pointerAtDown = useRef<[number, number] | null>(null);
+    let pointAtDown = useRef<number[] | null>(null);
+    let pointerIsDown = useRef<boolean>(false);
+    let pointerMovedSinceDown = useRef<boolean>(false);
+    let dragged = useRef<boolean>(false);
 
-    let calculatedX = useRef(null);
-    let calculatedY = useRef(null);
+    let calculatedX = useRef<number | null>(null);
+    let calculatedY = useRef<number | null>(null);
 
-    let lastPositionFromCore = useRef(null);
-    let previousPositionFromAnchor = useRef(null);
+    let lastPositionFromCore = useRef<number[] | null>(null);
+    let previousPositionFromAnchor = useRef<any>(null);
 
-    let fixed = useRef(false);
-    let fixLocation = useRef(false);
+    let fixed = useRef<boolean>(false);
+    let fixLocation = useRef<boolean>(false);
 
     fixed.current = SVs.fixed;
     fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
@@ -83,7 +99,7 @@ export default React.memo(function Text(props) {
         }
 
         //things to be passed to JSXGraph as attributes
-        let jsxTextAttributes = {
+        let jsxTextAttributes: Record<string, any> = {
             visible: !SVs.hidden,
             fixed: fixed.current,
             layer: 10 * SVs.layer + TEXT_LAYER_OFFSET,
@@ -97,13 +113,13 @@ export default React.memo(function Text(props) {
             parse: false,
         };
 
-        let newAnchorPointJXG;
+        let newAnchorPointJXG: JXGPoint;
 
         try {
             let anchor = me.fromAst(SVs.anchor);
             let anchorCoords = [
-                anchor.get_component(0).evaluate_to_constant(),
-                anchor.get_component(1).evaluate_to_constant(),
+                anchor.get_component(0).evaluate_to_constant() ?? NaN,
+                anchor.get_component(1).evaluate_to_constant() ?? NaN,
             ];
 
             if (!Number.isFinite(anchorCoords[0])) {
@@ -117,12 +133,12 @@ export default React.memo(function Text(props) {
 
             newAnchorPointJXG = board.create("point", anchorCoords, {
                 visible: false,
-            });
+            }) as JXGPoint;
         } catch (e) {
             jsxTextAttributes["visible"] = false;
             newAnchorPointJXG = board.create("point", [0, 0], {
                 visible: false,
-            });
+            }) as JXGPoint;
         }
 
         jsxTextAttributes.anchor = newAnchorPointJXG;
@@ -132,16 +148,16 @@ export default React.memo(function Text(props) {
         );
         jsxTextAttributes.anchorx = anchorx;
         jsxTextAttributes.anchory = anchory;
-        anchorRel.current = [anchorx, anchory];
+        anchorRel.current = [anchorx as string, anchory as string];
 
         let newTextJXG = board.create(
             "text",
             [0, 0, SVs.text],
             jsxTextAttributes,
-        );
+        ) as JXGText;
         newTextJXG.isDraggable = !fixLocation.current;
 
-        newTextJXG.on("down", function (e) {
+        newTextJXG.on("down", function (e: JXGEvent) {
             (document.activeElement as HTMLElement | null)?.blur();
 
             pointerAtDown.current = [e.x, e.y];
@@ -152,21 +168,21 @@ export default React.memo(function Text(props) {
             if (!fixed.current) {
                 callAction({
                     action: actions.textFocused,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
+                    args: { componentIdx },
                 });
             }
         });
 
-        newTextJXG.on("hit", function (e) {
+        newTextJXG.on("hit", function (e: JXGEvent) {
             pointAtDown.current = [...newAnchorPointJXG.coords.scrCoords];
             dragged.current = false;
             callAction({
                 action: actions.textFocused,
-                args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
+                args: { componentIdx },
             });
         });
 
-        newTextJXG.on("up", function (e) {
+        newTextJXG.on("up", function (e: JXGEvent) {
             if (dragged.current) {
                 callAction({
                     action: actions.moveText,
@@ -179,13 +195,13 @@ export default React.memo(function Text(props) {
             } else if (!pointerMovedSinceDown.current && !fixed.current) {
                 callAction({
                     action: actions.textClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
+                    args: { componentIdx },
                 });
             }
             pointerIsDown.current = false;
         });
 
-        newTextJXG.on("keyfocusout", function (e) {
+        newTextJXG.on("keyfocusout", function (e: JXGEvent) {
             if (dragged.current) {
                 callAction({
                     action: actions.moveText,
@@ -198,26 +214,26 @@ export default React.memo(function Text(props) {
             }
         });
 
-        newTextJXG.on("drag", function (e) {
+        newTextJXG.on("drag", function (e: JXGEvent) {
             let viaPointer = e.type === "pointermove";
 
             //Protect against very small unintended drags
             if (
                 !viaPointer ||
-                Math.abs(e.x - pointerAtDown.current[0]) >
+                Math.abs(e.x - pointerAtDown.current![0]) >
                     POINTER_DRAG_THRESHOLD ||
-                Math.abs(e.y - pointerAtDown.current[1]) >
+                Math.abs(e.y - pointerAtDown.current![1]) >
                     POINTER_DRAG_THRESHOLD
             ) {
                 dragged.current = true;
             }
 
             let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
-            let width = newTextJXG.size[0] / board.unitX;
-            let height = newTextJXG.size[1] / board.unitY;
+            let width = newTextJXG.size![0] / board.unitX;
+            let height = newTextJXG.size![1] / board.unitY;
 
-            let anchorx = anchorRel.current[0];
-            let anchory = anchorRel.current[1];
+            let anchorx = anchorRel.current![0];
+            let anchory = anchorRel.current![1];
 
             let offsetx = 0;
             if (anchorx === "middle") {
@@ -250,25 +266,25 @@ export default React.memo(function Text(props) {
                 var o = board.origin.scrCoords;
 
                 calculatedX.current =
-                    (pointAtDown.current[1] +
+                    (pointAtDown.current![1] +
                         e.x -
-                        pointerAtDown.current[0] -
+                        pointerAtDown.current![0] -
                         o[1]) /
                     board.unitX;
 
                 calculatedY.current =
                     (o[2] -
-                        (pointAtDown.current[2] +
+                        (pointAtDown.current![2] +
                             e.y -
-                            pointerAtDown.current[1])) /
+                            pointerAtDown.current![1])) /
                     board.unitY;
             } else {
                 calculatedX.current =
                     newAnchorPointJXG.X() +
-                    newTextJXG.relativeCoords.usrCoords[1];
+                    newTextJXG.relativeCoords!.usrCoords[1];
                 calculatedY.current =
                     newAnchorPointJXG.Y() +
-                    newTextJXG.relativeCoords.usrCoords[2];
+                    newTextJXG.relativeCoords!.usrCoords[2];
             }
 
             calculatedX.current = Math.min(
@@ -290,7 +306,7 @@ export default React.memo(function Text(props) {
                 },
             });
 
-            newTextJXG.relativeCoords.setCoordinates(
+            newTextJXG.relativeCoords!.setCoordinates(
                 JXG.COORDS_BY_USER,
                 [0, 0],
             );
@@ -300,7 +316,7 @@ export default React.memo(function Text(props) {
             );
         });
 
-        newTextJXG.on("keydown", function (e) {
+        newTextJXG.on("keydown", function (e: JXGEvent) {
             if (e.key === "Enter") {
                 if (dragged.current) {
                     callAction({
@@ -314,7 +330,7 @@ export default React.memo(function Text(props) {
                 }
                 callAction({
                     action: actions.textClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
+                    args: { componentIdx },
                 });
             }
         });
@@ -324,13 +340,13 @@ export default React.memo(function Text(props) {
         previousPositionFromAnchor.current = SVs.positionFromAnchor;
     }
 
-    function boardMoveHandler(e) {
+    function boardMoveHandler(e: JXGEvent) {
         if (pointerIsDown.current) {
             //Protect against very small unintended move
             if (
-                Math.abs(e.x - pointerAtDown.current[0]) >
+                Math.abs(e.x - pointerAtDown.current![0]) >
                     POINTER_DRAG_THRESHOLD ||
-                Math.abs(e.y - pointerAtDown.current[1]) >
+                Math.abs(e.y - pointerAtDown.current![1]) >
                     POINTER_DRAG_THRESHOLD
             ) {
                 pointerMovedSinceDown.current = true;
@@ -339,6 +355,7 @@ export default React.memo(function Text(props) {
     }
 
     function deleteTextJXG() {
+        if (!textJXG.current) return;
         textJXG.current.off("drag");
         textJXG.current.off("down");
         textJXG.current.off("hit");
@@ -350,12 +367,12 @@ export default React.memo(function Text(props) {
     }
 
     if (board) {
-        let anchorCoords;
+        let anchorCoords: number[];
         try {
             let anchor = me.fromAst(SVs.anchor);
             anchorCoords = [
-                anchor.get_component(0).evaluate_to_constant(),
-                anchor.get_component(1).evaluate_to_constant(),
+                anchor.get_component(0).evaluate_to_constant() ?? NaN,
+                anchor.get_component(1).evaluate_to_constant() ?? NaN,
             ];
         } catch (e) {
             anchorCoords = [NaN, NaN];
@@ -366,11 +383,11 @@ export default React.memo(function Text(props) {
         if (textJXG.current === null) {
             createTextJXG();
         } else {
-            textJXG.current.relativeCoords.setCoordinates(
+            textJXG.current.relativeCoords!.setCoordinates(
                 JXG.COORDS_BY_USER,
                 [0, 0],
             );
-            anchorPointJXG.current.coords.setCoordinates(
+            anchorPointJXG.current!.coords.setCoordinates(
                 JXG.COORDS_BY_USER,
                 anchorCoords,
             );
@@ -421,8 +438,8 @@ export default React.memo(function Text(props) {
             }
 
             if (textJXG.current.visProp.strokecolor !== textColor) {
-                textJXG.current.visProp.strokecolor = textColor;
-                textJXG.current.visProp.highlightstrokecolor = textColor;
+                textJXG.current.visProp.strokecolor = textColor!;
+                textJXG.current.visProp.highlightstrokecolor = textColor!;
             }
             if (textJXG.current.visProp.cssstyle !== cssStyle) {
                 textJXG.current.visProp.cssstyle = cssStyle;
@@ -441,15 +458,15 @@ export default React.memo(function Text(props) {
                 );
                 textJXG.current.visProp.anchorx = anchorx;
                 textJXG.current.visProp.anchory = anchory;
-                anchorRel.current = [anchorx, anchory];
+                anchorRel.current = [anchorx as string, anchory as string];
                 previousPositionFromAnchor.current = SVs.positionFromAnchor;
                 textJXG.current.fullUpdate();
             } else {
                 textJXG.current.update();
             }
 
-            anchorPointJXG.current.needsUpdate = true;
-            anchorPointJXG.current.update();
+            anchorPointJXG.current!.needsUpdate = true;
+            anchorPointJXG.current!.update();
             board.updateRenderer();
         }
 
@@ -463,7 +480,7 @@ export default React.memo(function Text(props) {
     }
 
     const style = !choiceInputInlineContext.inOption
-        ? textRendererStyle(darkMode, SVs.selectedStyle)
+        ? textRendererStyle(darkMode ?? "light", SVs.selectedStyle)
         : undefined;
 
     return (

--- a/packages/doenetml/src/Viewer/renderers/textInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/textInput.tsx
@@ -20,9 +20,32 @@ import { DescriptionPopover } from "./utils/Description";
 import { addValidationStateToShortDescription } from "./utils/description";
 import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
 
+interface TextInputSVs {
+    [key: string]: any;
+    hidden: boolean;
+    disabled: boolean;
+    fixed: boolean;
+    fixLocation: boolean;
+    draggable: boolean;
+    anchor: any;
+    positionFromAnchor: any;
+    label: string;
+    labelHasLatex: boolean;
+    labelPosition?: string;
+    immediateValue: string;
+    expanded: boolean;
+    width: { size: string; isAbsolute: boolean };
+    height?: { size: string; isAbsolute: boolean };
+    forceFullCheckWorkButton: boolean;
+    justSubmitted: boolean;
+    showCheckWork: boolean;
+    colorCorrectness: boolean;
+    shortDescription?: string;
+}
+
 export default function TextInput(props: UseDoenetRendererProps) {
     let { id, SVs, children, actions, ignoreUpdate, callAction } =
-        useDoenetRenderer(props);
+        useDoenetRenderer<TextInputSVs>(props);
 
     let width = sizeToCSS(SVs.width);
     let height = sizeToCSS(SVs.height); // only for TextArea
@@ -36,13 +59,13 @@ export default function TextInput(props: UseDoenetRendererProps) {
     const [rendererValue, setRendererValue] = useState(SVs.immediateValue);
 
     // add ref, because event handler called from jsxgraph doesn't get new value
-    let rendererValueRef = useRef(null);
+    let rendererValueRef = useRef<string | null>(null);
     rendererValueRef.current = rendererValue;
 
-    let valueToRevertTo = useRef(SVs.immediateValue);
+    let valueToRevertTo = useRef<string | null>(SVs.immediateValue);
     let focused = useRef<boolean | null>(null);
 
-    let immediateValueWhenSetState = useRef(null);
+    let immediateValueWhenSetState = useRef<string | null>(null);
 
     let inputJXG = useRef<JXGObject | null>(null);
     let anchorPointJXG = useRef<JXGObject | null>(null);
@@ -121,7 +144,7 @@ export default function TextInput(props: UseDoenetRendererProps) {
             let oldValue = valueToRevertTo.current;
 
             if (oldValue !== rendererValueRef.current) {
-                setRendererValue(oldValue);
+                setRendererValue(oldValue ?? "");
                 immediateValueWhenSetState.current = SVs.immediateValue;
 
                 callAction({
@@ -574,7 +597,7 @@ export default function TextInput(props: UseDoenetRendererProps) {
     );
 
     let input;
-    let label = SVs.label;
+    let label: React.ReactNode = SVs.label;
     const hasLabel =
         typeof SVs.label === "string" ? SVs.label.trim() !== "" : !!SVs.label;
     const labelId = `${id}-input-label`;

--- a/packages/doenetml/src/Viewer/renderers/utils/nonInlineMediaLayout.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/nonInlineMediaLayout.ts
@@ -1,10 +1,17 @@
+import type { CSSProperties } from "react";
+
 export function getNonInlineMediaLayoutStyles({
     horizontalAlign,
     mediaWidth,
 }: {
-    horizontalAlign: string;
-    mediaWidth: string;
-}) {
+    horizontalAlign: string | undefined;
+    mediaWidth: string | undefined;
+}): {
+    outerStyle: CSSProperties;
+    innerStyle: CSSProperties;
+    mediaContainerStyle: CSSProperties;
+    mediaColumnStyle: CSSProperties;
+} {
     return {
         outerStyle: {
             display: "flex",

--- a/packages/doenetml/src/Viewer/renderers/utils/styleToDash.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/styleToDash.ts
@@ -8,7 +8,10 @@
  * regionBetweenCurves) carry an independent `dashed` SV that should force
  * dashed regardless of `selectedStyle.lineStyle`.
  */
-export function styleToDash(style: string, dashed?: boolean): number {
+export function styleToDash(
+    style: string | undefined,
+    dashed?: boolean,
+): number {
     if (style === "dashed" || dashed) {
         return 2;
     }

--- a/packages/doenetml/src/Viewer/renderers/video.tsx
+++ b/packages/doenetml/src/Viewer/renderers/video.tsx
@@ -1,33 +1,50 @@
-// @ts-nocheck
 // youtube player code based on Ximera youtube player
 // https://github.com/XimeraProject/server
 // https://github.com/XimeraProject/server/blob/master/public/javascripts/youtube.js
 
 import React, { useRef, useEffect } from "react";
-import useDoenetRenderer from "../useDoenetRenderer";
+import useDoenetRenderer, {
+    UseDoenetRendererProps,
+} from "../useDoenetRenderer";
 import { sizeToCSS } from "./utils/css";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 import { DescriptionAsDetails, DescriptionPopover } from "./utils/Description";
 import { getNonInlineMediaLayoutStyles } from "./utils/nonInlineMediaLayout";
 import "./video.css";
 
-export default React.memo(function Video(props) {
-    let { id, SVs, children, actions, callAction } = useDoenetRenderer(props);
+interface VideoSVs {
+    [key: string]: any;
+    hidden: boolean;
+    width?: { size: string; isAbsolute: boolean };
+    aspectRatio?: number;
+    displayMode: string;
+    horizontalAlign?: string;
+    renderInlineForListItem?: boolean;
+    shortDescription?: string;
+    source?: string;
+    state?: string;
+    time?: number;
+    youtube?: string;
+}
 
-    let player = useRef(null);
-    let postSkipTime = useRef(null);
-    let preSkipTime = useRef(null);
-    let rates = useRef([]);
-    let lastPlayerState = useRef(null);
-    let pauseTimeoutId = useRef(null);
-    let lastPausedTime = useRef(0);
-    let lastPlayedTime = useRef(null);
-    let pollIntervalId = useRef(null);
-    let lastSetTimeAction = useRef(null);
+export default React.memo(function Video(props: UseDoenetRendererProps) {
+    let { id, SVs, children, actions, callAction } =
+        useDoenetRenderer<VideoSVs>(props);
 
-    let lastSVsState = useRef(null);
+    let player = useRef<any>(null);
+    let postSkipTime = useRef<number | null>(null);
+    let preSkipTime = useRef<number | null>(null);
+    let rates = useRef<any[]>([]);
+    let lastPlayerState = useRef<any>(null);
+    let pauseTimeoutId = useRef<any>(null);
+    let lastPausedTime = useRef<number>(0);
+    let lastPlayedTime = useRef<number | null>(null);
+    let pollIntervalId = useRef<any>(null);
+    let lastSetTimeAction = useRef<number | null>(null);
 
-    const ref = useRef(null);
+    let lastSVsState = useRef<any>(null);
+
+    const ref = useRef<HTMLDivElement | null>(null);
 
     useRecordVisibilityChanges(ref, callAction, actions);
 
@@ -35,10 +52,10 @@ export default React.memo(function Video(props) {
         if (SVs.youtube) {
             let cIdx = id;
 
-            // protect against window.YT being undefined,
+            // protect against (window as any).YT being undefined,
             // which could occur if cannot reach youtube
-            if (window.YT) {
-                player.current = new window.YT.Player(cIdx, {
+            if ((window as any).YT) {
+                player.current = new (window as any).YT.Player(cIdx, {
                     playerVars: {
                         autoplay: 0,
                         controls: 1,
@@ -53,7 +70,7 @@ export default React.memo(function Video(props) {
                 });
             }
         }
-    }, [window.YT]);
+    }, [(window as any).YT]);
 
     function pollCurrentTime() {
         let currentTime = player.current.getCurrentTime();
@@ -64,7 +81,7 @@ export default React.memo(function Video(props) {
         if (postSkipTime.current) {
             timeInterval = currentTime - postSkipTime.current;
         } else {
-            timeInterval = currentTime - preSkipTime.current;
+            timeInterval = currentTime - (preSkipTime.current ?? 0);
         }
 
         // We are polling every 200 ms,
@@ -75,7 +92,7 @@ export default React.memo(function Video(props) {
         // to be able to grab the current time to determine
         // the end of the watched segment)
         if (
-            !(preSkipTime.current >= 0) ||
+            !((preSkipTime.current ?? -1) >= 0) ||
             (timeInterval > 0 && timeInterval < 1)
         ) {
             preSkipTime.current = currentTime;
@@ -97,7 +114,7 @@ export default React.memo(function Video(props) {
         }
     }
 
-    function onPlayerReady(event) {
+    function onPlayerReady(event: any) {
         //setPlaybackQuality doesn't seem to work
         // event.target.setPlaybackQuality("hd720");
         // player.current.setPlaybackQuality("hd720");
@@ -110,7 +127,7 @@ export default React.memo(function Video(props) {
         });
     }
 
-    function onPlayerStateChange(event) {
+    function onPlayerStateChange(event: any) {
         //setPlaybackQuality doesn't seem to work
         // if (event.data == YT.PlayerState.BUFFERING) {
         // event.target.setPlaybackQuality('hd720');
@@ -120,7 +137,7 @@ export default React.memo(function Video(props) {
         let duration = player.current.getDuration();
 
         switch (event.data) {
-            case window.YT.PlayerState.PLAYING:
+            case (window as any).YT.PlayerState.PLAYING:
                 if (lastPlayerState.current !== event.data) {
                     let currentTime = player.current.getCurrentTime();
 
@@ -137,7 +154,8 @@ export default React.memo(function Video(props) {
                     );
 
                     if (
-                        lastPlayerState.current === window.YT.PlayerState.PAUSED
+                        lastPlayerState.current ===
+                        (window as any).YT.PlayerState.PAUSED
                     ) {
                         let timeSincePaused =
                             currentTime - lastPausedTime.current;
@@ -197,7 +215,7 @@ export default React.memo(function Video(props) {
 
                 break;
 
-            case window.YT.PlayerState.PAUSED:
+            case (window as any).YT.PlayerState.PAUSED:
                 // When a user pauses a video, we emit two events:
                 // a watched event summarizing that segment of watching
                 // and a paused event.
@@ -214,8 +232,8 @@ export default React.memo(function Video(props) {
                     clearInterval(pollIntervalId.current);
 
                     if (
-                        lastState === window.YT.PlayerState.PLAYING &&
-                        pausedTime > beginTime
+                        lastState === (window as any).YT.PlayerState.PLAYING &&
+                        pausedTime > (beginTime ?? 0)
                     ) {
                         rates.current[rates.current.length - 1].endingPoint =
                             pausedTime;
@@ -258,14 +276,14 @@ export default React.memo(function Video(props) {
 
                 break;
 
-            case window.YT.PlayerState.BUFFERING:
+            case (window as any).YT.PlayerState.BUFFERING:
                 clearTimeout(pauseTimeoutId.current);
                 let currentTime = player.current.getCurrentTime();
 
                 if (lastPlayedTime.current !== null) {
-                    let beginTime = lastPlayedTime.current;
+                    let beginTime: number = lastPlayedTime.current;
 
-                    if (preSkipTime.current > beginTime) {
+                    if ((preSkipTime.current ?? -1) > beginTime) {
                         rates.current[rates.current.length - 1].endingPoint =
                             preSkipTime.current;
 
@@ -286,7 +304,7 @@ export default React.memo(function Video(props) {
                             },
                         });
 
-                        beginTime = preSkipTime.current;
+                        beginTime = preSkipTime.current!;
                     }
 
                     // console.log("BUFFERING recordVideoSkipped", {
@@ -312,7 +330,7 @@ export default React.memo(function Video(props) {
 
                 break;
 
-            case window.YT.PlayerState.ENDED:
+            case (window as any).YT.PlayerState.ENDED:
                 // BADBAD: We're treating ENDED as though it meant the user
                 // completed the video, even thought it
                 // doesn't necessarily mean the learner watched ALL the video
@@ -358,14 +376,14 @@ export default React.memo(function Video(props) {
 
                 break;
 
-            case window.YT.PlayerState.UNSTARTED:
+            case (window as any).YT.PlayerState.UNSTARTED:
                 lastPlayerState.current = event.data;
 
                 break;
         }
     }
 
-    function onPlaybackRateChange(event) {
+    function onPlaybackRateChange(event: any) {
         let currentTime = player.current.getCurrentTime();
 
         rates.current[rates.current.length - 1].endingPoint = currentTime;
@@ -380,15 +398,15 @@ export default React.memo(function Video(props) {
         if (SVs.state !== lastSVsState.current) {
             if (SVs.state === "playing") {
                 if (
-                    playerState === window.YT.PlayerState.UNSTARTED ||
-                    playerState === window.YT.PlayerState.PAUSED ||
-                    playerState === window.YT.PlayerState.CUED ||
-                    playerState === window.YT.PlayerState.ENDED
+                    playerState === (window as any).YT.PlayerState.UNSTARTED ||
+                    playerState === (window as any).YT.PlayerState.PAUSED ||
+                    playerState === (window as any).YT.PlayerState.CUED ||
+                    playerState === (window as any).YT.PlayerState.ENDED
                 ) {
                     player.current.playVideo();
                 }
             } else if (SVs.state === "stopped") {
-                if (playerState === window.YT.PlayerState.PLAYING) {
+                if (playerState === (window as any).YT.PlayerState.PLAYING) {
                     player.current.pauseVideo();
                 }
             }
@@ -396,7 +414,7 @@ export default React.memo(function Video(props) {
         }
 
         if (SVs.time !== Number(lastSetTimeAction.current)) {
-            let time = SVs.time;
+            let time = SVs.time ?? 0;
             let duration = player.current.getDuration();
 
             if (time > duration) {
@@ -411,7 +429,7 @@ export default React.memo(function Video(props) {
             if (time !== Number(lastSetTimeAction.current)) {
                 if (
                     player.current.getPlayerState() ===
-                    window.YT.PlayerState.CUED
+                    (window as any).YT.PlayerState.CUED
                 ) {
                     // if cued, seeking will automatically start the video.
                     // Pausing it first doesn't seem to work
@@ -515,9 +533,8 @@ export default React.memo(function Video(props) {
             >
                 <source
                     src={SVs.source}
-                    type={`video/${SVs.source
-                        .split("/")
-                        .pop()
+                    type={`video/${SVs.source!.split("/")
+                        .pop()!
                         .split(".")
                         .pop()}`}
                 />
@@ -530,7 +547,7 @@ export default React.memo(function Video(props) {
 
     return (
         <div
-            tabIndex="0"
+            tabIndex={0}
             style={
                 SVs.renderInlineForListItem
                     ? { ...outerStyle, marginTop: 0 }


### PR DESCRIPTION
## Summary

- Continues PRs #1058–#1060: every `.tsx` renderer in `packages/doenetml/src/Viewer/renderers/` now declares an `XxxSVs` interface and passes it as the generic to `useDoenetRenderer<XxxSVs>(props)`. The 3 renderers that don't use the hook (`GraphFrame`, `JSXGraphRenderer`, `prefigure`) are typed via local prop interfaces.
- All `@ts-nocheck` directives in the `.tsx` renderer files in this directory are removed (was 20 files). `graph.tsx` exports a shared `GraphSVs` consumed by `GraphFrame` and `JSXGraphRenderer`.
- **Migration only.** No helper extraction, file splits, or dedup — deferred to PR B once duplication patterns across the larger set are visible.

68 files changed, ~1,600 insertions / ~700 deletions.

## Commit-level batching (single PR, sequenced inside the diff)

1. **JSXgraph "easy"** — `legend`, `pegboard`, `regionBetweenCurves`, `regionBetweenCurveXAxis`, `number`, `text`
2. **JSXgraph "harder" + infrastructure** — `graph`, `GraphFrame`, `JSXGraphRenderer`, `label`, `image`
3. **JSXgraph-embeddable inputs** — `booleanInput`, `button`, `math`, `textInput`
4. **Non-JSXgraph stragglers (had `@ts-nocheck`)** — `section`, `hint`, `embed`, `video`, `matrixInput`, `orbitalDiagram`, `orbitalDiagramInput`, `spreadsheet`, `subsetOfRealsInput`
5. **Markup + interactive** — ~45 small files (alert, answer, asList, blockQuote, boolean, br, c, cell, choiceInput, codeEditor, containerBlock, containerInline, ellipsis, em, _error, feedback, figure, footnote, hr, list, lq, lsq, mathInput, mdash, nbsp, ndash, p, paginatorControls, pre, pretzel, q, ref, row, rq, rsq, sideBySide, slider, solution, sq, summaryStatistics, table, tabular, tag)

## Patterns observed (input for PR B's plan)

- Text-on-graph renderers (`number`, `text`, `label`, `math`) share an essentially identical drag/anchor pattern (~150 LoC each).
- Most input renderers share `[label, labelHasLatex, labelPosition, justSubmitted, forceFullCheckWorkButton]`.
- Several markup renderers share `[hidden, _compositeReplacementActiveRange]`.
- `image.tsx` and `video.tsx` share the non-inline media layout pattern.

## Notable type-only fixes

- `regionBetweenCurves.tsx`: `Array.prototype.toSorted/toReversed` (ES2023) → `[...arr].sort()/reverse()` to match the project's `lib: ES2021`.
- `getNonInlineMediaLayoutStyles` return type tightened to `CSSProperties` and `horizontalAlign`/`mediaWidth` accept `string | undefined` — used by both `image.tsx` and `video.tsx`.

## Incidental changes worth flagging

- `orbitalDiagram.tsx` and `orbitalDiagramInput.tsx`: `createRef(SVs.fixed)` → `useRef<boolean>(SVs.fixed)`. `createRef()` ignores its argument and creates a new ref every render in function components — this is a latent bug fix bundled with the migration.
- JSX correctness fixes bundled in: `tabIndex="-1"` → `{-1}`, `tabIndex="0"` → `{0}`, `class="text-no-select"` → `className=...`, `size="4"` → `{4}` (orbital diagrams, section, subsetOfRealsInput).
- `JSXGraphRenderer.tsx`: `SVs.showNavigation && !SVs.fixAxes` wrapped in `Boolean(...)` to coerce the truthy/`undefined` expression to `boolean`. No behavior change, but worth noting.
- Drive-by display-name fixes (pre-existing copy-paste bugs in files this PR touched): `mdash.tsx` `function Ndash` → `Mdash`; `summaryStatistics.tsx` `function Tabular` → `SummaryStatistics`; `embed.tsx` `function Figure` → `Embed`.

## Known PR-B follow-ups (deliberately deferred)

- **`@ts-nocheck` still present in 3 helper files** under `renderers/utils/`: `useGridAndAxesSync.ts`, `useJSXGraphBoardSync.ts`, `useViewportAndNavigationSync.ts`. These are JSXGraph board-sync helpers consumed by the graph trio; typing them is bundled with the helper-extraction pass in PR B.
- **`[key: string]: any` index signatures** are present on most non-trivial SVs interfaces. They are needed today because helpers like `addCommasForCompositeRanges` accept `Record<string, any>`. The cleaner path is to give those helpers narrow input shapes and drop the index signature on the SVs side — punting until PR B so we can do the helper-typing pass once.
- **Heavy non-null assertions on refs (`!`)** in the drag/anchor renderers (`image`, `label`, `number`, `text`). Surrounding logic guarantees non-null in practice, but the assertions lose some type-system value. Will likely fall out naturally once the shared drag/anchor helper is extracted in PR B.
- **`as any` casts on `@doenet/ui-components`** (`Button`, `ToggleButton`, `ToggleButtonGroup` in `orbitalDiagramInput`, `subsetOfRealsInput`). Acceptable migration shim; real fix is to type the upstream components.
- **`video.tsx` YT player init effect uses `useEffect(..., [(window as any).YT])`** — pre-existing behavior preserved through this typing migration (the diff only added the `as any` cast around the existing dep). The dep won't reliably re-run when `SVs.youtube` transitions null→string or when the YT iframe API loads asynchronously. Out of scope for a type-only pass; track as a separate behavioral fix.
- **`button.tsx` `fillColor` fallback to `""` when `selectedStyle.highContrastColor` is undefined** emits invalid CSS (`background-color: ;` and `oklch(from  …)`). Pre-existing latent issue: pre-PR was `= SVs.selectedStyle.highContrastColor` under `@ts-nocheck`, which would have produced `background-color: undefined;` in the same case. Real fix (sensible fallback color, conditional CSS emission, or tightening `SelectedStyle.highContrastColor` to non-optional) is a behavioral choice that belongs outside a typing pass.

## Test plan

- [x] `npx tsc --noEmit` passes from `packages/doenetml/`
- [x] `grep -R "@ts-nocheck" packages/doenetml/src/Viewer/renderers/*.tsx` returns nothing (the 3 remaining occurrences live in `renderers/utils/` and are deferred to PR B — see Known PR-B follow-ups)
- [x] `npx vitest run --dir packages/doenetml/src/Viewer/renderers/graphControls` (13/13 pass)
- [x] Browser spot-check on `packages/doenetml/dev`: graph (point + line + polygon), `<choiceInput>`, `<mathInput>`, markup-heavy page (p, ref, lq, _error)
- [x] CI: full vitest suite + Cypress

🤖 Generated with [Claude Code](https://claude.com/claude-code)
