### PR TITLE
chore(claude): block git commit on unformatted staged files (Claude Code hook)

### DIFF
--- a/.claude/hooks/pre-commit-prettier.sh
+++ b/.claude/hooks/pre-commit-prettier.sh
@@ -26,7 +26,7 @@ cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null ||
 # Require `git` to be a command token: match only at line start or after
 # a shell command separator (;, &&, ||, |, &, (, {, !), so that `echo git
 # commit` or `rg "git commit" file` do not trigger this hook.
-if ! printf '%s' "$cmd" | grep -qE '(^|;|&&|\|\||[|&({!])[[:space:]]*git( +-[^ ]+( +[^ -][^ ]*)?)* +commit($|[^[:alnum:]])'; then
+if ! printf '%s' "$cmd" | grep -qE '(^|;|&&|\|\||[|&({!])[[:space:]]*git( +-[^ ]+( +[^ -][^ ]*)?)* +commit($|[[:space:]])'; then
     exit 0
 fi
 
@@ -34,15 +34,15 @@ repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
 cd "$repo_root" || exit 0
 
 # Files Claude is about to commit (added/copied/modified/renamed).
-staged=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null)
-[ -z "$staged" ] && exit 0
+# Use NUL separation for correctness with filenames containing newlines.
+mapfile -d '' staged_files < <(git diff --cached --name-only -z --diff-filter=ACMR 2>/dev/null)
+[ ${#staged_files[@]} -eq 0 ] && exit 0
 
 # Run prettier --check; capture both output and status.
 # Pass files as explicit arguments rather than via xargs so that prettier's
 # exit status (1 = unformatted, 2 = error) is preserved -- xargs would
 # translate 1-125 to 123, which would make the case below treat
 # "unformatted files" as "infrastructure error" and silently allow the commit.
-mapfile -t staged_files <<<"$staged"
 prettier_output=$(
     npx --no-install prettier --check --ignore-unknown -- "${staged_files[@]}" 2>&1
 )
@@ -60,7 +60,7 @@ Prettier found unformatted staged files; commit blocked.
 
 Fix (mirrors this hook's check; -z + xargs -0 handles spaces in filenames):
   git diff --cached --name-only -z --diff-filter=ACMR | \\
-    xargs -0 npx --no-install prettier --write --ignore-unknown
+    xargs -0 npx --no-install prettier --write --ignore-unknown --
   git diff --cached --name-only -z --diff-filter=ACMR | \\
     xargs -0 git add --
 

--- a/.claude/hooks/pre-commit-prettier.sh
+++ b/.claude/hooks/pre-commit-prettier.sh
@@ -24,7 +24,9 @@ cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null ||
 # Only act when the command runs `git commit`. Match `git` followed by
 # optional flags (-x, --long, --long=val, -C path) and then `commit`.
 # This avoids false positives like `git log --grep=commit`.
-if ! printf '%s' "$cmd" | grep -qE '\bgit( +-[^ ]+( +[^ -][^ ]*)?)* +commit\b'; then
+# Use POSIX character-class boundaries instead of `\b`; in BRE/ERE without
+# `-P`, `\b` matches a backspace on some greps (e.g., BSD grep on macOS).
+if ! printf '%s' "$cmd" | grep -qE '(^|[^[:alnum:]_])git( +-[^ ]+( +[^ -][^ ]*)?)* +commit($|[^[:alnum:]_])'; then
     exit 0
 fi
 
@@ -56,8 +58,9 @@ case $prettier_status in
         cat >&2 <<MSG
 Prettier found unformatted staged files; commit blocked.
 
-Fix:
-  npx prettier --write \$(git diff --cached --name-only --diff-filter=ACMR | xargs)
+Fix (mirrors this hook's check; -z + xargs -0 handles spaces in filenames):
+  git diff --cached --name-only -z --diff-filter=ACMR | \\
+    xargs -0 npx --no-install prettier --write --ignore-unknown
   git add -u
 
 Prettier output:

--- a/.claude/hooks/pre-commit-prettier.sh
+++ b/.claude/hooks/pre-commit-prettier.sh
@@ -35,7 +35,11 @@ cd "$repo_root" || exit 0
 
 # Files Claude is about to commit (added/copied/modified/renamed).
 # Use NUL separation for correctness with filenames containing newlines.
-mapfile -d '' staged_files < <(git diff --cached --name-only -z --diff-filter=ACMR 2>/dev/null)
+# Use while loop instead of mapfile for Bash 3.2+ compatibility.
+staged_files=()
+while IFS= read -r -d '' file; do
+    staged_files+=("$file")
+done < <(git diff --cached --name-only -z --diff-filter=ACMR 2>/dev/null)
 [ ${#staged_files[@]} -eq 0 ] && exit 0
 
 # Run prettier --check; capture both output and status.

--- a/.claude/hooks/pre-commit-prettier.sh
+++ b/.claude/hooks/pre-commit-prettier.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Claude Code PreToolUse(Bash) hook: when Claude tries to run `git commit`,
+# run `prettier --check` on staged files and refuse the commit if any are
+# unformatted. This is a defense in depth alongside CI's `prettier:check`;
+# the canonical fix would be a project-level husky/lint-staged pre-commit,
+# but this hook protects the Claude Code workflow specifically — including
+# the failure mode where Claude writes files via Bash (sed/python/heredoc)
+# and bypasses the existing PostToolUse formatter (which only matches
+# Write|Edit|MultiEdit|NotebookEdit).
+#
+# Bypass with: CLAUDE_SKIP_PRETTIER=1 (set in the shell Claude inherits).
+
+set -u
+
+if [ "${CLAUDE_SKIP_PRETTIER:-0}" = "1" ]; then
+    exit 0
+fi
+
+# Hook input is JSON on stdin; tool_input.command is the bash command.
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+
+# Only act when the command runs `git commit`. Match `git` followed by
+# optional flags (-x, --long, --long=val, -C path) and then `commit`.
+# This avoids false positives like `git log --grep=commit`.
+if ! printf '%s' "$cmd" | grep -qE '\bgit( +-[^ ]+( +[^ -][^ ]*)?)* +commit\b'; then
+    exit 0
+fi
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$repo_root" || exit 0
+
+# Files Claude is about to commit (added/copied/modified/renamed).
+staged=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null)
+[ -z "$staged" ] && exit 0
+
+# Run prettier --check; capture both output and status.
+# Pass files as explicit arguments rather than via xargs so that prettier's
+# exit status (1 = unformatted, 2 = error) is preserved -- xargs would
+# translate 1-125 to 123, which would make the case below treat
+# "unformatted files" as "infrastructure error" and silently allow the commit.
+mapfile -t staged_files <<<"$staged"
+prettier_output=$(
+    npx --no-install prettier --check --ignore-unknown "${staged_files[@]}" 2>&1
+)
+prettier_status=$?
+
+case $prettier_status in
+    0)
+        # All staged files formatted (or all ignored by prettier).
+        exit 0
+        ;;
+    1)
+        # Some staged files would be reformatted -> block.
+        cat >&2 <<MSG
+Prettier found unformatted staged files; commit blocked.
+
+Fix:
+  npx prettier --write \$(git diff --cached --name-only --diff-filter=ACMR | xargs)
+  git add -u
+
+Prettier output:
+$prettier_output
+
+(Set CLAUDE_SKIP_PRETTIER=1 to bypass this check.)
+MSG
+        exit 2
+        ;;
+    *)
+        # Any other status (e.g., prettier not installed, internal error).
+        # Don't block the commit on hook infrastructure failures.
+        exit 0
+        ;;
+esac

--- a/.claude/hooks/pre-commit-prettier.sh
+++ b/.claude/hooks/pre-commit-prettier.sh
@@ -23,10 +23,9 @@ cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null ||
 
 # Only act when the command runs `git commit`. Match `git` followed by
 # optional flags (-x, --long, --long=val, -C path) and then `commit`.
-# Require `git` to be a command token: match only at line start or after
-# a shell command separator (;, &&, ||, |, &, (, {, !), so that `echo git
-# commit` or `rg "git commit" file` do not trigger this hook.
-if ! printf '%s' "$cmd" | grep -qE '(^|;|&&|\|\||[|&({!])[[:space:]]*git( +-[^ ]+( +[^ -][^ ]*)?)* +commit($|[[:space:]])'; then
+# Require `git` to be the first command or to appear after a separator
+# (not inside a quoted string like `echo '; git commit'`).
+if ! printf '%s' "$cmd" | grep -qE '(^[[:space:]]*|[[:space:]](;|&&|\|\||[|&({!]))[[:space:]]*git( +-[^ ]+( +[^ -][^ ]*)?)* +commit($|[[:space:]])'; then
     exit 0
 fi
 

--- a/.claude/hooks/pre-commit-prettier.sh
+++ b/.claude/hooks/pre-commit-prettier.sh
@@ -23,10 +23,10 @@ cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null ||
 
 # Only act when the command runs `git commit`. Match `git` followed by
 # optional flags (-x, --long, --long=val, -C path) and then `commit`.
-# Require `git` to follow a command-start context (beginning of line,
-# whitespace, or a shell separator) so that `git commit` inside quoted
-# arguments like `rg "git commit" file` does not trigger this hook.
-if ! printf '%s' "$cmd" | grep -qE '(^|[[:space:];|&({!])git( +-[^ ]+( +[^ -][^ ]*)?)* +commit($|[^[:alnum:]])'; then
+# Require `git` to be a command token: match only at line start or after
+# a shell command separator (;, &&, ||, |, &, (, {, !), so that `echo git
+# commit` or `rg "git commit" file` do not trigger this hook.
+if ! printf '%s' "$cmd" | grep -qE '(^|;|&&|\|\||[|&({!])[[:space:]]*git( +-[^ ]+( +[^ -][^ ]*)?)* +commit($|[^[:alnum:]])'; then
     exit 0
 fi
 
@@ -44,7 +44,7 @@ staged=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null)
 # "unformatted files" as "infrastructure error" and silently allow the commit.
 mapfile -t staged_files <<<"$staged"
 prettier_output=$(
-    npx --no-install prettier --check --ignore-unknown "${staged_files[@]}" 2>&1
+    npx --no-install prettier --check --ignore-unknown -- "${staged_files[@]}" 2>&1
 )
 prettier_status=$?
 

--- a/.claude/hooks/pre-commit-prettier.sh
+++ b/.claude/hooks/pre-commit-prettier.sh
@@ -23,10 +23,10 @@ cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null ||
 
 # Only act when the command runs `git commit`. Match `git` followed by
 # optional flags (-x, --long, --long=val, -C path) and then `commit`.
-# This avoids false positives like `git log --grep=commit`.
-# Use POSIX character-class boundaries instead of `\b`; in BRE/ERE without
-# `-P`, `\b` matches a backspace on some greps (e.g., BSD grep on macOS).
-if ! printf '%s' "$cmd" | grep -qE '(^|[^[:alnum:]_])git( +-[^ ]+( +[^ -][^ ]*)?)* +commit($|[^[:alnum:]_])'; then
+# Require `git` to follow a command-start context (beginning of line,
+# whitespace, or a shell separator) so that `git commit` inside quoted
+# arguments like `rg "git commit" file` does not trigger this hook.
+if ! printf '%s' "$cmd" | grep -qE '(^|[[:space:];|&({!])git( +-[^ ]+( +[^ -][^ ]*)?)* +commit($|[^[:alnum:]])'; then
     exit 0
 fi
 
@@ -61,7 +61,8 @@ Prettier found unformatted staged files; commit blocked.
 Fix (mirrors this hook's check; -z + xargs -0 handles spaces in filenames):
   git diff --cached --name-only -z --diff-filter=ACMR | \\
     xargs -0 npx --no-install prettier --write --ignore-unknown
-  git add -u
+  git diff --cached --name-only -z --diff-filter=ACMR | \\
+    xargs -0 git add --
 
 Prettier output:
 $prettier_output

--- a/.claude/hooks/pre-commit-prettier.sh
+++ b/.claude/hooks/pre-commit-prettier.sh
@@ -22,10 +22,18 @@ input=$(cat)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
 
 # Only act when the command runs `git commit`. Match `git` followed by
-# optional flags (-x, --long, --long=val, -C path) and then `commit`.
-# Require `git` to be the first command or to appear after a separator
-# (not inside a quoted string like `echo '; git commit'`).
-if ! printf '%s' "$cmd" | grep -qE '(^[[:space:]]*|[[:space:]](;|&&|\|\||[|&({!]))[[:space:]]*git( +-[^ ]+( +[^ -][^ ]*)?)* +commit($|[[:space:]])'; then
+# optional flags (-x, --long, --long=val, -C path) and then `commit` as
+# a complete token (so `git commit-tree` and `git log --grep=commit`
+# don't trigger). Anchor `git` to the start of the command or to a shell
+# separator (`;`, `&&`/`&`, `||`/`|`, `(`, `{`, `` ` ``, `!`), with or
+# without surrounding whitespace, so that `cmd;git commit` and
+# `cmd && git commit` both intercept correctly.
+#
+# Known limitation: a regex cannot parse shell quoting, so a string like
+# `echo '; git commit'` will false-positive. False positives only block
+# one Bash call (Claude can retry with CLAUDE_SKIP_PRETTIER=1), so we
+# accept this rather than reaching for a real shell tokenizer.
+if ! printf '%s' "$cmd" | grep -qE '(^|[;&|`({!])[[:space:]]*git( +-[^ ]+( +[^ -][^ ]*)?)* +commit([^a-zA-Z0-9_-]|$)'; then
     exit 0
 fi
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "bash \"${CLAUDE_PROJECT_DIR:-$PWD}/.claude/hooks/pre-commit-prettier.sh\"",
+                        "command": "bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo \"${CLAUDE_PROJECT_DIR:-$PWD}\")/.claude/hooks/pre-commit-prettier.sh\"",
                         "timeout": 30
                     }
                 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo \"${CLAUDE_PROJECT_DIR:-$PWD}\")/.claude/hooks/pre-commit-prettier.sh\"",
+                        "command": "bash \"$([ -n \"${CLAUDE_PROJECT_DIR:-}\" ] && echo \"$CLAUDE_PROJECT_DIR\" || git rev-parse --show-toplevel 2>/dev/null || echo \"$PWD\")/.claude/hooks/pre-commit-prettier.sh\"",
                         "timeout": 30
                     }
                 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "bash \"$([ -n \"${CLAUDE_PROJECT_DIR:-}\" ] && echo \"$CLAUDE_PROJECT_DIR\" || git rev-parse --show-toplevel 2>/dev/null || echo \"$PWD\")/.claude/hooks/pre-commit-prettier.sh\"",
