### PR TITLE
refactor(renderers): explicit JXG default import in 22 leaf renderers

### DIFF
--- a/packages/doenetml/src/Viewer/renderers/JSXGraphRenderer.tsx
+++ b/packages/doenetml/src/Viewer/renderers/JSXGraphRenderer.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState, Context } from "react";
-// @ts-ignore
 import JXG from "jsxgraph";
 import {
     addNavigationButtons,

--- a/packages/doenetml/src/Viewer/renderers/angle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/angle.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useContext, useRef } from "react";
+import JXG from "jsxgraph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";

--- a/packages/doenetml/src/Viewer/renderers/booleanInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/booleanInput.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
+import JXG from "jsxgraph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";

--- a/packages/doenetml/src/Viewer/renderers/button.tsx
+++ b/packages/doenetml/src/Viewer/renderers/button.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useRef } from "react";
+import JXG from "jsxgraph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";

--- a/packages/doenetml/src/Viewer/renderers/circle.tsx
+++ b/packages/doenetml/src/Viewer/renderers/circle.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useRef } from "react";
+import JXG from "jsxgraph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";

--- a/packages/doenetml/src/Viewer/renderers/cobwebPolyline.tsx
+++ b/packages/doenetml/src/Viewer/renderers/cobwebPolyline.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useRef } from "react";
+import JXG from "jsxgraph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";

--- a/packages/doenetml/src/Viewer/renderers/curve.tsx
+++ b/packages/doenetml/src/Viewer/renderers/curve.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useRef } from "react";
+import JXG from "jsxgraph";
 import { createFunctionFromDefinition } from "@doenet/utils";
 import useDoenetRenderer, {
     UseDoenetRendererProps,

--- a/packages/doenetml/src/Viewer/renderers/image.tsx
+++ b/packages/doenetml/src/Viewer/renderers/image.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useContext, useRef } from "react";
+import JXG from "jsxgraph";
 import { BoardContext, IMAGE_LAYER_OFFSET } from "./graph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,

--- a/packages/doenetml/src/Viewer/renderers/label.tsx
+++ b/packages/doenetml/src/Viewer/renderers/label.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useRef } from "react";
+import JXG from "jsxgraph";
 import { BoardContext, TEXT_LAYER_OFFSET } from "./graph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,

--- a/packages/doenetml/src/Viewer/renderers/legend.tsx
+++ b/packages/doenetml/src/Viewer/renderers/legend.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useRef } from "react";
+import JXG from "jsxgraph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";

--- a/packages/doenetml/src/Viewer/renderers/line.tsx
+++ b/packages/doenetml/src/Viewer/renderers/line.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useRef } from "react";
+import JXG from "jsxgraph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";

--- a/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
+++ b/packages/doenetml/src/Viewer/renderers/lineSegment.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useRef } from "react";
+import JXG from "jsxgraph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";

--- a/packages/doenetml/src/Viewer/renderers/math.tsx
+++ b/packages/doenetml/src/Viewer/renderers/math.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useRef } from "react";
+import JXG from "jsxgraph";
 import { BoardContext, TEXT_LAYER_OFFSET } from "./graph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,

--- a/packages/doenetml/src/Viewer/renderers/number.tsx
+++ b/packages/doenetml/src/Viewer/renderers/number.tsx
@@ -1,6 +1,7 @@
 import { MathJax } from "better-react-mathjax";
 
 import React, { useContext, useRef } from "react";
+import JXG from "jsxgraph";
 import { BoardContext, TEXT_LAYER_OFFSET } from "./graph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,

--- a/packages/doenetml/src/Viewer/renderers/pegboard.tsx
+++ b/packages/doenetml/src/Viewer/renderers/pegboard.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useRef } from "react";
+import JXG from "jsxgraph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";

--- a/packages/doenetml/src/Viewer/renderers/point.tsx
+++ b/packages/doenetml/src/Viewer/renderers/point.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useRef } from "react";
+import JXG from "jsxgraph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";

--- a/packages/doenetml/src/Viewer/renderers/polygon.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polygon.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useRef } from "react";
+import JXG from "jsxgraph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";

--- a/packages/doenetml/src/Viewer/renderers/polyline.tsx
+++ b/packages/doenetml/src/Viewer/renderers/polyline.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useRef } from "react";
+import JXG from "jsxgraph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";

--- a/packages/doenetml/src/Viewer/renderers/ray.tsx
+++ b/packages/doenetml/src/Viewer/renderers/ray.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useRef } from "react";
+import JXG from "jsxgraph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";

--- a/packages/doenetml/src/Viewer/renderers/regionBetweenCurveXAxis.tsx
+++ b/packages/doenetml/src/Viewer/renderers/regionBetweenCurveXAxis.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useRef } from "react";
+import JXG from "jsxgraph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";

--- a/packages/doenetml/src/Viewer/renderers/text.tsx
+++ b/packages/doenetml/src/Viewer/renderers/text.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useRef } from "react";
+import JXG from "jsxgraph";
 import { BoardContext, TEXT_LAYER_OFFSET } from "./graph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,

--- a/packages/doenetml/src/Viewer/renderers/textInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/textInput.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
+import JXG from "jsxgraph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";

--- a/packages/doenetml/src/Viewer/renderers/utils/useGridAndAxesSync.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useGridAndAxesSync.ts
@@ -1,5 +1,4 @@
 import { useEffect, type RefObject } from "react";
-// @ts-ignore
 import JXG from "jsxgraph";
 import {
     applyAxisTickHeights,

--- a/packages/doenetml/src/Viewer/renderers/vector.tsx
+++ b/packages/doenetml/src/Viewer/renderers/vector.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useRef } from "react";
+import JXG from "jsxgraph";
 import useDoenetRenderer, {
     UseDoenetRendererProps,
 } from "../useDoenetRenderer";


### PR DESCRIPTION
## Summary

PR #1067 follow-up (PR-C1 of 6). 22 leaf renderers under `packages/doenetml/src/Viewer/renderers/` reach for the `JXG` namespace at runtime via `window.JXG` (side-effect-loaded by `JSXGraphRenderer`'s import) and at type level via the ambient namespace declaration. Make the dependency explicit by importing JXG directly.

Also drops the now-unneeded `// @ts-ignore` lines above the existing `import JXG from "jsxgraph"` in `JSXGraphRenderer.tsx` and `useGridAndAxesSync.ts` — `esModuleInterop` + `allowSyntheticDefaultImports` in `tsconfig.build.json` mean the default import type-checks cleanly. The new `useAnchoredGraphDragHandler.ts` already imports JXG without an escape hatch.

24 files changed, +22 / -2.

## Test plan

- [x] `npx tsc --noEmit` from `packages/doenetml/`
- [x] `grep -R "@ts-nocheck" packages/doenetml/src/Viewer/renderers/` returns nothing
- [x] CI: full vitest + Cypress

🤖 Generated with [Claude Code](https://claude.com/claude-code)