### PR TITLE
refactor(renderers): drop `!` on anchorPointJXG.current in label/text/number

### DIFF
--- a/packages/doenetml/src/Viewer/renderers/label.tsx
+++ b/packages/doenetml/src/Viewer/renderers/label.tsx
@@ -208,7 +208,7 @@ export default React.memo(function Label(props: UseDoenetRendererProps) {
                 JXG.COORDS_BY_USER,
                 [0, 0],
             );
-            anchorPointJXG.current!.coords.setCoordinates(
+            anchorPointJXG.current?.coords.setCoordinates(
                 JXG.COORDS_BY_USER,
                 anchorCoords,
             );
@@ -286,8 +286,10 @@ export default React.memo(function Label(props: UseDoenetRendererProps) {
                 labelJXG.current.update();
             }
 
-            anchorPointJXG.current!.needsUpdate = true;
-            anchorPointJXG.current!.update();
+            if (anchorPointJXG.current) {
+                anchorPointJXG.current.needsUpdate = true;
+                anchorPointJXG.current.update();
+            }
             board.updateRenderer();
         }
 

--- a/packages/doenetml/src/Viewer/renderers/number.tsx
+++ b/packages/doenetml/src/Viewer/renderers/number.tsx
@@ -193,7 +193,7 @@ export default React.memo(function NumberComponent(
                 JXG.COORDS_BY_USER,
                 [0, 0],
             );
-            anchorPointJXG.current!.coords.setCoordinates(
+            anchorPointJXG.current?.coords.setCoordinates(
                 JXG.COORDS_BY_USER,
                 anchorCoords,
             );
@@ -271,8 +271,10 @@ export default React.memo(function NumberComponent(
                 numberJXG.current.update();
             }
 
-            anchorPointJXG.current!.needsUpdate = true;
-            anchorPointJXG.current!.update();
+            if (anchorPointJXG.current) {
+                anchorPointJXG.current.needsUpdate = true;
+                anchorPointJXG.current.update();
+            }
             board.updateRenderer();
         }
 

--- a/packages/doenetml/src/Viewer/renderers/text.tsx
+++ b/packages/doenetml/src/Viewer/renderers/text.tsx
@@ -189,7 +189,7 @@ export default React.memo(function Text(props: UseDoenetRendererProps) {
                 JXG.COORDS_BY_USER,
                 [0, 0],
             );
-            anchorPointJXG.current!.coords.setCoordinates(
+            anchorPointJXG.current?.coords.setCoordinates(
                 JXG.COORDS_BY_USER,
                 anchorCoords,
             );
@@ -267,8 +267,10 @@ export default React.memo(function Text(props: UseDoenetRendererProps) {
                 textJXG.current.update();
             }
 
-            anchorPointJXG.current!.needsUpdate = true;
-            anchorPointJXG.current!.update();
+            if (anchorPointJXG.current) {
+                anchorPointJXG.current.needsUpdate = true;
+                anchorPointJXG.current.update();
+            }
             board.updateRenderer();
         }
 


### PR DESCRIPTION
## Summary

PR #1067 follow-up (PR-C2 of 6). Match `math.tsx`'s pattern: optional chaining on the `relativeCoords`-update read site, and an `if (anchorPointJXG.current)` guard around the `needsUpdate`/`update()` pair. Removes 9 `!` non-null assertions on a ref that genuinely starts `null`.

`image.tsx`'s ~22 residual `!` sites are deferred to PR-C6, which rewrites the same blocks during drag/anchor extraction.

3 files changed, +15 / -9.

## Test plan

- [x] `npx tsc --noEmit` from `packages/doenetml/`
- [ ] Browser spot-check: drag interactions on `<text>`, `<label>`, `<number>` on a graph
- [x] CI: full vitest + Cypress

🤖 Generated with [Claude Code](https://claude.com/claude-code)