### PR TITLE
fix(ci): move package-lock regeneration into version:changesets script

### DIFF
--- a/.github/workflows/changesets-version-pr.yml
+++ b/.github/workflows/changesets-version-pr.yml
@@ -34,6 +34,6 @@ jobs:
             - name: Create or update version PR
               uses: changesets/action@v1
               with:
-                  version: npm run version:changesets && npm install --package-lock-only
+                  version: npm run version:changesets
                   title: "chore: version packages"
                   commit: "chore: version packages"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "test:e2e-group5": "npm run test:group5 -w packages/test-cypress",
         "test:e2e-mistagged": "npm run test:mistagged -w packages/test-cypress",
         "test:codemirror-cypress": "npm run test-cypress-all -w packages/codemirror",
-        "version:changesets": "changeset version",
+        "version:changesets": "changeset version && npm install --package-lock-only",
         "version": "npm version -w packages/doenetml -w packages/standalone -w packages/doenetml-iframe -w packages/v06-to-v07 -w @doenet/vscode-extension -w doenet-vscode-extension"
     },
     "prettier": {


### PR DESCRIPTION
## Summary

Fix the `Changesets Version PR` workflow that has been failing since #1061. The changesets/action `version` input is exec'd directly without a shell, so `&&` in the workflow string was passed as positional args to npm, appended to the script, and broke `changeset version` with:

```
🦋  error Too many arguments passed to changesets - we only accept the command name as an argument
```

Because `changeset version` then errored, no version bumps happened, the force-pushed `changeset-release/main` was identical to `main`, and PR creation failed with `No commits between main and changeset-release/main`. The same failure on the #1061 merge run is what killed PR #1033 — its branch was force-pushed to a no-op state.

## Fix

- Move `&& npm install --package-lock-only` into the `version:changesets` npm script (npm runs scripts via shell, so `&&` works there).
- Revert the workflow to invoke a single command: `npm run version:changesets`.

## Test plan

- [ ] Merge this PR and confirm the next push to `main` triggers the workflow successfully and creates a `chore: version packages` PR consuming the 4 pending changesets in `.changeset/`.
- [ ] Or trigger via `workflow_dispatch` after merge to verify without waiting for the next merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)