+                        "command": "h=\"$([ -n \"${CLAUDE_PROJECT_DIR:-}\" ] && echo \"$CLAUDE_PROJECT_DIR\" || git rev-parse --show-toplevel 2>/dev/null || echo \"$PWD\")/.claude/hooks/pre-commit-prettier.sh\"; [ -x \"$h\" ] || exit 0; bash \"$h\"",
                         "timeout": 30
                     }
                 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
     "hooks": {
+        "PreToolUse": [
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "bash \"${CLAUDE_PROJECT_DIR:-$PWD}/.claude/hooks/pre-commit-prettier.sh\"",
+                        "timeout": 30
+                    }
+                ]
+            }
+        ],
         "PostToolUse": [
             {
                 "matcher": "Write|Edit|MultiEdit|NotebookEdit",


### PR DESCRIPTION
## Summary

Adds a Claude Code `PreToolUse(Bash)` hook that intercepts `git commit` and runs `prettier --check` on staged files. If any are unformatted, the hook exits non-zero — Claude sees the offending files plus the exact `prettier --write` invocation to fix them, and the commit is blocked.

This is **option B** from the discussion that followed PR #1063: a defense in depth alongside CI's `prettier:check`. The canonical pre-commit gate would be project-level husky + lint-staged (which protects every contributor); this hook only protects the Claude Code workflow, but specifically covers the gap where Claude writes files via Bash (sed, python, heredoc) and bypasses the existing `PostToolUse` formatter — whose matcher only fires on `Write|Edit|MultiEdit|NotebookEdit`. That gap is exactly what slipped 15 unformatted files into PR #1063.

## Files

- **`.claude/hooks/pre-commit-prettier.sh`** — new, executable. Reads the hook input JSON from stdin, matches `\bgit( +-...)*+ +commit\b` to avoid false positives like `git log --grep=commit`, runs `prettier --check` on `git diff --cached --name-only --diff-filter=ACMR`, and exits 2 with a useful message if prettier reports unformatted files.
- **`.claude/settings.json`** — adds the `PreToolUse` matcher; existing `PostToolUse` and `UserPromptExpansion` hooks unchanged.

## Implementation notes

- Pass staged files as explicit arguments (`prettier --check "${files[@]}"`) rather than via `xargs`, since xargs collapses prettier's exit-1 (unformatted) into 123, which would silently allow the commit. This bug was caught while writing the tests below.
- On infrastructure failures (prettier not installed, internal error, exit ≠ 0/1), the hook exits 0 rather than blocking — fresh checkouts without `npm install` still commit.
- Bypass for intentional WIP commits: `CLAUDE_SKIP_PRETTIER=1`.

## Test plan

Verified locally before pushing:

- [x] non-commit Bash command → exit 0 (no-op)
- [x] `git commit` with nothing staged → exit 0
- [x] `git log --grep=commit` (false-positive guard) → exit 0
- [x] `git add ... && git commit ...` (chained) → triggers correctly
- [x] staged unformatted `.ts` file → exit 2, message printed
- [x] staged formatted `.ts` file → exit 0
- [x] `CLAUDE_SKIP_PRETTIER=1` → exit 0 even with unformatted staged file
- [ ] Smoke test in a fresh Claude Code session: try to commit an unformatted file via Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)