### PR TITLE
refactor(renderers): dedup & helper extraction (PR B of 2)

### DIFF
--- a/packages/doenetml/src/Viewer/renderers/JSXGraphRenderer.tsx
+++ b/packages/doenetml/src/Viewer/renderers/JSXGraphRenderer.tsx
@@ -86,7 +86,7 @@ export default function JSXGraphRenderer({
                 const xscale = Math.abs(xMax - xMin);
                 const yscale = Math.abs(yMax - yMin);
                 const diffs = newBoundingbox.map((v: number, i: number) =>
-                    Math.abs(v - previousBoundingbox.current![i]),
+                    Math.abs(v - previousBoundingbox.current[i]),
                 );
                 if (
                     Math.max(

--- a/packages/doenetml/src/Viewer/renderers/JSXGraphRenderer.tsx
+++ b/packages/doenetml/src/Viewer/renderers/JSXGraphRenderer.tsx
@@ -5,6 +5,7 @@ import {
     addNavigationButtons,
     createXAxis,
     createYAxis,
+    type AxisJXG,
 } from "./utils/jsxgraph";
 import useJSXGraphBoardSync from "./utils/useJSXGraphBoardSync";
 import { JXGBoard } from "./jsxgraph-distrib/types";
@@ -37,10 +38,10 @@ export default function JSXGraphRenderer({
     const previousDimensions = useRef<{
         width: number;
         aspectRatio: string | number;
-    } | null>(null);
-    const previousBoundingbox = useRef<number[] | null>(null);
-    const xaxis = useRef<any>(null);
-    const yaxis = useRef<any>(null);
+    }>({ width: 0, aspectRatio: 1 });
+    const previousBoundingbox = useRef<number[]>([0, 0, 0, 0]);
+    const xaxis = useRef<AxisJXG | null | undefined>(null);
+    const yaxis = useRef<AxisJXG | null | undefined>(null);
     const settingBoundingBox = useRef<boolean>(false);
     const boardJustInitialized = useRef<boolean>(false);
 

--- a/packages/doenetml/src/Viewer/renderers/blockQuote.tsx
+++ b/packages/doenetml/src/Viewer/renderers/blockQuote.tsx
@@ -2,36 +2,25 @@ import React, { useRef } from "react";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
-import { addCommasForCompositeRanges } from "./utils/composites";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
+import { MarkupSVsBase, renderMarkupBody } from "./utils/markupRenderer";
 
-interface BlockQuoteSVs {
+interface BlockQuoteSVs extends MarkupSVsBase {
     [key: string]: any;
-    hidden: boolean;
-    _compositeReplacementActiveRange?: any;
     renderInlineForListItem: boolean;
 }
 
 export default React.memo(function Container(props: UseDoenetRendererProps) {
-    let { id, SVs, children, actions, callAction } =
+    const { id, SVs, children, actions, callAction } =
         useDoenetRenderer<BlockQuoteSVs>(props);
 
     const ref = useRef(null);
 
     useRecordVisibilityChanges(ref, callAction, actions);
 
-    if (SVs.hidden) {
+    const body = renderMarkupBody({ SVs, children });
+    if (body === null) {
         return null;
-    }
-
-    if (SVs._compositeReplacementActiveRange) {
-        children = addCommasForCompositeRanges({
-            children,
-            compositeReplacementActiveRange:
-                SVs._compositeReplacementActiveRange,
-            startInd: 0,
-            endInd: children.length - 1,
-        });
     }
 
     return (
@@ -42,7 +31,7 @@ export default React.memo(function Container(props: UseDoenetRendererProps) {
             // native blockquote side/bottom spacing from stylesheet defaults.
             style={SVs.renderInlineForListItem ? { marginTop: 0 } : undefined}
         >
-            {children}
+            {body}
         </blockquote>
     );
 });

--- a/packages/doenetml/src/Viewer/renderers/c.tsx
+++ b/packages/doenetml/src/Viewer/renderers/c.tsx
@@ -2,34 +2,22 @@ import React from "react";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
-import { addCommasForCompositeRanges } from "./utils/composites";
+import { MarkupSVsBase, renderMarkupBody } from "./utils/markupRenderer";
 
-interface CSVs {
+interface CSVs extends MarkupSVsBase {
     [key: string]: any;
-    hidden: boolean;
-    _compositeReplacementActiveRange?: any;
 }
 
 export default React.memo(function C(props: UseDoenetRendererProps) {
-    let { id, SVs, children } = useDoenetRenderer<CSVs>(props);
+    const { id, SVs, children } = useDoenetRenderer<CSVs>(props);
 
-    if (SVs.hidden) {
+    const body = renderMarkupBody({ SVs, children });
+    if (body === null) {
         return null;
     }
-
-    if (SVs._compositeReplacementActiveRange) {
-        children = addCommasForCompositeRanges({
-            children,
-            compositeReplacementActiveRange:
-                SVs._compositeReplacementActiveRange,
-            startInd: 0,
-            endInd: children.length - 1,
-        });
-    }
-
     return (
         <code id={id} style={{ margin: "12px 0" }}>
-            {children}
+            {body}
         </code>
     );
 });

--- a/packages/doenetml/src/Viewer/renderers/em.tsx
+++ b/packages/doenetml/src/Viewer/renderers/em.tsx
@@ -2,30 +2,18 @@ import React from "react";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
-import { addCommasForCompositeRanges } from "./utils/composites";
+import { MarkupSVsBase, renderMarkupBody } from "./utils/markupRenderer";
 
-interface EmSVs {
+interface EmSVs extends MarkupSVsBase {
     [key: string]: any;
-    hidden: boolean;
-    _compositeReplacementActiveRange?: any;
 }
 
 export default React.memo(function Em(props: UseDoenetRendererProps) {
-    let { id, SVs, children } = useDoenetRenderer<EmSVs>(props);
+    const { id, SVs, children } = useDoenetRenderer<EmSVs>(props);
 
-    if (SVs.hidden) {
+    const body = renderMarkupBody({ SVs, children });
+    if (body === null) {
         return null;
     }
-
-    if (SVs._compositeReplacementActiveRange) {
-        children = addCommasForCompositeRanges({
-            children,
-            compositeReplacementActiveRange:
-                SVs._compositeReplacementActiveRange,
-            startInd: 0,
-            endInd: children.length - 1,
-        });
-    }
-
-    return <em id={id}>{children}</em>;
+    return <em id={id}>{body}</em>;
 });

--- a/packages/doenetml/src/Viewer/renderers/image.tsx
+++ b/packages/doenetml/src/Viewer/renderers/image.tsx
@@ -38,7 +38,7 @@ type JXGImage = JXGElement & {
     Y(): number;
     W(): number;
     H(): number;
-    relativeCoords?: {
+    relativeCoords: {
         usrCoords: [number, number, number];
         setCoordinates: Function;
     };
@@ -352,11 +352,11 @@ export default React.memo(function Image(props: UseDoenetRendererProps) {
             } else {
                 calculatedX.current =
                     newAnchorPointJXG.X() +
-                    newImageJXG.relativeCoords!.usrCoords[1] -
+                    newImageJXG.relativeCoords.usrCoords[1] -
                     currentOffset.current![0];
                 calculatedY.current =
                     newAnchorPointJXG.Y() +
-                    newImageJXG.relativeCoords!.usrCoords[2] -
+                    newImageJXG.relativeCoords.usrCoords[2] -
                     currentOffset.current![1];
             }
 
@@ -379,7 +379,7 @@ export default React.memo(function Image(props: UseDoenetRendererProps) {
                 },
             });
 
-            newImageJXG.relativeCoords!.setCoordinates(
+            newImageJXG.relativeCoords.setCoordinates(
                 JXG.COORDS_BY_USER,
                 currentOffset.current,
             );
@@ -553,7 +553,7 @@ export default React.memo(function Image(props: UseDoenetRendererProps) {
                     offset = [-width, -height / 2];
                 }
 
-                imageJXG.current.relativeCoords!.setCoordinates(
+                imageJXG.current.relativeCoords.setCoordinates(
                     JXG.COORDS_BY_USER,
                     offset,
                 );
@@ -562,7 +562,7 @@ export default React.memo(function Image(props: UseDoenetRendererProps) {
                 currentOffset.current = offset;
                 imageJXG.current.fullUpdate();
             } else {
-                imageJXG.current.relativeCoords!.setCoordinates(
+                imageJXG.current.relativeCoords.setCoordinates(
                     JXG.COORDS_BY_USER,
                     currentOffset.current,
                 );

--- a/packages/doenetml/src/Viewer/renderers/image.tsx
+++ b/packages/doenetml/src/Viewer/renderers/image.tsx
@@ -9,6 +9,7 @@ import me from "math-expressions";
 import { POINTER_DRAG_THRESHOLD } from "./utils/graph";
 import { DescriptionAsDetails, DescriptionPopover } from "./utils/Description";
 import { getNonInlineMediaLayoutStyles } from "./utils/nonInlineMediaLayout";
+import { NonInlineMediaWrapper } from "./utils/NonInlineMediaWrapper";
 import { JXGElement, JXGEvent, JXGPoint } from "./jsxgraph-distrib/types";
 
 interface ImageSVs {
@@ -643,56 +644,34 @@ export default React.memo(function Image(props: UseDoenetRendererProps) {
             );
     }
 
-    return (
-        <div
-            style={
-                SVs.renderInlineForListItem
-                    ? { ...outerStyle, marginTop: 0 }
-                    : outerStyle
-            }
-            ref={ref}
-            id={`${id}-container`}
-        >
-            <div style={innerStyle}>
-                {SVs.displayMode === "inline" ? (
-                    urlOrSource ? (
-                        <img
-                            id={id}
-                            src={urlOrSource}
-                            style={imageStyle}
-                            alt={shortDescription}
-                            aria-details={descriptionId}
-                        />
-                    ) : (
-                        <div id={id} style={imageStyle}>
-                            {SVs.shortDescription}
-                        </div>
-                    )
-                ) : (
-                    <div style={mediaContainerStyle}>
-                        {urlOrSource ? (
-                            <img
-                                id={id}
-                                src={urlOrSource}
-                                style={imageStyle}
-                                alt={shortDescription}
-                                aria-details={descriptionId}
-                            />
-                        ) : (
-                            <div id={id} style={imageStyle}>
-                                {SVs.shortDescription}
-                            </div>
-                        )}
-                    </div>
-                )}
-                {SVs.displayMode === "inline" || !description ? (
-                    description
-                ) : (
-                    <div style={mediaContainerStyle}>
-                        <div style={mediaColumnStyle}>{description}</div>
-                    </div>
-                )}
-            </div>
+    const media = urlOrSource ? (
+        <img
+            id={id}
+            src={urlOrSource}
+            style={imageStyle}
+            alt={shortDescription}
+            aria-details={descriptionId}
+        />
+    ) : (
+        <div id={id} style={imageStyle}>
+            {SVs.shortDescription}
         </div>
+    );
+
+    return (
+        <NonInlineMediaWrapper
+            id={id}
+            displayMode={SVs.displayMode}
+            suppressTopMargin={Boolean(SVs.renderInlineForListItem)}
+            layoutStyles={{
+                outerStyle,
+                innerStyle,
+                mediaContainerStyle,
+                mediaColumnStyle,
+            }}
+            media={media}
+            description={description}
+            containerRef={ref}
+        />
     );
 });

--- a/packages/doenetml/src/Viewer/renderers/jsxgraph-distrib/types.ts
+++ b/packages/doenetml/src/Viewer/renderers/jsxgraph-distrib/types.ts
@@ -79,11 +79,11 @@ export interface JXGElement {
 export interface JXGPoint extends JXGElement {
     X(): number;
     Y(): number;
-    relativeCoords?: {
+    relativeCoords: {
         usrCoords: [number, number, number];
         setCoordinates: Function;
     };
-    size?: [number, number];
+    size: [number, number];
 }
 
 export interface JXGLine extends JXGElement {
@@ -118,11 +118,11 @@ export interface JXGCurve extends JXGElement {
 
 export interface JXGText extends JXGElement {
     setText(text: string): void;
-    relativeCoords?: {
+    relativeCoords: {
         usrCoords: [number, number, number];
         setCoordinates: Function;
     };
-    size?: [number, number];
+    size: [number, number];
     rendNodeInput?: HTMLInputElement;
     rendNodeLabel?: HTMLElement;
 }

--- a/packages/doenetml/src/Viewer/renderers/label.tsx
+++ b/packages/doenetml/src/Viewer/renderers/label.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef } from "react";
+import React, { useContext, useRef } from "react";
 import { BoardContext, TEXT_LAYER_OFFSET } from "./graph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
@@ -6,14 +6,19 @@ import useDoenetRenderer, {
 import { MathJax } from "better-react-mathjax";
 import me from "math-expressions";
 import { textRendererStyle } from "@doenet/utils";
-import {
-    getPositionFromAnchorByCoordinate,
-    POINTER_DRAG_THRESHOLD,
-} from "./utils/graph";
+import { getPositionFromAnchorByCoordinate } from "./utils/graph";
 import { DocContext } from "../DocViewer";
 import { ChoiceInputInlineContext } from "./choiceInput";
-import { JXGEvent, JXGPoint, JXGText } from "./jsxgraph-distrib/types";
+import { JXGPoint, JXGText } from "./jsxgraph-distrib/types";
 import { SelectedStyle } from "./utils/graphicalSVs";
+import { usePointerDragState } from "./utils/pointerDragState";
+import { useDraggableRefs } from "./utils/useDraggableRefs";
+import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
+import {
+    attachAnchoredGraphDragHandlers,
+    detachAnchoredGraphElement,
+} from "./utils/useAnchoredGraphDragHandler";
+import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
 
 interface LabelSVs {
     hidden: boolean;
@@ -37,51 +42,31 @@ export default React.memo(function Label(props: UseDoenetRendererProps) {
     // @ts-ignore
     Label.ignoreActionsWithoutCore = () => true;
 
-    let labelJXG = useRef<JXGText | null>(null);
-    let anchorPointJXG = useRef<JXGPoint | null>(null);
-    let anchorRel = useRef<[string, string] | null>(null);
+    const labelJXG = useRef<JXGText | null>(null);
+    const anchorPointJXG = useRef<JXGPoint | null>(null);
+    const anchorRel = useRef<[string, string] | null>(null);
 
     const board = useContext(BoardContext);
     const choiceInputInlineContext = useContext(ChoiceInputInlineContext);
 
-    let pointerAtDown = useRef<[number, number] | null>(null);
-    let pointAtDown = useRef<number[] | null>(null);
-    let pointerIsDown = useRef<boolean>(false);
-    let pointerMovedSinceDown = useRef<boolean>(false);
-    let dragged = useRef<boolean>(false);
+    const pointerState = usePointerDragState();
+    const pointAtDown = useRef<number[] | null>(null);
+    const calculatedX = useRef<number | null>(null);
+    const calculatedY = useRef<number | null>(null);
+    const previousPositionFromAnchor = useRef<any>(null);
 
-    let calculatedX = useRef<number | null>(null);
-    let calculatedY = useRef<number | null>(null);
+    const { fixed, fixLocation, lastPositionFromCore } = useDraggableRefs<
+        number[] | null
+    >(SVs, null);
 
-    let lastPositionFromCore = useRef<number[] | null>(null);
-    let previousPositionFromAnchor = useRef<any>(null);
+    useBoardPointerTracking(board, pointerState);
 
-    let fixed = useRef<boolean>(false);
-    let fixLocation = useRef<boolean>(false);
-
-    fixed.current = SVs.fixed;
-    fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
+    useJSXGraphCleanup({
+        objectRef: labelJXG,
+        destroy: () => detachAnchoredGraphElement(labelJXG, board),
+    });
 
     const { darkMode } = useContext(DocContext) || {};
-
-    useEffect(() => {
-        //On unmount
-        return () => {
-            if (labelJXG.current !== null) {
-                deleteLabelJXG();
-            }
-
-            if (board) {
-                board.off("move", boardMoveHandler);
-            }
-        };
-    }, []);
-
-    useEffect(() => {
-        if (board) {
-            board.on("move", boardMoveHandler);
-        }
-    }, [board]);
 
     function createLabelJXG() {
         if (board === null) {
@@ -160,184 +145,27 @@ export default React.memo(function Label(props: UseDoenetRendererProps) {
             [0, 0, SVs.value],
             jsxLabelAttributes,
         ) as JXGText;
-        newLabelJXG.isDraggable = !fixLocation.current;
 
-        newLabelJXG.on("down", function (e: JXGEvent) {
-            (document.activeElement as HTMLElement | null)?.blur();
-
-            pointerAtDown.current = [e.x, e.y];
-            pointAtDown.current = [...newAnchorPointJXG.coords.scrCoords];
-            dragged.current = false;
-            pointerIsDown.current = true;
-            pointerMovedSinceDown.current = false;
-            if (!fixed.current) {
-                callAction({
-                    action: actions.labelFocused,
-                    args: { componentIdx },
-                });
-            }
-        });
-
-        newLabelJXG.on("hit", function (e: JXGEvent) {
-            pointAtDown.current = [...newAnchorPointJXG.coords.scrCoords];
-            dragged.current = false;
-            callAction({
-                action: actions.labelFocused,
-                args: { componentIdx },
-            });
-        });
-
-        newLabelJXG.on("up", function (e: JXGEvent) {
-            if (dragged.current) {
-                callAction({
-                    action: actions.moveLabel,
-                    args: {
-                        x: calculatedX.current,
-                        y: calculatedY.current,
-                    },
-                });
-                dragged.current = false;
-            } else if (!pointerMovedSinceDown.current && !fixed.current) {
-                callAction({
-                    action: actions.labelClicked,
-                    args: { componentIdx },
-                });
-            }
-            pointerIsDown.current = false;
-        });
-
-        newLabelJXG.on("keyfocusout", function (e: JXGEvent) {
-            if (dragged.current) {
-                callAction({
-                    action: actions.moveLabel,
-                    args: {
-                        x: calculatedX.current,
-                        y: calculatedY.current,
-                    },
-                });
-                dragged.current = false;
-            }
-        });
-
-        newLabelJXG.on("drag", function (e: JXGEvent) {
-            let viaPointer = e.type === "pointermove";
-
-            //Protect against very small unintended drags
-            if (
-                !viaPointer ||
-                Math.abs(e.x - pointerAtDown.current![0]) >
-                    POINTER_DRAG_THRESHOLD ||
-                Math.abs(e.y - pointerAtDown.current![1]) >
-                    POINTER_DRAG_THRESHOLD
-            ) {
-                dragged.current = true;
-            }
-
-            let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
-            let width = newLabelJXG.size![0] / board.unitX;
-            let height = newLabelJXG.size![1] / board.unitY;
-
-            let anchorx = anchorRel.current![0];
-            let anchory = anchorRel.current![1];
-
-            let offsetx = 0;
-            if (anchorx === "middle") {
-                offsetx = -width / 2;
-            } else if (anchorx === "right") {
-                offsetx = -width;
-            }
-            let offsety = 0;
-            if (anchory === "middle") {
-                offsety = -height / 2;
-            } else if (anchory === "top") {
-                offsety = -height;
-            }
-
-            let xminAdjusted = xMin + 0.04 * (xMax - xMin) - offsetx - width;
-            let xmaxAdjusted = xMax - 0.04 * (xMax - xMin) - offsetx;
-            let yminAdjusted = yMin + 0.04 * (yMax - yMin) - offsety - height;
-            let ymaxAdjusted = yMax - 0.04 * (yMax - yMin) - offsety;
-
-            if (viaPointer) {
-                // the reason we calculate point position with this algorithm,
-                // rather than using .X() and .Y() directly
-                // is that attributes .X() and .Y() are affected by the
-                // .setCoordinates function called in update().
-                // Due to this dependence, the location of .X() and .Y()
-                // can be affected by constraints of objects that the points depends on,
-                // leading to a different location on up than on drag
-                // (as dragging uses the mouse location)
-                // TODO: find an example where need this this additional complexity
-                var o = board.origin.scrCoords;
-
-                calculatedX.current =
-                    (pointAtDown.current![1] +
-                        e.x -
-                        pointerAtDown.current![0] -
-                        o[1]) /
-                    board.unitX;
-
-                calculatedY.current =
-                    (o[2] -
-                        (pointAtDown.current![2] +
-                            e.y -
-                            pointerAtDown.current![1])) /
-                    board.unitY;
-            } else {
-                calculatedX.current =
-                    newAnchorPointJXG.X() +
-                    newLabelJXG.relativeCoords!.usrCoords[1];
-                calculatedY.current =
-                    newAnchorPointJXG.Y() +
-                    newLabelJXG.relativeCoords!.usrCoords[2];
-            }
-
-            calculatedX.current = Math.min(
-                xmaxAdjusted,
-                Math.max(xminAdjusted, calculatedX.current),
-            );
-            calculatedY.current = Math.min(
-                ymaxAdjusted,
-                Math.max(yminAdjusted, calculatedY.current),
-            );
-
-            callAction({
-                action: actions.moveLabel,
-                args: {
-                    x: calculatedX.current,
-                    y: calculatedY.current,
-                    transient: true,
-                    skippable: true,
-                },
-            });
-
-            newLabelJXG.relativeCoords!.setCoordinates(
-                JXG.COORDS_BY_USER,
-                [0, 0],
-            );
-            newAnchorPointJXG.coords.setCoordinates(
-                JXG.COORDS_BY_USER,
-                lastPositionFromCore.current,
-            );
-        });
-
-        newLabelJXG.on("keydown", function (e: JXGEvent) {
-            if (e.key === "Enter") {
-                if (dragged.current) {
-                    callAction({
-                        action: actions.moveLabel,
-                        args: {
-                            x: calculatedX.current,
-                            y: calculatedY.current,
-                        },
-                    });
-                    dragged.current = false;
-                }
-                callAction({
-                    action: actions.labelClicked,
-                    args: { componentIdx },
-                });
-            }
+        attachAnchoredGraphDragHandlers({
+            board,
+            newJXG: newLabelJXG,
+            newAnchorPoint: newAnchorPointJXG,
+            anchorRel,
+            pointerState,
+            pointAtDown,
+            calculatedX,
+            calculatedY,
+            fixed,
+            fixLocation,
+            lastPositionFromCore,
+            componentIdx,
+            actions,
+            callAction,
+            actionNames: {
+                move: "moveLabel",
+                focused: "labelFocused",
+                clicked: "labelClicked",
+            },
         });
 
         labelJXG.current = newLabelJXG;
@@ -357,32 +185,6 @@ export default React.memo(function Label(props: UseDoenetRendererProps) {
                 }
             }, 1000);
         }
-    }
-
-    function boardMoveHandler(e: JXGEvent) {
-        if (pointerIsDown.current) {
-            //Protect against very small unintended move
-            if (
-                Math.abs(e.x - pointerAtDown.current![0]) >
-                    POINTER_DRAG_THRESHOLD ||
-                Math.abs(e.y - pointerAtDown.current![1]) >
-                    POINTER_DRAG_THRESHOLD
-            ) {
-                pointerMovedSinceDown.current = true;
-            }
-        }
-    }
-
-    function deleteLabelJXG() {
-        if (!labelJXG.current) return;
-        labelJXG.current.off("drag");
-        labelJXG.current.off("down");
-        labelJXG.current.off("hit");
-        labelJXG.current.off("up");
-        labelJXG.current.off("keyfocusout");
-        labelJXG.current.off("keydown");
-        board?.removeObject(labelJXG.current);
-        labelJXG.current = null;
     }
 
     if (board) {

--- a/packages/doenetml/src/Viewer/renderers/label.tsx
+++ b/packages/doenetml/src/Viewer/renderers/label.tsx
@@ -204,7 +204,7 @@ export default React.memo(function Label(props: UseDoenetRendererProps) {
         if (labelJXG.current === null) {
             createLabelJXG();
         } else {
-            labelJXG.current.relativeCoords!.setCoordinates(
+            labelJXG.current.relativeCoords.setCoordinates(
                 JXG.COORDS_BY_USER,
                 [0, 0],
             );

--- a/packages/doenetml/src/Viewer/renderers/math.tsx
+++ b/packages/doenetml/src/Viewer/renderers/math.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef } from "react";
+import React, { useContext, useRef } from "react";
 import { BoardContext, TEXT_LAYER_OFFSET } from "./graph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
@@ -6,14 +6,19 @@ import useDoenetRenderer, {
 import { MathJax } from "better-react-mathjax";
 import me from "math-expressions";
 import { textRendererStyle } from "@doenet/utils";
-import {
-    getPositionFromAnchorByCoordinate,
-    POINTER_DRAG_THRESHOLD,
-} from "./utils/graph";
+import { getPositionFromAnchorByCoordinate } from "./utils/graph";
 import { DocContext } from "../DocViewer";
-import { JXGEvent, JXGObject } from "./jsxgraph-distrib/types";
+import { JXGObject } from "./jsxgraph-distrib/types";
 import { ChoiceInputInlineContext } from "./choiceInput";
 import { SelectedStyle } from "./utils/graphicalSVs";
+import { usePointerDragState } from "./utils/pointerDragState";
+import { useDraggableRefs } from "./utils/useDraggableRefs";
+import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
+import {
+    attachAnchoredGraphDragHandlers,
+    detachAnchoredGraphElement,
+} from "./utils/useAnchoredGraphDragHandler";
+import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
 
 interface MathSVs {
     [key: string]: any;
@@ -31,60 +36,54 @@ interface MathSVs {
     selectedStyle: SelectedStyle;
 }
 
+function getMathDelimiters(SVs: MathSVs): [string, string] {
+    if (SVs.renderMode === "inline") {
+        return ["\\(", "\\)"];
+    } else if (SVs.renderMode === "display") {
+        return ["\\[", "\\]"];
+    } else if (SVs.renderMode === "numbered") {
+        return [`\\begin{gather}\\tag{${SVs.equationTag}}`, "\\end{gather}"];
+    } else if (SVs.renderMode === "align") {
+        return ["\\begin{align}", "\\end{align}"];
+    }
+    // treat as inline if have unrecognized renderMode
+    return ["\\(", "\\)"];
+}
+
 export default React.memo(function MathComponent(
     props: UseDoenetRendererProps,
 ) {
-    let { componentIdx, id, SVs, actions, sourceOfUpdate, callAction } =
+    let { componentIdx, id, SVs, actions, callAction } =
         useDoenetRenderer<MathSVs>(props);
 
     // @ts-ignore
     MathComponent.ignoreActionsWithoutCore = () => true;
 
-    let mathJXG = useRef<JXGObject | null>(null);
-    let anchorPointJXG = useRef<JXGObject | null>(null);
-    let anchorRel = useRef<[string, string] | null>(null);
+    const mathJXG = useRef<JXGObject | null>(null);
+    const anchorPointJXG = useRef<JXGObject | null>(null);
+    const anchorRel = useRef<[string, string] | null>(null);
 
     const board = useContext(BoardContext);
     const choiceInputInlineContext = useContext(ChoiceInputInlineContext);
 
-    let pointerAtDown = useRef<[number, number] | null>(null);
-    let pointAtDown = useRef<[number, number, number] | null>(null);
-    let pointerIsDown = useRef(false);
-    let pointerMovedSinceDown = useRef(false);
-    let dragged = useRef(false);
+    const pointerState = usePointerDragState();
+    const pointAtDown = useRef<number[] | null>(null);
+    const calculatedX = useRef<number | null>(null);
+    const calculatedY = useRef<number | null>(null);
+    const previousPositionFromAnchor = useRef(null);
 
-    let calculatedX = useRef<number | null>(null);
-    let calculatedY = useRef<number | null>(null);
+    const { fixed, fixLocation, lastPositionFromCore } = useDraggableRefs<
+        number[] | null
+    >(SVs, null);
 
-    let lastPositionFromCore = useRef<[number, number] | null>(null);
-    let previousPositionFromAnchor = useRef(null);
+    useBoardPointerTracking(board, pointerState);
 
-    let fixed = useRef(false);
-    let fixLocation = useRef(false);
-
-    fixed.current = SVs.fixed;
-    fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
+    useJSXGraphCleanup({
+        objectRef: mathJXG,
+        destroy: () => detachAnchoredGraphElement(mathJXG, board),
+    });
 
     const { darkMode } = useContext(DocContext) || {};
-
-    useEffect(() => {
-        //On unmount
-        return () => {
-            if (mathJXG.current !== null) {
-                deleteMathJXG();
-            }
-
-            if (board) {
-                board.off("move", boardMoveHandler);
-            }
-        };
-    }, []);
-
-    useEffect(() => {
-        if (board) {
-            board.on("move", boardMoveHandler);
-        }
-    }, [board]);
 
     function createMathJXG() {
         if (board === null) {
@@ -158,219 +157,34 @@ export default React.memo(function MathComponent(
         jsxMathAttributes.anchory = anchory;
         anchorRel.current = [anchorx, anchory];
 
-        let beginDelim: string, endDelim: string;
-        if (SVs.renderMode === "inline") {
-            beginDelim = "\\(";
-            endDelim = "\\)";
-        } else if (SVs.renderMode === "display") {
-            beginDelim = "\\[";
-            endDelim = "\\]";
-        } else if (SVs.renderMode === "numbered") {
-            beginDelim = `\\begin{gather}\\tag{${SVs.equationTag}}`;
-            endDelim = "\\end{gather}";
-        } else if (SVs.renderMode === "align") {
-            beginDelim = "\\begin{align}";
-            endDelim = "\\end{align}";
-        } else {
-            // treat as inline if have unrecognized renderMode
-            beginDelim = "\\(";
-            endDelim = "\\)";
-        }
+        const [beginDelim, endDelim] = getMathDelimiters(SVs);
 
         let newMathJXG: JXGObject = board.create(
             "text",
             [0, 0, beginDelim + SVs.latex + endDelim],
             jsxMathAttributes,
         );
-        newMathJXG.isDraggable = !fixLocation.current;
 
-        newMathJXG.on("down", function (e) {
-            (document.activeElement as HTMLElement | null)?.blur();
-
-            pointerAtDown.current = [e.x, e.y];
-            pointAtDown.current = [
-                ...(newAnchorPointJXG.coords.scrCoords as [
-                    number,
-                    number,
-                    number,
-                ]),
-            ];
-            dragged.current = false;
-            pointerIsDown.current = true;
-            pointerMovedSinceDown.current = false;
-            if (!fixed.current) {
-                callAction({
-                    action: actions.mathFocused,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                });
-            }
-        });
-
-        newMathJXG.on("hit", function (e) {
-            pointAtDown.current = [
-                ...(newAnchorPointJXG.coords.scrCoords as [
-                    number,
-                    number,
-                    number,
-                ]),
-            ];
-            dragged.current = false;
-            callAction({
-                action: actions.mathFocused,
-                args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-            });
-        });
-
-        newMathJXG.on("up", function (e) {
-            if (dragged.current) {
-                callAction({
-                    action: actions.moveMath,
-                    args: {
-                        x: calculatedX.current,
-                        y: calculatedY.current,
-                    },
-                });
-                dragged.current = false;
-            } else if (!pointerMovedSinceDown.current && !fixed.current) {
-                callAction({
-                    action: actions.mathClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                });
-            }
-            pointerIsDown.current = false;
-        });
-
-        newMathJXG.on("keyfocusout", function (e) {
-            if (dragged.current) {
-                callAction({
-                    action: actions.moveMath,
-                    args: {
-                        x: calculatedX.current,
-                        y: calculatedY.current,
-                    },
-                });
-                dragged.current = false;
-            }
-        });
-
-        newMathJXG.on("drag", function (e) {
-            let viaPointer = e.type === "pointermove";
-
-            //Protect against very small unintended drags
-            if (
-                !viaPointer ||
-                Math.abs(e.x - pointerAtDown.current![0]) >
-                    POINTER_DRAG_THRESHOLD ||
-                Math.abs(e.y - pointerAtDown.current![1]) >
-                    POINTER_DRAG_THRESHOLD
-            ) {
-                dragged.current = true;
-            }
-
-            let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
-            let width = newMathJXG.size[0] / board.unitX;
-            let height = newMathJXG.size[1] / board.unitY;
-
-            let anchorx = anchorRel.current?.[0];
-            let anchory = anchorRel.current?.[1];
-
-            let offsetx = 0;
-            if (anchorx === "middle") {
-                offsetx = -width / 2;
-            } else if (anchorx === "right") {
-                offsetx = -width;
-            }
-            let offsety = 0;
-            if (anchory === "middle") {
-                offsety = -height / 2;
-            } else if (anchory === "top") {
-                offsety = -height;
-            }
-
-            let xminAdjusted = xMin + 0.04 * (xMax - xMin) - offsetx - width;
-            let xmaxAdjusted = xMax - 0.04 * (xMax - xMin) - offsetx;
-            let yminAdjusted = yMin + 0.04 * (yMax - yMin) - offsety - height;
-            let ymaxAdjusted = yMax - 0.04 * (yMax - yMin) - offsety;
-
-            if (viaPointer && pointAtDown.current && pointerAtDown.current) {
-                // the reason we calculate point position with this algorithm,
-                // rather than using .X() and .Y() directly
-                // is that attributes .X() and .Y() are affected by the
-                // .setCoordinates function called in update().
-                // Due to this dependence, the location of .X() and .Y()
-                // can be affected by constraints of objects that the points depends on,
-                // leading to a different location on up than on drag
-                // (as dragging uses the mouse location)
-                // TODO: find an example where need this this additional complexity
-                var o = board.origin.scrCoords;
-                calculatedX.current =
-                    (pointAtDown.current[1] +
-                        e.x -
-                        pointerAtDown.current[0] -
-                        o[1]) /
-                    board.unitX;
-
-                calculatedY.current =
-                    (o[2] -
-                        (pointAtDown.current[2] +
-                            e.y -
-                            pointerAtDown.current[1])) /
-                    board.unitY;
-            } else {
-                calculatedX.current =
-                    newAnchorPointJXG.X() +
-                    newMathJXG.relativeCoords.usrCoords[1];
-                calculatedY.current =
-                    newAnchorPointJXG.Y() +
-                    newMathJXG.relativeCoords.usrCoords[2];
-            }
-
-            calculatedX.current = Math.min(
-                xmaxAdjusted,
-                Math.max(xminAdjusted, calculatedX.current),
-            );
-            calculatedY.current = Math.min(
-                ymaxAdjusted,
-                Math.max(yminAdjusted, calculatedY.current),
-            );
-
-            callAction({
-                action: actions.moveMath,
-                args: {
-                    x: calculatedX.current,
-                    y: calculatedY.current,
-                    transient: true,
-                    skippable: true,
-                },
-            });
-
-            newMathJXG.relativeCoords.setCoordinates(
-                JXG.COORDS_BY_USER,
-                [0, 0],
-            );
-            newAnchorPointJXG.coords.setCoordinates(
-                JXG.COORDS_BY_USER,
-                lastPositionFromCore.current,
-            );
-        });
-
-        newMathJXG.on("keydown", function (e) {
-            if (e.key === "Enter") {
-                if (dragged.current) {
-                    callAction({
-                        action: actions.moveMath,
-                        args: {
-                            x: calculatedX.current,
-                            y: calculatedY.current,
-                        },
-                    });
-                    dragged.current = false;
-                }
-                callAction({
-                    action: actions.mathClicked,
-                    args: { componentIdx }, // send componentIdx so get original componentIdx if adapted
-                });
-            }
+        attachAnchoredGraphDragHandlers({
+            board,
+            newJXG: newMathJXG,
+            newAnchorPoint: newAnchorPointJXG,
+            anchorRel,
+            pointerState,
+            pointAtDown,
+            calculatedX,
+            calculatedY,
+            fixed,
+            fixLocation,
+            lastPositionFromCore,
+            componentIdx,
+            actions,
+            callAction,
+            actionNames: {
+                move: "moveMath",
+                focused: "mathFocused",
+                clicked: "mathClicked",
+            },
         });
 
         mathJXG.current = newMathJXG;
@@ -389,34 +203,6 @@ export default React.memo(function MathComponent(
                 board.updateRenderer();
             }
         }, 1000);
-    }
-
-    function boardMoveHandler(e: JXGEvent) {
-        if (pointerIsDown.current && pointerAtDown.current) {
-            //Protect against very small unintended move
-            if (
-                Math.abs(e.x - pointerAtDown.current[0]) >
-                    POINTER_DRAG_THRESHOLD ||
-                Math.abs(e.y - pointerAtDown.current[1]) >
-                    POINTER_DRAG_THRESHOLD
-            ) {
-                pointerMovedSinceDown.current = true;
-            }
-        }
-    }
-
-    function deleteMathJXG() {
-        if (!mathJXG.current) {
-            return;
-        }
-        mathJXG.current.off("drag");
-        mathJXG.current.off("down");
-        mathJXG.current.off("hit");
-        mathJXG.current.off("up");
-        mathJXG.current.off("keyfocusout");
-        mathJXG.current.off("keydown");
-        board?.removeObject(mathJXG.current);
-        mathJXG.current = null;
     }
 
     if (board) {
@@ -445,24 +231,7 @@ export default React.memo(function MathComponent(
                 anchorCoords,
             );
 
-            let beginDelim, endDelim;
-            if (SVs.renderMode === "inline") {
-                beginDelim = "\\(";
-                endDelim = "\\)";
-            } else if (SVs.renderMode === "display") {
-                beginDelim = "\\[";
-                endDelim = "\\]";
-            } else if (SVs.renderMode === "numbered") {
-                beginDelim = `\\begin{gather}\\tag{${SVs.equationTag}}`;
-                endDelim = "\\end{gather}";
-            } else if (SVs.renderMode === "align") {
-                beginDelim = "\\begin{align}";
-                endDelim = "\\end{align}";
-            } else {
-                // treat as inline if have unrecognized renderMode
-                beginDelim = "\\(";
-                endDelim = "\\)";
-            }
+            const [beginDelim, endDelim] = getMathDelimiters(SVs);
 
             mathJXG.current.setText(beginDelim + SVs.latex + endDelim);
 
@@ -553,26 +322,8 @@ export default React.memo(function MathComponent(
         return null;
     }
 
-    let beginDelim, endDelim;
-    if (SVs.renderMode === "inline") {
-        beginDelim = "\\(";
-        endDelim = "\\)";
-    } else if (SVs.renderMode === "display") {
-        beginDelim = "\\[";
-        endDelim = "\\]";
-    } else if (SVs.renderMode === "numbered") {
-        beginDelim = `\\begin{gather}\\tag{${SVs.equationTag}}`;
-        endDelim = "\\end{gather}";
-    } else if (SVs.renderMode === "align") {
-        beginDelim = "\\begin{align}";
-        endDelim = "\\end{align}";
-    } else {
-        // treat as inline if have unrecognized renderMode
-        beginDelim = "\\(";
-        endDelim = "\\)";
-    }
-
-    let latexWithDelims = beginDelim + SVs.latex + endDelim;
+    const [beginDelim, endDelim] = getMathDelimiters(SVs);
+    const latexWithDelims = beginDelim + SVs.latex + endDelim;
 
     let anchors = [];
     if (SVs.mrowChildRendererIds) {

--- a/packages/doenetml/src/Viewer/renderers/number.tsx
+++ b/packages/doenetml/src/Viewer/renderers/number.tsx
@@ -189,7 +189,7 @@ export default React.memo(function NumberComponent(
         if (numberJXG.current === null) {
             createNumberJXG();
         } else {
-            numberJXG.current.relativeCoords!.setCoordinates(
+            numberJXG.current.relativeCoords.setCoordinates(
                 JXG.COORDS_BY_USER,
                 [0, 0],
             );

--- a/packages/doenetml/src/Viewer/renderers/number.tsx
+++ b/packages/doenetml/src/Viewer/renderers/number.tsx
@@ -1,20 +1,25 @@
 import { MathJax } from "better-react-mathjax";
 
-import React, { useContext, useEffect, useRef } from "react";
+import React, { useContext, useRef } from "react";
 import { BoardContext, TEXT_LAYER_OFFSET } from "./graph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 import me from "math-expressions";
 import { textRendererStyle } from "@doenet/utils";
-import {
-    getPositionFromAnchorByCoordinate,
-    POINTER_DRAG_THRESHOLD,
-} from "./utils/graph";
+import { getPositionFromAnchorByCoordinate } from "./utils/graph";
 import { DocContext } from "../DocViewer";
 import { ChoiceInputInlineContext } from "./choiceInput";
-import { JXGEvent, JXGPoint, JXGText } from "./jsxgraph-distrib/types";
+import { JXGPoint, JXGText } from "./jsxgraph-distrib/types";
 import { SelectedStyle } from "./utils/graphicalSVs";
+import { usePointerDragState } from "./utils/pointerDragState";
+import { useDraggableRefs } from "./utils/useDraggableRefs";
+import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
+import {
+    attachAnchoredGraphDragHandlers,
+    detachAnchoredGraphElement,
+} from "./utils/useAnchoredGraphDragHandler";
+import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
 
 interface NumberSVs {
     hidden: boolean;
@@ -38,51 +43,31 @@ export default React.memo(function NumberComponent(
     // @ts-ignore
     NumberComponent.ignoreActionsWithoutCore = () => true;
 
-    let numberJXG = useRef<JXGText | null>(null);
-    let anchorPointJXG = useRef<JXGPoint | null>(null);
-    let anchorRel = useRef<[string, string] | null>(null);
+    const numberJXG = useRef<JXGText | null>(null);
+    const anchorPointJXG = useRef<JXGPoint | null>(null);
+    const anchorRel = useRef<[string, string] | null>(null);
 
     const board = useContext(BoardContext);
     const choiceInputInlineContext = useContext(ChoiceInputInlineContext);
 
-    let pointerAtDown = useRef<[number, number] | null>(null);
-    let pointAtDown = useRef<number[] | null>(null);
-    let pointerIsDown = useRef<boolean>(false);
-    let pointerMovedSinceDown = useRef<boolean>(false);
-    let dragged = useRef<boolean>(false);
+    const pointerState = usePointerDragState();
+    const pointAtDown = useRef<number[] | null>(null);
+    const calculatedX = useRef<number | null>(null);
+    const calculatedY = useRef<number | null>(null);
+    const previousPositionFromAnchor = useRef<any>(null);
 
-    let calculatedX = useRef<number | null>(null);
-    let calculatedY = useRef<number | null>(null);
+    const { fixed, fixLocation, lastPositionFromCore } = useDraggableRefs<
+        number[] | null
+    >(SVs, null);
 
-    let lastPositionFromCore = useRef<number[] | null>(null);
-    let previousPositionFromAnchor = useRef<any>(null);
+    useBoardPointerTracking(board, pointerState);
 
-    let fixed = useRef<boolean>(false);
-    let fixLocation = useRef<boolean>(false);
-
-    fixed.current = SVs.fixed;
-    fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
+    useJSXGraphCleanup({
+        objectRef: numberJXG,
+        destroy: () => detachAnchoredGraphElement(numberJXG, board),
+    });
 
     const { darkMode } = useContext(DocContext) || {};
-
-    useEffect(() => {
-        //On unmount
-        return () => {
-            if (numberJXG.current !== null) {
-                deleteNumberJXG();
-            }
-
-            if (board) {
-                board.off("move", boardMoveHandler);
-            }
-        };
-    }, []);
-
-    useEffect(() => {
-        if (board) {
-            board.on("move", boardMoveHandler);
-        }
-    }, [board]);
 
     function createNumberJXG() {
         if (board === null) {
@@ -159,215 +144,32 @@ export default React.memo(function NumberComponent(
             [0, 0, SVs.text],
             jsxNumberAttributes,
         ) as JXGText;
-        newNumberJXG.isDraggable = !fixLocation.current;
 
-        newNumberJXG.on("down", function (e: JXGEvent) {
-            (document.activeElement as HTMLElement | null)?.blur();
-
-            pointerAtDown.current = [e.x, e.y];
-            pointAtDown.current = [...newAnchorPointJXG.coords.scrCoords];
-            dragged.current = false;
-            pointerIsDown.current = true;
-            pointerMovedSinceDown.current = false;
-            if (!fixed.current) {
-                callAction({
-                    action: actions.numberFocused,
-                    args: { componentIdx },
-                });
-            }
-        });
-
-        newNumberJXG.on("hit", function (e: JXGEvent) {
-            pointAtDown.current = [...newAnchorPointJXG.coords.scrCoords];
-            dragged.current = false;
-            callAction({
-                action: actions.numberFocused,
-                args: { componentIdx },
-            });
-        });
-
-        newNumberJXG.on("up", function (e: JXGEvent) {
-            if (dragged.current) {
-                callAction({
-                    action: actions.moveNumber,
-                    args: {
-                        x: calculatedX.current,
-                        y: calculatedY.current,
-                    },
-                });
-                dragged.current = false;
-            } else if (!pointerMovedSinceDown.current && !fixed.current) {
-                callAction({
-                    action: actions.numberClicked,
-                    args: { componentIdx },
-                });
-            }
-            pointerIsDown.current = false;
-        });
-
-        newNumberJXG.on("keyfocusout", function (e: JXGEvent) {
-            if (dragged.current) {
-                callAction({
-                    action: actions.moveNumber,
-                    args: {
-                        x: calculatedX.current,
-                        y: calculatedY.current,
-                    },
-                });
-                dragged.current = false;
-            }
-        });
-
-        newNumberJXG.on("drag", function (e: JXGEvent) {
-            let viaPointer = e.type === "pointermove";
-
-            //Protect against very small unintended drags
-            if (
-                !viaPointer ||
-                Math.abs(e.x - pointerAtDown.current![0]) >
-                    POINTER_DRAG_THRESHOLD ||
-                Math.abs(e.y - pointerAtDown.current![1]) >
-                    POINTER_DRAG_THRESHOLD
-            ) {
-                dragged.current = true;
-            }
-
-            let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
-            let width = newNumberJXG.size![0] / board.unitX;
-            let height = newNumberJXG.size![1] / board.unitY;
-
-            let anchorx = anchorRel.current![0];
-            let anchory = anchorRel.current![1];
-
-            let offsetx = 0;
-            if (anchorx === "middle") {
-                offsetx = -width / 2;
-            } else if (anchorx === "right") {
-                offsetx = -width;
-            }
-            let offsety = 0;
-            if (anchory === "middle") {
-                offsety = -height / 2;
-            } else if (anchory === "top") {
-                offsety = -height;
-            }
-
-            let xminAdjusted = xMin + 0.04 * (xMax - xMin) - offsetx - width;
-            let xmaxAdjusted = xMax - 0.04 * (xMax - xMin) - offsetx;
-            let yminAdjusted = yMin + 0.04 * (yMax - yMin) - offsety - height;
-            let ymaxAdjusted = yMax - 0.04 * (yMax - yMin) - offsety;
-
-            if (viaPointer) {
-                // the reason we calculate point position with this algorithm,
-                // rather than using .X() and .Y() directly
-                // is that attributes .X() and .Y() are affected by the
-                // .setCoordinates function called in update().
-                // Due to this dependence, the location of .X() and .Y()
-                // can be affected by constraints of objects that the points depends on,
-                // leading to a different location on up than on drag
-                // (as dragging uses the mouse location)
-                // TODO: find an example where need this this additional complexity
-                var o = board.origin.scrCoords;
-
-                calculatedX.current =
-                    (pointAtDown.current![1] +
-                        e.x -
-                        pointerAtDown.current![0] -
-                        o[1]) /
-                    board.unitX;
-
-                calculatedY.current =
-                    (o[2] -
-                        (pointAtDown.current![2] +
-                            e.y -
-                            pointerAtDown.current![1])) /
-                    board.unitY;
-            } else {
-                calculatedX.current =
-                    newAnchorPointJXG.X() +
-                    newNumberJXG.relativeCoords!.usrCoords[1];
-                calculatedY.current =
-                    newAnchorPointJXG.Y() +
-                    newNumberJXG.relativeCoords!.usrCoords[2];
-            }
-
-            calculatedX.current = Math.min(
-                xmaxAdjusted,
-                Math.max(xminAdjusted, calculatedX.current),
-            );
-            calculatedY.current = Math.min(
-                ymaxAdjusted,
-                Math.max(yminAdjusted, calculatedY.current),
-            );
-
-            callAction({
-                action: actions.moveNumber,
-                args: {
-                    x: calculatedX.current,
-                    y: calculatedY.current,
-                    transient: true,
-                    skippable: true,
-                },
-            });
-
-            newNumberJXG.relativeCoords!.setCoordinates(
-                JXG.COORDS_BY_USER,
-                [0, 0],
-            );
-            newAnchorPointJXG.coords.setCoordinates(
-                JXG.COORDS_BY_USER,
-                lastPositionFromCore.current,
-            );
-        });
-
-        newNumberJXG.on("keydown", function (e: JXGEvent) {
-            if (e.key === "Enter") {
-                if (dragged.current) {
-                    callAction({
-                        action: actions.moveNumber,
-                        args: {
-                            x: calculatedX.current,
-                            y: calculatedY.current,
-                        },
-                    });
-                    dragged.current = false;
-                }
-                callAction({
-                    action: actions.numberClicked,
-                    args: { componentIdx },
-                });
-            }
+        attachAnchoredGraphDragHandlers({
+            board,
+            newJXG: newNumberJXG,
+            newAnchorPoint: newAnchorPointJXG,
+            anchorRel,
+            pointerState,
+            pointAtDown,
+            calculatedX,
+            calculatedY,
+            fixed,
+            fixLocation,
+            lastPositionFromCore,
+            componentIdx,
+            actions,
+            callAction,
+            actionNames: {
+                move: "moveNumber",
+                focused: "numberFocused",
+                clicked: "numberClicked",
+            },
         });
 
         numberJXG.current = newNumberJXG;
         anchorPointJXG.current = newAnchorPointJXG;
         previousPositionFromAnchor.current = SVs.positionFromAnchor;
-    }
-
-    function boardMoveHandler(e: JXGEvent) {
-        if (pointerIsDown.current) {
-            //Protect against very small unintended move
-            if (
-                Math.abs(e.x - pointerAtDown.current![0]) >
-                    POINTER_DRAG_THRESHOLD ||
-                Math.abs(e.y - pointerAtDown.current![1]) >
-                    POINTER_DRAG_THRESHOLD
-            ) {
-                pointerMovedSinceDown.current = true;
-            }
-        }
-    }
-
-    function deleteNumberJXG() {
-        if (!numberJXG.current) return;
-        numberJXG.current.off("drag");
-        numberJXG.current.off("down");
-        numberJXG.current.off("hit");
-        numberJXG.current.off("up");
-        numberJXG.current.off("keyfocusout");
-        numberJXG.current.off("keydown");
-        board?.removeObject(numberJXG.current);
-        numberJXG.current = null;
     }
 
     if (board) {

--- a/packages/doenetml/src/Viewer/renderers/orbitalDiagramInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/orbitalDiagramInput.tsx
@@ -2,8 +2,7 @@ import React, { useRef } from "react";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
-import { Button as ButtonUntyped } from "@doenet/ui-components";
-const Button = ButtonUntyped as any;
+import { Button } from "@doenet/ui-components";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 
 interface OrbitalRowData {

--- a/packages/doenetml/src/Viewer/renderers/q.tsx
+++ b/packages/doenetml/src/Viewer/renderers/q.tsx
@@ -2,35 +2,18 @@ import React from "react";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
-import { addCommasForCompositeRanges } from "./utils/composites";
+import { MarkupSVsBase, renderMarkupBody } from "./utils/markupRenderer";
 
-interface QSVs {
+interface QSVs extends MarkupSVsBase {
     [key: string]: any;
-    hidden: boolean;
-    _compositeReplacementActiveRange?: any;
 }
 
 export default React.memo(function Q(props: UseDoenetRendererProps) {
-    let {
-        componentIdx: name,
-        id,
-        SVs,
-        children,
-    } = useDoenetRenderer<QSVs>(props);
+    const { SVs, children } = useDoenetRenderer<QSVs>(props);
 
-    if (SVs.hidden) {
+    const body = renderMarkupBody({ SVs, children });
+    if (body === null) {
         return null;
     }
-
-    if (SVs._compositeReplacementActiveRange) {
-        children = addCommasForCompositeRanges({
-            children,
-            compositeReplacementActiveRange:
-                SVs._compositeReplacementActiveRange,
-            startInd: 0,
-            endInd: children.length - 1,
-        });
-    }
-
-    return <>&ldquo;{children}&rdquo;</>;
+    return <>&ldquo;{body}&rdquo;</>;
 });

--- a/packages/doenetml/src/Viewer/renderers/sq.tsx
+++ b/packages/doenetml/src/Viewer/renderers/sq.tsx
@@ -2,30 +2,18 @@ import React from "react";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
-import { addCommasForCompositeRanges } from "./utils/composites";
+import { MarkupSVsBase, renderMarkupBody } from "./utils/markupRenderer";
 
-interface SqSVs {
+interface SqSVs extends MarkupSVsBase {
     [key: string]: any;
-    hidden: boolean;
-    _compositeReplacementActiveRange?: any;
 }
 
 export default React.memo(function Sq(props: UseDoenetRendererProps) {
-    let { id, SVs, children } = useDoenetRenderer<SqSVs>(props);
+    const { SVs, children } = useDoenetRenderer<SqSVs>(props);
 
-    if (SVs.hidden) {
+    const body = renderMarkupBody({ SVs, children });
+    if (body === null) {
         return null;
     }
-
-    if (SVs._compositeReplacementActiveRange) {
-        children = addCommasForCompositeRanges({
-            children,
-            compositeReplacementActiveRange:
-                SVs._compositeReplacementActiveRange,
-            startInd: 0,
-            endInd: children.length - 1,
-        });
-    }
-
-    return <>&lsquo;{children}&rsquo;</>;
+    return <>&lsquo;{body}&rsquo;</>;
 });

--- a/packages/doenetml/src/Viewer/renderers/subsetOfRealsInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/subsetOfRealsInput.tsx
@@ -4,13 +4,10 @@ import useDoenetRenderer, {
 } from "../useDoenetRenderer";
 import { ActionButton } from "@doenet/ui-components";
 import { ActionButtonGroup } from "@doenet/ui-components";
-import { ToggleButton as ToggleButtonUntyped } from "@doenet/ui-components";
-import { ToggleButtonGroup as ToggleButtonGroupUntyped } from "@doenet/ui-components";
+import { ToggleButton } from "@doenet/ui-components";
+import { ToggleButtonGroup } from "@doenet/ui-components";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 import "./subsetOfRealsInput.css";
-
-const ToggleButton = ToggleButtonUntyped as any;
-const ToggleButtonGroup = ToggleButtonGroupUntyped as any;
 
 interface PointDisplayed {
     value: number;

--- a/packages/doenetml/src/Viewer/renderers/text.tsx
+++ b/packages/doenetml/src/Viewer/renderers/text.tsx
@@ -185,7 +185,7 @@ export default React.memo(function Text(props: UseDoenetRendererProps) {
         if (textJXG.current === null) {
             createTextJXG();
         } else {
-            textJXG.current.relativeCoords!.setCoordinates(
+            textJXG.current.relativeCoords.setCoordinates(
                 JXG.COORDS_BY_USER,
                 [0, 0],
             );

--- a/packages/doenetml/src/Viewer/renderers/text.tsx
+++ b/packages/doenetml/src/Viewer/renderers/text.tsx
@@ -1,18 +1,23 @@
-import React, { useContext, useEffect, useRef } from "react";
+import React, { useContext, useRef } from "react";
 import { BoardContext, TEXT_LAYER_OFFSET } from "./graph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";
 import me from "math-expressions";
 import { textRendererStyle } from "@doenet/utils";
-import {
-    getPositionFromAnchorByCoordinate,
-    POINTER_DRAG_THRESHOLD,
-} from "./utils/graph";
+import { getPositionFromAnchorByCoordinate } from "./utils/graph";
 import { DocContext } from "../DocViewer";
 import { ChoiceInputInlineContext } from "./choiceInput";
-import { JXGEvent, JXGPoint, JXGText } from "./jsxgraph-distrib/types";
+import { JXGPoint, JXGText } from "./jsxgraph-distrib/types";
 import { SelectedStyle } from "./utils/graphicalSVs";
+import { usePointerDragState } from "./utils/pointerDragState";
+import { useDraggableRefs } from "./utils/useDraggableRefs";
+import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
+import {
+    attachAnchoredGraphDragHandlers,
+    detachAnchoredGraphElement,
+} from "./utils/useAnchoredGraphDragHandler";
+import { useJSXGraphCleanup } from "./utils/useJSXGraphCleanup";
 
 interface TextSVs {
     hidden: boolean;
@@ -33,51 +38,31 @@ export default React.memo(function Text(props: UseDoenetRendererProps) {
     // @ts-ignore
     Text.ignoreActionsWithoutCore = () => true;
 
-    let textJXG = useRef<JXGText | null>(null);
-    let anchorPointJXG = useRef<JXGPoint | null>(null);
-    let anchorRel = useRef<[string, string] | null>(null);
+    const textJXG = useRef<JXGText | null>(null);
+    const anchorPointJXG = useRef<JXGPoint | null>(null);
+    const anchorRel = useRef<[string, string] | null>(null);
 
     const board = useContext(BoardContext);
     const choiceInputInlineContext = useContext(ChoiceInputInlineContext);
 
-    let pointerAtDown = useRef<[number, number] | null>(null);
-    let pointAtDown = useRef<number[] | null>(null);
-    let pointerIsDown = useRef<boolean>(false);
-    let pointerMovedSinceDown = useRef<boolean>(false);
-    let dragged = useRef<boolean>(false);
+    const pointerState = usePointerDragState();
+    const pointAtDown = useRef<number[] | null>(null);
+    const calculatedX = useRef<number | null>(null);
+    const calculatedY = useRef<number | null>(null);
+    const previousPositionFromAnchor = useRef<any>(null);
 
-    let calculatedX = useRef<number | null>(null);
-    let calculatedY = useRef<number | null>(null);
+    const { fixed, fixLocation, lastPositionFromCore } = useDraggableRefs<
+        number[] | null
+    >(SVs, null);
 
-    let lastPositionFromCore = useRef<number[] | null>(null);
-    let previousPositionFromAnchor = useRef<any>(null);
+    useBoardPointerTracking(board, pointerState);
 
-    let fixed = useRef<boolean>(false);
-    let fixLocation = useRef<boolean>(false);
-
-    fixed.current = SVs.fixed;
-    fixLocation.current = !SVs.draggable || SVs.fixLocation || SVs.fixed;
+    useJSXGraphCleanup({
+        objectRef: textJXG,
+        destroy: () => detachAnchoredGraphElement(textJXG, board),
+    });
 
     const { darkMode } = useContext(DocContext) || {};
-
-    useEffect(() => {
-        //On unmount
-        return () => {
-            if (textJXG.current !== null) {
-                deleteTextJXG();
-            }
-
-            if (board) {
-                board.off("move", boardMoveHandler);
-            }
-        };
-    }, []);
-
-    useEffect(() => {
-        if (board) {
-            board.on("move", boardMoveHandler);
-        }
-    }, [board]);
 
     function createTextJXG() {
         if (board === null) {
@@ -155,215 +140,32 @@ export default React.memo(function Text(props: UseDoenetRendererProps) {
             [0, 0, SVs.text],
             jsxTextAttributes,
         ) as JXGText;
-        newTextJXG.isDraggable = !fixLocation.current;
 
-        newTextJXG.on("down", function (e: JXGEvent) {
-            (document.activeElement as HTMLElement | null)?.blur();
-
-            pointerAtDown.current = [e.x, e.y];
-            pointAtDown.current = [...newAnchorPointJXG.coords.scrCoords];
-            dragged.current = false;
-            pointerIsDown.current = true;
-            pointerMovedSinceDown.current = false;
-            if (!fixed.current) {
-                callAction({
-                    action: actions.textFocused,
-                    args: { componentIdx },
-                });
-            }
-        });
-
-        newTextJXG.on("hit", function (e: JXGEvent) {
-            pointAtDown.current = [...newAnchorPointJXG.coords.scrCoords];
-            dragged.current = false;
-            callAction({
-                action: actions.textFocused,
-                args: { componentIdx },
-            });
-        });
-
-        newTextJXG.on("up", function (e: JXGEvent) {
-            if (dragged.current) {
-                callAction({
-                    action: actions.moveText,
-                    args: {
-                        x: calculatedX.current,
-                        y: calculatedY.current,
-                    },
-                });
-                dragged.current = false;
-            } else if (!pointerMovedSinceDown.current && !fixed.current) {
-                callAction({
-                    action: actions.textClicked,
-                    args: { componentIdx },
-                });
-            }
-            pointerIsDown.current = false;
-        });
-
-        newTextJXG.on("keyfocusout", function (e: JXGEvent) {
-            if (dragged.current) {
-                callAction({
-                    action: actions.moveText,
-                    args: {
-                        x: calculatedX.current,
-                        y: calculatedY.current,
-                    },
-                });
-                dragged.current = false;
-            }
-        });
-
-        newTextJXG.on("drag", function (e: JXGEvent) {
-            let viaPointer = e.type === "pointermove";
-
-            //Protect against very small unintended drags
-            if (
-                !viaPointer ||
-                Math.abs(e.x - pointerAtDown.current![0]) >
-                    POINTER_DRAG_THRESHOLD ||
-                Math.abs(e.y - pointerAtDown.current![1]) >
-                    POINTER_DRAG_THRESHOLD
-            ) {
-                dragged.current = true;
-            }
-
-            let [xMin, yMax, xMax, yMin] = board.getBoundingBox();
-            let width = newTextJXG.size![0] / board.unitX;
-            let height = newTextJXG.size![1] / board.unitY;
-
-            let anchorx = anchorRel.current![0];
-            let anchory = anchorRel.current![1];
-
-            let offsetx = 0;
-            if (anchorx === "middle") {
-                offsetx = -width / 2;
-            } else if (anchorx === "right") {
-                offsetx = -width;
-            }
-            let offsety = 0;
-            if (anchory === "middle") {
-                offsety = -height / 2;
-            } else if (anchory === "top") {
-                offsety = -height;
-            }
-
-            let xminAdjusted = xMin + 0.04 * (xMax - xMin) - offsetx - width;
-            let xmaxAdjusted = xMax - 0.04 * (xMax - xMin) - offsetx;
-            let yminAdjusted = yMin + 0.04 * (yMax - yMin) - offsety - height;
-            let ymaxAdjusted = yMax - 0.04 * (yMax - yMin) - offsety;
-
-            if (viaPointer) {
-                // the reason we calculate point position with this algorithm,
-                // rather than using .X() and .Y() directly
-                // is that attributes .X() and .Y() are affected by the
-                // .setCoordinates function called in update().
-                // Due to this dependence, the location of .X() and .Y()
-                // can be affected by constraints of objects that the points depends on,
-                // leading to a different location on up than on drag
-                // (as dragging uses the mouse location)
-                // TODO: find an example where need this this additional complexity
-                var o = board.origin.scrCoords;
-
-                calculatedX.current =
-                    (pointAtDown.current![1] +
-                        e.x -
-                        pointerAtDown.current![0] -
-                        o[1]) /
-                    board.unitX;
-
-                calculatedY.current =
-                    (o[2] -
-                        (pointAtDown.current![2] +
-                            e.y -
-                            pointerAtDown.current![1])) /
-                    board.unitY;
-            } else {
-                calculatedX.current =
-                    newAnchorPointJXG.X() +
-                    newTextJXG.relativeCoords!.usrCoords[1];
-                calculatedY.current =
-                    newAnchorPointJXG.Y() +
-                    newTextJXG.relativeCoords!.usrCoords[2];
-            }
-
-            calculatedX.current = Math.min(
-                xmaxAdjusted,
-                Math.max(xminAdjusted, calculatedX.current),
-            );
-            calculatedY.current = Math.min(
-                ymaxAdjusted,
-                Math.max(yminAdjusted, calculatedY.current),
-            );
-
-            callAction({
-                action: actions.moveText,
-                args: {
-                    x: calculatedX.current,
-                    y: calculatedY.current,
-                    transient: true,
-                    skippable: true,
-                },
-            });
-
-            newTextJXG.relativeCoords!.setCoordinates(
-                JXG.COORDS_BY_USER,
-                [0, 0],
-            );
-            newAnchorPointJXG.coords.setCoordinates(
-                JXG.COORDS_BY_USER,
-                lastPositionFromCore.current,
-            );
-        });
-
-        newTextJXG.on("keydown", function (e: JXGEvent) {
-            if (e.key === "Enter") {
-                if (dragged.current) {
-                    callAction({
-                        action: actions.moveText,
-                        args: {
-                            x: calculatedX.current,
-                            y: calculatedY.current,
-                        },
-                    });
-                    dragged.current = false;
-                }
-                callAction({
-                    action: actions.textClicked,
-                    args: { componentIdx },
-                });
-            }
+        attachAnchoredGraphDragHandlers({
+            board,
+            newJXG: newTextJXG,
+            newAnchorPoint: newAnchorPointJXG,
+            anchorRel,
+            pointerState,
+            pointAtDown,
+            calculatedX,
+            calculatedY,
+            fixed,
+            fixLocation,
+            lastPositionFromCore,
+            componentIdx,
+            actions,
+            callAction,
+            actionNames: {
+                move: "moveText",
+                focused: "textFocused",
+                clicked: "textClicked",
+            },
         });
 
         textJXG.current = newTextJXG;
         anchorPointJXG.current = newAnchorPointJXG;
         previousPositionFromAnchor.current = SVs.positionFromAnchor;
-    }
-
-    function boardMoveHandler(e: JXGEvent) {
-        if (pointerIsDown.current) {
-            //Protect against very small unintended move
-            if (
-                Math.abs(e.x - pointerAtDown.current![0]) >
-                    POINTER_DRAG_THRESHOLD ||
-                Math.abs(e.y - pointerAtDown.current![1]) >
-                    POINTER_DRAG_THRESHOLD
-            ) {
-                pointerMovedSinceDown.current = true;
-            }
-        }
-    }
-
-    function deleteTextJXG() {
-        if (!textJXG.current) return;
-        textJXG.current.off("drag");
-        textJXG.current.off("down");
-        textJXG.current.off("hit");
-        textJXG.current.off("up");
-        textJXG.current.off("keyfocusout");
-        textJXG.current.off("keydown");
-        board?.removeObject(textJXG.current);
-        textJXG.current = null;
     }
 
     if (board) {

--- a/packages/doenetml/src/Viewer/renderers/utils/NonInlineMediaWrapper.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/NonInlineMediaWrapper.tsx
@@ -1,0 +1,89 @@
+import React, { type CSSProperties, type Ref } from "react";
+
+interface MediaLayoutStyles {
+    outerStyle: CSSProperties;
+    innerStyle: CSSProperties;
+    mediaContainerStyle: CSSProperties;
+    mediaColumnStyle: CSSProperties;
+}
+
+interface NonInlineMediaWrapperProps {
+    id: string;
+    /** "inline" preserves inline layout; any other value uses non-inline. */
+    displayMode: string;
+    /**
+     * When true, suppress the outer container's top margin. Used when the
+     * renderer is the first child of a list-item container so list-item
+     * numbering top-aligns with the media.
+     */
+    suppressTopMargin: boolean;
+    /**
+     * Pre-built style bundle. Inline-mode renderers build a small two-style
+     * pair manually; non-inline-mode renderers source it from
+     * `getNonInlineMediaLayoutStyles()`. The unused fields can be empty.
+     */
+    layoutStyles: MediaLayoutStyles;
+    /** The actual media element (e.g. <img>, <video>, <iframe>). */
+    media: React.ReactNode;
+    /** Description content (already wrapped in popover/details by the caller). */
+    description: React.ReactNode | null;
+    containerRef?: Ref<HTMLDivElement>;
+    /**
+     * Extra attributes for the outer container <div>. Use this for
+     * renderer-specific outer-div decorations (e.g. `tabIndex`, `className`).
+     * `id`, `ref`, and `style` are managed by the wrapper.
+     */
+    containerAttrs?: React.HTMLAttributes<HTMLDivElement>;
+}
+
+/**
+ * Shared layout wrapper for the image and video renderers' off-graph
+ * fallback path. Handles the outer/inner container nesting and the
+ * inline-vs-non-inline conditional that interleaves the media element with
+ * its description.
+ *
+ * Pre-extraction, the same nested-div block was duplicated between
+ * `image.tsx` and `video.tsx` — only the outer-div decorations
+ * (`tabIndex`, `className`) and the media-element type differed.
+ */
+export function NonInlineMediaWrapper({
+    id,
+    displayMode,
+    suppressTopMargin,
+    layoutStyles,
+    media,
+    description,
+    containerRef,
+    containerAttrs,
+}: NonInlineMediaWrapperProps) {
+    const { outerStyle, innerStyle, mediaContainerStyle, mediaColumnStyle } =
+        layoutStyles;
+    const containerStyle = suppressTopMargin
+        ? { ...outerStyle, marginTop: 0 }
+        : outerStyle;
+    const isInline = displayMode === "inline";
+
+    return (
+        <div
+            {...containerAttrs}
+            id={`${id}-container`}
+            ref={containerRef}
+            style={containerStyle}
+        >
+            <div style={innerStyle}>
+                {isInline ? (
+                    media
+                ) : (
+                    <div style={mediaContainerStyle}>{media}</div>
+                )}
+                {isInline || !description ? (
+                    description
+                ) : (
+                    <div style={mediaContainerStyle}>
+                        <div style={mediaColumnStyle}>{description}</div>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/packages/doenetml/src/Viewer/renderers/utils/jsxgraph.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/jsxgraph.ts
@@ -3,7 +3,7 @@ import { cesc } from "@doenet/utils";
 import type { RefObject } from "react";
 import { JXGBoard, JXGElement } from "../jsxgraph-distrib/types";
 
-type AxisJXG = JXGElement & {
+export type AxisJXG = JXGElement & {
     defaultTicks: {
         getDistanceMajorTicks: () => number;
         visProp: Record<string, any>;
@@ -13,7 +13,7 @@ type AxisJXG = JXGElement & {
     getLabelAnchor?: () => { scrCoords?: number[] };
 };
 
-type AxisRef = RefObject<AxisJXG | null | undefined>;
+export type AxisRef = RefObject<AxisJXG | null | undefined>;
 
 /**
  * Minimal structural shape for the line-like objects these helpers touch.
@@ -53,7 +53,7 @@ export function applyAxisTickHeights({
     displayXAxisTicks = true,
     displayYAxisTicks = true,
 }: {
-    grid: string;
+    grid: unknown;
     xaxisRef: AxisRef;
     yaxisRef: AxisRef;
     displayXAxisTicks?: boolean;

--- a/packages/doenetml/src/Viewer/renderers/utils/markupRenderer.tsx
+++ b/packages/doenetml/src/Viewer/renderers/utils/markupRenderer.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { addCommasForCompositeRanges } from "./composites";
+
+/**
+ * Minimum SV shape consumed by `renderMarkupBody`. Markup-style renderers
+ * (em, c, q, sq, blockQuote, …) carry these two fields plus their own
+ * wrapper-specific fields; this base captures the common pair.
+ */
+export interface MarkupSVsBase {
+    hidden: boolean;
+    _compositeReplacementActiveRange?: any;
+}
+
+/**
+ * Compute the body for a simple markup renderer that wraps its children in
+ * a single element and conditionally interleaves composite-range commas.
+ *
+ * Returns `null` when the renderer should render nothing (`hidden`), or the
+ * (possibly transformed) children otherwise. The caller decides which
+ * wrapper element (e.g. `<em>`, `<code>`, `<blockquote>`) to drop the body
+ * into.
+ */
+export function renderMarkupBody({
+    SVs,
+    children,
+}: {
+    SVs: MarkupSVsBase;
+    children: React.ReactNode[];
+}): React.ReactNode[] | null {
+    if (SVs.hidden) {
+        return null;
+    }
+
+    if (SVs._compositeReplacementActiveRange) {
+        return addCommasForCompositeRanges({
+            children,
+            compositeReplacementActiveRange:
+                SVs._compositeReplacementActiveRange,
+            startInd: 0,
+            endInd: children.length - 1,
+        });
+    }
+
+    return children;
+}

--- a/packages/doenetml/src/Viewer/renderers/utils/useAnchoredGraphDragHandler.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useAnchoredGraphDragHandler.ts
@@ -1,5 +1,4 @@
 import type { RefObject } from "react";
-// @ts-ignore
 import JXG from "jsxgraph";
 import {
     JXGBoard,

--- a/packages/doenetml/src/Viewer/renderers/utils/useAnchoredGraphDragHandler.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useAnchoredGraphDragHandler.ts
@@ -1,0 +1,272 @@
+import type { RefObject } from "react";
+import {
+    JXGBoard,
+    JXGEvent,
+    JXGObject,
+    JXGPoint,
+    JXGText,
+} from "../jsxgraph-distrib/types";
+import type { CallActionArgs, RendererAction } from "../../useDoenetRenderer";
+import { exceededDragThreshold } from "./dragThreshold";
+import { pointerEventToUserCoords } from "./pointerToBoardCoords";
+import type { PointerDragState } from "./pointerDragState";
+import { LINE_FAMILY_EVENTS, removeJXGEventHandlers } from "./jsxgraph";
+
+/**
+ * Action names dispatched by the anchored-graph drag controller. Each
+ * renderer that anchors a JSXgraph text/math element to a draggable point
+ * (number, text, label, math) has its own triple following the same
+ * naming pattern: `move<Kind>`, `<kind>Focused`, `<kind>Clicked`.
+ */
+export interface AnchoredGraphActionNames {
+    move: string;
+    focused: string;
+    clicked: string;
+}
+
+interface AttachAnchoredGraphDragHandlersParams<
+    TJXG extends JXGText | JXGObject,
+> {
+    board: JXGBoard;
+    /** The JSXgraph text/math element receiving the handlers. */
+    newJXG: TJXG;
+    /** The hidden anchor point the element is anchored to. */
+    newAnchorPoint: JXGPoint | JXGObject;
+    /** Mutable ref tracking the resolved [anchorx, anchory] pair. */
+    anchorRel: RefObject<[string, string] | null>;
+    /** Pointer state shared with `useBoardPointerTracking`. */
+    pointerState: PointerDragState;
+    /**
+     * Mutable ref where the anchor point's screen coordinates at pointerdown
+     * are stashed; the drag handler reads it to compute the pointer delta.
+     */
+    pointAtDown: RefObject<number[] | null>;
+    /** Output coordinates the drag handler writes; up/keydown read them. */
+    calculatedX: RefObject<number | null>;
+    calculatedY: RefObject<number | null>;
+    /** Mirror of `SVs.fixed`, kept in a ref to avoid stale closures. */
+    fixed: RefObject<boolean>;
+    /** Mirror of `!SVs.draggable || SVs.fixLocation || SVs.fixed`. */
+    fixLocation: RefObject<boolean>;
+    /** Latest authoritative coordinates from core; drag resets to this. */
+    lastPositionFromCore: RefObject<number[] | null>;
+    componentIdx: number;
+    actions: Record<string, RendererAction>;
+    callAction: (argObj: CallActionArgs) => void;
+    actionNames: AnchoredGraphActionNames;
+}
+
+/**
+ * Bind the standard "anchored graph element" drag handlers on a freshly
+ * created JSXgraph text/math element. Encapsulates the down → drag → up
+ * lifecycle plus keyboard analogues (keyfocusout, keydown Enter) shared
+ * across `number`, `text`, `label`, and `math` renderers.
+ *
+ * The renderer remains responsible for creating the JXG element and the
+ * hidden anchor point, calling `usePointerDragState`, `useDraggableRefs`,
+ * and `useBoardPointerTracking` at the top level, and providing refs the
+ * handlers read/write (`anchorRel`, `pointAtDown`, `calculatedX`,
+ * `calculatedY`).
+ */
+export function attachAnchoredGraphDragHandlers<
+    TJXG extends JXGText | JXGObject,
+>({
+    board,
+    newJXG,
+    newAnchorPoint,
+    anchorRel,
+    pointerState,
+    pointAtDown,
+    calculatedX,
+    calculatedY,
+    fixed,
+    fixLocation,
+    lastPositionFromCore,
+    componentIdx,
+    actions,
+    callAction,
+    actionNames,
+}: AttachAnchoredGraphDragHandlersParams<TJXG>): void {
+    newJXG.isDraggable = !fixLocation.current;
+
+    newJXG.on("down", function (e: JXGEvent) {
+        (document.activeElement as HTMLElement | null)?.blur();
+
+        pointerState.pointerAtDown.current = [e.x, e.y];
+        pointAtDown.current = [...newAnchorPoint.coords.scrCoords];
+        pointerState.dragged.current = false;
+        pointerState.pointerIsDown.current = true;
+        pointerState.pointerMovedSinceDown.current = false;
+        if (!fixed.current) {
+            callAction({
+                action: actions[actionNames.focused],
+                args: { componentIdx },
+            });
+        }
+    });
+
+    newJXG.on("hit", function () {
+        pointAtDown.current = [...newAnchorPoint.coords.scrCoords];
+        pointerState.dragged.current = false;
+        callAction({
+            action: actions[actionNames.focused],
+            args: { componentIdx },
+        });
+    });
+
+    newJXG.on("up", function () {
+        if (pointerState.dragged.current) {
+            callAction({
+                action: actions[actionNames.move],
+                args: {
+                    x: calculatedX.current,
+                    y: calculatedY.current,
+                },
+            });
+            pointerState.dragged.current = false;
+        } else if (
+            !pointerState.pointerMovedSinceDown.current &&
+            !fixed.current
+        ) {
+            callAction({
+                action: actions[actionNames.clicked],
+                args: { componentIdx },
+            });
+        }
+        pointerState.pointerIsDown.current = false;
+    });
+
+    newJXG.on("keyfocusout", function () {
+        if (pointerState.dragged.current) {
+            callAction({
+                action: actions[actionNames.move],
+                args: {
+                    x: calculatedX.current,
+                    y: calculatedY.current,
+                },
+            });
+            pointerState.dragged.current = false;
+        }
+    });
+
+    newJXG.on("drag", function (e: JXGEvent) {
+        const viaPointer = e.type === "pointermove";
+        const pointerAtDown = pointerState.pointerAtDown.current;
+
+        if (exceededDragThreshold(e, pointerAtDown)) {
+            pointerState.dragged.current = true;
+        }
+
+        const [xMin, yMax, xMax, yMin] = board.getBoundingBox();
+        const width = newJXG.size![0] / board.unitX;
+        const height = newJXG.size![1] / board.unitY;
+
+        const anchorx = anchorRel.current?.[0];
+        const anchory = anchorRel.current?.[1];
+
+        let offsetx = 0;
+        if (anchorx === "middle") {
+            offsetx = -width / 2;
+        } else if (anchorx === "right") {
+            offsetx = -width;
+        }
+        let offsety = 0;
+        if (anchory === "middle") {
+            offsety = -height / 2;
+        } else if (anchory === "top") {
+            offsety = -height;
+        }
+
+        const xminAdjusted = xMin + 0.04 * (xMax - xMin) - offsetx - width;
+        const xmaxAdjusted = xMax - 0.04 * (xMax - xMin) - offsetx;
+        const yminAdjusted = yMin + 0.04 * (yMax - yMin) - offsety - height;
+        const ymaxAdjusted = yMax - 0.04 * (yMax - yMin) - offsety;
+
+        const pointAtDownCoords = pointAtDown.current;
+        if (viaPointer && pointerAtDown && pointAtDownCoords) {
+            // We compute position from the pointer delta rather than
+            // reading newJXG.X()/Y() directly because those getters can be
+            // affected by setCoordinates calls during update(), causing
+            // attractor-driven snaps to leave the dragged location out of
+            // sync with the cursor.
+            const [x, y] = pointerEventToUserCoords(
+                e,
+                pointerAtDown,
+                [
+                    pointAtDownCoords[0],
+                    pointAtDownCoords[1],
+                    pointAtDownCoords[2],
+                ],
+                board,
+            );
+            calculatedX.current = x;
+            calculatedY.current = y;
+        } else {
+            calculatedX.current =
+                newAnchorPoint.X() + newJXG.relativeCoords!.usrCoords[1];
+            calculatedY.current =
+                newAnchorPoint.Y() + newJXG.relativeCoords!.usrCoords[2];
+        }
+
+        calculatedX.current = Math.min(
+            xmaxAdjusted,
+            Math.max(xminAdjusted, calculatedX.current),
+        );
+        calculatedY.current = Math.min(
+            ymaxAdjusted,
+            Math.max(yminAdjusted, calculatedY.current),
+        );
+
+        callAction({
+            action: actions[actionNames.move],
+            args: {
+                x: calculatedX.current,
+                y: calculatedY.current,
+                transient: true,
+                skippable: true,
+            },
+        });
+
+        newJXG.relativeCoords!.setCoordinates(JXG.COORDS_BY_USER, [0, 0]);
+        newAnchorPoint.coords.setCoordinates(
+            JXG.COORDS_BY_USER,
+            lastPositionFromCore.current,
+        );
+    });
+
+    newJXG.on("keydown", function (e: JXGEvent) {
+        if (e.key === "Enter") {
+            if (pointerState.dragged.current) {
+                callAction({
+                    action: actions[actionNames.move],
+                    args: {
+                        x: calculatedX.current,
+                        y: calculatedY.current,
+                    },
+                });
+                pointerState.dragged.current = false;
+            }
+            callAction({
+                action: actions[actionNames.clicked],
+                args: { componentIdx },
+            });
+        }
+    });
+}
+
+/**
+ * Tear down a JSXgraph text/math element previously wired up by
+ * `attachAnchoredGraphDragHandlers`. Detaches the standard event handlers
+ * and removes the element from the board.
+ */
+export function detachAnchoredGraphElement<TJXG extends JXGText | JXGObject>(
+    jxgRef: RefObject<TJXG | null>,
+    board: JXGBoard | null,
+): void {
+    if (!jxgRef.current) {
+        return;
+    }
+    removeJXGEventHandlers(jxgRef.current, LINE_FAMILY_EVENTS);
+    board?.removeObject(jxgRef.current);
+    jxgRef.current = null;
+}

--- a/packages/doenetml/src/Viewer/renderers/utils/useAnchoredGraphDragHandler.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useAnchoredGraphDragHandler.ts
@@ -158,8 +158,8 @@ export function attachAnchoredGraphDragHandlers<
         }
 
         const [xMin, yMax, xMax, yMin] = board.getBoundingBox();
-        const width = newJXG.size![0] / board.unitX;
-        const height = newJXG.size![1] / board.unitY;
+        const width = newJXG.size[0] / board.unitX;
+        const height = newJXG.size[1] / board.unitY;
 
         const anchorx = anchorRel.current?.[0];
         const anchory = anchorRel.current?.[1];
@@ -203,9 +203,9 @@ export function attachAnchoredGraphDragHandlers<
             calculatedY.current = y;
         } else {
             calculatedX.current =
-                newAnchorPoint.X() + newJXG.relativeCoords!.usrCoords[1];
+                newAnchorPoint.X() + newJXG.relativeCoords.usrCoords[1];
             calculatedY.current =
-                newAnchorPoint.Y() + newJXG.relativeCoords!.usrCoords[2];
+                newAnchorPoint.Y() + newJXG.relativeCoords.usrCoords[2];
         }
 
         calculatedX.current = Math.min(
@@ -227,7 +227,7 @@ export function attachAnchoredGraphDragHandlers<
             },
         });
 
-        newJXG.relativeCoords!.setCoordinates(JXG.COORDS_BY_USER, [0, 0]);
+        newJXG.relativeCoords.setCoordinates(JXG.COORDS_BY_USER, [0, 0]);
         newAnchorPoint.coords.setCoordinates(
             JXG.COORDS_BY_USER,
             lastPositionFromCore.current,

--- a/packages/doenetml/src/Viewer/renderers/utils/useAnchoredGraphDragHandler.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useAnchoredGraphDragHandler.ts
@@ -1,4 +1,6 @@
 import type { RefObject } from "react";
+// @ts-ignore
+import JXG from "jsxgraph";
 import {
     JXGBoard,
     JXGEvent,

--- a/packages/doenetml/src/Viewer/renderers/utils/useDraggableRefs.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useDraggableRefs.ts
@@ -1,5 +1,15 @@
 import { useRef, type RefObject } from "react";
-import type { DraggableGraphicalSVs } from "./graphicalSVs";
+
+/**
+ * Minimum SV shape `useDraggableRefs` reads. Matches the relevant fields on
+ * `DraggableGraphicalSVs` (and other renderer SVs interfaces that carry the
+ * same triple without extending it).
+ */
+type DraggableRefsSVs = {
+    fixed: boolean;
+    fixLocation: boolean;
+    draggable: boolean;
+};
 
 /**
  * Bookkeeping refs that every draggable JSXgraph renderer needs.
@@ -17,7 +27,7 @@ import type { DraggableGraphicalSVs } from "./graphicalSVs";
  * hook only owns the universal triple.
  */
 export function useDraggableRefs<TPos>(
-    SVs: DraggableGraphicalSVs,
+    SVs: DraggableRefsSVs,
     position: TPos,
 ): {
     lastPositionFromCore: RefObject<TPos>;

--- a/packages/doenetml/src/Viewer/renderers/utils/useGridAndAxesSync.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useGridAndAxesSync.ts
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import { useEffect } from "react";
+import { useEffect, type RefObject } from "react";
 // @ts-ignore
 import JXG from "jsxgraph";
 import {
@@ -7,7 +6,20 @@ import {
     createXAxis,
     createYAxis,
     setMinorTicks,
+    type AxisJXG,
 } from "./jsxgraph";
+import type { JXGBoard } from "../jsxgraph-distrib/types";
+import type { GraphSVs } from "../graph";
+
+interface UseGridAndAxesSyncParams {
+    enabled: boolean;
+    board: JXGBoard | null;
+    SVs: GraphSVs;
+    xaxisRef: RefObject<AxisJXG | null | undefined>;
+    yaxisRef: RefObject<AxisJXG | null | undefined>;
+    previousXaxisWithLabelRef: RefObject<boolean>;
+    previousYaxisWithLabelRef: RefObject<boolean>;
+}
 
 export default function useGridAndAxesSync({
     enabled,
@@ -17,7 +29,7 @@ export default function useGridAndAxesSync({
     yaxisRef,
     previousXaxisWithLabelRef,
     previousYaxisWithLabelRef,
-}) {
+}: UseGridAndAxesSyncParams) {
     useEffect(() => {
         if (!enabled || !board) {
             return;
@@ -89,7 +101,7 @@ export default function useGridAndAxesSync({
                     drawLabels: SVs.displayXAxisTickLabels,
                 });
                 setMinorTicks(xaxisRef.current);
-                if (xaxisRef.current.hasLabel) {
+                if (xaxisRef.current.hasLabel && xaxisRef.current.label) {
                     let position = "rt";
                     let offset = [5, 10];
                     let anchorx = "right";
@@ -133,7 +145,7 @@ export default function useGridAndAxesSync({
                     drawLabels: SVs.displayYAxisTickLabels,
                 });
                 setMinorTicks(yaxisRef.current);
-                if (yaxisRef.current.hasLabel) {
+                if (yaxisRef.current.hasLabel && yaxisRef.current.label) {
                     let position = "rt";
                     let offset = [-10, -5];
                     let anchorx = "right";

--- a/packages/doenetml/src/Viewer/renderers/utils/useGridAndAxesSync.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useGridAndAxesSync.ts
@@ -101,6 +101,9 @@ export default function useGridAndAxesSync({
                     drawLabels: SVs.displayXAxisTickLabels,
                 });
                 setMinorTicks(xaxisRef.current);
+                // Invariant: JSXgraph keeps `hasLabel` and `label` in lockstep,
+                // so the second clause only narrows the type — it never gates
+                // out a state that should be reachable.
                 if (xaxisRef.current.hasLabel && xaxisRef.current.label) {
                     let position = "rt";
                     let offset = [5, 10];
@@ -145,6 +148,7 @@ export default function useGridAndAxesSync({
                     drawLabels: SVs.displayYAxisTickLabels,
                 });
                 setMinorTicks(yaxisRef.current);
+                // Invariant: see x-axis above — `hasLabel` ⇒ `label` defined.
                 if (yaxisRef.current.hasLabel && yaxisRef.current.label) {
                     let position = "rt";
                     let offset = [-10, -5];

--- a/packages/doenetml/src/Viewer/renderers/utils/useJSXGraphBoardSync.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useJSXGraphBoardSync.ts
@@ -1,7 +1,32 @@
-// @ts-nocheck
-import { useEffect } from "react";
+import { useEffect, type CSSProperties, type RefObject } from "react";
 import useGridAndAxesSync from "./useGridAndAxesSync";
 import useViewportAndNavigationSync from "./useViewportAndNavigationSync";
+import type { AxisJXG } from "./jsxgraph";
+import type { JXGBoard } from "../jsxgraph-distrib/types";
+import type { GraphSVs } from "../graph";
+
+interface PreviousDimensions {
+    width: number;
+    aspectRatio: string | number;
+}
+
+interface UseJSXGraphBoardSyncParams {
+    board: JXGBoard | null;
+    id: string;
+    SVs: GraphSVs;
+    ignoreUpdate: boolean;
+    showNavigation: boolean;
+    surfaceStyle: CSSProperties;
+    previousDimensionsRef: RefObject<PreviousDimensions>;
+    previousBoundingboxRef: RefObject<number[]>;
+    xaxisRef: RefObject<AxisJXG | null | undefined>;
+    yaxisRef: RefObject<AxisJXG | null | undefined>;
+    settingBoundingBoxRef: RefObject<boolean>;
+    boardJustInitializedRef: RefObject<boolean>;
+    previousShowNavigationRef: RefObject<boolean>;
+    previousXaxisWithLabelRef: RefObject<boolean>;
+    previousYaxisWithLabelRef: RefObject<boolean>;
+}
 
 export default function useJSXGraphBoardSync({
     board,
@@ -19,7 +44,7 @@ export default function useJSXGraphBoardSync({
     previousShowNavigationRef,
     previousXaxisWithLabelRef,
     previousYaxisWithLabelRef,
-}) {
+}: UseJSXGraphBoardSyncParams) {
     const enabled = Boolean(board) && !boardJustInitializedRef.current;
 
     useGridAndAxesSync({

--- a/packages/doenetml/src/Viewer/renderers/utils/useViewportAndNavigationSync.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useViewportAndNavigationSync.ts
@@ -1,6 +1,26 @@
-// @ts-nocheck
-import { useEffect } from "react";
+import { useEffect, type CSSProperties, type RefObject } from "react";
 import { addNavigationButtons, removeNavigationButtons } from "./jsxgraph";
+import type { JXGBoard } from "../jsxgraph-distrib/types";
+import type { GraphSVs } from "../graph";
+
+interface PreviousDimensions {
+    width: number;
+    aspectRatio: string | number;
+}
+
+interface UseViewportAndNavigationSyncParams {
+    enabled: boolean;
+    board: JXGBoard | null;
+    id: string;
+    SVs: GraphSVs;
+    ignoreUpdate: boolean;
+    showNavigation: boolean;
+    surfaceStyle: CSSProperties;
+    previousDimensionsRef: RefObject<PreviousDimensions>;
+    previousBoundingboxRef: RefObject<number[]>;
+    settingBoundingBoxRef: RefObject<boolean>;
+    previousShowNavigationRef: RefObject<boolean>;
+}
 
 export default function useViewportAndNavigationSync({
     enabled,
@@ -14,7 +34,7 @@ export default function useViewportAndNavigationSync({
     previousBoundingboxRef,
     settingBoundingBoxRef,
     previousShowNavigationRef,
-}) {
+}: UseViewportAndNavigationSyncParams) {
     useEffect(() => {
         if (!enabled || !board) {
             return;
@@ -36,8 +56,8 @@ export default function useViewportAndNavigationSync({
         }
 
         // Track surface dimensions to preserve existing resize semantics.
-        const currentDimensions = {
-            width: parseFloat(surfaceStyle.width),
+        const currentDimensions: PreviousDimensions = {
+            width: parseFloat(surfaceStyle.width as string),
             aspectRatio: SVs.aspectRatio,
         };
 

--- a/packages/doenetml/src/Viewer/renderers/video.tsx
+++ b/packages/doenetml/src/Viewer/renderers/video.tsx
@@ -10,6 +10,7 @@ import { sizeToCSS } from "./utils/css";
 import { useRecordVisibilityChanges } from "../../utils/visibility";
 import { DescriptionAsDetails, DescriptionPopover } from "./utils/Description";
 import { getNonInlineMediaLayoutStyles } from "./utils/nonInlineMediaLayout";
+import { NonInlineMediaWrapper } from "./utils/NonInlineMediaWrapper";
 import "./video.css";
 
 interface VideoSVs {
@@ -453,10 +454,10 @@ export default React.memo(function Video(props: UseDoenetRendererProps) {
 
     if (SVs.hidden) return null;
 
-    let outerStyle = {};
-    let innerStyle = {};
-    let mediaContainerStyle = {};
-    let mediaColumnStyle = {};
+    let outerStyle: React.CSSProperties = {};
+    let innerStyle: React.CSSProperties = {};
+    let mediaContainerStyle: React.CSSProperties = {};
+    let mediaColumnStyle: React.CSSProperties = {};
 
     if (SVs.displayMode === "inline") {
         outerStyle = {
@@ -546,31 +547,20 @@ export default React.memo(function Video(props: UseDoenetRendererProps) {
     }
 
     return (
-        <div
-            tabIndex={0}
-            style={
-                SVs.renderInlineForListItem
-                    ? { ...outerStyle, marginTop: 0 }
-                    : outerStyle
-            }
-            id={`${id}-container`}
-            ref={ref}
-            className="video"
-        >
-            <div style={innerStyle}>
-                {SVs.displayMode === "inline" ? (
-                    videoTag
-                ) : (
-                    <div style={mediaContainerStyle}>{videoTag}</div>
-                )}
-                {SVs.displayMode === "inline" || !description ? (
-                    description
-                ) : (
-                    <div style={mediaContainerStyle}>
-                        <div style={mediaColumnStyle}>{description}</div>
-                    </div>
-                )}
-            </div>
-        </div>
+        <NonInlineMediaWrapper
+            id={id}
+            displayMode={SVs.displayMode}
+            suppressTopMargin={Boolean(SVs.renderInlineForListItem)}
+            layoutStyles={{
+                outerStyle,
+                innerStyle,
+                mediaContainerStyle,
+                mediaColumnStyle,
+            }}
+            media={videoTag}
+            description={description}
+            containerRef={ref}
+            containerAttrs={{ tabIndex: 0, className: "video" }}
+        />
     );
 });

--- a/packages/ui-components/src/components/Button.tsx
+++ b/packages/ui-components/src/components/Button.tsx
@@ -15,6 +15,7 @@ export function Button(
         valueHasLatex?: boolean;
         disabled?: boolean;
         onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+        onBlur?: (e: React.FocusEvent<HTMLButtonElement>) => void;
         className?: string;
         ariaLabel?: string;
     }>,
@@ -41,6 +42,7 @@ export function Button(
             id={props.id}
             disabled={props.disabled}
             onClick={props.onClick}
+            onBlur={props.onBlur}
             className={classNames(
                 "doenet-button",
                 {


### PR DESCRIPTION
## Summary

Continues PR #1063. PR A migrated every `.tsx` renderer in `packages/doenetml/src/Viewer/renderers/` to typed state variables (removing all `@ts-nocheck` from the `.tsx` files). PR B is the **refactor-only** follow-up: extract duplication into helpers, type the last three `.ts` board-sync hooks, and drop the migration shims.

23 files changed, ~787 insertions / ~1253 deletions (net **−466 LoC**).

## Commit-level batching (single PR, sequenced inside the diff)

1. **Type the 3 board-sync helpers.** Removes the last `@ts-nocheck` from the renderers tree (the 3 `.ts` hooks under `renderers/utils/`: `useGridAndAxesSync`, `useViewportAndNavigationSync`, `useJSXGraphBoardSync`). Reuses the existing `GraphSVs`, `JXGBoard`, and `AxisJXG` types; `AxisJXG`/`AxisRef` are now exported from `utils/jsxgraph.ts`. `applyAxisTickHeights`'s `grid` param widens from `string` to `unknown` to honestly model what the call site passes (`SVs.grid` is `unknown`).

2. **Extract `useAnchoredGraphDragHandler`** — the big one. The four text-on-graph renderers (`number`, `text`, `label`, `math`) shared an essentially identical drag/anchor pattern (~150 LoC each, with ~13 `!` non-null assertions per file). Extract `attachAnchoredGraphDragHandlers` plus a small `detachAnchoredGraphElement` companion into `utils/useAnchoredGraphDragHandler.ts`. Each renderer now wires the existing helpers it should have been using all along: `usePointerDragState`, `useDraggableRefs`, `useBoardPointerTracking`, `exceededDragThreshold`, `pointerEventToUserCoords`, `useJSXGraphCleanup`. ~52 `!` assertions across the four files disappear.

3. **`MarkupSVsBase` + `renderMarkupBody`** — five small markup renderers (`em`, `c`, `q`, `sq`, `blockQuote`) shared an identical body pattern: `hidden` gate + optional `addCommasForCompositeRanges` over the children. Each collapses to a `renderMarkupBody({ SVs, children })` call.

4. **`NonInlineMediaWrapper`** — `image.tsx` and `video.tsx` shared the same outer/inner container nesting and inline-vs-non-inline conditional that interleaves the media element with its description. Extract into a single component; renderer-specific outer-div decorations (video's `tabIndex={0}` + `className="video"`) pass through via a `containerAttrs` prop.

5. **Drop `as any` casts on `@doenet/ui-components`** — `orbitalDiagramInput` and `subsetOfRealsInput` cast `Button` / `ToggleButton` / `ToggleButtonGroup` to `any` as a migration shim. Drop the casts. `ToggleButton` and `ToggleButtonGroup` were already typed cleanly upstream. `Button` needed an `onBlur` prop pass-through to type cleanly — see *Latent bug fix* below.

6. **Tighten `JXG{Text,Point,Image}` types and drop redundant `!`.** `relativeCoords` and `size` were typed optional on `JXGText`/`JXGPoint` (and the local `JXGImage`), but every consumer in the renderers tree dereferences them unconditionally — the `?` was a defensive mistype that forced `!` assertions in callers without reflecting any real nullability. Flip both to required and drop the now-redundant `!` at 9 sites (across `image.tsx`, `label.tsx`, `text.tsx`, `number.tsx`, and `useAnchoredGraphDragHandler.ts`), plus one redundant `!` on `previousBoundingbox.current` in `JSXGraphRenderer.tsx`.

## Patterns NOT extracted (deliberate)

- The four quote-mark renderers `lq`, `rq`, `lsq`, `rsq` only render a single character glyph — no children, so no body pattern to share. Skipped.
- `p`, `pre`, `hint` carry additional concerns (visibility tracking + checkWork; `displayDoenetMLIndices`; collapsible UI) and were intentionally left bespoke rather than forced into the markup helper.
- `image.tsx`'s drag/anchor pattern is shaped enough like the other four to be tempting, but its `currentSize` / `currentOffset` aspect-ratio plumbing and rotation transform would force the helper to take many callbacks. Deferred — see Known PR-C follow-ups.

## Latent bug fix bundled with commit 5

`orbitalDiagramInput.tsx` passes `onBlur={(e) => deselect(e)}` to six `<Button>` instances (add-row, add-box, remove-box, add-up-arrow, add-down-arrow, remove-arrow). Pre-PR, `Button` did not declare or forward `onBlur` — the prop was silently dropped at runtime, but the `as any` cast hid that from the type checker. Removing the cast forced the upstream type to be honest, which surfaced six `onBlur` errors at the call sites.

The renderer's `deselect` function is fully implemented and clearly intended to fire on focus loss — it determines whether focus moved outside the orbital diagram and clears the selection if so. Adding `onBlur` to the `Button` prop type and forwarding it to the underlying Ariakit button (one line each) makes the renderer's intent actually take effect.

This is the only behavioral change in PR B. The diff is two lines in `packages/ui-components/src/components/Button.tsx`.

## Known PR-C follow-ups (deliberately deferred)

- **`[key: string]: any` index signatures on ~45 SV interfaces.** Root cause is structural — multiple helpers (`addCommasForCompositeRanges`, `buildGraphicalAttributes`'s 3 functions, `jsxgraph.ts`, and others) accept or return `Record<string, any>`, so SVs must be wide enough to satisfy them. `addCommasForCompositeRanges` is already narrowly typed; the remaining helpers need a typing pass before SVs can shed their index signatures cleanly. Larger structural rework, separate PR.

- **`image.tsx` drag/anchor extraction.** Same general pattern as the four text-on-graph renderers but with image-specific bounding-box clamping (`currentSize` / `currentOffset` for aspect-ratio handling) and rotation transform. ~170 LoC potential savings; would either generalize `useAnchoredGraphDragHandler`'s signature or warrant a sibling helper. Lower-priority follow-up.

- **`button.tsx:67` invalid CSS fallback.** `let fillColor: string = SVs.selectedStyle.highContrastColor ?? "";` produces `background-color: ;` and `oklch(from  …)` when `highContrastColor` is undefined. `SelectedStyle.highContrastColor` is intentionally optional; the fix is a behavioral choice (sensible default color, conditional CSS emission, or tightening the type). Behavioral, not refactor — separate PR.

- **`video.tsx:73` YouTube-API `useEffect` dep.** `useEffect(..., [(window as any).YT])` won't reliably re-run when `SVs.youtube` transitions `null → string` or when the YT iframe API loads asynchronously. Pre-existing pattern preserved by the typing migration; the real fix needs a different lifecycle approach. Behavioral, separate PR.

- **`useViewportAndNavigationSync.ts:59-72` resize tracking is broken for `%`-width graphs and string `aspectRatio`.** `parseFloat(surfaceStyle.width)` returns the percentage number (e.g. `90` for `"90%"`), not the actual pixel width — so when the parent container resizes, the tracking ref never detects a change. And `Number.isFinite(currentDimensions.aspectRatio)` returns `false` for any string aspectRatio (the type allows `string | number`), gating out aspectRatio-change detection entirely for that branch. Pre-existing behavior — byte-identical to main; PR B only added the `: PreviousDimensions` annotation and the `as string` cast forced by dropping `@ts-nocheck`. Behavioral fix needs `typeof` checks (and probably measuring the actual container width via a ResizeObserver / `getBoundingClientRect`), separate PR.

- **3 `@ts-nocheck` in renderer-adjacent code outside the renderers tree** (if any surface during review). The renderers tree itself is now `@ts-nocheck`-free as of commit 1.

- **Remaining `useRef<X | null>(null).current!` assertions.** After commit 6, the only `!` left in the touched files are on refs that genuinely start `null` and are populated later (pointerdown, element creation): ~15 sites in `image.tsx` (`pointerAtDown`, `pointAtDown`, `currentOffset`, `currentSize`, `rotationTransform`, `anchorPointJXG`) and 3 each in `label.tsx`/`text.tsx`/`number.tsx` (`anchorPointJXG`). Removing them requires an intermediate-guard refactor (`const x = ref.current; if (!x) return;`) inside each handler — mechanical but out of scope for this PR.

- **Bare `JXG.X` references in leaf renderers without an explicit `import JXG from "jsxgraph"`.** ~10–15 leaf renderers (`text`, `label`, `number`, `math`, `image`, `button`, `textInput`, `booleanInput`, `vector`, `polygon`, `lineSegment`, `cobwebPolyline`, `legend`, …) reach for `JXG.COORDS_BY_USER` (and other namespace members) without importing `JXG`. Type-checks pass because `jsxgraph`'s types declare `JXG` as an ambient namespace (`node_modules/jsxgraph/src/index.d.ts:18`); runtime works because `jsxgraph/src/index.js:239` sets `window.JXG` as a side effect when imported by a parent (`JSXGraphRenderer`, `useGridAndAxesSync`). The new `useAnchoredGraphDragHandler` helper added an explicit import in commit 7 since it's the canonical home for that access pattern, but the leaf renderers were left as-is to keep this PR's scope tight. A standalone follow-up PR can sweep them all in one pass — and at the same time, drop the now-unneeded `// @ts-ignore` lines above `import JXG from "jsxgraph"` in `JSXGraphRenderer.tsx:2` and `useGridAndAxesSync.ts:2` (the root tsconfig enables `esModuleInterop` + `allowSyntheticDefaultImports`, so the default import type-checks cleanly without an escape hatch — see commit 8 for the same removal in the new helper).

## Test plan

- [x] `npx tsc --noEmit` passes from `packages/doenetml/`
- [x] `grep -R "@ts-nocheck" packages/doenetml/src/Viewer/renderers/` returns nothing
- [x] `npx vitest run packages/doenetml/src/Viewer/renderers/graphControls` (13/13 pass)
- [x] Browser spot-check on `packages/doenetml/dev`: graph with draggable `<number>` / `<text>` / `<label>` / `<math>`; markup-heavy page (`<p>`, `<em>`, `<c>`, `<q>`, `<blockQuote>`); `<image>` and `<video>` in non-inline layout with description; `<orbitalDiagramInput>` and `<subsetOfRealsInput>` button interactions (especially the orbital deselect-on-blur behavior, which is now actually wired up)
- [x] CI: full vitest suite + Cypress

🤖 Generated with [Claude Code](https://claude.com/claude-code)
