### PR TITLE
feat(schema): add component summary and attribute/property descriptions

### DIFF
--- a/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
@@ -22,7 +22,8 @@ export default class SelectFromSequence extends Sequence {
     static componentType = "selectFromSequence";
 
     static componentDocs = {
-        summary: "Randomly selects values from a numerical or letter sequence.",
+        summary:
+            "Randomly selects values from a sequence of numbers, math expressions, or letters.",
     };
 
     static takesIndex = true;

--- a/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
@@ -21,6 +21,10 @@ import me from "math-expressions";
 export default class SelectFromSequence extends Sequence {
     static componentType = "selectFromSequence";
 
+    static componentDocs = {
+        summary: "Randomly selects values from a numerical or letter sequence.",
+    };
+
     static takesIndex = true;
 
     static createsVariants = true;
@@ -32,12 +36,15 @@ export default class SelectFromSequence extends Sequence {
             createStateVariable: "numToSelect",
             defaultValue: 1,
             public: true,
+            description: "How many values to select from the sequence.",
         };
         attributes.withReplacement = {
             createComponentOfType: "boolean",
             createStateVariable: "withReplacement",
             defaultValue: false,
             public: true,
+            description:
+                "Whether the same value can be selected more than once.",
         };
         attributes.sort = {
             createComponentOfType: "text",
@@ -48,15 +55,21 @@ export default class SelectFromSequence extends Sequence {
             valueForTrue: "increasing",
             valueForFalse: "unsorted",
             validValues: ["unsorted", "increasing", "decreasing"],
+            description:
+                "Sort the selected values: unsorted (default), increasing, or decreasing.",
         };
         attributes.excludeCombinations = {
             createComponentOfType: "_componentListOfListsWithSelectableType",
+            description:
+                "Lists of value combinations to exclude from the selection.",
         };
         attributes.coprime = {
             createComponentOfType: "boolean",
             createStateVariable: "coprime",
             defaultValue: false,
             public: true,
+            description:
+                "Require the selected numbers to be pairwise coprime (numbers only).",
         };
         return attributes;
     }

--- a/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
@@ -55,8 +55,7 @@ export default class SelectFromSequence extends Sequence {
             valueForTrue: "increasing",
             valueForFalse: "unsorted",
             validValues: ["unsorted", "increasing", "decreasing"],
-            description:
-                "Sort the selected values: unsorted (default), increasing, or decreasing.",
+            description: "Whether and how to sort the selected values.",
         };
         attributes.excludeCombinations = {
             createComponentOfType: "_componentListOfListsWithSelectableType",

--- a/packages/doenetml-worker-javascript/src/components/Sequence.js
+++ b/packages/doenetml-worker-javascript/src/components/Sequence.js
@@ -11,6 +11,11 @@ import { convertUnresolvedAttributesForComponentType } from "../utils/dast/conve
 export default class Sequence extends CompositeComponent {
     static componentType = "sequence";
 
+    static componentDocs = {
+        summary:
+            "Generates a sequence of numbers, math expressions, or letters defined by from, to, length, and step.",
+    };
+
     static takesIndex = true;
 
     static stateVariableToEvaluateAfterReplacements =

--- a/packages/doenetml-worker-javascript/src/components/When.js
+++ b/packages/doenetml-worker-javascript/src/components/When.js
@@ -56,6 +56,8 @@ export default class When extends BooleanComponent {
                     shadowingInstructions: {
                         createComponentOfType: "number",
                     },
+                    description:
+                        "Fraction of the boolean condition that is satisfied (0 to 1).",
                 },
                 {
                     variableName: "conditionSatisfied",

--- a/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
@@ -1127,11 +1127,13 @@ export default class BaseComponent {
                             createComponentOfType,
                             public: true,
                             isArray: false,
+                            description: attrObj.description,
                         };
                     } else {
                         stateVariableDescriptions[varName] = {
                             public: false,
                             isArray: false,
+                            description: attrObj.description,
                         };
                     }
                 }
@@ -1157,11 +1159,13 @@ export default class BaseComponent {
                                 .createComponentOfType,
                         public: true,
                         isArray: Boolean(theStateDef.isArray),
+                        description: theStateDef.description,
                     };
                 } else {
                     stateVariableDescriptions[varName] = {
                         public: false,
                         isArray: Boolean(theStateDef.isArray),
+                        description: theStateDef.description,
                     };
                 }
                 if (theStateDef.isArray) {

--- a/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
@@ -1127,16 +1127,19 @@ export default class BaseComponent {
                             createComponentOfType,
                             public: true,
                             isArray: false,
-                            description: attrObj.description,
-                            fromAttribute: attrName === varName,
                         };
                     } else {
                         stateVariableDescriptions[varName] = {
                             public: false,
                             isArray: false,
-                            description: attrObj.description,
-                            fromAttribute: attrName === varName,
                         };
+                    }
+                    if (attrName === varName) {
+                        stateVariableDescriptions[varName].fromAttribute = true;
+                    }
+                    if (attrObj.description !== undefined) {
+                        stateVariableDescriptions[varName].description =
+                            attrObj.description;
                     }
                 }
             }
@@ -1161,14 +1164,16 @@ export default class BaseComponent {
                                 .createComponentOfType,
                         public: true,
                         isArray: Boolean(theStateDef.isArray),
-                        description: theStateDef.description,
                     };
                 } else {
                     stateVariableDescriptions[varName] = {
                         public: false,
                         isArray: Boolean(theStateDef.isArray),
-                        description: theStateDef.description,
                     };
+                }
+                if (theStateDef.description !== undefined) {
+                    stateVariableDescriptions[varName].description =
+                        theStateDef.description;
                 }
                 if (theStateDef.isArray) {
                     stateVariableDescriptions[varName].isArray = true;

--- a/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
@@ -1128,12 +1128,14 @@ export default class BaseComponent {
                             public: true,
                             isArray: false,
                             description: attrObj.description,
+                            fromAttribute: attrName === varName,
                         };
                     } else {
                         stateVariableDescriptions[varName] = {
                             public: false,
                             isArray: false,
                             description: attrObj.description,
+                            fromAttribute: attrName === varName,
                         };
                     }
                 }

--- a/packages/doenetml-worker-javascript/src/utils/sequence.js
+++ b/packages/doenetml-worker-javascript/src/utils/sequence.js
@@ -10,8 +10,7 @@ export function returnStandardSequenceAttributes() {
             defaultPrimitiveValue: "number",
             toLowerCase: true,
             validValues: ["number", "math", "letters"],
-            description:
-                "Whether the sequence is of numbers, math expressions, or letters.",
+            description: "The kind of values in the sequence.",
         },
         from: {
             createComponentOfType: "_componentWithSelectableType",

--- a/packages/doenetml-worker-javascript/src/utils/sequence.js
+++ b/packages/doenetml-worker-javascript/src/utils/sequence.js
@@ -10,21 +10,30 @@ export function returnStandardSequenceAttributes() {
             defaultPrimitiveValue: "number",
             toLowerCase: true,
             validValues: ["number", "math", "letters"],
+            description:
+                "Whether the sequence is of numbers, math expressions, or letters.",
         },
         from: {
             createComponentOfType: "_componentWithSelectableType",
+            description: "The first value in the sequence.",
         },
         to: {
             createComponentOfType: "_componentWithSelectableType",
+            description:
+                "The last value in the sequence. Used together with from to determine length when length is not specified.",
         },
         step: {
             createComponentOfType: "math",
+            description:
+                "The increment between successive values in the sequence.",
         },
         length: {
             createComponentOfType: "integer",
+            description: "The number of values in the sequence.",
         },
         exclude: {
             createComponentOfType: "_componentListWithSelectableType",
+            description: "Values to exclude from the sequence.",
         },
     };
 }

--- a/packages/static-assets/scripts/generate-schema.ts
+++ b/packages/static-assets/scripts/generate-schema.ts
@@ -7,7 +7,7 @@ const schema = getSchema();
 reportHelpCoverage(schema.elements);
 console.log(
     "Writing",
-    Object.keys(schema.elements).length,
+    schema.elements.length,
     "schema items to",
     destUrl.pathname,
 );

--- a/packages/static-assets/scripts/generate-schema.ts
+++ b/packages/static-assets/scripts/generate-schema.ts
@@ -1,9 +1,10 @@
 import * as fs from "node:fs/promises";
-import { getSchema } from "./get-schema";
+import { getSchema, reportHelpCoverage } from "./get-schema";
 
 const destUrl = new URL("../src/generated/doenet-schema.json", import.meta.url);
 
 const schema = getSchema();
