### PR TITLE
refactor(style): consolidate SelectedStyle into ResolvedStyleDefinition

### DIFF
--- a/packages/doenetml/src/Viewer/renderers/button.tsx
+++ b/packages/doenetml/src/Viewer/renderers/button.tsx
@@ -10,9 +10,8 @@ import {
     getPositionFromAnchorByCoordinate,
     POINTER_DRAG_THRESHOLD,
 } from "./utils/graph";
-import { cesc } from "@doenet/utils";
+import { cesc, type ResolvedStyleDefinition } from "@doenet/utils";
 import { JXGEvent, JXGObject } from "./jsxgraph-distrib/types";
-import { ResolvedStyleDefinition } from "@doenet/utils";
 
 interface ButtonSVs {
     [key: string]: any;

--- a/packages/doenetml/src/Viewer/renderers/button.tsx
+++ b/packages/doenetml/src/Viewer/renderers/button.tsx
@@ -12,7 +12,7 @@ import {
 } from "./utils/graph";
 import { cesc } from "@doenet/utils";
 import { JXGEvent, JXGObject } from "./jsxgraph-distrib/types";
-import { SelectedStyle } from "./utils/graphicalSVs";
+import { ResolvedStyleDefinition } from "@doenet/utils";
 
 interface ButtonSVs {
     [key: string]: any;
@@ -26,7 +26,7 @@ interface ButtonSVs {
     label: string;
     labelHasLatex: boolean;
     clickAction: any;
-    selectedStyle: SelectedStyle;
+    selectedStyle: ResolvedStyleDefinition;
 }
 
 export default React.memo(function ButtonComponent(
@@ -65,7 +65,7 @@ export default React.memo(function ButtonComponent(
 
     let label = SVs.label ? SVs.label : "Button";
 
-    let fillColor: string = SVs.selectedStyle.highContrastColor ?? "";
+    let fillColor: string = SVs.selectedStyle.highContrastColor;
 
     useEffect(() => {
         //On unmount

--- a/packages/doenetml/src/Viewer/renderers/label.tsx
+++ b/packages/doenetml/src/Viewer/renderers/label.tsx
@@ -11,7 +11,7 @@ import { getPositionFromAnchorByCoordinate } from "./utils/graph";
 import { DocContext } from "../DocViewer";
 import { ChoiceInputInlineContext } from "./choiceInput";
 import { JXGPoint, JXGText } from "./jsxgraph-distrib/types";
-import { SelectedStyle } from "./utils/graphicalSVs";
+import { ResolvedStyleDefinition } from "@doenet/utils";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
@@ -33,7 +33,7 @@ interface LabelSVs {
     hasLatex: boolean;
     forTargetRendererId?: string;
     forTargetIsGroup?: boolean;
-    selectedStyle: SelectedStyle;
+    selectedStyle: ResolvedStyleDefinition;
 }
 
 export default React.memo(function Label(props: UseDoenetRendererProps) {

--- a/packages/doenetml/src/Viewer/renderers/label.tsx
+++ b/packages/doenetml/src/Viewer/renderers/label.tsx
@@ -11,7 +11,7 @@ import { getPositionFromAnchorByCoordinate } from "./utils/graph";
 import { DocContext } from "../DocViewer";
 import { ChoiceInputInlineContext } from "./choiceInput";
 import { JXGPoint, JXGText } from "./jsxgraph-distrib/types";
-import { ResolvedStyleDefinition } from "@doenet/utils";
+import type { ResolvedStyleDefinition } from "@doenet/utils";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";

--- a/packages/doenetml/src/Viewer/renderers/math.tsx
+++ b/packages/doenetml/src/Viewer/renderers/math.tsx
@@ -11,7 +11,7 @@ import { getPositionFromAnchorByCoordinate } from "./utils/graph";
 import { DocContext } from "../DocViewer";
 import { JXGObject } from "./jsxgraph-distrib/types";
 import { ChoiceInputInlineContext } from "./choiceInput";
-import { SelectedStyle } from "./utils/graphicalSVs";
+import { ResolvedStyleDefinition } from "@doenet/utils";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
@@ -34,7 +34,7 @@ interface MathSVs {
     renderMode?: string;
     equationTag?: string;
     mrowChildRendererIds?: string[];
-    selectedStyle: SelectedStyle;
+    selectedStyle: ResolvedStyleDefinition;
 }
 
 function getMathDelimiters(SVs: MathSVs): [string, string] {

--- a/packages/doenetml/src/Viewer/renderers/math.tsx
+++ b/packages/doenetml/src/Viewer/renderers/math.tsx
@@ -11,7 +11,7 @@ import { getPositionFromAnchorByCoordinate } from "./utils/graph";
 import { DocContext } from "../DocViewer";
 import { JXGObject } from "./jsxgraph-distrib/types";
 import { ChoiceInputInlineContext } from "./choiceInput";
-import { ResolvedStyleDefinition } from "@doenet/utils";
+import type { ResolvedStyleDefinition } from "@doenet/utils";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";

--- a/packages/doenetml/src/Viewer/renderers/number.tsx
+++ b/packages/doenetml/src/Viewer/renderers/number.tsx
@@ -12,7 +12,7 @@ import { getPositionFromAnchorByCoordinate } from "./utils/graph";
 import { DocContext } from "../DocViewer";
 import { ChoiceInputInlineContext } from "./choiceInput";
 import { JXGPoint, JXGText } from "./jsxgraph-distrib/types";
-import { ResolvedStyleDefinition } from "@doenet/utils";
+import type { ResolvedStyleDefinition } from "@doenet/utils";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";

--- a/packages/doenetml/src/Viewer/renderers/number.tsx
+++ b/packages/doenetml/src/Viewer/renderers/number.tsx
@@ -12,7 +12,7 @@ import { getPositionFromAnchorByCoordinate } from "./utils/graph";
 import { DocContext } from "../DocViewer";
 import { ChoiceInputInlineContext } from "./choiceInput";
 import { JXGPoint, JXGText } from "./jsxgraph-distrib/types";
-import { SelectedStyle } from "./utils/graphicalSVs";
+import { ResolvedStyleDefinition } from "@doenet/utils";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
@@ -32,7 +32,7 @@ interface NumberSVs {
     positionFromAnchor: any;
     text: string;
     renderAsMath: boolean;
-    selectedStyle: SelectedStyle;
+    selectedStyle: ResolvedStyleDefinition;
 }
 
 export default React.memo(function NumberComponent(

--- a/packages/doenetml/src/Viewer/renderers/text.tsx
+++ b/packages/doenetml/src/Viewer/renderers/text.tsx
@@ -10,7 +10,7 @@ import { getPositionFromAnchorByCoordinate } from "./utils/graph";
 import { DocContext } from "../DocViewer";
 import { ChoiceInputInlineContext } from "./choiceInput";
 import { JXGPoint, JXGText } from "./jsxgraph-distrib/types";
-import { SelectedStyle } from "./utils/graphicalSVs";
+import { ResolvedStyleDefinition } from "@doenet/utils";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";
@@ -29,7 +29,7 @@ interface TextSVs {
     anchor: any;
     positionFromAnchor: any;
     text: string;
-    selectedStyle: SelectedStyle;
+    selectedStyle: ResolvedStyleDefinition;
 }
 
 export default React.memo(function Text(props: UseDoenetRendererProps) {

--- a/packages/doenetml/src/Viewer/renderers/text.tsx
+++ b/packages/doenetml/src/Viewer/renderers/text.tsx
@@ -10,7 +10,7 @@ import { getPositionFromAnchorByCoordinate } from "./utils/graph";
 import { DocContext } from "../DocViewer";
 import { ChoiceInputInlineContext } from "./choiceInput";
 import { JXGPoint, JXGText } from "./jsxgraph-distrib/types";
-import { ResolvedStyleDefinition } from "@doenet/utils";
+import type { ResolvedStyleDefinition } from "@doenet/utils";
 import { usePointerDragState } from "./utils/pointerDragState";
 import { useDraggableRefs } from "./utils/useDraggableRefs";
 import { useBoardPointerTracking } from "./utils/useBoardPointerTracking";

--- a/packages/doenetml/src/Viewer/renderers/utils/graphicalSVs.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/graphicalSVs.ts
@@ -1,4 +1,4 @@
-import { ResolvedStyleDefinition } from "@doenet/utils";
+import type { ResolvedStyleDefinition } from "@doenet/utils";
 import { LabelPosition } from "./graph";
 
 /**

--- a/packages/doenetml/src/Viewer/renderers/utils/graphicalSVs.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/graphicalSVs.ts
@@ -1,44 +1,5 @@
+import { ResolvedStyleDefinition } from "@doenet/utils";
 import { LabelPosition } from "./graph";
-
-/**
- * Resolved style values delivered to a renderer.
- *
- * Mirrors the keys produced by `returnSelectedStyleStateVariableDefinition` in
- * `@doenet/utils/style/style.ts`. All values are primitives (the wrapper
- * `{ style }` shape from the worker is unwrapped before reaching the renderer).
- */
-export interface SelectedStyle {
-    lineColor: string;
-    lineColorWord: string;
-    lineColorDarkMode: string;
-    lineColorWordDarkMode: string;
-    lineOpacity: number;
-    lineWidth: number;
-    lineWidthWord: string;
-    lineStyle: string;
-    lineStyleWord: string;
-    markerColor: string;
-    markerColorWord: string;
-    markerColorDarkMode: string;
-    markerColorWordDarkMode: string;
-    markerOpacity: number;
-    markerStyle: string;
-    markerStyleWord: string;
-    markerSize: number;
-    fillColor: string;
-    fillColorWord: string;
-    fillColorDarkMode: string;
-    fillColorWordDarkMode: string;
-    fillOpacity: number;
-    textColor?: string;
-    textColorWord?: string;
-    textColorDarkMode?: string;
-    textColorWordDarkMode?: string;
-    highContrastColor?: string;
-    highContrastColorDarkMode?: string;
-    backgroundColor?: string;
-    backgroundColorDarkMode?: string;
-}
 
 /**
  * Truly universal state-variable shape — present on every JSXgraph-renderable
@@ -51,7 +12,7 @@ export interface GraphicalSVs {
     labelHasLatex: boolean;
     labelPosition: LabelPosition;
     applyStyleToLabel: boolean;
-    selectedStyle: SelectedStyle;
+    selectedStyle: ResolvedStyleDefinition;
 }
 
 /**

--- a/packages/doenetml/src/Viewer/renderers/utils/styleColors.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/styleColors.ts
@@ -1,4 +1,4 @@
-import { SelectedStyle } from "./graphicalSVs";
+import { ResolvedStyleDefinition } from "@doenet/utils";
 
 export type DarkMode = "dark" | "light" | undefined;
 
@@ -12,21 +12,21 @@ export type DarkMode = "dark" | "light" | undefined;
  * palettes, etc.) lives in one place.
  */
 export function resolveLineColor(
-    style: Pick<SelectedStyle, "lineColor" | "lineColorDarkMode">,
+    style: Pick<ResolvedStyleDefinition, "lineColor" | "lineColorDarkMode">,
     darkMode: DarkMode,
 ): string {
     return darkMode === "dark" ? style.lineColorDarkMode : style.lineColor;
 }
 
 export function resolveFillColor(
-    style: Pick<SelectedStyle, "fillColor" | "fillColorDarkMode">,
+    style: Pick<ResolvedStyleDefinition, "fillColor" | "fillColorDarkMode">,
     darkMode: DarkMode,
 ): string {
     return darkMode === "dark" ? style.fillColorDarkMode : style.fillColor;
 }
 
 export function resolveMarkerColor(
-    style: Pick<SelectedStyle, "markerColor" | "markerColorDarkMode">,
+    style: Pick<ResolvedStyleDefinition, "markerColor" | "markerColorDarkMode">,
     darkMode: DarkMode,
 ): string {
     return darkMode === "dark" ? style.markerColorDarkMode : style.markerColor;

--- a/packages/doenetml/src/Viewer/renderers/utils/styleColors.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/styleColors.ts
@@ -1,4 +1,4 @@
-import { ResolvedStyleDefinition } from "@doenet/utils";
+import type { ResolvedStyleDefinition } from "@doenet/utils";
 
 export type DarkMode = "dark" | "light" | undefined;
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -16,6 +16,7 @@ export * from "./math/rounding";
 export * from "./math/subset-of-reals-operations";
 export * from "./style/colorWords";
 export * from "./style/style";
+export * from "./style/styleDefinitionHelpers";
 export * from "./types/core";
 export * from "./url/url";
 export * from "./version/doenetMLversion";

--- a/packages/utils/src/style/style.ts
+++ b/packages/utils/src/style/style.ts
@@ -1,9 +1,11 @@
 import { colorValueToWord } from "./colorWords";
 import {
+    DEFAULT_STYLE_VALUES,
     getStyleValueNumber,
     getStyleValueString,
     normalizeStyleDefinitionValues,
     normalizeStyleDefinitionsValues,
+    resolveStyleDefinition,
     setStyleValue,
     unwrapStyleDefinition,
     type RawStyleDefinition,
@@ -69,28 +71,7 @@ export let styleAttributes: StyleAttributes = {
  * Color words are intentionally omitted here and injected on demand so there is
  * one source of truth for color values.
  */
-let defaultStyle: RawStyleDefinition = {
-    lineColor: "#648FFF",
-    lineColorDarkMode: "#648FFF",
-    lineOpacity: 0.7,
-    lineWidth: 4,
-    lineWidthWord: "thick",
-    lineStyle: "solid",
-    lineStyleWord: "",
-    markerColor: "#648FFF",
-    markerColorDarkMode: "#648FFF",
-    markerOpacity: 0.7,
-    markerStyle: "circle",
-    markerStyleWord: "point",
-    markerSize: 5,
-    fillColor: "#648FFF",
-    fillColorDarkMode: "#648FFF",
-    fillOpacity: 0.3,
-    textColor: "black",
-    textColorDarkMode: "white",
-    highContrastColor: "#2963FF",
-    highContrastColorDarkMode: "#2963FF",
-};
+let defaultStyle: RawStyleDefinition = { ...DEFAULT_STYLE_VALUES };
 
 const coloredItemsForWords = [
     "line",
@@ -641,7 +622,9 @@ export function returnSelectedStyleStateVariableDefinition(): StateVariableDefin
 
                 return {
                     setValue: {
-                        selectedStyle: unwrapStyleDefinition(selectedStyle),
+                        selectedStyle: resolveStyleDefinition(
+                            unwrapStyleDefinition(selectedStyle),
+                        ),
                     },
                 };
             },

--- a/packages/utils/src/style/style.ts
+++ b/packages/utils/src/style/style.ts
@@ -180,28 +180,7 @@ function addMissingChildStyleColorFields(
 function returnDefaultStyleDefinitions(): StyleDefinitions {
     return addMissingColorWordsToStyleDefinitions(
         normalizeStyleDefinitionsValues({
-            1: {
-                lineColor: "#648FFF",
-                lineColorDarkMode: "#648FFF",
-                lineOpacity: 0.7,
-                lineWidth: 4,
-                lineWidthWord: "thick",
-                lineStyle: "solid",
-                lineStyleWord: "",
-                markerColor: "#648FFF",
-                markerColorDarkMode: "#648FFF",
-                markerOpacity: 0.7,
-                markerStyle: "circle",
-                markerStyleWord: "point",
-                markerSize: 5,
-                fillColor: "#648FFF",
-                fillColorDarkMode: "#648FFF",
-                fillOpacity: 0.3,
-                textColor: "black",
-                textColorDarkMode: "white",
-                highContrastColor: "#2963FF",
-                highContrastColorDarkMode: "#2963FF",
-            },
+            1: { ...DEFAULT_STYLE_VALUES },
             2: {
                 lineColor: "#D4042D",
                 lineColorDarkMode: "#D4042D",

--- a/packages/utils/src/style/styleDefinitionHelpers.ts
+++ b/packages/utils/src/style/styleDefinitionHelpers.ts
@@ -63,11 +63,13 @@ export type PrimitiveStyleDefinition = Partial<
 >;
 
 /**
- * Fully-resolved primitive style definition delivered to renderers via the
- * `selectedStyle` state variable. Every supported key is guaranteed present —
- * unauthored color keys default to `""` so renderer truthy guards continue to
- * mean "no authored color". Excludes the `*Word` variants for highContrast and
- * background, which are conditionally produced and never read by renderers.
+ * Fully-resolved primitive style definition delivered via the `selectedStyle`
+ * state variable. Every supported key is guaranteed present — unauthored color
+ * and word keys default to `""` so consumers' truthy guards continue to mean
+ * "no authored value". Includes every `*Word` variant because the derived
+ * `textColor` / `backgroundColor` state-variable definitions in `style.ts`
+ * read them off `selectedStyle` to build human-readable descriptions, even
+ * though renderers themselves only consume the color values.
  */
 export interface ResolvedStyleDefinition {
     lineColor: string;
@@ -97,9 +99,13 @@ export interface ResolvedStyleDefinition {
     textColorDarkMode: string;
     textColorWordDarkMode: string;
     highContrastColor: string;
+    highContrastColorWord: string;
     highContrastColorDarkMode: string;
+    highContrastColorWordDarkMode: string;
     backgroundColor: string;
+    backgroundColorWord: string;
     backgroundColorDarkMode: string;
+    backgroundColorWordDarkMode: string;
 }
 
 export type ResolvedStyleDefinitionKey = keyof ResolvedStyleDefinition;
@@ -296,16 +302,19 @@ export const DEFAULT_STYLE_VALUES = {
  * encode "no authored value" rather than fabricate a placeholder. Two consumer
  * patterns make this safe:
  *
- *   - **Truthy guards.** Renderers handle the legitimately-optional keys with
- *     checks like `if (backgroundColor) { … }` (math.tsx, text.tsx, label.tsx,
- *     number.tsx); `""` is falsy, so the guard treats it as absent. The
- *     guarded keys are `backgroundColor`/`backgroundColorDarkMode`, which are
- *     intentionally not in `DEFAULT_STYLE_VALUES` (its absence is what keeps
+ *   - **Truthy guards.** Renderers and the derived `backgroundColor`
+ *     state-variable definition handle legitimately-optional keys with checks
+ *     like `if (backgroundColor) { … }` (math.tsx, text.tsx, label.tsx,
+ *     number.tsx; `style.ts:706` for `backgroundColorWord`). `""` is falsy, so
+ *     the guard treats it as absent. The guarded color keys are
+ *     `backgroundColor`/`backgroundColorDarkMode`, which are intentionally not
+ *     in `DEFAULT_STYLE_VALUES` (its absence is what keeps
  *     `addMissingColorWordsToStyleDefinition` from synthesizing a derived
  *     background color word).
  *   - **Word variants are derived, not authored.** `lineColorWord`,
- *     `markerColorWord`, `fillColorWord`, `textColorWord` (and DarkMode pairs)
- *     are populated by `addMissingColorWordsToStyleDefinition` from their
+ *     `markerColorWord`, `fillColorWord`, `textColorWord`,
+ *     `highContrastColorWord`, `backgroundColorWord` (and DarkMode pairs) are
+ *     populated by `addMissingColorWordsToStyleDefinition` from their
  *     corresponding color values. The `""` fallback only surfaces when the
  *     paired color is itself missing from the authored definition — an edge
  *     case where neither the color nor its word is meaningful.
@@ -320,8 +329,12 @@ const RESOLVED_STYLE_FALLBACKS: ResolvedStyleDefinition = {
     fillColorWordDarkMode: "",
     textColorWord: "",
     textColorWordDarkMode: "",
+    highContrastColorWord: "",
+    highContrastColorWordDarkMode: "",
     backgroundColor: "",
+    backgroundColorWord: "",
     backgroundColorDarkMode: "",
+    backgroundColorWordDarkMode: "",
 };
 
 /**

--- a/packages/utils/src/style/styleDefinitionHelpers.ts
+++ b/packages/utils/src/style/styleDefinitionHelpers.ts
@@ -302,11 +302,10 @@ export const DEFAULT_STYLE_VALUES = {
  * encode "no authored value" rather than fabricate a placeholder. Two consumer
  * patterns make this safe:
  *
- *   - **Truthy guards.** Renderers and the derived `backgroundColor`
- *     state-variable definition handle legitimately-optional keys with checks
- *     like `if (backgroundColor) { … }` (math.tsx, text.tsx, label.tsx,
- *     number.tsx; `style.ts:706` for `backgroundColorWord`). `""` is falsy, so
- *     the guard treats it as absent. The guarded color keys are
+ *   - **Truthy guards.** Renderers and `returnTextStyleDescriptionDefinitions`
+ *     handle legitimately-optional keys with checks like
+ *     `if (backgroundColor) { … }`; `""` is falsy, so the guard treats it as
+ *     absent. The guarded color keys are
  *     `backgroundColor`/`backgroundColorDarkMode`, which are intentionally not
  *     in `DEFAULT_STYLE_VALUES` (its absence is what keeps
  *     `addMissingColorWordsToStyleDefinition` from synthesizing a derived

--- a/packages/utils/src/style/styleDefinitionHelpers.ts
+++ b/packages/utils/src/style/styleDefinitionHelpers.ts
@@ -62,6 +62,48 @@ export type PrimitiveStyleDefinition = Partial<
     Record<StyleDefinitionKey, StyleDefinitionPrimitive>
 >;
 
+/**
+ * Fully-resolved primitive style definition delivered to renderers via the
+ * `selectedStyle` state variable. Every supported key is guaranteed present —
+ * unauthored color keys default to `""` so renderer truthy guards continue to
+ * mean "no authored color". Excludes the `*Word` variants for highContrast and
+ * background, which are conditionally produced and never read by renderers.
+ */
+export interface ResolvedStyleDefinition {
+    lineColor: string;
+    lineColorWord: string;
+    lineColorDarkMode: string;
+    lineColorWordDarkMode: string;
+    lineOpacity: number;
+    lineWidth: number;
+    lineWidthWord: string;
+    lineStyle: string;
+    lineStyleWord: string;
+    markerColor: string;
+    markerColorWord: string;
+    markerColorDarkMode: string;
+    markerColorWordDarkMode: string;
+    markerOpacity: number;
+    markerStyle: string;
+    markerStyleWord: string;
+    markerSize: number;
+    fillColor: string;
+    fillColorWord: string;
+    fillColorDarkMode: string;
+    fillColorWordDarkMode: string;
+    fillOpacity: number;
+    textColor: string;
+    textColorWord: string;
+    textColorDarkMode: string;
+    textColorWordDarkMode: string;
+    highContrastColor: string;
+    highContrastColorDarkMode: string;
+    backgroundColor: string;
+    backgroundColorDarkMode: string;
+}
+
+export type ResolvedStyleDefinitionKey = keyof ResolvedStyleDefinition;
+
 export type StyleDefinitions = Record<string, StyleDefinition>;
 
 export type RawStyleDefinitions = Record<string, RawStyleDefinition>;
@@ -208,6 +250,108 @@ export function unwrapStyleDefinition(
     }
 
     return unwrappedStyleDefinition;
+}
+
+/**
+ * Default style values shared between the worker-side `defaultStyle` preset and
+ * the renderer-facing `RESOLVED_STYLE_FALLBACKS`. Single source of truth so the
+ * two cannot drift apart.
+ *
+ * `backgroundColor` is intentionally absent: its absence in `defaultStyle` is
+ * load-bearing — `addMissingColorWordsToStyleDefinition` only emits a `*Word`
+ * variant when the corresponding color is truthy, so leaving it out prevents a
+ * background description from being derived for components with no authored
+ * background. The renderer-facing fallbacks override it back to `""` for the
+ * truthy-guard semantics renderers rely on.
+ */
+export const DEFAULT_STYLE_VALUES = {
+    lineOpacity: 0.7,
+    lineWidth: 4,
+    lineWidthWord: "thick",
+    lineStyle: "solid",
+    lineStyleWord: "",
+    markerOpacity: 0.7,
+    markerStyle: "circle",
+    markerStyleWord: "point",
+    markerSize: 5,
+    fillOpacity: 0.3,
+    lineColor: "#648FFF",
+    lineColorDarkMode: "#648FFF",
+    markerColor: "#648FFF",
+    markerColorDarkMode: "#648FFF",
+    fillColor: "#648FFF",
+    fillColorDarkMode: "#648FFF",
+    textColor: "black",
+    textColorDarkMode: "white",
+    highContrastColor: "#2963FF",
+    highContrastColorDarkMode: "#2963FF",
+} as const satisfies Partial<
+    Record<StyleDefinitionKey, StyleDefinitionPrimitive>
+>;
+
+/**
+ * Final-stop fallbacks used when a key is genuinely absent at unwrap time.
+ *
+ * Color/word entries here are `""` — not a valid color or color-word — to
+ * encode "no authored value" rather than fabricate a placeholder. Two consumer
+ * patterns make this safe:
+ *
+ *   - **Truthy guards.** Renderers handle the legitimately-optional keys with
+ *     checks like `if (backgroundColor) { … }` (math.tsx, text.tsx, label.tsx,
+ *     number.tsx); `""` is falsy, so the guard treats it as absent. The
+ *     guarded keys are `backgroundColor`/`backgroundColorDarkMode`, which are
+ *     intentionally not in `DEFAULT_STYLE_VALUES` (its absence is what keeps
+ *     `addMissingColorWordsToStyleDefinition` from synthesizing a derived
+ *     background color word).
+ *   - **Word variants are derived, not authored.** `lineColorWord`,
+ *     `markerColorWord`, `fillColorWord`, `textColorWord` (and DarkMode pairs)
+ *     are populated by `addMissingColorWordsToStyleDefinition` from their
+ *     corresponding color values. The `""` fallback only surfaces when the
+ *     paired color is itself missing from the authored definition — an edge
+ *     case where neither the color nor its word is meaningful.
+ */
+const RESOLVED_STYLE_FALLBACKS: ResolvedStyleDefinition = {
+    ...DEFAULT_STYLE_VALUES,
+    lineColorWord: "",
+    lineColorWordDarkMode: "",
+    markerColorWord: "",
+    markerColorWordDarkMode: "",
+    fillColorWord: "",
+    fillColorWordDarkMode: "",
+    textColorWord: "",
+    textColorWordDarkMode: "",
+    backgroundColor: "",
+    backgroundColorDarkMode: "",
+};
+
+/**
+ * Fills any missing keys in a primitive style definition with renderer-facing
+ * fallbacks, returning the fully-resolved shape used by the `selectedStyle`
+ * state variable.
+ *
+ * @param styleDef - Primitive (partial) style definition.
+ * @returns Resolved style definition with every supported key present.
+ */
+export function resolveStyleDefinition(
+    styleDef: PrimitiveStyleDefinition,
+): ResolvedStyleDefinition {
+    const resolved: ResolvedStyleDefinition = { ...RESOLVED_STYLE_FALLBACKS };
+
+    const writable = resolved as Record<
+        ResolvedStyleDefinitionKey,
+        StyleDefinitionPrimitive
+    >;
+
+    for (const key of Object.keys(
+        RESOLVED_STYLE_FALLBACKS,
+    ) as ResolvedStyleDefinitionKey[]) {
+        const value = styleDef[key];
+        if (value !== undefined) {
+            writable[key] = value;
+        }
+    }
+
+    return resolved;
 }
 
 /**

--- a/packages/utils/test/styleDefinitionHelpers.test.ts
+++ b/packages/utils/test/styleDefinitionHelpers.test.ts
@@ -43,12 +43,13 @@ const expectedKeys: (keyof ResolvedStyleDefinition)[] = [
 ];
 
 describe("resolveStyleDefinition", () => {
-    it("returns every supported key when given empty input", () => {
+    it("returns exactly the supported keys when given empty input", () => {
         const resolved = resolveStyleDefinition({});
 
-        for (const key of expectedKeys) {
-            expect(resolved, `missing key ${key}`).toHaveProperty(key);
-        }
+        // Asserting the exact set (not just `.toHaveProperty` per key) so a new
+        // key added to `ResolvedStyleDefinition` without updating `expectedKeys`
+        // fails this test instead of silently drifting.
+        expect(Object.keys(resolved).sort()).toEqual([...expectedKeys].sort());
     });
 
     it("fills color keys present in DEFAULT_STYLE_VALUES with their default", () => {

--- a/packages/utils/test/styleDefinitionHelpers.test.ts
+++ b/packages/utils/test/styleDefinitionHelpers.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+    DEFAULT_STYLE_VALUES,
+    resolveStyleDefinition,
+    type ResolvedStyleDefinition,
+} from "../src/style/styleDefinitionHelpers";
+
+const expectedKeys: (keyof ResolvedStyleDefinition)[] = [
+    "lineColor",
+    "lineColorWord",
+    "lineColorDarkMode",
+    "lineColorWordDarkMode",
+    "lineOpacity",
+    "lineWidth",
+    "lineWidthWord",
+    "lineStyle",
+    "lineStyleWord",
+    "markerColor",
+    "markerColorWord",
+    "markerColorDarkMode",
+    "markerColorWordDarkMode",
+    "markerOpacity",
+    "markerStyle",
+    "markerStyleWord",
+    "markerSize",
+    "fillColor",
+    "fillColorWord",
+    "fillColorDarkMode",
+    "fillColorWordDarkMode",
+    "fillOpacity",
+    "textColor",
+    "textColorWord",
+    "textColorDarkMode",
+    "textColorWordDarkMode",
+    "highContrastColor",
+    "highContrastColorWord",
+    "highContrastColorDarkMode",
+    "highContrastColorWordDarkMode",
+    "backgroundColor",
+    "backgroundColorWord",
+    "backgroundColorDarkMode",
+    "backgroundColorWordDarkMode",
+];
+
+describe("resolveStyleDefinition", () => {
+    it("returns every supported key when given empty input", () => {
+        const resolved = resolveStyleDefinition({});
+
+        for (const key of expectedKeys) {
+            expect(resolved, `missing key ${key}`).toHaveProperty(key);
+        }
+    });
+
+    it("fills color keys present in DEFAULT_STYLE_VALUES with their default", () => {
+        const resolved = resolveStyleDefinition({});
+
+        expect(resolved.textColor).eq("black");
+        expect(resolved.textColorDarkMode).eq("white");
+        expect(resolved.highContrastColor).eq("#2963FF");
+        expect(resolved.highContrastColorDarkMode).eq("#2963FF");
+        expect(resolved.lineColor).eq("#648FFF");
+        expect(resolved.fillOpacity).eq(0.3);
+    });
+
+    it("fills color and word keys absent from DEFAULT_STYLE_VALUES with empty string", () => {
+        const resolved = resolveStyleDefinition({});
+
+        expect(resolved.backgroundColor).eq("");
+        expect(resolved.backgroundColorDarkMode).eq("");
+        expect(resolved.backgroundColorWord).eq("");
+        expect(resolved.backgroundColorWordDarkMode).eq("");
+        expect(resolved.highContrastColorWord).eq("");
+        expect(resolved.highContrastColorWordDarkMode).eq("");
+        expect(resolved.lineColorWord).eq("");
+        expect(resolved.textColorWord).eq("");
+    });
+
+    it("preserves authored values, overriding fallbacks", () => {
+        const resolved = resolveStyleDefinition({
+            textColor: "red",
+            backgroundColor: "blue",
+            backgroundColorWord: "blue",
+            lineWidth: 2,
+        });
+
+        expect(resolved.textColor).eq("red");
+        expect(resolved.backgroundColor).eq("blue");
+        expect(resolved.backgroundColorWord).eq("blue");
+        expect(resolved.lineWidth).eq(2);
+        // Untouched keys still get fallbacks.
+        expect(resolved.textColorDarkMode).eq("white");
+        expect(resolved.lineColor).eq("#648FFF");
+    });
+
+    it("treats explicit undefined as absent and falls through to the fallback", () => {
+        const resolved = resolveStyleDefinition({
+            textColor: undefined,
+            backgroundColor: undefined,
+        });
+
+        expect(resolved.textColor).eq("black");
+        expect(resolved.backgroundColor).eq("");
+    });
+
+    it("round-trips every supported key the worker can populate", () => {
+        // Locks in the contract that no key gets silently dropped — the bug
+        // that caused `selectedStyle.backgroundColorWord` to disappear before
+        // it reached `returnTextStyleDescriptionDefinitions`.
+        const fullInput: Record<string, string | number> = {};
+        for (const key of expectedKeys) {
+            fullInput[key] =
+                key.endsWith("Opacity") ||
+                key.endsWith("Width") ||
+                key.endsWith("Size")
+                    ? 1
+                    : `value-${key}`;
+        }
+
+        const resolved = resolveStyleDefinition(
+            fullInput as Parameters<typeof resolveStyleDefinition>[0],
+        );
+
+        for (const key of expectedKeys) {
+            expect(resolved[key], `key ${key} was not preserved`).eq(
+                fullInput[key],
+            );
+        }
+    });
+
+    it("does not mutate the input object", () => {
+        const input = { textColor: "red" } as const;
+        const snapshot = { ...input };
+        resolveStyleDefinition(input);
+        expect(input).toEqual(snapshot);
+    });
+});
+
+describe("DEFAULT_STYLE_VALUES", () => {
+    it("intentionally omits backgroundColor (load-bearing for description-word derivation)", () => {
+        expect(DEFAULT_STYLE_VALUES).not.toHaveProperty("backgroundColor");
+        expect(DEFAULT_STYLE_VALUES).not.toHaveProperty(
+            "backgroundColorDarkMode",
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- Remove the renderer-side `SelectedStyle` interface (`packages/doenetml/src/Viewer/renderers/utils/graphicalSVs.ts`), which had an arbitrary mix of required and optional fields, and replace it with a single `ResolvedStyleDefinition` interface in `packages/utils/src/style/styleDefinitionHelpers.ts` where every key is required. Renderers and `styleColors.ts` now import `ResolvedStyleDefinition` from `@doenet/utils`.
- Add `resolveStyleDefinition(primitive)` in `styleDefinitionHelpers.ts`. It fills missing keys with renderer-facing fallbacks so the contract advertised by the type matches what reaches the renderer. Wired into `returnSelectedStyleStateVariableDefinition` in `packages/utils/src/style/style.ts` so the boundary conversion happens once, at the state-variable level.
- Introduce `DEFAULT_STYLE_VALUES` as the single source of truth for default style values. `defaultStyle` (style.ts) and preset 1 in `returnDefaultStyleDefinitions` now both spread it directly; `RESOLVED_STYLE_FALLBACKS` extends it with the `*Word` variants and `backgroundColor`/`backgroundColorDarkMode` set to `""` (the docstring on `RESOLVED_STYLE_FALLBACKS` explains why empty strings are safe — truthy guards on consumers and derived word variants).
- Drop the redundant `?? ""` on `selectedStyle.highContrastColor` in `button.tsx` (now guaranteed `string`).

### Behavior change for unauthored colors in custom `<styleDefinitions>`

Previously `selectedStyle.X` was `string | undefined` for the optional keys (`textColor`, `textColorDarkMode`, `highContrastColor`, `highContrastColorDarkMode`, `backgroundColor`, `backgroundColorDarkMode`). After this PR, every key is `string` and unauthored entries are filled at the state-variable boundary by `resolveStyleDefinition`:

- `backgroundColor` / `backgroundColorDarkMode` (and every `*Word` variant) fall back to `""` — every consumer (renderers and the derived `backgroundColor` state variable) uses a truthy guard, so `""` and `undefined` are interchangeable. **No observable change.**
- `textColor` / `textColorDarkMode` / `highContrastColor` / `highContrastColorDarkMode` fall back to their `DEFAULT_STYLE_VALUES` entries (`"black"` / `"white"` / `"#2963FF"` / `"#2963FF"`). Renderers consume these values directly (e.g. as a CSS `color`), so a custom `<styleDefinitions>` ancestor that explicitly omits one of those keys will now paint the default value instead of inheriting from the surrounding context.

The seven built-in presets in `returnDefaultStyleDefinitions` all set every color key, so default users see no change. The new behavior only applies when an author writes a `<styleDefinitions>`/`<styleDefinition>` block that omits one of these keys — a rare edge case, and arguably more useful than rendering `color: undefined` (no-op).

### Test coverage for the boundary

`packages/utils/test/styleDefinitionHelpers.test.ts` locks in the resolved-shape contract: empty input fills every supported key, color keys with `DEFAULT_STYLE_VALUES` defaults are populated, color/word keys absent from the defaults fall back to `""`, authored values override fallbacks, explicit `undefined` falls through, every key the worker can populate round-trips, and input is not mutated. The round-trip case directly guards against the regression a draft of this refactor introduced (the `*Word` variants for `highContrast`/`background` were initially excluded from the resolved type and silently dropped on the way to `returnTextStyleDescriptionDefinitions`).

### Follow-up
The prefigure pipeline still has its own separate `SelectedStyle` interface (`packages/doenetml-worker-javascript/src/utils/prefigure/types.ts`) for SSR conversion. Different shape (index signature + all-optional), different consumer. Out of scope for this PR; tracked in #1076.

### No changeset
Pure type/internal refactor; no user-visible change for the default presets. Custom `<styleDefinitions>` that omit `textColor`/`highContrastColor` see the new fallback behavior described above — see "Behavior change" section.

## Test plan
- [x] Typecheck `@doenet/utils` and `@doenet/doenetml` — clean (only pre-existing unrelated errors in `media/cid.ts` and `orbitalDiagramInput.tsx`).
- [x] Build `@doenet/utils` to verify dist `.d.ts` exports `ResolvedStyleDefinition`.
- [x] `npm test` in `packages/utils` — all 21 tests pass (13 pre-existing + 8 new for `resolveStyleDefinition`).
- [x] Worker tests `text.test.ts` (13/13) and `mathdisplay.test.ts` (23/23) pass.
- [x] `grep -rn "SelectedStyle\b" packages/doenetml/src/ packages/utils/src/` — empty (only prefigure remains, intentionally).
- [x] Manual smoke: render a doc with `<m>`, `<text>`, `<number>`, `<label>` (background-color path) and `<button>` (highContrastColor path) in light and dark modes; visual output unchanged for built-in presets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)