### PR TITLE
chore(claude-hooks): derive repo root from CLAUDE_PROJECT_DIR, not PWD

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,7 @@
                 "hooks": [
                     {
                         "type": "command",
-                        "command": "jq -r '.tool_response.filePath // .tool_input.file_path' 2>/dev/null | { read -r f; [ -n \"$f\" ] && repo_root=$(realpath \"$PWD\") && target=$(realpath \"$f\") && case \"$target\" in \"$repo_root\"|\"$repo_root\"/*) npx --no-install prettier --write --ignore-unknown \"$target\" ;; esac; } 2>/dev/null || true",
+                        "command": "jq -r '.tool_response.filePath // .tool_input.file_path' 2>/dev/null | { read -r f; [ -n \"$f\" ] || exit 0; repo_root=\"${CLAUDE_PROJECT_DIR:-$(git -C \"$(dirname \"$f\")\" rev-parse --show-toplevel 2>/dev/null)}\"; [ -n \"$repo_root\" ] || exit 0; repo_root=$(realpath \"$repo_root\"); target=$(realpath \"$f\"); case \"$target\" in \"$repo_root\"|\"$repo_root\"/*) (cd \"$repo_root\" && npx --no-install prettier --write --ignore-unknown \"$target\") ;; esac; }",
                         "timeout": 30
                     }
                 ]


### PR DESCRIPTION
## Summary

The PostToolUse prettier hook used `realpath "$PWD"` as the repo root for its case-match safety filter. Bash sessions persist their CWD, so any time we `cd` into a subpackage and then edit a file in a different subpackage, the target falls outside the perceived root and the case silently fails — prettier never runs.

Switch to `$CLAUDE_PROJECT_DIR` (with a `git -C "$(dirname "$f")" rev-parse --show-toplevel` fallback) and run prettier from the resolved root. Drop the trailing `2>/dev/null || true` so genuine prettier failures surface.

Split out from #1088 — purely a Claude Code harness fix, unrelated to that PR's autocomplete-descriptions scope.

## Test plan

- [x] Manual: hook fires on Edit from `CWD=packages/utils` against a file in `packages/codemirror` — file gets formatted (the old command silently skipped this scenario).
- [x] Manual: hook still no-ops cleanly for files outside the repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)