### PR TITLE
fix(schema): exclude properties derived from excludeFromSchema attributes

### DIFF
--- a/.changeset/exclude-derived-properties.md
+++ b/.changeset/exclude-derived-properties.md
@@ -1,0 +1,9 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Exclude properties derived from `excludeFromSchema` attributes. When an attribute is marked `excludeFromSchema: true` and creates a companion state variable via `createStateVariable`, that state variable is now also excluded from the schema. This stops `collaborateGroups`, `modifyIndirectly`, and `permid` from leaking into autocomplete and context-help despite their backing attributes already being hidden. Tracked in #1089.

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -490,6 +490,20 @@ export function getSchema() {
     > {
         const attributes: SchemaAttribute[] = [];
         const attrObj = cClass.createAttributesObject();
+        // Collect state-variable names produced by attributes that are
+        // themselves excluded from the schema. Their companion properties
+        // should be excluded too — otherwise `<booleanInput>`'s already
+        // hidden `collaborateGroups` attribute leaks back into the schema
+        // as a property. Tracked in #1089; the broader proposal is to also
+        // honor an explicit `excludeFromSchema` flag on state-variable
+        // definitions for properties not derived from attributes.
+        const excludedStateVariableNames = new Set<string>();
+        for (const attrName in attrObj) {
+            const attrDef = attrObj[attrName];
+            if (attrDef.excludeFromSchema && attrDef.createStateVariable) {
+                excludedStateVariableNames.add(attrDef.createStateVariable);
+            }
+        }
         for (const attrName in attrObj) {
             const attrDef = attrObj[attrName];
             if (attrDef.excludeFromSchema) continue;
@@ -530,7 +544,10 @@ export function getSchema() {
             attributes.push(attrSpec);
         }
 
-        const properties = buildPropertiesForType(type);
+        const properties = buildPropertiesForType(
+            type,
+            excludedStateVariableNames,
+        );
 
         const out: Pick<
             SchemaElement,
@@ -550,7 +567,10 @@ export function getSchema() {
         return out;
     }
 
-    function buildPropertiesForType(type: string): PropertyDescription[] {
+    function buildPropertiesForType(
+        type: string,
+        excludedStateVariableNames: ReadonlySet<string> = new Set(),
+    ): PropertyDescription[] {
         const info = componentInfoObjects.publicStateVariableInfo[type];
         if (!info) return [];
         const {
@@ -572,6 +592,7 @@ export function getSchema() {
         const properties: PropertyDescription[] = [];
 
         for (const varName in publicStateVariableDescriptions) {
+            if (excludedStateVariableNames.has(varName)) continue;
             const description = publicStateVariableDescriptions[varName];
             properties.push(
                 ...propFromDescription({
@@ -590,6 +611,10 @@ export function getSchema() {
         for (const aliasName in aliases) {
             const aliasInfo = aliases[aliasName];
             const aliasTargetName = aliasInfo.target;
+            // Skip aliases that point at an excluded state variable; they
+            // would otherwise act as a backdoor for the same excluded property.
+            if (excludedStateVariableNames.has(aliasTargetName)) continue;
+            if (excludedStateVariableNames.has(aliasName)) continue;
             const aliasTarget =
                 publicStateVariableDescriptions[aliasTargetName];
             if (aliasTarget) {

--- a/packages/static-assets/src/generated/doenet-schema.json
+++ b/packages/static-assets/src/generated/doenet-schema.json
@@ -220,13 +220,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -238,13 +231,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -633,13 +619,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -651,13 +630,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -1389,13 +1361,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -1407,13 +1372,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -1768,13 +1726,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -1786,13 +1737,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -2163,13 +2107,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -2181,13 +2118,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -2668,13 +2598,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -2686,13 +2609,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -3157,13 +3073,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -3175,13 +3084,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -3646,13 +3548,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -3664,13 +3559,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -3977,13 +3865,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -3995,13 +3876,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -4253,13 +4127,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -4271,13 +4138,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -4393,13 +4253,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -4411,13 +4264,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -4744,13 +4590,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -4762,13 +4601,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -5182,13 +5014,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -5200,13 +5025,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -5506,13 +5324,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -5524,13 +5335,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -5887,13 +5691,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -5905,13 +5702,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -6268,13 +6058,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -6286,13 +6069,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -6514,13 +6290,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -6532,13 +6301,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -6748,13 +6510,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -6766,13 +6521,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -7131,13 +6879,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -7149,13 +6890,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -7545,13 +7279,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -7563,13 +7290,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -7909,13 +7629,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -7927,13 +7640,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -8267,13 +7973,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -8285,13 +7984,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -8625,13 +8317,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -8643,13 +8328,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -9050,13 +8728,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -9068,13 +8739,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -9475,13 +9139,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -9493,13 +9150,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -9914,13 +9564,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -9932,13 +9575,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -10443,13 +10079,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -10461,13 +10090,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -11196,13 +10818,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -11214,13 +10829,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -11941,13 +11549,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -11959,13 +11560,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -12686,13 +12280,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -12704,13 +12291,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -13431,13 +13011,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -13449,13 +13022,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -14171,13 +13737,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -14189,13 +13748,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -14891,13 +14443,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -14909,13 +14454,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -15606,13 +15144,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -15624,13 +15155,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -16327,13 +15851,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -16345,13 +15862,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -17048,13 +16558,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -17066,13 +16569,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -17769,13 +17265,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -17787,13 +17276,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -18508,13 +17990,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -18526,13 +18001,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -19261,13 +18729,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -19279,13 +18740,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -20023,13 +19477,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -20041,13 +19488,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -20792,13 +20232,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -20810,13 +20243,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -21552,13 +20978,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -21570,13 +20989,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -22305,13 +21717,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -22323,13 +21728,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -23058,13 +22456,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -23076,13 +22467,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -23811,13 +23195,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -23829,13 +23206,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -24564,13 +23934,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -24582,13 +23945,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -25317,13 +24673,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -25335,13 +24684,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -26074,13 +25416,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -26092,13 +25427,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -26805,13 +26133,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -26823,13 +26144,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -27620,13 +26934,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -27638,13 +26945,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -28433,13 +27733,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -28451,13 +27744,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -29121,13 +28407,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -29139,13 +28418,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -29541,13 +28813,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -29559,13 +28824,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -29831,13 +29089,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -29849,13 +29100,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -30121,13 +29365,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -30139,13 +29376,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -30411,13 +29641,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -30429,13 +29652,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -30701,13 +29917,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -30719,13 +29928,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -30991,13 +30193,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -31009,13 +30204,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -31281,13 +30469,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -31299,13 +30480,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -31571,13 +30745,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -31589,13 +30756,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -31861,13 +31021,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -31879,13 +31032,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -32151,13 +31297,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -32169,13 +31308,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -32297,13 +31429,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -32315,13 +31440,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -32443,13 +31561,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -32461,13 +31572,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -32589,13 +31693,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -32607,13 +31704,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -32735,13 +31825,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -32753,13 +31836,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -32881,13 +31957,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -32899,13 +31968,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -33027,13 +32089,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -33045,13 +32100,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -33173,13 +32221,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -33191,13 +32232,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -33319,13 +32353,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -33337,13 +32364,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -33855,13 +32875,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -33873,13 +32886,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -34511,13 +33517,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -34529,13 +33528,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -35167,13 +34159,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -35185,13 +34170,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -35823,13 +34801,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -35841,13 +34812,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -36505,13 +35469,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -36523,13 +35480,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -37168,13 +36118,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -37186,13 +36129,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -37832,13 +36768,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -37850,13 +36779,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -38496,13 +37418,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -38514,13 +37429,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -39160,13 +38068,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -39178,13 +38079,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -39824,13 +38718,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -39842,13 +38729,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -40480,13 +39360,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -40498,13 +39371,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -41136,13 +40002,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -41154,13 +40013,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -41792,13 +40644,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -41810,13 +40655,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -42448,13 +41286,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -42466,13 +41297,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -43104,13 +41928,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -43122,13 +41939,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -43760,13 +42570,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -43778,13 +42581,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -44437,13 +43233,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -44455,13 +43244,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -45088,13 +43870,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -45106,13 +43881,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -45732,13 +44500,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -45750,13 +44511,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -46012,13 +44766,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -46030,13 +44777,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -46180,13 +44920,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -46198,13 +44931,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -46623,13 +45349,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -46641,13 +45360,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -46915,13 +45627,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -46933,13 +45638,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -47479,13 +46177,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -47497,13 +46188,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -48148,13 +46832,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -48166,13 +46843,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -48706,13 +47376,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -48724,13 +47387,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -49324,13 +47980,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -49342,13 +47991,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -49867,13 +48509,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -49885,13 +48520,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -50196,13 +48824,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -50214,13 +48835,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -50436,13 +49050,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -50454,13 +49061,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -50873,13 +49473,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -50891,13 +49484,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -51420,13 +50006,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -51438,13 +50017,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -51576,13 +50148,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -51594,13 +50159,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -51754,13 +50312,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -51772,13 +50323,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -52030,24 +50574,10 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "isResponse",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -52251,13 +50781,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -52269,13 +50792,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -52468,13 +50984,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -52486,13 +50995,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -52893,13 +51395,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -52911,13 +51406,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -53175,13 +51663,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -53193,13 +51674,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -53528,13 +52002,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -53546,13 +52013,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -53940,13 +52400,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -53958,13 +52411,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -54429,13 +52875,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -54447,13 +52886,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -54853,13 +53285,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -54871,13 +53296,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -55224,13 +53642,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -55242,13 +53653,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -55624,13 +54028,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -55642,13 +54039,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -55795,13 +54185,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -55813,13 +54196,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -56108,13 +54484,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -56126,20 +54495,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "collaborateGroups",
-                    "type": "collaborateGroups",
-                    "isArray": false,
-                    "description": "Groups of users that collaborate when working with this input. (Currently ignored.)",
                     "fromAttribute": true
                 },
                 {
@@ -56649,13 +55004,6 @@
             ],
             "properties": [
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -56667,13 +55015,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -56991,13 +55332,6 @@
             ],
             "properties": [
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -57009,13 +55343,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -57387,13 +55714,6 @@
             ],
             "properties": [
                 {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
-                    "fromAttribute": true
-                },
-                {
                     "name": "documentWideCheckWork",
                     "type": "boolean",
                     "isArray": false,
@@ -57696,13 +56016,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -57714,13 +56027,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -58062,24 +56368,10 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
                     "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -58408,13 +56700,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -58426,13 +56711,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -58812,13 +57090,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -58830,13 +57101,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -59075,24 +57339,10 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
                     "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -59471,13 +57721,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -59489,13 +57732,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -60084,24 +58320,10 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
                     "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -60398,24 +58620,10 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
                     "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -60673,24 +58881,10 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
                     "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -60780,13 +58974,6 @@
                 }
             ],
             "properties": [
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
-                    "fromAttribute": true
-                },
                 {
                     "name": "maxNumber",
                     "type": "number",
@@ -61132,13 +59319,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -61150,13 +59330,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -61525,13 +59698,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -61543,13 +59709,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -62119,13 +60278,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -62137,13 +60289,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -62762,13 +60907,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -62780,13 +60918,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -63217,13 +61348,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -63235,13 +61359,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -63596,13 +61713,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -63614,13 +61724,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -64034,13 +62137,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -64052,13 +62148,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -64551,13 +62640,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -64569,13 +62651,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -65113,13 +63188,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -65131,13 +63199,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -65691,13 +63752,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -65709,13 +63763,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -66301,13 +64348,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -66319,13 +64359,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -66979,13 +65012,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -66997,13 +65023,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -67605,13 +65624,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -67623,13 +65635,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -68204,13 +66209,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -68222,13 +66220,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -68788,13 +66779,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -68806,13 +66790,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -69066,24 +67043,10 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
                     "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -69462,13 +67425,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -69480,13 +67436,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -70005,13 +67954,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -70023,13 +67965,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -70681,13 +68616,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -70699,13 +68627,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -71445,13 +69366,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -71463,13 +69377,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -71981,13 +69888,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -71999,13 +69899,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -72461,13 +70354,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -72479,20 +70365,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "collaborateGroups",
-                    "type": "collaborateGroups",
-                    "isArray": false,
-                    "description": "Groups of users that collaborate when working with this input. (Currently ignored.)",
                     "fromAttribute": true
                 },
                 {
@@ -73061,13 +70933,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -73079,20 +70944,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "collaborateGroups",
-                    "type": "collaborateGroups",
-                    "isArray": false,
-                    "description": "Groups of users that collaborate when working with this input. (Currently ignored.)",
                     "fromAttribute": true
                 },
                 {
@@ -73552,13 +71403,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -73570,20 +71414,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "collaborateGroups",
-                    "type": "collaborateGroups",
-                    "isArray": false,
-                    "description": "Groups of users that collaborate when working with this input. (Currently ignored.)",
                     "fromAttribute": true
                 },
                 {
@@ -73871,13 +71701,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -73889,20 +71712,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "collaborateGroups",
-                    "type": "collaborateGroups",
-                    "isArray": false,
-                    "description": "Groups of users that collaborate when working with this input. (Currently ignored.)",
                     "fromAttribute": true
                 },
                 {
@@ -74462,13 +72271,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -74480,13 +72282,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -74840,13 +72635,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -74858,13 +72646,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -75267,13 +73048,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -75285,13 +73059,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -75930,13 +73697,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -75948,13 +73708,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -76349,13 +74102,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -76367,13 +74113,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -76524,13 +74263,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -76542,13 +74274,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -76939,13 +74664,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -76957,13 +74675,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -77632,13 +75343,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -77650,13 +75354,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -78414,13 +76111,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -78432,13 +76122,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -79114,13 +76797,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -79132,13 +76808,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -79321,13 +76990,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -79339,13 +77001,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -79637,13 +77292,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -79655,13 +77303,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -79966,13 +77607,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -79984,13 +77618,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -80609,13 +78236,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -80627,13 +78247,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -80876,13 +78489,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -80894,13 +78500,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -81086,13 +78685,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -81104,13 +78696,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -81249,13 +78834,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -81267,13 +78845,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -81484,13 +79055,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -81502,13 +79066,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -81896,13 +79453,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -81914,13 +79464,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -82270,13 +79813,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -82288,13 +79824,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -82505,13 +80034,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -82523,13 +80045,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -82916,24 +80431,10 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
                     "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -83299,24 +80800,10 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
                     "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -83456,13 +80943,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -83474,13 +80954,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -83681,13 +81154,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -83699,13 +81165,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -83868,13 +81327,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -83886,13 +81338,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -84069,13 +81514,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -84087,13 +81525,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -84371,13 +81802,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -84389,13 +81813,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -84614,13 +82031,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -84632,13 +82042,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -84777,13 +82180,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -84795,13 +82191,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -84932,13 +82321,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -84950,13 +82332,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -85171,13 +82546,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -85189,13 +82557,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -85339,24 +82700,10 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "isResponse",
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -85689,13 +83036,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -85707,13 +83047,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -85949,13 +83282,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -85967,13 +83293,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -86129,13 +83448,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -86147,13 +83459,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -86366,13 +83671,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -86384,13 +83682,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -86540,13 +83831,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -86558,13 +83842,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -86922,24 +84199,10 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
                     "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -87106,13 +84369,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -87124,13 +84380,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -87498,13 +84747,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -87516,13 +84758,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -88058,13 +85293,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -88076,13 +85304,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -88311,13 +85532,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -88329,13 +85543,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -88543,13 +85750,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -88561,13 +85761,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -88738,13 +85931,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -88756,13 +85942,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -89214,13 +86393,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -89232,13 +86404,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -89605,13 +86770,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -89623,13 +86781,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -90226,13 +87377,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -90244,13 +87388,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -90519,13 +87656,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -90537,13 +87667,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -90972,13 +88095,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -90990,13 +88106,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -91262,13 +88371,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -91280,13 +88382,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -91692,13 +88787,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -91710,13 +88798,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -92215,13 +89296,6 @@
             ],
             "properties": [
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -92233,13 +89307,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -92586,13 +89653,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -92604,13 +89664,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -92965,13 +90018,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -92983,13 +90029,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -93146,13 +90185,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -93164,13 +90196,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -93393,13 +90418,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -93411,13 +90429,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -93654,13 +90665,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -93672,13 +90676,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -93900,13 +90897,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -93918,13 +90908,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -94136,13 +91119,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -94154,13 +91130,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -94612,20 +91581,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
-                    "fromAttribute": true
-                },
-                {
                     "name": "rendered",
                     "type": "boolean",
                     "isArray": false,
@@ -94952,13 +91907,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -94970,13 +91918,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -95301,13 +92242,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -95319,13 +92253,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -95561,13 +92488,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -95579,13 +92499,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -95911,13 +92824,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -95929,13 +92835,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -96303,13 +93202,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -96321,13 +93213,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -96921,13 +93806,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -96939,13 +93817,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -97295,13 +94166,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -97313,13 +94177,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -97511,13 +94368,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -97529,13 +94379,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -97754,13 +94597,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -97772,13 +94608,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -98297,13 +95126,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -98315,13 +95137,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -99077,13 +95892,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -99095,13 +95903,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -99281,13 +96082,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -99299,13 +96093,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -99671,13 +96458,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -99689,13 +96469,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -99907,13 +96680,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -99925,13 +96691,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -100151,13 +96910,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -100169,13 +96921,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -100644,13 +97389,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -100662,13 +97400,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -101087,13 +97818,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -101105,13 +97829,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -101341,13 +98058,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -101359,13 +98069,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -101582,13 +98285,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -101600,13 +98296,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -101891,13 +98580,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -101909,13 +98591,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -102258,13 +98933,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -102276,13 +98944,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -102710,13 +99371,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -102728,13 +99382,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -103208,13 +99855,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -103226,13 +99866,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -103781,13 +100414,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -103799,13 +100425,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -104147,13 +100766,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -104165,13 +100777,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -104660,13 +101265,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -104678,13 +101276,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -104927,13 +101518,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -104945,13 +101529,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -105211,13 +101788,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -105229,13 +101799,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -105922,13 +102485,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -105940,13 +102496,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -106332,13 +102881,6 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
@@ -106350,13 +102892,6 @@
                     "type": "boolean",
                     "isArray": false,
                     "description": "Whether this component is treated as a response for the purposes of assessment.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -106728,24 +103263,10 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
                     "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -106976,24 +103497,10 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
                     "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -107224,24 +103731,10 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
                     "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -107431,24 +103924,10 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
                     "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {
@@ -107660,24 +104139,10 @@
                     "fromAttribute": true
                 },
                 {
-                    "name": "modifyIndirectly",
-                    "type": "boolean",
-                    "isArray": false,
-                    "description": "Whether this component can be modified indirectly through a property reference.",
-                    "fromAttribute": true
-                },
-                {
                     "name": "styleNumber",
                     "type": "integer",
                     "isArray": false,
                     "description": "The style number used to select this component's visual styling from the available style definitions.",
-                    "fromAttribute": true
-                },
-                {
-                    "name": "permid",
-                    "type": "text",
-                    "isArray": false,
-                    "description": "A persistent identifier for this component, stable across edits (currently unused but present for compatibility).",
                     "fromAttribute": true
                 },
                 {


### PR DESCRIPTION
## Summary

When an attribute is marked `excludeFromSchema: true` and creates a companion state variable via `createStateVariable`, that state variable is now also excluded from the schema. Previously, attributes that were intentionally hidden (e.g. `collaborateGroups` on inputs) still leaked into the schema as properties, surfacing in context-sensitive help (#1085) and autocomplete (#1088).

Excludes 501 entries across the schema covering 3 distinct property names: `collaborateGroups`, `modifyIndirectly`, `permid` — all of which are already marked `excludeFromSchema: true` on their backing attributes.

Refs #1089. The broader feature requested in the issue (excluding directly-defined state variables that aren't attribute-derived) is left for a follow-up.

## Test plan

- [x] Regenerated `doenet-schema.json`; verified `collaborateGroups`, `modifyIndirectly`, `permid` no longer appear on any element
- [x] Verified the diff removes only the three intended property names
- [x] CI green
- [x] Manual smoke: typing `$myInput.` in the editor no longer offers `collaborateGroups`

🤖 Generated with [Claude Code](https://claude.com/claude-code)