### PR TITLE
fix(button): fall back to selectedStyle.fillColor when highContrastColor is undefined

### DIFF
--- a/packages/doenetml/src/Viewer/renderers/button.tsx
+++ b/packages/doenetml/src/Viewer/renderers/button.tsx
@@ -64,7 +64,8 @@ export default React.memo(function ButtonComponent(
 
     let label = SVs.label ? SVs.label : "Button";
 
-    let fillColor: string = SVs.selectedStyle.highContrastColor ?? "";
+    let fillColor =
+        SVs.selectedStyle.highContrastColor ?? SVs.selectedStyle.fillColor;
 
     useEffect(() => {
         //On unmount


### PR DESCRIPTION
## Summary

PR #1067 follow-up (PR-C3 of 6). `SelectedStyle.highContrastColor` is declared optional in `utils/graphicalSVs.ts:37`. With the previous `?? ""` fallback at `button.tsx:67`, an undefined value produced:

- `background-color: ;` (invalid)
- `oklch(from  calc(l * 1.5) c h)` (malformed — empty `from` argument)

in the generated CSS at lines 420–427. Fall back to `SVs.selectedStyle.fillColor` instead — it's required (non-optional) on `SelectedStyle` and is the natural non-high-contrast counterpart.

1 file changed, +2 / -1.

## Test plan

- [x] `npx tsc --noEmit` from `packages/doenetml/`
- [ ] Browser spot-check: a `<button>` without high-contrast styling renders with a sensible background and a working `:hover` oklch derivation
- [x] CI: full vitest + Cypress

🤖 Generated with [Claude Code](https://claude.com/claude-code)