### PR TITLE
refactor(renderers): drop dead dimension-tracking from useViewportAndNavigationSync

### DIFF
--- a/packages/doenetml/src/Viewer/renderers/JSXGraphRenderer.tsx
+++ b/packages/doenetml/src/Viewer/renderers/JSXGraphRenderer.tsx
@@ -35,10 +35,6 @@ export default function JSXGraphRenderer({
 }: JSXGraphRendererProps) {
     const [board, setBoard] = useState<JXGBoard | null>(null);
 
-    const previousDimensions = useRef<{
-        width: number;
-        aspectRatio: string | number;
-    }>({ width: 0, aspectRatio: 1 });
     const previousBoundingbox = useRef<number[]>([0, 0, 0, 0]);
     const xaxis = useRef<AxisJXG | null | undefined>(null);
     const yaxis = useRef<AxisJXG | null | undefined>(null);
@@ -107,11 +103,6 @@ export default function JSXGraphRenderer({
         });
 
         setBoard(newBoard);
-
-        previousDimensions.current = {
-            width: parseFloat(surfaceStyle.width as string),
-            aspectRatio: SVs.aspectRatio,
-        };
 
         if (SVs.displayXAxis) {
             createXAxis({
@@ -186,8 +177,6 @@ export default function JSXGraphRenderer({
         SVs,
         ignoreUpdate,
         showNavigation,
-        surfaceStyle,
-        previousDimensionsRef: previousDimensions,
         previousBoundingboxRef: previousBoundingbox,
         xaxisRef: xaxis,
         yaxisRef: yaxis,

--- a/packages/doenetml/src/Viewer/renderers/utils/useJSXGraphBoardSync.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useJSXGraphBoardSync.ts
@@ -1,14 +1,9 @@
-import { useEffect, type CSSProperties, type RefObject } from "react";
+import { useEffect, type RefObject } from "react";
 import useGridAndAxesSync from "./useGridAndAxesSync";
 import useViewportAndNavigationSync from "./useViewportAndNavigationSync";
 import type { AxisJXG } from "./jsxgraph";
 import type { JXGBoard } from "../jsxgraph-distrib/types";
 import type { GraphSVs } from "../graph";
-
-interface PreviousDimensions {
-    width: number;
-    aspectRatio: string | number;
-}
 
 interface UseJSXGraphBoardSyncParams {
     board: JXGBoard | null;
@@ -16,8 +11,6 @@ interface UseJSXGraphBoardSyncParams {
     SVs: GraphSVs;
     ignoreUpdate: boolean;
     showNavigation: boolean;
-    surfaceStyle: CSSProperties;
-    previousDimensionsRef: RefObject<PreviousDimensions>;
     previousBoundingboxRef: RefObject<number[]>;
     xaxisRef: RefObject<AxisJXG | null | undefined>;
     yaxisRef: RefObject<AxisJXG | null | undefined>;
@@ -34,8 +27,6 @@ export default function useJSXGraphBoardSync({
     SVs,
     ignoreUpdate,
     showNavigation,
-    surfaceStyle,
-    previousDimensionsRef,
     previousBoundingboxRef,
     xaxisRef,
     yaxisRef,
@@ -64,8 +55,6 @@ export default function useJSXGraphBoardSync({
         SVs,
         ignoreUpdate,
         showNavigation,
-        surfaceStyle,
-        previousDimensionsRef,
         previousBoundingboxRef,
         settingBoundingBoxRef,
         previousShowNavigationRef,

--- a/packages/doenetml/src/Viewer/renderers/utils/useViewportAndNavigationSync.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useViewportAndNavigationSync.ts
@@ -1,12 +1,7 @@
-import { useEffect, type CSSProperties, type RefObject } from "react";
+import { useEffect, type RefObject } from "react";
 import { addNavigationButtons, removeNavigationButtons } from "./jsxgraph";
 import type { JXGBoard } from "../jsxgraph-distrib/types";
 import type { GraphSVs } from "../graph";
-
-interface PreviousDimensions {
-    width: number;
-    aspectRatio: string | number;
-}
 
 interface UseViewportAndNavigationSyncParams {
     enabled: boolean;
@@ -15,8 +10,6 @@ interface UseViewportAndNavigationSyncParams {
     SVs: GraphSVs;
     ignoreUpdate: boolean;
     showNavigation: boolean;
-    surfaceStyle: CSSProperties;
-    previousDimensionsRef: RefObject<PreviousDimensions>;
     previousBoundingboxRef: RefObject<number[]>;
     settingBoundingBoxRef: RefObject<boolean>;
     previousShowNavigationRef: RefObject<boolean>;
@@ -29,8 +22,6 @@ export default function useViewportAndNavigationSync({
     SVs,
     ignoreUpdate,
     showNavigation,
-    surfaceStyle,
-    previousDimensionsRef,
     previousBoundingboxRef,
     settingBoundingBoxRef,
     previousShowNavigationRef,
@@ -53,22 +44,6 @@ export default function useViewportAndNavigationSync({
         } else if (previousShowNavigationRef.current) {
             removeNavigationButtons({ board, id });
             previousShowNavigationRef.current = false;
-        }
-
-        // Track surface dimensions to preserve existing resize semantics.
-        const currentDimensions: PreviousDimensions = {
-            width: parseFloat(surfaceStyle.width as string),
-            aspectRatio: SVs.aspectRatio,
-        };
-
-        if (
-            (currentDimensions.width !== previousDimensionsRef.current.width ||
-                currentDimensions.aspectRatio !==
-                    previousDimensionsRef.current.aspectRatio) &&
-            Number.isFinite(currentDimensions.width) &&
-            Number.isFinite(currentDimensions.aspectRatio)
-        ) {
-            previousDimensionsRef.current = currentDimensions;
         }
 
         // Apply bounding-box updates only when not ignored and values changed.


### PR DESCRIPTION
## Summary

PR #1067 follow-up (PR-C5 of 6). The dimension-tracking block in `useViewportAndNavigationSync` wrote `previousDimensionsRef` but nothing read it. The intended `board.resizeContainer(...)` call has been commented out since PR #921 (~March 2026) and was never restored. The parsing was also broken — `parseFloat("90%")` returns the percentage number, not the rendered pixel width — but since the ref is never consumed, this had no observable effect.

Remove the block, the `previousDimensions` ref in `JSXGraphRenderer`, and the now-unused `surfaceStyle` / `previousDimensionsRef` parameters from `useJSXGraphBoardSync` and `useViewportAndNavigationSync`. If container-resize support is wanted later, a fresh implementation using `ResizeObserver` + `board.resizeContainer` is the right shape — file an issue.

3 files changed, +2 / -49.

## Test plan

- [x] `npx tsc --noEmit` from `packages/doenetml/`
- [x] Browser spot-check: graph renders at expected dimensions; resizing the window does not regress (the deleted code wasn't doing anything anyway)
- [x] CI: full vitest + Cypress

🤖 Generated with [Claude Code](https://claude.com/claude-code)