+reportHelpCoverage(schema.elements);
 console.log(
     "Writing",
     Object.keys(schema.elements).length,

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -520,10 +520,10 @@ export function getSchema() {
 }
 
 /**
- * Print a coverage summary to stdout listing schema elements, attributes, and
- * properties that lack help (`summary`/`description`). Warnings only — never
- * fails the build. Helps track authoring progress as descriptions are
- * backfilled across the ~200+ component classes.
+ * Print aggregate coverage counts to stdout for schema elements, attributes,
+ * and properties with help (`summary`/`description`) authored. Warnings only
+ * — never fails the build. Helps track authoring progress as descriptions
+ * are backfilled across the ~200+ component classes.
  */
 export function reportHelpCoverage(
     elements: ReturnType<typeof getSchema>["elements"],

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -93,6 +93,7 @@ type PropertyDescription = {
     numDimensions?: number;
     indexedArrayDescription?: ArrayElementDescription[];
     description?: string;
+    fromAttribute?: boolean;
 };
 
 type ArrayElementDescription = {
@@ -121,6 +122,7 @@ type StateVariableDescription = {
     getArrayKeysFromVarName?: Function;
     arrayVarNameFromPropIndex?: Function;
     description?: string;
+    fromAttribute?: boolean;
 };
 
 type PublicStateVariableDescription = {
@@ -133,6 +135,7 @@ type PublicStateVariableDescription = {
     getArrayKeysFromVarName?: Function;
     arrayVarNameFromPropIndex?: Function;
     description?: string;
+    fromAttribute?: boolean;
 };
 
 type SchemaAttribute = {
@@ -444,7 +447,10 @@ export function getSchema() {
                 properties.push(
                     ...propFromDescription({
                         varName: aliasName,
-                        description: aliasTarget,
+                        // Aliases never inherit `fromAttribute` from their target:
+                        // the alias has a different name and is not itself created
+                        // from a same-named attribute.
+                        description: { ...aliasTarget, fromAttribute: false },
                         arrayEntryPrefixes,
                         includeSchemaSubarrays: false,
                     }),
@@ -605,6 +611,10 @@ function propFromDescription({
                         numDimensions: schemaSubarrayDescription.numDimensions,
                         wrappingComponents:
                             prefixDescription.wrappingComponents,
+                        // Subarray entries have a different name from the
+                        // parent array; they're never themselves created
+                        // directly from a same-named attribute.
+                        fromAttribute: false,
                     },
                     arrayEntryPrefixes,
                 }),
@@ -634,6 +644,10 @@ function singlePropFromDescription({
 
     if (description.description) {
         prop.description = description.description;
+    }
+
+    if (description.fromAttribute) {
+        prop.fromAttribute = true;
     }
 
     if (description.isArray) {

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -521,9 +521,9 @@ export function getSchema() {
 
 /**
  * Print aggregate coverage counts to stdout for schema elements, attributes,
- * and properties with help (`summary`/`description`) authored. Warnings only
- * — never fails the build. Helps track authoring progress as descriptions
- * are backfilled across the ~200+ component classes.
+ * and properties with help (`summary`/`description`) authored. Informational
+ * only — never fails the build. Helps track authoring progress as
+ * descriptions are backfilled across the ~200+ component classes.
  */
 export function reportHelpCoverage(
     elements: ReturnType<typeof getSchema>["elements"],

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -17,6 +17,7 @@ type AttributeObject = {
     validValues?: unknown[];
     valueForTrue?: unknown;
     valueForFalse?: unknown;
+    description?: string;
 };
 
 type ComponentClass = {
@@ -75,6 +76,8 @@ type ComponentClass = {
     additionalSchemaChildren?: string[];
     /** If `true` and `additionalSchemaChildren` is set, then those children will not be inherited by subclasses */
     additionalSchemaChildrenDoNotInherit?: boolean;
+    /** Class-level help metadata: a one-sentence summary plus future-extensible fields. */
+    componentDocs?: { summary?: string };
 };
 
 interface ComponentInfoObjects extends ReturnType<
@@ -89,6 +92,7 @@ type PropertyDescription = {
     isArray: boolean;
     numDimensions?: number;
     indexedArrayDescription?: ArrayElementDescription[];
+    description?: string;
 };
 
 type ArrayElementDescription = {
@@ -116,6 +120,7 @@ type StateVariableDescription = {
     wrappingComponents?: WrappingComponentElement[][];
     getArrayKeysFromVarName?: Function;
     arrayVarNameFromPropIndex?: Function;
+    description?: string;
 };
 
 type PublicStateVariableDescription = {
@@ -127,6 +132,7 @@ type PublicStateVariableDescription = {
     wrappingComponents?: WrappingComponentElement[][];
     getArrayKeysFromVarName?: Function;
     arrayVarNameFromPropIndex?: Function;
+    description?: string;
 };
 
 type SchemaAttribute = {
@@ -135,6 +141,8 @@ type SchemaAttribute = {
     values?: unknown[];
     /** Optional author-facing subset used for autocomplete suggestions. */
     autocompleteValues?: unknown[];
+    /** One-sentence description of the attribute, surfaced in editor help and docs. */
+    description?: string;
 };
 
 type SchemaElement = {
@@ -152,6 +160,8 @@ type SchemaElement = {
     acceptsStringChildren: boolean;
     /** Whether descendants are accessible only via index */
     takesIndex: boolean;
+    /** One-sentence summary of the component, surfaced in editor help and docs. */
+    summary?: string;
 };
 
 /**
@@ -352,6 +362,10 @@ export function getSchema() {
                     name: attrName,
                 };
 
+                if (attrDef.description) {
+                    attrSpec.description = attrDef.description;
+                }
+
                 const booleanAliasValues: string[] = [];
                 if (attrDef.valueForTrue !== undefined) {
                     booleanAliasValues.push("true");
@@ -476,7 +490,7 @@ export function getSchema() {
             }
         }
 
-        elements.push({
+        const element: SchemaElement = {
             name: type,
             children,
             attributes,
@@ -486,10 +500,57 @@ export function getSchema() {
                 documentChildrenSet.has(cClass.componentType),
             acceptsStringChildren,
             takesIndex: cClass.takesIndex ?? false,
-        });
+        };
+
+        const summary = cClass.componentDocs?.summary;
+        if (summary) {
+            element.summary = summary;
+        }
+
+        elements.push(element);
     }
 
     return { elements };
+}
+
+/**
+ * Print a coverage summary to stdout listing schema elements, attributes, and
+ * properties that lack help (`summary`/`description`). Warnings only — never
+ * fails the build. Helps track authoring progress as descriptions are
+ * backfilled across the ~200+ component classes.
+ */
+export function reportHelpCoverage(
+    elements: ReturnType<typeof getSchema>["elements"],
+) {
+    let elementsWithSummary = 0;
+    let attributesWithDescription = 0;
+    let propertiesWithDescription = 0;
+    let totalAttributes = 0;
+    let totalProperties = 0;
+
+    for (const element of elements) {
+        if (element.summary) {
+            elementsWithSummary++;
+        }
+        for (const attr of element.attributes) {
+            totalAttributes++;
+            if (attr.description) {
+                attributesWithDescription++;
+            }
+        }
+        for (const prop of element.properties) {
+            totalProperties++;
+            if (prop.description) {
+                propertiesWithDescription++;
+            }
+        }
+    }
+
+    console.log(
+        `Help coverage: ${elementsWithSummary}/${elements.length} elements have summary, ` +
+            `${attributesWithDescription}/${totalAttributes} attributes have description, ` +
+            `${propertiesWithDescription}/${totalProperties} properties have description`,
+    );
 }
 
 function propFromDescription({
@@ -570,6 +631,10 @@ function singlePropFromDescription({
         type: componentType,
         isArray: description.isArray,
     };
+
+    if (description.description) {
+        prop.description = description.description;
+    }
 
     if (description.isArray) {
         const numDimensions = description.numDimensions || 1;

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -114875,22 +114875,26 @@
                 {
                     "name": "numToSelect",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "description": "How many values to select from the sequence."
                 },
                 {
                     "name": "withReplacement",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "description": "Whether the same value can be selected more than once."
                 },
                 {
                     "name": "sort",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "description": "Sort the selected values: unsorted (default), increasing, or decreasing."
                 },
                 {
                     "name": "coprime",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "description": "Require the selected numbers to be pairwise coprime (numbers only)."
                 },
                 {
                     "name": "doenetML",

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -734,27 +734,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -1261,97 +1266,116 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -2393,52 +2417,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -3027,42 +3061,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -3676,42 +3718,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -4600,52 +4650,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -5509,52 +5569,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -6418,52 +6488,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -6900,47 +6980,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isLatex",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -7133,27 +7222,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -7252,27 +7346,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -7866,52 +7965,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -8728,27 +8837,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -9315,42 +9429,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -9947,42 +10069,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -10579,42 +10709,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -10793,42 +10931,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -10997,42 +11143,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -11631,42 +11785,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -12180,87 +12342,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -12500,87 +12679,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -12815,87 +13011,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -13130,87 +13343,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -13646,87 +13876,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -14162,87 +14409,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -14691,97 +14955,116 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "limits",
                     "type": "numberList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "strict",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -15302,107 +15585,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -16106,107 +16410,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -16908,107 +17233,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "lowerValue",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "upperValue",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -17710,107 +18056,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "lowerValue",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "upperValue",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -18512,107 +18879,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numDecimals",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numDigits",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -19308,102 +19696,122 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "threshold",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -20086,97 +20494,116 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -20861,97 +21288,116 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -21641,97 +22087,116 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -22421,97 +22886,116 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -23201,97 +23685,116 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -23995,107 +24498,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -24799,107 +25323,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -25610,112 +26155,134 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "population",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -26426,112 +26993,134 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "population",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -27235,107 +27824,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -28039,107 +28649,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -28843,107 +29474,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -29647,107 +30299,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -30451,107 +31124,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -31255,107 +31949,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -32067,107 +32782,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "operandNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "argumentNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -32891,27 +33627,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandSpecified",
@@ -32921,42 +33662,50 @@
                 {
                     "name": "xscale",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yscale",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "lowerValue",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "upperValue",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -33805,27 +34554,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandSpecified",
@@ -33835,42 +34589,50 @@
                 {
                     "name": "xscale",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yscale",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "lowerValue",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "upperValue",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -34719,27 +35481,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandSpecified",
@@ -34749,32 +35516,38 @@
                 {
                     "name": "xscale",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yscale",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -35490,47 +36263,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isLatex",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -36153,27 +36935,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -36707,27 +37494,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -37261,27 +38053,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -37815,27 +38612,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -38369,27 +39171,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -38923,27 +39730,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -39477,27 +40289,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -40031,27 +40848,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -40585,27 +41407,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -41139,27 +41966,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -41263,27 +42095,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -41387,27 +42224,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -41511,27 +42353,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -41635,27 +42482,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -41759,27 +42611,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -41883,27 +42740,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -42007,27 +42869,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -42131,27 +42998,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -43094,87 +43966,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -44147,87 +45036,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -45200,87 +46106,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -46253,87 +47176,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -47327,92 +48267,110 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "collapsible",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -48385,87 +49343,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -49445,87 +50420,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -50505,87 +51497,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -51565,87 +52574,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -52625,87 +53651,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -53678,87 +54721,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -54731,87 +55791,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -55784,87 +56861,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -56837,87 +57931,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -57890,87 +59001,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -58943,87 +60071,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -60016,87 +61161,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "collapsible",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -61068,82 +62230,98 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -62115,82 +63293,98 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -62355,32 +63549,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "label",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -62510,32 +63710,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "label",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -63384,52 +64590,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -63649,67 +64865,80 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "independentVariable",
                     "type": "_variableName",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "initialIndependentVariableValue",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "chunkSize",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "tolerance",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxIterations",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hideInitialCondition",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "number",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -64158,92 +65387,110 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rigid",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowRotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowTranslation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowReflection",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "attractThreshold",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPoints",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "variable",
                     "type": "_variableName",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numIterationsRequired",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -64930,77 +66177,92 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlOrder",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "stable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "switchable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -65595,62 +66857,74 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "stable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "switchable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -66308,102 +67582,122 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "flipFunction",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numDiscretizationPoints",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "periodic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splineTension",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "extrapolateBackward",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "extrapolateForward",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splineForm",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "stable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "switchable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -66782,27 +68076,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -67071,27 +68370,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -67288,27 +68592,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -67835,97 +69144,116 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -68467,27 +69795,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -68603,27 +69936,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -68759,27 +70097,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -69082,22 +70425,26 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -69428,27 +70775,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -69633,27 +70985,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -70492,27 +71849,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -70940,47 +72302,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isLatex",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -71402,27 +72773,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -72251,52 +73627,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -73160,52 +74546,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -74010,27 +75406,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -74820,27 +76221,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -75656,27 +77062,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -75809,42 +77220,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "previousLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "nextLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "pageLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -76099,77 +77518,92 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "collaborateGroups",
                     "type": "collaborateGroups",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showSizeControls",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "prefill",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unionFromU",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -76983,22 +78417,26 @@
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -77699,22 +79137,26 @@
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -78544,27 +79986,32 @@
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "documentWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -79006,47 +80453,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isLatex",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -79486,32 +80942,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unordered",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -80095,52 +81557,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -80634,87 +82106,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -80881,32 +82370,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unordered",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -81393,97 +82888,116 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -82097,42 +83611,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -82553,42 +84075,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -82976,27 +84506,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -83081,12 +84616,14 @@
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -83875,32 +85412,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "textType",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -84421,67 +85964,80 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlOrder",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -85094,92 +86650,110 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -85835,52 +87409,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -86235,67 +87819,80 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlOrder",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -86575,52 +88172,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -86966,72 +88573,86 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rigid",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowRotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowTranslation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowReflection",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -87417,87 +89038,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rigid",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowRotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowTranslation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowReflection",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "filled",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlOrder",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -87903,87 +89541,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rigid",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowRotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowTranslation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowReflection",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "filled",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlOrder",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -88409,87 +90064,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rigid",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowRotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowTranslation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowReflection",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "filled",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlOrder",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -88960,87 +90632,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rigid",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowRotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowTranslation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowReflection",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "filled",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlOrder",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -89715,107 +91404,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "flipFunction",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numDiscretizationPoints",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "periodic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splineTension",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "extrapolateBackward",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "extrapolateForward",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splineForm",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "filled",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlOrder",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -90423,92 +92133,110 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "flipFunction",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numDiscretizationPoints",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "periodic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splineTension",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "extrapolateBackward",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "extrapolateForward",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splineForm",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -91116,92 +92844,110 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "flipFunction",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numDiscretizationPoints",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "periodic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splineTension",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "extrapolateBackward",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "extrapolateForward",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splineForm",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -91787,32 +93533,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "alwaysVisible",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -92216,37 +93968,44 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "direction",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "pointNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -92751,72 +94510,86 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayWithAngleBrackets",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlOrder",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -93400,62 +95173,74 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "radius",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "chooseReflexAngle",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "inDegrees",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "emphasizeRightAngle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -94188,47 +95973,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "handGraded",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchPartial",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumAttempts",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "colorCorrectnessPreliminary",
@@ -94238,162 +96032,194 @@
                 {
                     "name": "disableAfterCorrect",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForResponses",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "inline",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceFullCheckWorkButton",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSmallCheckWorkButton",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numAwardsCredited",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "selectMultiple",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "shuffleOrder",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "preserveLastChoice",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "disableWrongChoices",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "creditByAttempt",
                     "type": "numberList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expanded",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "description",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showPreview",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -95013,117 +96839,140 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "credit",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchPartial",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "feedbackCodes",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "feedbackText",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -95652,92 +97501,110 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchPartial",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -95772,7 +97639,8 @@
                 {
                     "name": "fractionSatisfied",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "description": "Fraction of the boolean condition that is satisfied (0 to 1)."
                 },
                 {
                     "name": "conditionSatisfied",
@@ -96242,87 +98110,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "collaborateGroups",
                     "type": "collaborateGroups",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "prefill",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "prefillLatex",
                     "type": "latex",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unionFromU",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hideNaN",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "minWidth",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -96922,67 +98807,80 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "collaborateGroups",
                     "type": "collaborateGroups",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "prefill",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expanded",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "height",
                     "type": "componentSize",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -97545,62 +99443,74 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "collaborateGroups",
                     "type": "collaborateGroups",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "prefill",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asToggleButton",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -97829,62 +99739,74 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "collaborateGroups",
                     "type": "collaborateGroups",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "selectMultiple",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchPartial",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "shuffleOrder",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "preserveLastChoice",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -98830,42 +100752,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "credit",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "feedbackCodes",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "feedbackText",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -99365,47 +101295,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderAsMath",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -99940,47 +101879,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderAsMath",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -100798,122 +102746,146 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "horizontalAlign",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "identicalAxisScales",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayXAxis",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayYAxis",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlsPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayXAxisTicks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayYAxisTicks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "xLabelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "xTickScaleFactor",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yLabelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yLabelAlignment",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yTickScaleFactor",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showNavigation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showBorder",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hideOffGraphIndicators",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "decorative",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderer",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -101138,27 +103110,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -101296,47 +103273,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "text",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "speech",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sonify",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "circular",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -101855,27 +103841,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandSpecified",
@@ -101885,32 +103876,38 @@
                 {
                     "name": "xscale",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yscale",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -102489,27 +104486,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandSpecified",
@@ -102519,32 +104521,38 @@
                 {
                     "name": "xscale",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yscale",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -103339,92 +105347,110 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -104424,37 +106450,44 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "selectForVariants",
                     "type": "textListFromString",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "selectWeight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -104627,27 +106660,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -105074,77 +107112,92 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "width",
                     "type": "componentSize",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "height",
                     "type": "componentSize",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showControls",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showTicks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rotateTickLabels",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showValue",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "from",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "to",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "step",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -105367,72 +107420,86 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "width",
                     "type": "componentSize",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "minNumRows",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "minNumColumns",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "columnHeaders",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rowHeaders",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "fixedRowsTop",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "fixedColumnsLeft",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hiddenColumns",
                     "type": "numberList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hiddenRows",
                     "type": "numberList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -106429,47 +108496,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rowNum",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "colNum",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "colSpan",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "prefill",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -106673,37 +108749,44 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rowNum",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "header",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -106861,32 +108944,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "colNum",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -107013,37 +109102,44 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rowNum",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "colNum",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -107214,67 +109310,80 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "width",
                     "type": "componentSize",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "height",
                     "type": "componentSize",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "halign",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "valign",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "top",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "left",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "bottom",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "right",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -107979,27 +110088,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -108719,27 +110833,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -109082,27 +111201,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -109938,22 +112062,26 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -110779,22 +112907,26 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -110930,62 +113062,74 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "dx",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "dy",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "xoffset",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yoffset",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -111125,57 +113269,68 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "dx",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "dy",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "dz",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "xoffset",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yoffset",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "zoffset",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -111280,32 +113435,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "buffer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -111465,77 +113626,92 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "dx",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "dy",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "dz",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "xoffset",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yoffset",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "zoffset",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "xthreshold",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "ythreshold",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "zthreshold",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeGridlines",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -111888,32 +114064,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "relativeToGraphScales",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -112272,32 +114454,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "relativeToGraphScales",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -112429,27 +114617,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -112582,32 +114775,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "threshold",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -112960,32 +115159,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "relativeToGraphScales",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -113128,22 +115333,26 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -113926,27 +116135,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -114455,27 +116669,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -114621,27 +116840,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -114850,51 +117074,60 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numToSelect",
                     "type": "integer",
                     "isArray": false,
-                    "description": "How many values to select from the sequence."
+                    "description": "How many values to select from the sequence.",
+                    "fromAttribute": true
                 },
                 {
                     "name": "withReplacement",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the same value can be selected more than once."
+                    "description": "Whether the same value can be selected more than once.",
+                    "fromAttribute": true
                 },
                 {
                     "name": "sort",
                     "type": "text",
                     "isArray": false,
-                    "description": "Sort the selected values: unsorted (default), increasing, or decreasing."
+                    "description": "Sort the selected values: unsorted (default), increasing, or decreasing.",
+                    "fromAttribute": true
                 },
                 {
                     "name": "coprime",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Require the selected numbers to be pairwise coprime (numbers only)."
+                    "description": "Require the selected numbers to be pairwise coprime (numbers only).",
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -115006,37 +117239,44 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numToSelect",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "withReplacement",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -115831,27 +118071,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rendered",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -116004,47 +118249,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "animationOn",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "animationMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "animationInterval",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowAdjustmentsWhileRunning",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -116340,112 +118594,134 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unordered",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -116830,37 +119106,44 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "type",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numToSelect",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -117069,42 +119352,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSamples",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "type",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "variantDeterminesSeed",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -117267,57 +119558,68 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "from",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "to",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "exclude",
                     "type": "numberList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numToSelect",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "withReplacement",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sort",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -117434,52 +119736,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSamples",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "from",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "to",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "exclude",
                     "type": "numberList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "variantDeterminesSeed",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -118333,52 +120645,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "type",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchWholeWord",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchCase",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "preserveCase",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -118675,127 +120997,152 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "minIndex",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxIndex",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "offsets",
                     "type": "mathList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "period",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "minIndexAsList",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxIndexAsList",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -119208,77 +121555,92 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "horizontalAlign",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "decorative",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "source",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asFileName",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "mimeType",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rotate",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -119461,47 +121823,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "horizontalAlign",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "youtube",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "source",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -120336,27 +122707,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -120788,47 +123164,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isLatex",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -121361,57 +123746,68 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isLatex",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "pluralForm",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "basedOnNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -122306,22 +124702,26 @@
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -123111,27 +125511,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -123928,27 +126333,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -124094,47 +126504,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "minSentencesPerParagraph",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxSentencesPerParagraph",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "minWordsPerSentence",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxWordsPerSentence",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -124318,47 +126737,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -124563,47 +126991,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "actionName",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -124790,42 +127227,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -124998,42 +127443,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numIterates",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -125900,22 +128353,26 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rendered",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -126685,27 +129142,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -127481,27 +129943,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -128010,27 +130477,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -128731,27 +131203,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -129276,77 +131753,92 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlOrder",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "open",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "switchable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -130291,37 +132783,44 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sortVectorsBy",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sortByComponent",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -131104,27 +133603,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -131468,32 +133972,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numDiscretizationPoints",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -131689,72 +134199,86 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "xMin",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "xMax",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "width",
                     "type": "componentSize",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "height",
                     "type": "componentSize",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "xlabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "dx",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "variable",
                     "type": "_variableName",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "prefill",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -132321,102 +134845,122 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -133472,27 +136016,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -133674,47 +136223,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -134015,47 +136573,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "boundaryValues",
                     "type": "numberList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -134230,52 +136797,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "boundaryValues",
                     "type": "numberList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "flipFunctions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -134442,57 +137019,68 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "horizontal",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "boundaryValue",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "greaterThan",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -135358,62 +137946,74 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "prefill",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "width",
                     "type": "componentSize",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "height",
                     "type": "componentSize",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showResults",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showFormatter",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "resultsLocation",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "readOnly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -135891,87 +138491,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -136099,37 +138716,44 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "source",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hasHeader",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -136317,32 +138941,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "byCategoryColumn",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -136585,52 +139215,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "position",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayClosedSwatches",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -137209,42 +139849,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -137757,117 +140405,140 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowImplicitIdentities",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowPermutations",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "requireNumericMatches",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "requireVariableMatches",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "excludeMatches",
                     "type": "mathList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchExpressionWithBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -138179,97 +140850,116 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -138834,27 +141524,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -139396,47 +142091,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isLatex",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -140325,27 +143029,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -140739,52 +143448,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "relativeToGraphScales",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "angleThreshold",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -140986,47 +143705,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "handGraded",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchPartial",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumAttempts",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "colorCorrectnessPreliminary",
@@ -141036,37 +143764,44 @@
                 {
                     "name": "disableAfterCorrect",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForResponses",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumColumns",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "mode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -142090,87 +144825,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hideFutureSections",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -142632,47 +145384,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isLatex",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -143159,27 +145920,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -143562,27 +146328,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -143965,27 +146736,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",

--- a/packages/static-assets/src/generated/doenet-relaxng-schema.json
+++ b/packages/static-assets/src/generated/doenet-relaxng-schema.json
@@ -117119,7 +117119,7 @@
                     "name": "sort",
                     "type": "text",
                     "isArray": false,
-                    "description": "Sort the selected values: unsorted (default), increasing, or decreasing.",
+                    "description": "Whether and how to sort the selected values.",
                     "fromAttribute": true
                 },
                 {

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -61688,7 +61688,8 @@
                 {
                     "name": "fractionSatisfied",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "description": "Fraction of the boolean condition that is satisfied (0 to 1)."
                 },
                 {
                     "name": "conditionSatisfied",

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -73939,7 +73939,7 @@
             "top": true,
             "acceptsStringChildren": false,
             "takesIndex": true,
-            "summary": "Randomly selects values from a numerical or letter sequence."
+            "summary": "Randomly selects values from a sequence of numbers, math expressions, or letters."
         },
         {
             "name": "select",

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -65749,6 +65749,7 @@
                 },
                 {
                     "name": "type",
+                    "description": "Whether the sequence is of numbers, math expressions, or letters.",
                     "values": [
                         "number",
                         "math",
@@ -65756,19 +65757,24 @@
                     ]
                 },
                 {
-                    "name": "from"
+                    "name": "from",
+                    "description": "The first value in the sequence."
                 },
                 {
-                    "name": "to"
+                    "name": "to",
+                    "description": "The last value in the sequence. Used together with from to determine length when length is not specified."
                 },
                 {
-                    "name": "step"
+                    "name": "step",
+                    "description": "The increment between successive values in the sequence."
                 },
                 {
-                    "name": "length"
+                    "name": "length",
+                    "description": "The number of values in the sequence."
                 },
                 {
-                    "name": "exclude"
+                    "name": "exclude",
+                    "description": "Values to exclude from the sequence."
                 },
                 {
                     "name": "asList",
@@ -65812,7 +65818,8 @@
             ],
             "top": true,
             "acceptsStringChildren": false,
-            "takesIndex": true
+            "takesIndex": true,
+            "summary": "Generates a sequence of numbers, math expressions, or letters defined by from, to, length, and step."
         },
         {
             "name": "slider",
@@ -69099,6 +69106,7 @@
                 },
                 {
                     "name": "type",
+                    "description": "Whether the sequence is of numbers, math expressions, or letters.",
                     "values": [
                         "number",
                         "math",
@@ -69106,19 +69114,24 @@
                     ]
                 },
                 {
-                    "name": "from"
+                    "name": "from",
+                    "description": "The first value in the sequence."
                 },
                 {
-                    "name": "to"
+                    "name": "to",
+                    "description": "The last value in the sequence. Used together with from to determine length when length is not specified."
                 },
                 {
-                    "name": "step"
+                    "name": "step",
+                    "description": "The increment between successive values in the sequence."
                 },
                 {
-                    "name": "length"
+                    "name": "length",
+                    "description": "The number of values in the sequence."
                 },
                 {
-                    "name": "exclude"
+                    "name": "exclude",
+                    "description": "Values to exclude from the sequence."
                 },
                 {
                     "name": "valueName"
@@ -71559,6 +71572,7 @@
                 },
                 {
                     "name": "type",
+                    "description": "Whether the sequence is of numbers, math expressions, or letters.",
                     "values": [
                         "number",
                         "math",
@@ -71566,19 +71580,24 @@
                     ]
                 },
                 {
-                    "name": "from"
+                    "name": "from",
+                    "description": "The first value in the sequence."
                 },
                 {
-                    "name": "to"
+                    "name": "to",
+                    "description": "The last value in the sequence. Used together with from to determine length when length is not specified."
                 },
                 {
-                    "name": "step"
+                    "name": "step",
+                    "description": "The increment between successive values in the sequence."
                 },
                 {
-                    "name": "length"
+                    "name": "length",
+                    "description": "The number of values in the sequence."
                 },
                 {
-                    "name": "exclude"
+                    "name": "exclude",
+                    "description": "Values to exclude from the sequence."
                 },
                 {
                     "name": "asList",
@@ -71588,10 +71607,12 @@
                     ]
                 },
                 {
-                    "name": "numToSelect"
+                    "name": "numToSelect",
+                    "description": "How many values to select from the sequence."
                 },
                 {
                     "name": "withReplacement",
+                    "description": "Whether the same value can be selected more than once.",
                     "values": [
                         "true",
                         "false"
@@ -71599,6 +71620,7 @@
                 },
                 {
                     "name": "sort",
+                    "description": "Sort the selected values: unsorted (default), increasing, or decreasing.",
                     "values": [
                         "unsorted",
                         "increasing",
@@ -71613,10 +71635,12 @@
                     ]
                 },
                 {
-                    "name": "excludeCombinations"
+                    "name": "excludeCombinations",
+                    "description": "Lists of value combinations to exclude from the selection."
                 },
                 {
                     "name": "coprime",
+                    "description": "Require the selected numbers to be pairwise coprime (numbers only).",
                     "values": [
                         "true",
                         "false"
@@ -71652,22 +71676,26 @@
                 {
                     "name": "numToSelect",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "description": "How many values to select from the sequence."
                 },
                 {
                     "name": "withReplacement",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "description": "Whether the same value can be selected more than once."
                 },
                 {
                     "name": "sort",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "description": "Sort the selected values: unsorted (default), increasing, or decreasing."
                 },
                 {
                     "name": "coprime",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "description": "Require the selected numbers to be pairwise coprime (numbers only)."
                 },
                 {
                     "name": "doenetML",
@@ -71677,7 +71705,8 @@
             ],
             "top": true,
             "acceptsStringChildren": false,
-            "takesIndex": true
+            "takesIndex": true,
+            "summary": "Randomly selects values from a numerical or letter sequence."
         },
         {
             "name": "select",
@@ -72188,6 +72217,7 @@
                 },
                 {
                     "name": "type",
+                    "description": "Whether the sequence is of numbers, math expressions, or letters.",
                     "values": [
                         "number",
                         "math",
@@ -72195,19 +72225,24 @@
                     ]
                 },
                 {
-                    "name": "from"
+                    "name": "from",
+                    "description": "The first value in the sequence."
                 },
                 {
-                    "name": "to"
+                    "name": "to",
+                    "description": "The last value in the sequence. Used together with from to determine length when length is not specified."
                 },
                 {
-                    "name": "step"
+                    "name": "step",
+                    "description": "The increment between successive values in the sequence."
                 },
                 {
-                    "name": "length"
+                    "name": "length",
+                    "description": "The number of values in the sequence."
                 },
                 {
-                    "name": "exclude"
+                    "name": "exclude",
+                    "description": "Values to exclude from the sequence."
                 },
                 {
                     "name": "target"

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -67782,7 +67782,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Whether the sequence is of numbers, math expressions, or letters.",
+                    "description": "The kind of values in the sequence.",
                     "values": [
                         "number",
                         "math",
@@ -71234,7 +71234,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Whether the sequence is of numbers, math expressions, or letters.",
+                    "description": "The kind of values in the sequence.",
                     "values": [
                         "number",
                         "math",
@@ -73796,7 +73796,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Whether the sequence is of numbers, math expressions, or letters.",
+                    "description": "The kind of values in the sequence.",
                     "values": [
                         "number",
                         "math",
@@ -73844,7 +73844,7 @@
                 },
                 {
                     "name": "sort",
-                    "description": "Sort the selected values: unsorted (default), increasing, or decreasing.",
+                    "description": "Whether and how to sort the selected values.",
                     "values": [
                         "unsorted",
                         "increasing",
@@ -73920,7 +73920,7 @@
                     "name": "sort",
                     "type": "text",
                     "isArray": false,
-                    "description": "Sort the selected values: unsorted (default), increasing, or decreasing.",
+                    "description": "Whether and how to sort the selected values.",
                     "fromAttribute": true
                 },
                 {
@@ -74462,7 +74462,7 @@
                 },
                 {
                     "name": "type",
-                    "description": "Whether the sequence is of numbers, math expressions, or letters.",
+                    "description": "The kind of values in the sequence.",
                     "values": [
                         "number",
                         "math",

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -200,27 +200,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -536,97 +541,116 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -1185,52 +1209,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -1510,42 +1544,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -1850,42 +1892,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -2291,52 +2341,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -2717,52 +2777,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -3143,52 +3213,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -3420,47 +3500,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isLatex",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -3642,27 +3731,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -3750,27 +3844,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -4051,52 +4150,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -4442,27 +4551,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -4726,42 +4840,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -5055,42 +5177,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -5384,42 +5514,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -5577,42 +5715,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -5760,42 +5906,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -6091,42 +6245,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -6435,87 +6597,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -6716,87 +6895,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -6992,87 +7188,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -7268,87 +7481,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -7611,87 +7841,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -7954,87 +8201,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -8307,97 +8571,116 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "limits",
                     "type": "numberList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "strict",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -8727,107 +9010,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -9340,107 +9644,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -9945,107 +10270,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "lowerValue",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "upperValue",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -10550,107 +10896,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "lowerValue",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "upperValue",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -11155,107 +11522,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numDecimals",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numDigits",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -11757,102 +12145,122 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "threshold",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -12344,97 +12752,116 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -12928,97 +13355,116 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -13517,97 +13963,116 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -14106,97 +14571,116 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -14695,97 +15179,116 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -15298,107 +15801,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -15911,107 +16435,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -16531,112 +17076,134 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "population",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -17156,112 +17723,134 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "population",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -17774,107 +18363,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -18387,107 +18997,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -19000,107 +19631,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -19613,107 +20265,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -20226,107 +20899,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -20839,107 +21533,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -21454,107 +22169,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "operandNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "argumentNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -22054,27 +22790,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandSpecified",
@@ -22084,42 +22825,50 @@
                 {
                     "name": "xscale",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yscale",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "lowerValue",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "upperValue",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -22744,27 +23493,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandSpecified",
@@ -22774,42 +23528,50 @@
                 {
                     "name": "xscale",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yscale",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "lowerValue",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "upperValue",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -23434,27 +24196,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandSpecified",
@@ -23464,32 +24231,38 @@
                 {
                     "name": "xscale",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yscale",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -24028,47 +24801,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isLatex",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -24394,27 +25176,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -24651,27 +25438,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -24908,27 +25700,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -25165,27 +25962,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -25422,27 +26224,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -25679,27 +26486,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -25936,27 +26748,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -26193,27 +27010,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -26450,27 +27272,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -26707,27 +27534,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -26820,27 +27652,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -26933,27 +27770,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -27046,27 +27888,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -27159,27 +28006,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -27272,27 +28124,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -27385,27 +28242,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -27498,27 +28360,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -27611,27 +28478,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -28073,87 +28945,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -28625,87 +29514,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -29177,87 +30083,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -29729,87 +30652,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -30302,92 +31242,110 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "collapsible",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -30859,87 +31817,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -31418,87 +32393,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -31977,87 +32969,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -32536,87 +33545,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -33095,87 +34121,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -33647,87 +34690,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -34199,87 +35259,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -34751,87 +35828,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -35303,87 +36397,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -35855,87 +36966,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -36407,87 +37535,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeParentNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -36976,87 +38121,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "collapsible",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -37524,82 +38686,98 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -38067,82 +39245,98 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -38280,32 +39474,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "label",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -38408,32 +39608,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "label",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -38799,52 +40005,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -39016,67 +40232,80 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "independentVariable",
                     "type": "_variableName",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "initialIndependentVariableValue",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "chunkSize",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "tolerance",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxIterations",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hideInitialCondition",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "number",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -39458,92 +40687,110 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rigid",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowRotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowTranslation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowReflection",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "attractThreshold",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPoints",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "variable",
                     "type": "_variableName",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numIterationsRequired",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -40013,77 +41260,92 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlOrder",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "stable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "switchable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -40471,62 +41733,74 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "stable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "switchable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -40975,102 +42249,122 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "flipFunction",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numDiscretizationPoints",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "periodic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splineTension",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "extrapolateBackward",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "extrapolateForward",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splineForm",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "stable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "switchable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -41423,27 +42717,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -41688,27 +42987,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -41879,27 +43183,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -42235,97 +43544,116 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -42691,27 +44019,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -42810,27 +44143,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -42949,27 +44287,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -43159,22 +44502,26 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -43345,27 +44692,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -43520,27 +44872,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -43908,27 +45265,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -44148,47 +45510,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isLatex",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -44447,27 +45818,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -44813,52 +46189,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -45239,52 +46625,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -45618,27 +47014,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -45957,27 +47358,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -46319,27 +47725,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -46449,42 +47860,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "previousLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "nextLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "pageLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -46681,77 +48100,92 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "collaborateGroups",
                     "type": "collaborateGroups",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showSizeControls",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "prefill",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unionFromU",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -47160,22 +48594,26 @@
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -47471,22 +48909,26 @@
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -47829,27 +49271,32 @@
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "documentWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -48086,47 +49533,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isLatex",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -48394,32 +49850,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unordered",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -48690,52 +50152,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -49024,87 +50496,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -49225,32 +50714,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unordered",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -49546,97 +51041,116 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -50049,42 +51563,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -50304,42 +51826,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -50532,27 +52062,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -50620,12 +52155,14 @@
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -50937,32 +52474,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "textType",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -51266,67 +52809,80 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlOrder",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -51748,92 +53304,110 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -52282,52 +53856,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -52649,67 +54233,80 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlOrder",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -52949,52 +54546,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -53294,72 +54901,86 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rigid",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowRotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowTranslation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowReflection",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -53700,87 +55321,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rigid",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowRotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowTranslation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowReflection",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "filled",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlOrder",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -54141,87 +55779,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rigid",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowRotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowTranslation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowReflection",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "filled",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlOrder",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -54595,87 +56250,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rigid",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowRotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowTranslation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowReflection",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "filled",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlOrder",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -55073,87 +56745,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rigid",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowRotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowTranslation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowReflection",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "filled",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlOrder",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -55627,107 +57316,128 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "flipFunction",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numDiscretizationPoints",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "periodic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splineTension",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "extrapolateBackward",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "extrapolateForward",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splineForm",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "filled",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlOrder",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -56134,92 +57844,110 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "flipFunction",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numDiscretizationPoints",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "periodic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splineTension",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "extrapolateBackward",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "extrapolateForward",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splineForm",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -56618,92 +58346,110 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "flipFunction",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numDiscretizationPoints",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "periodic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splineTension",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "extrapolateBackward",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "extrapolateForward",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splineForm",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -57116,32 +58862,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "alwaysVisible",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -57347,37 +59099,44 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "direction",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "pointNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -57676,72 +59435,86 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayWithAngleBrackets",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlOrder",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -58121,62 +59894,74 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "radius",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "chooseReflexAngle",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "inDegrees",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "emphasizeRightAngle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -58661,47 +60446,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "handGraded",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchPartial",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumAttempts",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "colorCorrectnessPreliminary",
@@ -58711,162 +60505,194 @@
                 {
                     "name": "disableAfterCorrect",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForResponses",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "inline",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceFullCheckWorkButton",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSmallCheckWorkButton",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numAwardsCredited",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "selectMultiple",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "shuffleOrder",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "preserveLastChoice",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "disableWrongChoices",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "creditByAttempt",
                     "type": "numberList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expanded",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "description",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showPreview",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -59267,117 +61093,140 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "credit",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchPartial",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "feedbackCodes",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "feedbackText",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -59701,92 +61550,110 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchPartial",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -60080,87 +61947,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "collaborateGroups",
                     "type": "collaborateGroups",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "prefill",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "prefillLatex",
                     "type": "latex",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unionFromU",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hideNaN",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "minWidth",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -60575,67 +62459,80 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "collaborateGroups",
                     "type": "collaborateGroups",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "prefill",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expanded",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "height",
                     "type": "componentSize",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -60987,62 +62884,74 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "collaborateGroups",
                     "type": "collaborateGroups",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "prefill",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asToggleButton",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -61234,62 +63143,74 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "collaborateGroups",
                     "type": "collaborateGroups",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "selectMultiple",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchPartial",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "shuffleOrder",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "preserveLastChoice",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -61755,42 +63676,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "credit",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "feedbackCodes",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "feedbackText",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -62071,47 +64000,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderAsMath",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -62427,47 +64365,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderAsMath",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -62974,122 +64921,146 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "horizontalAlign",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "identicalAxisScales",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayXAxis",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayYAxis",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlsPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayXAxisTicks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayYAxisTicks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "xLabelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "xTickScaleFactor",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yLabelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yLabelAlignment",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yTickScaleFactor",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showNavigation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showBorder",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hideOffGraphIndicators",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "decorative",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderer",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -63299,27 +65270,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -63433,47 +65409,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "text",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "speech",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sonify",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "circular",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -63774,27 +65759,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandSpecified",
@@ -63804,32 +65794,38 @@
                 {
                     "name": "xscale",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yscale",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -64356,27 +66352,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandSpecified",
@@ -64386,32 +66387,38 @@
                 {
                     "name": "xscale",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yscale",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -65015,92 +67022,110 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -65623,37 +67648,44 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "selectForVariants",
                     "type": "textListFromString",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "selectWeight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -65788,27 +67820,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -66041,77 +68078,92 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "width",
                     "type": "componentSize",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "height",
                     "type": "componentSize",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showControls",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showTicks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rotateTickLabels",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showValue",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "from",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "to",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "step",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -66287,72 +68339,86 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "width",
                     "type": "componentSize",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "minNumRows",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "minNumColumns",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "columnHeaders",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rowHeaders",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "fixedRowsTop",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "fixedColumnsLeft",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hiddenColumns",
                     "type": "numberList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hiddenRows",
                     "type": "numberList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -66857,47 +68923,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rowNum",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "colNum",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "colSpan",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "prefill",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -67065,37 +69140,44 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rowNum",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "header",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -67229,32 +69311,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "colNum",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -67354,37 +69442,44 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rowNum",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "colNum",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -67534,67 +69629,80 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "width",
                     "type": "componentSize",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "height",
                     "type": "componentSize",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "halign",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "valign",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "top",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "left",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "bottom",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "right",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -67894,27 +70002,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -68229,27 +70342,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -68429,27 +70547,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -68799,22 +70922,26 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -69151,22 +71278,26 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -69268,62 +71399,74 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "dx",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "dy",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "xoffset",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yoffset",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -69434,57 +71577,68 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "dx",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "dy",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "dz",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "xoffset",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yoffset",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "zoffset",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -69575,32 +71729,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "buffer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -69722,77 +71882,92 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "dx",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "dy",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "dz",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "xoffset",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "yoffset",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "zoffset",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "xthreshold",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "ythreshold",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "zthreshold",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeGridlines",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -69970,32 +72145,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "relativeToGraphScales",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -70176,32 +72357,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "relativeToGraphScales",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -70304,27 +72491,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -70425,32 +72617,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "threshold",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -70628,32 +72826,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "relativeToGraphScales",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -70761,22 +72965,26 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -71084,27 +73292,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -71316,27 +73529,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -71456,27 +73674,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -71651,51 +73874,60 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numToSelect",
                     "type": "integer",
                     "isArray": false,
-                    "description": "How many values to select from the sequence."
+                    "description": "How many values to select from the sequence.",
+                    "fromAttribute": true
                 },
                 {
                     "name": "withReplacement",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Whether the same value can be selected more than once."
+                    "description": "Whether the same value can be selected more than once.",
+                    "fromAttribute": true
                 },
                 {
                     "name": "sort",
                     "type": "text",
                     "isArray": false,
-                    "description": "Sort the selected values: unsorted (default), increasing, or decreasing."
+                    "description": "Sort the selected values: unsorted (default), increasing, or decreasing.",
+                    "fromAttribute": true
                 },
                 {
                     "name": "coprime",
                     "type": "boolean",
                     "isArray": false,
-                    "description": "Require the selected numbers to be pairwise coprime (numbers only)."
+                    "description": "Require the selected numbers to be pairwise coprime (numbers only).",
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -71787,37 +74019,44 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numToSelect",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "withReplacement",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -72132,27 +74371,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rendered",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -72279,47 +74523,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "animationOn",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "animationMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "animationInterval",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowAdjustmentsWhileRunning",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -72578,112 +74831,134 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unordered",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -73018,37 +75293,44 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "type",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numToSelect",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -73207,42 +75489,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSamples",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "type",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "variantDeterminesSeed",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -73384,57 +75674,68 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "from",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "to",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "exclude",
                     "type": "numberList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numToSelect",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "withReplacement",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sort",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -73528,52 +75829,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSamples",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "from",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "to",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "exclude",
                     "type": "numberList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "variantDeterminesSeed",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -73948,52 +76259,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "type",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchWholeWord",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchCase",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "preserveCase",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -74241,127 +76562,152 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "minIndex",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxIndex",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "offsets",
                     "type": "mathList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "period",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "minIndexAsList",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxIndexAsList",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -74733,77 +77079,92 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "horizontalAlign",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "decorative",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "source",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asFileName",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "mimeType",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rotate",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -74957,47 +77318,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "horizontalAlign",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "youtube",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "source",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -75361,27 +77731,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -75608,47 +77983,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isLatex",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -75970,57 +78354,68 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isLatex",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "pluralForm",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "basedOnNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -76441,22 +78836,26 @@
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -76775,27 +79174,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -77121,27 +79525,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -77255,47 +79664,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "minSentencesPerParagraph",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxSentencesPerParagraph",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "minWordsPerSentence",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxWordsPerSentence",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -77449,47 +79867,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -77651,47 +80078,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "actionName",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -77843,42 +80279,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -78022,42 +80466,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numIterates",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceSymbolic",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "forceNumeric",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -78447,22 +80899,26 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "rendered",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -78761,27 +81217,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -79082,27 +81543,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -79314,27 +81780,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -79630,27 +82101,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -79958,77 +82434,92 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showCoordsWhenDragging",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "addControls",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "controlOrder",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "open",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "switchable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -80493,37 +82984,44 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sortVectorsBy",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sortByComponent",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -80832,27 +83330,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -81013,32 +83516,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numDiscretizationPoints",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -81196,72 +83705,86 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "xMin",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "xMax",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "width",
                     "type": "componentSize",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "height",
                     "type": "componentSize",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "xlabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "dx",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "variable",
                     "type": "_variableName",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "prefill",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -81634,102 +84157,122 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -82314,27 +84857,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -82473,47 +85021,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelPosition",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -82786,47 +85343,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "boundaryValues",
                     "type": "numberList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -82966,52 +85532,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "boundaryValues",
                     "type": "numberList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "flipFunctions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -83153,57 +85729,68 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "horizontal",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "boundaryValue",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "greaterThan",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -83577,62 +86164,74 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "prefill",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "width",
                     "type": "componentSize",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "height",
                     "type": "componentSize",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showResults",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "showFormatter",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "resultsLocation",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "readOnly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -83934,87 +86533,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -84125,37 +86741,44 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "source",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hasHeader",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -84311,32 +86934,38 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "byCategoryColumn",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -84557,52 +87186,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "position",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayClosedSwatches",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -84872,42 +87511,50 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -85241,117 +87888,140 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "symbolicEquality",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expandOnCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplifyOnCompare",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "unorderedCompare",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchByExactPositions",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorInNumbers",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeErrorInNumberExponents",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowedErrorIsAbsolute",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numSignErrorsMatched",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "numPeriodicSetMatchesRequired",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "caseInsensitiveMatch",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowImplicitIdentities",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "allowPermutations",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "requireNumericMatches",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "requireVariableMatches",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "excludeMatches",
                     "type": "mathList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchExpressionWithBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -85617,97 +88287,116 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "format",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "simplify",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "expand",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "renderMode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createVectors",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "createIntervals",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "functionSymbols",
                     "type": "textList",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "splitSymbols",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "parseScientificNotation",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayBlanks",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "assumptions",
                     "type": "math",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -86092,27 +88781,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -86409,47 +89103,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isLatex",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -86867,27 +89570,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -87091,52 +89799,62 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "labelIsName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "applyStyleToLabel",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "relativeToGraphScales",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "angleThreshold",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -87304,47 +90022,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "handGraded",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "matchPartial",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumAttempts",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "colorCorrectnessPreliminary",
@@ -87354,37 +90081,44 @@
                 {
                     "name": "disableAfterCorrect",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForResponses",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumColumns",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "mode",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -87904,87 +90638,104 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "weight",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "sectionWideCheckWork",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabel",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "submitLabelNoCorrectness",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "displayDigitsForCreditAchieved",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoName",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumber",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "noAutoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNameIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "includeAutoNumberIfNoTitle",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "asList",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hideFutureSections",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -88241,47 +90992,56 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isResponse",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "draggable",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "layer",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "isLatex",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "positionFromAnchor",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "hidden",
@@ -88573,27 +91333,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -88781,27 +91546,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",
@@ -88989,27 +91759,32 @@
                 {
                     "name": "hide",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "modifyIndirectly",
                     "type": "boolean",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "styleNumber",
                     "type": "integer",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "permid",
                     "type": "text",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "maxNumber",
                     "type": "number",
-                    "isArray": false
+                    "isArray": false,
+                    "fromAttribute": true
                 },
                 {
                     "name": "doenetML",

--- a/packages/static-assets/src/schema.ts
+++ b/packages/static-assets/src/schema.ts
@@ -7,6 +7,7 @@ export type SchemaProperty = {
     numDimensions?: number;
     indexedArrayDescription?: unknown[];
     description?: string;
+    fromAttribute?: boolean;
 };
 
 export { doenetSchema };

--- a/packages/static-assets/src/schema.ts
+++ b/packages/static-assets/src/schema.ts
@@ -6,6 +6,7 @@ export type SchemaProperty = {
     isArray: boolean;
     numDimensions?: number;
     indexedArrayDescription?: unknown[];
+    description?: string;
 };
 
 export { doenetSchema };

--- a/packages/static-assets/test/schema-help.test.ts
+++ b/packages/static-assets/test/schema-help.test.ts
@@ -10,6 +10,7 @@ describe("generated schema help fields", () => {
 
     const sequence = elementsByName.sequence;
     const selectFromSequence = elementsByName.selectFromSequence;
+    const when = elementsByName.when;
 
     it("populates element summary from static componentDocs", () => {
         expect(sequence.summary).toBeTruthy();
@@ -62,5 +63,27 @@ describe("generated schema help fields", () => {
         );
         expect(doenetML).toBeDefined();
         expect(doenetML?.fromAttribute).not.toBe(true);
+    });
+
+    it("propagates description from an additionalStateVariablesDefined sibling to the schema property", () => {
+        // <when> defines `value` with two siblings via additionalStateVariablesDefined;
+        // a description authored on the sibling object literal must reach the schema.
+        const fractionSatisfied = when.properties.find(
+            (property) => property.name === "fractionSatisfied",
+        );
+        expect(fractionSatisfied).toBeDefined();
+        expect(fractionSatisfied?.description).toBe(
+            "Fraction of the boolean condition that is satisfied (0 to 1).",
+        );
+    });
+
+    it("does not auto-copy a parent state-var description to additionalStateVariablesDefined siblings", () => {
+        // `conditionSatisfied` is a sibling of `value` but has no description of its own;
+        // a description on the parent (`value`) must not leak onto the sibling property.
+        const conditionSatisfied = when.properties.find(
+            (property) => property.name === "conditionSatisfied",
+        );
+        expect(conditionSatisfied).toBeDefined();
+        expect(conditionSatisfied?.description).toBeUndefined();
     });
 });

--- a/packages/static-assets/test/schema-help.test.ts
+++ b/packages/static-assets/test/schema-help.test.ts
@@ -76,14 +76,4 @@ describe("generated schema help fields", () => {
             "Fraction of the boolean condition that is satisfied (0 to 1).",
         );
     });
-
-    it("does not auto-copy a parent state-var description to additionalStateVariablesDefined siblings", () => {
-        // `conditionSatisfied` is a sibling of `value` but has no description of its own;
-        // a description on the parent (`value`) must not leak onto the sibling property.
-        const conditionSatisfied = when.properties.find(
-            (property) => property.name === "conditionSatisfied",
-        );
-        expect(conditionSatisfied).toBeDefined();
-        expect(conditionSatisfied?.description).toBeUndefined();
-    });
 });

--- a/packages/static-assets/test/schema-help.test.ts
+++ b/packages/static-assets/test/schema-help.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { getSchema } from "../scripts/get-schema";
+
+describe("generated schema help fields", () => {
+    const schema = getSchema();
+    const elementsByName = Object.fromEntries(
+        schema.elements.map((element) => [element.name, element]),
+    );
+
+    const sequence = elementsByName.sequence;
+    const selectFromSequence = elementsByName.selectFromSequence;
+
+    it("populates element summary from static componentDocs", () => {
+        expect(sequence.summary).toBeTruthy();
+        expect(selectFromSequence.summary).toBeTruthy();
+    });
+
+    it("populates description on a component's own attribute", () => {
+        const numToSelect = selectFromSequence.attributes.find(
+            (attribute) => attribute.name === "numToSelect",
+        );
+        expect(numToSelect?.description).toBeTruthy();
+    });
+
+    it("flows attribute descriptions to subclasses through inheritance", () => {
+        const fromOnSubclass = selectFromSequence.attributes.find(
+            (attribute) => attribute.name === "from",
+        );
+        const fromOnParent = sequence.attributes.find(
+            (attribute) => attribute.name === "from",
+        );
+        expect(fromOnSubclass?.description).toBeTruthy();
+        expect(fromOnSubclass?.description).toBe(fromOnParent?.description);
+    });
+
+    it("reuses an attribute's description on its auto-created public property", () => {
+        const numToSelectAttribute = selectFromSequence.attributes.find(
+            (attribute) => attribute.name === "numToSelect",
+        );
+        const numToSelectProperty = selectFromSequence.properties.find(
+            (property) => property.name === "numToSelect",
+        );
+        expect(numToSelectProperty?.description).toBeTruthy();
+        expect(numToSelectProperty?.description).toBe(
+            numToSelectAttribute?.description,
+        );
+    });
+});

--- a/packages/static-assets/test/schema-help.test.ts
+++ b/packages/static-assets/test/schema-help.test.ts
@@ -12,6 +12,14 @@ describe("generated schema help fields", () => {
     const selectFromSequence = elementsByName.selectFromSequence;
     const when = elementsByName.when;
 
+    it("has the piloted components present in the generated schema", () => {
+        // Asserted up front so later tests don't fail with confusing
+        // TypeErrors if a piloted component is renamed or removed.
+        expect(sequence).toBeDefined();
+        expect(selectFromSequence).toBeDefined();
+        expect(when).toBeDefined();
+    });
+
     it("populates element summary from static componentDocs", () => {
         expect(sequence.summary).toBeTruthy();
         expect(selectFromSequence.summary).toBeTruthy();

--- a/packages/static-assets/test/schema-help.test.ts
+++ b/packages/static-assets/test/schema-help.test.ts
@@ -46,4 +46,21 @@ describe("generated schema help fields", () => {
             numToSelectAttribute?.description,
         );
     });
+
+    it("flags properties auto-created from a same-named attribute with fromAttribute: true", () => {
+        const numToSelectProperty = selectFromSequence.properties.find(
+            (property) => property.name === "numToSelect",
+        );
+        expect(numToSelectProperty?.fromAttribute).toBe(true);
+    });
+
+    it("does not flag explicitly defined state-variable properties with fromAttribute", () => {
+        // `doenetML` is an explicit state variable defined in
+        // returnStateVariableDefinitions(), not auto-derived from an attribute.
+        const doenetML = selectFromSequence.properties.find(
+            (property) => property.name === "doenetML",
+        );
+        expect(doenetML).toBeDefined();
+        expect(doenetML?.fromAttribute).not.toBe(true);
+    });
 });


### PR DESCRIPTION
## Summary
- Adds inline-authored docs fields harvested into `doenet-schema.json`: `static componentDocs = { summary }` on component classes, and `description` on each attribute literal and public state-variable definition.
- Single source feeds both the forthcoming context-sensitive help side panel and the docs-nextra site (which already consumes the schema).
- Threads `description` through `returnStateVariableInfo` so an attribute-derived property reuses the attribute's description with no extra authoring. Sibling state vars defined via `additionalStateVariablesDefined` carry their own description through to the schema.
- Adds a `fromAttribute: true` flag on schema properties auto-created from a same-named attribute, so consumers can distinguish attribute-properties from explicitly authored state vars.
- Pilot on `Sequence` + `SelectFromSequence`; inherited attributes (`from`, `to`, `length`, `step`, `type`, `exclude`) flow descriptions to subclasses automatically via `super.createAttributesObject()`.
- Build-time coverage report logs how many components/attributes/properties have help authored (warn, not fail).
- Schema additions are purely additive and `description` / `fromAttribute` / `summary` are all optional.

## Authoring convention

Descriptions are self-contained prose — they should **not** duplicate values that are already structured fields on the schema (`validValues`, `defaultValue`). Consumers may render those alongside the prose. Keeping them out of the description text also removes English-only connector phrases like "(default)" and "values: a, b, c", smoothing the path to localization (see #1080).

## Deferred (called out explicitly)
- Descriptions on array entry-prefix properties (e.g. `<function>`'s `maximaLocations`) and aliases whose target is an array entry (e.g. `point.x → x1`).
- Runtime parity by adding `description` to the `_copyPassthroughAttributes` whitelist in `StateVariableDefinitionFactory.ts` (schema is the canonical source today).

## Test plan
- [x] `npm test` in `packages/static-assets` — 12/12 pass (7 new schema-docs assertions + 5 existing)
- [x] `npm test` in `packages/lsp-tools` — 166/166 pass (downstream schema consumer)
- [x] `npm test` in `packages/doenetml-worker-javascript` — 2896/2896 pass (`BaseComponent.js` threading change)
- [x] `npm run build` at monorepo root — green
- [x] Spot-checked regenerated `doenet-schema.json` for piloted entries (own attribute description, inherited attribute description, attribute-→-property description equality, element summary, `fromAttribute` flag, sibling state-var description)

🤖 Generated with [Claude Code](https://claude.com/claude-code)