### PR TITLE
feat(editor): programmatic control of diagnostics panel

### DIFF
--- a/.changeset/doenet-editor-diagnostics-panel-control.md
+++ b/.changeset/doenet-editor-diagnostics-panel-control.md
@@ -1,0 +1,13 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Add programmatic control of the `<DoenetEditor>` diagnostics/responses panel:
+
+- New `initialOpenTab` prop opens the panel on the given tab when the editor mounts. Valid IDs: `"errors" | "warnings" | "info" | "accessibility" | "responses"`.
+- `<DoenetEditor>` now accepts a `ref` exposing a `DoenetEditorHandle` with `openDiagnosticsTab(tabId)` and `closeDiagnosticsPanel()` for runtime control.
+- The iframe wrapper (`@doenet/doenetml-iframe`) supports the same prop and ref handle, with calls made before the iframe finishes loading queued and replayed on ready.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,7 @@ jobs:
                         e2e-group4,
                         e2e-group5,
                         codemirror-cypress,
+                        doenetml-cypress,
                     ]
         steps:
             - uses: actions/checkout@v3
@@ -190,17 +191,17 @@ jobs:
                   WIREIT_CACHE: "local"
 
             - name: Start preview server
-              if: matrix.test-group != 'codemirror-cypress'
+              if: matrix.test-group != 'codemirror-cypress' && matrix.test-group != 'doenetml-cypress'
               run: |
                   npm run preview --workspace packages/test-cypress > /tmp/preview-server.log 2>&1 &
                   echo $! > /tmp/preview-server.pid
 
             - name: Wait for server
-              if: matrix.test-group != 'codemirror-cypress'
+              if: matrix.test-group != 'codemirror-cypress' && matrix.test-group != 'doenetml-cypress'
               run: npx wait-on http://localhost:4173 --timeout 60000
 
             - name: Check server logs if wait-on fails
-              if: failure() && matrix.test-group != 'codemirror-cypress'
+              if: failure() && matrix.test-group != 'codemirror-cypress' && matrix.test-group != 'doenetml-cypress'
               run: |
                   echo "=== Preview Server Log ===" && cat /tmp/preview-server.log || true
                   echo "=== Server processes ===" && ps aux | grep "node\|npm" || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,18 +190,21 @@ jobs:
               env:
                   WIREIT_CACHE: "local"
 
+            # Cypress *component* test groups (codemirror-cypress, doenetml-cypress, ...)
+            # spin up their own Vite dev server. Only the e2e groups need the
+            # shared preview server below.
             - name: Start preview server
-              if: matrix.test-group != 'codemirror-cypress' && matrix.test-group != 'doenetml-cypress'
+              if: ${{ !endsWith(matrix.test-group, '-cypress') }}
               run: |
                   npm run preview --workspace packages/test-cypress > /tmp/preview-server.log 2>&1 &
                   echo $! > /tmp/preview-server.pid
 
             - name: Wait for server
-              if: matrix.test-group != 'codemirror-cypress' && matrix.test-group != 'doenetml-cypress'
+              if: ${{ !endsWith(matrix.test-group, '-cypress') }}
               run: npx wait-on http://localhost:4173 --timeout 60000
 
             - name: Check server logs if wait-on fails
-              if: failure() && matrix.test-group != 'codemirror-cypress' && matrix.test-group != 'doenetml-cypress'
+              if: ${{ failure() && !endsWith(matrix.test-group, '-cypress') }}
               run: |
                   echo "=== Preview Server Log ===" && cat /tmp/preview-server.log || true
                   echo "=== Server processes ===" && ps aux | grep "node\|npm" || true

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "test:e2e-group5": "npm run test:group5 -w packages/test-cypress",
         "test:e2e-mistagged": "npm run test:mistagged -w packages/test-cypress",
         "test:codemirror-cypress": "npm run test-cypress-all -w packages/codemirror",
+        "test:doenetml-cypress": "npm run test-cypress-all -w packages/doenetml",
         "version:changesets": "changeset version && npm install --package-lock-only",
         "version": "npm version -w packages/doenetml -w packages/standalone -w packages/doenetml-iframe -w packages/v06-to-v07 -w @doenet/vscode-extension -w doenet-vscode-extension"
     },

--- a/packages/doenetml-iframe/README.md
+++ b/packages/doenetml-iframe/README.md
@@ -49,6 +49,12 @@ Valid tab IDs: `"errors" | "warnings" | "info" | "accessibility" | "responses"`.
 See the `@doenet/doenetml` README for usage patterns including the lazy-mount
 "link in a different panel" scenario.
 
+> **Note:** The handle methods are fire-and-forget across the iframe boundary.
+> Although they share the same `DoenetEditorHandle` type as the in-process
+> editor (so consumers can swap implementations), the iframe variant cannot
+> surface a completion signal or error to the caller — failures from the
+> underlying ComLink RPC are logged to the console rather than thrown.
+
 ## Development
 
 Source code in `src/iframe-viewer-index.ts` and `src/iframe-editor-index.ts`

--- a/packages/doenetml-iframe/README.md
+++ b/packages/doenetml-iframe/README.md
@@ -4,6 +4,51 @@ This workspace contains a DoenetML viewer and editor that render inside of an if
 This allows DoenetML to be used without affecting the surrounding page.
 It also allows multiple versions of DoenetML to be used at the same time.
 
+## DoenetEditor
+
+### Programmatic control of the diagnostics panel
+
+The iframe `<DoenetEditor>` accepts the same `initialOpenTab` prop and
+`DoenetEditorHandle` ref API as the in-process `<DoenetEditor>` from
+`@doenet/doenetml`. Calls bridge into the iframe via ComLink. If the
+ref handle is invoked before the iframe has finished loading, the call
+is queued in the outer wrapper and replayed once the iframe is ready —
+consumers do not need to coordinate timing.
+
+```tsx
+import { useRef } from "react";
+import {
+    DoenetEditor,
+    type DoenetEditorHandle,
+} from "@doenet/doenetml-iframe";
+
+function App() {
+    const editorRef = useRef<DoenetEditorHandle>(null);
+    return (
+        <>
+            <button
+                onClick={() =>
+                    editorRef.current?.openDiagnosticsTab("accessibility")
+                }
+            >
+                Show accessibility violations
+            </button>
+            <DoenetEditor ref={editorRef} doenetML="..." />
+        </>
+    );
+}
+```
+
+Mount-time form (panel opens on the requested tab on first paint):
+
+```tsx
+<DoenetEditor doenetML="..." initialOpenTab="accessibility" />
+```
+
+Valid tab IDs: `"errors" | "warnings" | "info" | "accessibility" | "responses"`.
+See the `@doenet/doenetml` README for usage patterns including the lazy-mount
+"link in a different panel" scenario.
+
 ## Development
 
 Source code in `src/iframe-viewer-index.ts` and `src/iframe-editor-index.ts`

--- a/packages/doenetml-iframe/src/iframe-editor-index.ts
+++ b/packages/doenetml-iframe/src/iframe-editor-index.ts
@@ -4,13 +4,19 @@ declare const editorId: string;
 declare const doenetEditorProps: Record<string, any>;
 declare const doenetEditorPropsSpecified: string[];
 declare const ComlinkEditor: { expose: Function; windowEndpoint: Function };
+type EditorControlHandle = {
+    openDiagnosticsTab: (tabId: string) => void;
+    closeDiagnosticsPanel: () => void;
+};
 interface Window {
     renderDoenetEditorToContainer: (
         container: Element,
         doenetMLSource?: string,
         config?: object,
-    ) => void;
+    ) => EditorControlHandle | void;
 }
+
+let editorControlHandle: EditorControlHandle | null = null;
 
 document.addEventListener("DOMContentLoaded", async () => {
     let pause100 = function () {
@@ -35,7 +41,27 @@ document.addEventListener("DOMContentLoaded", async () => {
 });
 
 ComlinkEditor.expose(
-    { renderEditorWithFunctionProps },
+    {
+        renderEditorWithFunctionProps,
+        openDiagnosticsTab(tabId: string) {
+            if (!editorControlHandle) {
+                console.warn(
+                    "iframe DoenetEditor: openDiagnosticsTab invoked before render",
+                );
+                return;
+            }
+            editorControlHandle.openDiagnosticsTab(tabId);
+        },
+        closeDiagnosticsPanel() {
+            if (!editorControlHandle) {
+                console.warn(
+                    "iframe DoenetEditor: closeDiagnosticsPanel invoked before render",
+                );
+                return;
+            }
+            editorControlHandle.closeDiagnosticsPanel();
+        },
+    },
     ComlinkEditor.windowEndpoint(globalThis.parent),
 );
 
@@ -64,11 +90,14 @@ function renderEditorWithFunctionProps(...args: (string | Function)[]) {
         }
     }
 
-    window.renderDoenetEditorToContainer(
+    const handle = window.renderDoenetEditorToContainer(
         document.getElementById("root")!,
         undefined,
         augmentedDoenetEditorProps,
     );
+    if (handle) {
+        editorControlHandle = handle;
+    }
 }
 
 messageParentFromEditor({ iframeReady: true });

--- a/packages/doenetml-iframe/src/iframe-editor-index.ts
+++ b/packages/doenetml-iframe/src/iframe-editor-index.ts
@@ -1,26 +1,22 @@
 // All code in this file will be executed in the context of an iframe
 // created by DoenetEditor.
-import type { DiagnosticsTabId } from "@doenet/doenetml";
+import type { DiagnosticsTabId, DoenetEditorHandle } from "@doenet/doenetml";
 
 declare const editorId: string;
 declare const doenetEditorProps: Record<string, any>;
 declare const doenetEditorPropsSpecified: string[];
 declare const ComlinkEditor: { expose: Function; windowEndpoint: Function };
-type EditorControlHandle = {
-    openDiagnosticsTab: (tabId: DiagnosticsTabId) => void;
-    closeDiagnosticsPanel: () => void;
-};
 declare global {
     interface Window {
         renderDoenetEditorToContainer: (
             container: Element,
             doenetMLSource?: string,
             config?: object,
-        ) => EditorControlHandle | void;
+        ) => DoenetEditorHandle | void;
     }
 }
 
-let editorControlHandle: EditorControlHandle | null = null;
+let editorControlHandle: DoenetEditorHandle | null = null;
 
 document.addEventListener("DOMContentLoaded", async () => {
     let pause100 = function () {

--- a/packages/doenetml-iframe/src/iframe-editor-index.ts
+++ b/packages/doenetml-iframe/src/iframe-editor-index.ts
@@ -1,19 +1,23 @@
 // All code in this file will be executed in the context of an iframe
 // created by DoenetEditor.
+import type { DiagnosticsTabId } from "@doenet/doenetml";
+
 declare const editorId: string;
 declare const doenetEditorProps: Record<string, any>;
 declare const doenetEditorPropsSpecified: string[];
 declare const ComlinkEditor: { expose: Function; windowEndpoint: Function };
 type EditorControlHandle = {
-    openDiagnosticsTab: (tabId: string) => void;
+    openDiagnosticsTab: (tabId: DiagnosticsTabId) => void;
     closeDiagnosticsPanel: () => void;
 };
-interface Window {
-    renderDoenetEditorToContainer: (
-        container: Element,
-        doenetMLSource?: string,
-        config?: object,
-    ) => EditorControlHandle | void;
+declare global {
+    interface Window {
+        renderDoenetEditorToContainer: (
+            container: Element,
+            doenetMLSource?: string,
+            config?: object,
+        ) => EditorControlHandle | void;
+    }
 }
 
 let editorControlHandle: EditorControlHandle | null = null;
@@ -43,7 +47,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 ComlinkEditor.expose(
     {
         renderEditorWithFunctionProps,
-        openDiagnosticsTab(tabId: string) {
+        openDiagnosticsTab(tabId: DiagnosticsTabId) {
             if (!editorControlHandle) {
                 console.warn(
                     "iframe DoenetEditor: openDiagnosticsTab invoked before render",

--- a/packages/doenetml-iframe/src/iframe-editor-index.ts
+++ b/packages/doenetml-iframe/src/iframe-editor-index.ts
@@ -50,7 +50,7 @@ ComlinkEditor.expose(
         openDiagnosticsTab(tabId: DiagnosticsTabId) {
             if (!editorControlHandle) {
                 console.warn(
-                    "iframe DoenetEditor: openDiagnosticsTab invoked before render",
+                    "iframe DoenetEditor: openDiagnosticsTab arrived before renderEditorWithFunctionProps completed — likely a bug in the iframe wrapper's queue/replay sequencing.",
                 );
                 return;
             }
@@ -59,7 +59,7 @@ ComlinkEditor.expose(
         closeDiagnosticsPanel() {
             if (!editorControlHandle) {
                 console.warn(
-                    "iframe DoenetEditor: closeDiagnosticsPanel invoked before render",
+                    "iframe DoenetEditor: closeDiagnosticsPanel arrived before renderEditorWithFunctionProps completed — likely a bug in the iframe wrapper's queue/replay sequencing.",
                 );
                 return;
             }

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -309,7 +309,7 @@ export function DoenetViewer({
  */
 type EditorIframeRemote = Comlink.Remote<{
     renderEditorWithFunctionProps: (...args: (string | Function)[]) => void;
-    openDiagnosticsTab: (tabId: string) => void;
+    openDiagnosticsTab: (tabId: DiagnosticsTabId) => void;
     closeDiagnosticsPanel: () => void;
 }>;
 

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -21,6 +21,8 @@ const latestDoenetmlVersion: string = version;
 
 export { mathjaxConfig } from "@doenet/utils";
 export type { DiagnosticRecord, ErrorRecord, WarningRecord };
+export type { DiagnosticsTabId, DoenetEditorHandle } from "@doenet/doenetml";
+import type { DiagnosticsTabId, DoenetEditorHandle } from "@doenet/doenetml";
 import { detectVersionFromDoenetML } from "@doenet/parser";
 
 import { ExternalVirtualKeyboard } from "@doenet/virtual-keyboard";
@@ -305,24 +307,67 @@ export function DoenetViewer({
  * DoenetML component. Instead you must use the message passing interface of `DoenetEditor` to communicate
  * with the underlying DoenetML component.
  */
-export function DoenetEditor({
-    doenetML,
-    standaloneUrl: specifiedStandaloneUrl,
-    cssUrl: specifiedCssUrl,
-    doenetmlVersion: specifiedDoenetmlVersion,
-    width = "100%",
-    height = "500px",
-    autodetectVersion = true,
-    ...doenetEditorProps
-}: DoenetEditorIframeProps) {
+type EditorIframeRemote = Comlink.Remote<{
+    renderEditorWithFunctionProps: (...args: (string | Function)[]) => void;
+    openDiagnosticsTab: (tabId: string) => void;
+    closeDiagnosticsPanel: () => void;
+}>;
+
+export const DoenetEditor = React.forwardRef<
+    DoenetEditorHandle,
+    DoenetEditorIframeProps
+>(function DoenetEditor(
+    {
+        doenetML,
+        standaloneUrl: specifiedStandaloneUrl,
+        cssUrl: specifiedCssUrl,
+        doenetmlVersion: specifiedDoenetmlVersion,
+        width = "100%",
+        height = "500px",
+        autodetectVersion = true,
+        ...doenetEditorProps
+    },
+    forwardedRef,
+) {
     const [id, _] = React.useState(() => Math.random().toString(36).slice(2));
     const ref = React.useRef<HTMLIFrameElement>(null);
+    const editorIframeRef = React.useRef<EditorIframeRemote | null>(null);
+    const pendingActions = React.useRef<
+        ((remote: EditorIframeRemote) => void)[]
+    >([]);
     const [inErrorState, setInErrorState] = React.useState<string | null>(null);
     const [ignoreDetectedVersion, setIgnoreDetectedVersion] =
         React.useState(false);
     const [initialDiagnostics, setInitialDiagnostics] = React.useState<
         DiagnosticRecord[]
     >([]);
+
+    React.useImperativeHandle(
+        forwardedRef,
+        () => ({
+            openDiagnosticsTab(tabId: DiagnosticsTabId) {
+                const action = (remote: EditorIframeRemote) => {
+                    remote.openDiagnosticsTab(tabId);
+                };
+                if (editorIframeRef.current) {
+                    action(editorIframeRef.current);
+                } else {
+                    pendingActions.current.push(action);
+                }
+            },
+            closeDiagnosticsPanel() {
+                const action = (remote: EditorIframeRemote) => {
+                    remote.closeDiagnosticsPanel();
+                };
+                if (editorIframeRef.current) {
+                    action(editorIframeRef.current);
+                } else {
+                    pendingActions.current.push(action);
+                }
+            },
+        }),
+        [],
+    );
 
     // Augment the DoenetEditor props by adding any initial diagnostics found
     const augmentedDoenetEditorProps = { ...doenetEditorProps };
@@ -383,11 +428,7 @@ export function DoenetEditor({
                 // and we can call `renderEditorWithFunctionProps`
 
                 if (ref.current) {
-                    const editorIframe: Comlink.Remote<{
-                        renderEditorWithFunctionProps: (
-                            ...args: (string | Function)[]
-                        ) => void;
-                    }> = Comlink.wrap(
+                    const editorIframe: EditorIframeRemote = Comlink.wrap(
                         Comlink.windowEndpoint(ref.current.contentWindow!),
                     );
 
@@ -407,6 +448,15 @@ export function DoenetEditor({
                     editorIframe?.renderEditorWithFunctionProps(
                         ...proxiedFunctions,
                     );
+
+                    // Make the remote available to the imperative handle and
+                    // replay any actions queued before the iframe was ready.
+                    editorIframeRef.current = editorIframe;
+                    const queued = pendingActions.current;
+                    pendingActions.current = [];
+                    for (const action of queued) {
+                        action(editorIframe);
+                    }
                 }
             }
         };
@@ -485,4 +535,4 @@ export function DoenetEditor({
             />
         </React.Fragment>
     );
-}
+});

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -482,6 +482,24 @@ export const DoenetEditor = React.forwardRef<
         };
     }, []);
 
+    const srcDoc = createHtmlForDoenetEditor(
+        id,
+        doenetML,
+        width,
+        augmentedDoenetEditorProps,
+        standaloneUrl,
+        cssUrl,
+    );
+
+    // When `srcDoc` changes, React updates the iframe attribute and the browser
+    // reloads the iframe document. The previous Comlink remote becomes bound to
+    // a torn-down `contentWindow` until the new iframe sends `iframeReady`.
+    // Clear the remote so calls during the reload window queue and replay on
+    // the next `iframeReady` instead of dispatching into a dead remote.
+    React.useEffect(() => {
+        editorIframeRef.current = null;
+    }, [srcDoc]);
+
     if (inErrorState) {
         if (foundAutoVersion) {
             setIgnoreDetectedVersion(true);
@@ -530,14 +548,7 @@ export const DoenetEditor = React.forwardRef<
             <iframe
                 title="Doenet Editor"
                 ref={ref}
-                srcDoc={createHtmlForDoenetEditor(
-                    id,
-                    doenetML,
-                    width,
-                    augmentedDoenetEditorProps,
-                    standaloneUrl,
-                    cssUrl,
-                )}
+                srcDoc={srcDoc}
                 style={{
                     width,
                     boxSizing: "content-box",

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -459,9 +459,11 @@ export const DoenetEditor = React.forwardRef<
                             proxiedFunctions.push(Comlink.proxy(prop));
                         }
                     }
-                    editorIframe?.renderEditorWithFunctionProps(
-                        ...proxiedFunctions,
-                    );
+                    editorIframe
+                        ?.renderEditorWithFunctionProps(...proxiedFunctions)
+                        .catch(
+                            logComlinkError("renderEditorWithFunctionProps"),
+                        );
 
                     // Make the remote available to the imperative handle and
                     // replay any actions queued before the iframe was ready.

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -313,6 +313,16 @@ type EditorIframeRemote = Comlink.Remote<{
     closeDiagnosticsPanel: () => void;
 }>;
 
+// ComLink RPC calls return Promises, but the imperative handle methods are
+// `void` (matching the in-process handle so consumers can use one type for
+// both). Attach an explicit catch handler so we don't leave the Promise
+// unhandled — surface errors via console rather than swallowing them.
+function logComlinkError(method: string) {
+    return (err: unknown) => {
+        console.warn(`iframe DoenetEditor: ${method} failed`, err);
+    };
+}
+
 export const DoenetEditor = React.forwardRef<
     DoenetEditorHandle,
     DoenetEditorIframeProps
@@ -347,7 +357,9 @@ export const DoenetEditor = React.forwardRef<
         () => ({
             openDiagnosticsTab(tabId: DiagnosticsTabId) {
                 const action = (remote: EditorIframeRemote) => {
-                    remote.openDiagnosticsTab(tabId);
+                    remote
+                        .openDiagnosticsTab(tabId)
+                        .catch(logComlinkError("openDiagnosticsTab"));
                 };
                 if (editorIframeRef.current) {
                     action(editorIframeRef.current);
@@ -357,7 +369,9 @@ export const DoenetEditor = React.forwardRef<
             },
             closeDiagnosticsPanel() {
                 const action = (remote: EditorIframeRemote) => {
-                    remote.closeDiagnosticsPanel();
+                    remote
+                        .closeDiagnosticsPanel()
+                        .catch(logComlinkError("closeDiagnosticsPanel"));
                 };
                 if (editorIframeRef.current) {
                     action(editorIframeRef.current);
@@ -452,8 +466,7 @@ export const DoenetEditor = React.forwardRef<
                     // Make the remote available to the imperative handle and
                     // replay any actions queued before the iframe was ready.
                     editorIframeRef.current = editorIframe;
-                    const queued = pendingActions.current;
-                    pendingActions.current = [];
+                    const queued = pendingActions.current.splice(0);
                     for (const action of queued) {
                         action(editorIframe);
                     }

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -21,8 +21,8 @@ const latestDoenetmlVersion: string = version;
 
 export { mathjaxConfig } from "@doenet/utils";
 export type { DiagnosticRecord, ErrorRecord, WarningRecord };
-export type { DiagnosticsTabId, DoenetEditorHandle } from "@doenet/doenetml";
 import type { DiagnosticsTabId, DoenetEditorHandle } from "@doenet/doenetml";
+export type { DiagnosticsTabId, DoenetEditorHandle };
 import { detectVersionFromDoenetML } from "@doenet/parser";
 
 import { ExternalVirtualKeyboard } from "@doenet/virtual-keyboard";

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -496,9 +496,10 @@ export const DoenetEditor = React.forwardRef<
     // When `srcDoc` changes, React updates the iframe attribute and the browser
     // reloads the iframe document. The previous Comlink remote becomes bound to
     // a torn-down `contentWindow` until the new iframe sends `iframeReady`.
-    // Clear the remote so calls during the reload window queue and replay on
-    // the next `iframeReady` instead of dispatching into a dead remote.
-    React.useEffect(() => {
+    // Clear the remote synchronously at commit (via `useLayoutEffect`) so any
+    // imperative-handle calls between commit and the next paint queue and
+    // replay against the new remote instead of dispatching into a dead one.
+    React.useLayoutEffect(() => {
         editorIframeRef.current = null;
     }, [srcDoc]);
 

--- a/packages/doenetml-iframe/src/test-main.tsx
+++ b/packages/doenetml-iframe/src/test-main.tsx
@@ -3,9 +3,9 @@
  * It does not show up in the bundled package.
  */
 
-import React from "react";
+import React, { useRef } from "react";
 import ReactDOM from "react-dom/client";
-import { DoenetViewer, DoenetEditor } from "./index";
+import { DoenetViewer, DoenetEditor, type DoenetEditorHandle } from "./index";
 
 // @ts-ignore
 import STANDALONE_SOURCE from "@doenet/standalone/doenet-standalone.js?raw";
@@ -28,6 +28,7 @@ root.render(<App />);
 
 function App() {
     const DOENET_LEGACY_VERSION = "0.6.5";
+    const editorRef = useRef<DoenetEditorHandle>(null);
 
     return (
         <React.Fragment>
@@ -59,7 +60,38 @@ function App() {
             </button>
 
             <h4>DoenetML {STANDALONE_VERSION} (locally-built copy):</h4>
+            <div
+                style={{ display: "flex", gap: "0.5em", marginBottom: "0.5em" }}
+            >
+                <button
+                    onClick={() =>
+                        editorRef.current?.openDiagnosticsTab("errors")
+                    }
+                >
+                    Open errors
+                </button>
+                <button
+                    onClick={() =>
+                        editorRef.current?.openDiagnosticsTab("warnings")
+                    }
+                >
+                    Open warnings
+                </button>
+                <button
+                    onClick={() =>
+                        editorRef.current?.openDiagnosticsTab("accessibility")
+                    }
+                >
+                    Open accessibility
+                </button>
+                <button
+                    onClick={() => editorRef.current?.closeDiagnosticsPanel()}
+                >
+                    Close panel
+                </button>
+            </div>
             <DoenetEditor
+                ref={editorRef}
                 doenetML={`<mathInput /><p><mathInput />Use this to test DoenetML<mathInput /></p>
                 <problem copy="doenet:abcdef" />
                 <graph />
@@ -69,7 +101,7 @@ function App() {
                 standaloneUrl={STANDALONE_BLOB_URL}
                 cssUrl={STANDALONE_CSS_BLOB_URL}
                 activityId={"a"}
-                showDiagnostics={false}
+                showDiagnostics={true}
                 showResponses={false}
                 fetchExternalDoenetML={fetchExternalDoenetML}
             />

--- a/packages/doenetml/README.md
+++ b/packages/doenetml/README.md
@@ -16,6 +16,81 @@ Semantic markup for building interactive web activities.
 
 -   Internally manages a directed acyclic graph of dependencies to coordinate updates of self-referential worksheets
 
+## DoenetEditor
+
+### Programmatic control of the diagnostics panel
+
+`<DoenetEditor>` exposes a ref handle (`DoenetEditorHandle`) so embedding apps
+can open or close the diagnostics/responses panel and switch between its tabs
+(`"errors" | "warnings" | "info" | "accessibility" | "responses"`). Each call
+is independent, so re-clicking a link after the user has closed the panel
+reopens it without consumer state management.
+
+```tsx
+import { useRef } from "react";
+import { DoenetEditor, type DoenetEditorHandle } from "@doenet/doenetml";
+
+function App() {
+    const editorRef = useRef<DoenetEditorHandle>(null);
+    return (
+        <>
+            <button
+                onClick={() =>
+                    editorRef.current?.openDiagnosticsTab("accessibility")
+                }
+            >
+                Show accessibility violations
+            </button>
+            <button
+                onClick={() => editorRef.current?.closeDiagnosticsPanel()}
+            >
+                Close panel
+            </button>
+            <DoenetEditor ref={editorRef} doenetML="..." />
+        </>
+    );
+}
+```
+
+For the "open with the panel already on a tab on first paint" case, set
+`initialOpenTab`. Reactive changes after mount are ignored — use the ref
+handle for runtime control.
+
+```tsx
+<DoenetEditor doenetML="..." initialOpenTab="accessibility" />
+```
+
+If the editor may be lazy-mounted (e.g., the link is in a different panel of
+your app from the editor embed), combine the two: pass `initialOpenTab` on
+first mount, then use the ref handle on subsequent clicks.
+
+```tsx
+const [showEditor, setShowEditor] = useState(false);
+const [pendingTab, setPendingTab] = useState<
+    DiagnosticsTabId | undefined
+>(undefined);
+const editorRef = useRef<DoenetEditorHandle>(null);
+
+function onLinkClick(tab: DiagnosticsTabId) {
+    if (showEditor && editorRef.current) {
+        editorRef.current.openDiagnosticsTab(tab);
+    } else {
+        setShowEditor(true);
+        setPendingTab(tab);
+    }
+}
+
+return (
+    showEditor && (
+        <DoenetEditor
+            ref={editorRef}
+            doenetML="..."
+            initialOpenTab={pendingTab}
+        />
+    )
+);
+```
+
 ## Quick Start
 
 In the project folder:

--- a/packages/doenetml/cypress.config.ts
+++ b/packages/doenetml/cypress.config.ts
@@ -74,6 +74,23 @@ export default defineConfig({
                         "@doenet/doenetml-worker",
                         "@doenet/codemirror",
                     ],
+                    // Aliasing `@doenet/codemirror` to source means Vite only
+                    // discovers its transitive deps when the first spec is
+                    // already loading, triggering a mid-flight reload that
+                    // aborts the spec's dynamic import (one spec fails, the
+                    // next passes). Pre-include them so the first scan
+                    // catches everything before any spec runs.
+                    include: [
+                        "@codemirror/state",
+                        "@codemirror/view",
+                        "@codemirror/language",
+                        "@codemirror/lint",
+                        "@codemirror/autocomplete",
+                        "@uiw/react-codemirror",
+                        "@lezer/highlight",
+                        "@qualified/lsp-connection",
+                        "@qualified/vscode-jsonrpc-ww",
+                    ],
                 },
             },
         },

--- a/packages/doenetml/cypress.config.ts
+++ b/packages/doenetml/cypress.config.ts
@@ -1,0 +1,57 @@
+import { defineConfig } from "cypress";
+import vitePreprocessor from "cypress-vite";
+import fs from "fs";
+import { version as doenetmlVersion } from "./package.json";
+
+export default defineConfig({
+    component: {
+        devServer: {
+            framework: "react",
+            bundler: "vite",
+            viteConfig: {
+                define: {
+                    DOENETML_VERSION: JSON.stringify(doenetmlVersion),
+                },
+                plugins: [
+                    {
+                        // Large pre-built IIFE bundles imported via `?raw`
+                        // (the LSP language server, the inlined doenetml worker)
+                        // trigger a parse error in Vite's import-analysis on
+                        // its multi-MB string literal. Intercept the load and
+                        // return a base64-encoded string that decodes at
+                        // runtime so es-module-lexer never sees the raw blob.
+                        name: "raw-large-bundle",
+                        enforce: "pre" as const,
+                        load(id: string) {
+                            if (
+                                /[?&]raw\b/.test(id) &&
+                                (id.includes("@doenet/lsp") ||
+                                    id.includes("/packages/lsp/") ||
+                                    id.includes("@doenet/doenetml-worker") ||
+                                    id.includes("/packages/doenetml-worker/"))
+                            ) {
+                                const filePath = id.replace(/[?#].*$/, "");
+                                const content = fs.readFileSync(
+                                    filePath,
+                                    "utf-8",
+                                );
+                                const b64 =
+                                    Buffer.from(content).toString("base64");
+                                return `export default atob(${JSON.stringify(b64)});`;
+                            }
+                        },
+                    },
+                ],
+                optimizeDeps: {
+                    exclude: ["@doenet/lsp", "@doenet/doenetml-worker"],
+                },
+            },
+        },
+        specPattern: "test/cypress/component/**/*.cy.{js,jsx,ts,tsx}",
+        supportFile: "test/cypress/support/component.ts",
+        indexHtmlFile: "test/cypress/support/component-index.html",
+        setupNodeEvents(on) {
+            on("file:preprocessor", vitePreprocessor());
+        },
+    },
+});

--- a/packages/doenetml/cypress.config.ts
+++ b/packages/doenetml/cypress.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from "cypress";
 import vitePreprocessor from "cypress-vite";
 import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
 import { version as doenetmlVersion } from "./package.json";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const codemirrorSrc = path.resolve(__dirname, "../codemirror/src/index.ts");
 
 export default defineConfig({
     component: {
@@ -11,6 +16,27 @@ export default defineConfig({
             viteConfig: {
                 define: {
                     DOENETML_VERSION: JSON.stringify(doenetmlVersion),
+                },
+                resolve: {
+                    alias: [
+                        // Resolve `@doenet/codemirror` to its source rather
+                        // than the built dist. The dist embeds the LSP IIFE
+                        // (which itself contains a data-URL-inlined WASM) as
+                        // a single string literal: when Rust builds the WASM
+                        // unoptimized (e.g. CI without `wasm-opt`), that
+                        // literal exceeds esbuild's parser limits and Vite's
+                        // `vite:client-inject` transform fails with
+                        // "Unterminated string literal". Consuming the source
+                        // routes the `?raw` LSP import through the
+                        // `raw-large-bundle` plugin below, which sidesteps
+                        // the problem regardless of WASM size. Subpath
+                        // imports (`/style.css`, `/*json`) still resolve via
+                        // the package exports against the dist.
+                        {
+                            find: /^@doenet\/codemirror$/,
+                            replacement: codemirrorSrc,
+                        },
+                    ],
                 },
                 plugins: [
                     {
@@ -43,7 +69,11 @@ export default defineConfig({
                     },
                 ],
                 optimizeDeps: {
-                    exclude: ["@doenet/lsp", "@doenet/doenetml-worker"],
+                    exclude: [
+                        "@doenet/lsp",
+                        "@doenet/doenetml-worker",
+                        "@doenet/codemirror",
+                    ],
                 },
             },
         },

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -28,6 +28,8 @@
         "build": "wireit",
         "preview": "vite preview",
         "test": "vitest",
+        "test-cypress": "cypress open --component",
+        "test-cypress-all": "cypress run --component -b 'chrome' --config video=false --headless",
         "publish": "npm run build && cd dist && npm publish"
     },
     "wireit": {

--- a/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
+++ b/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
@@ -38,6 +38,26 @@ type SubmittedResponse = {
     submittedAt: string;
 };
 
+/** IDs of the tabs rendered by `DiagnosticsResponseTabstrip`. */
+export type DiagnosticsTabId =
+    | "errors"
+    | "warnings"
+    | "info"
+    | "accessibility"
+    | "responses";
+
+/** Imperative handle exposed by `<DoenetEditor>` for programmatic panel control. */
+export type DoenetEditorHandle = {
+    /**
+     * Switch the diagnostics/responses panel to `tabId` and open it.
+     * If `tabId` references a tab disabled by `showDiagnostics={false}` or
+     * `showResponses={false}`, the call is ignored with a `console.warn`.
+     */
+    openDiagnosticsTab: (tabId: DiagnosticsTabId) => void;
+    /** Close the diagnostics/responses panel. */
+    closeDiagnosticsPanel: () => void;
+};
+
 /** Human-readable label for diagnostic source line, when position exists. */
 function diagnosticLocationLabel(diagnostic: {
     position?: { start: { line: number } };

--- a/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
+++ b/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
@@ -461,11 +461,15 @@ export function DiagnosticsResponseTabContents({
         };
     }, [isOpen]);
 
+    // Auto-scroll-to-bottom on open is desired only for the "responses" tab so
+    // the most recent submission is in view; for other tabs it would jump the
+    // user past the top of the report when the panel opens.
+    const selectedTabIdForScroll = store.useState("selectedId");
     useEffect(() => {
-        if (isOpen) {
+        if (isOpen && selectedTabIdForScroll === "responses") {
             scrollToBottom();
         }
-    }, [isOpen]);
+    }, [isOpen, selectedTabIdForScroll]);
 
     useEffect(() => {
         if (isOpen) {

--- a/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
+++ b/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
@@ -379,6 +379,7 @@ export function DiagnosticsResponseTabstrip({
                         title="Close panel"
                         aria-label="Close panel"
                         className="close-button"
+                        data-test="diagnostics-panel-close"
                         onClick={() => {
                             setIsOpen(false);
                         }}

--- a/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
+++ b/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
@@ -475,7 +475,7 @@ export function DiagnosticsResponseTabContents({
     }, [isOpen, selectedTabIdForScroll]);
 
     useEffect(() => {
-        if (isOpen) {
+        if (isOpen && selectedTabIdForScroll === "responses") {
             if (lastScrolledToBottom.current) {
                 scrollToBottom();
             }

--- a/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
+++ b/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
@@ -461,9 +461,11 @@ export function DiagnosticsResponseTabContents({
         };
     }, [isOpen]);
 
-    // Auto-scroll-to-bottom on open is desired only for the "responses" tab so
-    // the most recent submission is in view; for other tabs it would jump the
-    // user past the top of the report when the panel opens.
+    // Auto-scroll-to-bottom is desired only for the "responses" tab so the
+    // most recent submission is in view; for other tabs it would jump the
+    // user past the top of the report. Firing on `selectedTabIdForScroll`
+    // changes too is intentional: switching to "responses" while the panel
+    // is already open should also bring the latest submission into view.
     const selectedTabIdForScroll = store.useState("selectedId");
     useEffect(() => {
         if (isOpen && selectedTabIdForScroll === "responses") {

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -198,7 +198,7 @@ export const EditorViewer = React.forwardRef<
         if (initialOpenTabWarning) {
             console.warn(initialOpenTabWarning);
         }
-    }, []);
+    }, [initialOpenTabWarning]);
 
     const [infoPanelIsOpen, setInfoPanelIsOpen] = useState(
         resolvedInitialOpenTab !== undefined,

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -2,6 +2,7 @@ import React, {
     ReactElement,
     useCallback,
     useEffect,
+    useImperativeHandle,
     useMemo,
     useRef,
     useState,
@@ -13,6 +14,10 @@ import { DocViewer } from "../Viewer/DocViewer";
 import {
     DiagnosticsResponseTabContents,
     DiagnosticsResponseTabstrip,
+} from "./DiagnosticsResponseTabs";
+import type {
+    DiagnosticsTabId,
+    DoenetEditorHandle,
 } from "./DiagnosticsResponseTabs";
 import { DiagnosticRecord, nanInfinityReviver } from "@doenet/utils";
 import { nanoid } from "nanoid";
@@ -41,35 +46,7 @@ const HELP_NONE: HelpContent = { kind: "none" };
 // each render, refiring every effect/memo that depends on `initialDiagnostics`.
 const EMPTY_INITIAL_DIAGNOSTICS: DiagnosticRecord[] = [];
 
-/**
- * Combined DoenetML editor/viewer shell with diagnostics, responses, formatting, and variants.
- */
-export function EditorViewer({
-    doenetML: initialDoenetML,
-    activityId: specifiedActivityId,
-    prefixForIds = "",
-    doenetViewerUrl,
-    darkMode = "light",
-    showAnswerResponseButton = false,
-    answerResponseCounts = {},
-    width = "100%",
-    height = "500px",
-    showViewer = true,
-    viewerLocation = "right",
-    doenetmlChangeCallback,
-    immediateDoenetmlChangeCallback,
-    documentStructureCallback,
-    diagnosticsSummaryCallback,
-    id: specifiedId,
-    readOnly = false,
-    showFormatter = true,
-    showDiagnostics = true,
-    showResponses = true,
-    border = "1px solid",
-    initialDiagnostics = EMPTY_INITIAL_DIAGNOSTICS,
-    fetchExternalDoenetML,
-    docsURL = "https://docs.doenet.org",
-}: {
+type EditorViewerProps = {
     doenetML: string;
     activityId?: string;
     prefixForIds?: string;
@@ -96,7 +73,50 @@ export function EditorViewer({
     initialDiagnostics?: DiagnosticRecord[];
     fetchExternalDoenetML?: (arg: string) => Promise<string>;
     docsURL?: string;
-}) {
+    /**
+     * If set, the diagnostics/responses panel mounts open on the given tab.
+     * Reactive changes after mount are ignored — use the imperative ref handle
+     * (`openDiagnosticsTab` / `closeDiagnosticsPanel`) for runtime control.
+     */
+    initialOpenTab?: DiagnosticsTabId;
+};
+
+/**
+ * Combined DoenetML editor/viewer shell with diagnostics, responses, formatting, and variants.
+ */
+export const EditorViewer = React.forwardRef<
+    DoenetEditorHandle,
+    EditorViewerProps
+>(function EditorViewer(
+    {
+        doenetML: initialDoenetML,
+        activityId: specifiedActivityId,
+        prefixForIds = "",
+        doenetViewerUrl,
+        darkMode = "light",
+        showAnswerResponseButton = false,
+        answerResponseCounts = {},
+        width = "100%",
+        height = "500px",
+        showViewer = true,
+        viewerLocation = "right",
+        doenetmlChangeCallback,
+        immediateDoenetmlChangeCallback,
+        documentStructureCallback,
+        diagnosticsSummaryCallback,
+        id: specifiedId,
+        readOnly = false,
+        showFormatter = true,
+        showDiagnostics = true,
+        showResponses = true,
+        border = "1px solid",
+        initialDiagnostics = EMPTY_INITIAL_DIAGNOSTICS,
+        fetchExternalDoenetML,
+        docsURL = "https://docs.doenet.org",
+        initialOpenTab,
+    },
+    ref,
+) {
     //Win, Mac or Linux
     let platform = "Linux";
     if (navigator.platform.indexOf("Win") != -1) {
@@ -144,7 +164,31 @@ export function EditorViewer({
         allPossibleVariants: ["a"],
     });
 
-    const [infoPanelIsOpen, setInfoPanelIsOpen] = useState(false);
+    // Resolve `initialOpenTab` once at mount: if the requested tab is disabled
+    // by `showDiagnostics={false}` / `showResponses={false}` (and inferring
+    // `showResponses` from `showViewer` above), warn and fall back to default.
+    const [resolvedInitialOpenTab] = useState<DiagnosticsTabId | undefined>(
+        () => {
+            if (initialOpenTab === undefined) {
+                return undefined;
+            }
+            const tabEnabled =
+                initialOpenTab === "responses"
+                    ? showResponses
+                    : showDiagnostics;
+            if (!tabEnabled) {
+                console.warn(
+                    `DoenetEditor: initialOpenTab="${initialOpenTab}" is not enabled (showDiagnostics=${showDiagnostics}, showResponses=${showResponses}); falling back to default.`,
+                );
+                return undefined;
+            }
+            return initialOpenTab;
+        },
+    );
+
+    const [infoPanelIsOpen, setInfoPanelIsOpen] = useState(
+        resolvedInitialOpenTab !== undefined,
+    );
 
     const [diagnostics, setDiagnostics] = useState<DiagnosticRecord[]>([]);
     // Track whether we've received diagnostics from the viewer at least once.
@@ -168,7 +212,9 @@ export function EditorViewer({
     const helpIsVisibleRef = useRef(false);
 
     const tabStore = useTabStore({
-        defaultSelectedId: showDiagnostics ? "errors" : "responses",
+        defaultSelectedId:
+            resolvedInitialOpenTab ??
+            (showDiagnostics ? "errors" : "responses"),
     });
     const selectedTabId = tabStore.useState("selectedId");
     const isAccessibilityReportOpen =
@@ -184,6 +230,28 @@ export function EditorViewer({
         tabStore.setSelectedId("accessibility");
         setInfoPanelIsOpen(true);
     }
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            openDiagnosticsTab(tabId: DiagnosticsTabId) {
+                const tabEnabled =
+                    tabId === "responses" ? showResponses : showDiagnostics;
+                if (!tabEnabled) {
+                    console.warn(
+                        `DoenetEditor: openDiagnosticsTab("${tabId}") ignored — tab is not enabled (showDiagnostics=${showDiagnostics}, showResponses=${showResponses}).`,
+                    );
+                    return;
+                }
+                tabStore.setSelectedId(tabId);
+                setInfoPanelIsOpen(true);
+            },
+            closeDiagnosticsPanel() {
+                setInfoPanelIsOpen(false);
+            },
+        }),
+        [tabStore, showDiagnostics, showResponses],
+    );
 
     /** Receives diagnostics from DocViewer and stores them for panel/LSP sync. */
     function setDiagnosticsCallback(newDiagnostics: DiagnosticRecord[]) {
@@ -693,4 +761,4 @@ export function EditorViewer({
             border={border}
         />
     );
-}
+});

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -166,26 +166,39 @@ export const EditorViewer = React.forwardRef<
 
     // Resolve `initialOpenTab` once at mount: if the requested tab is disabled
     // by `showDiagnostics={false}` / `showResponses={false}` (with
-    // `showResponses` forced to `false` by `showViewer={false}` above), warn
-    // and fall back to default.
-    const [resolvedInitialOpenTab] = useState<DiagnosticsTabId | undefined>(
-        () => {
-            if (initialOpenTab === undefined) {
-                return undefined;
-            }
-            const tabEnabled =
-                initialOpenTab === "responses"
-                    ? showResponses
-                    : showDiagnostics;
-            if (!tabEnabled) {
-                console.warn(
-                    `DoenetEditor: initialOpenTab="${initialOpenTab}" is not enabled (showDiagnostics=${showDiagnostics}, showResponses=${showResponses}); falling back to default.`,
-                );
-                return undefined;
-            }
-            return initialOpenTab;
-        },
-    );
+    // `showResponses` forced to `false` by `showViewer={false}` above), capture
+    // a warning message and fall back to default. The warning is emitted from
+    // an effect below so the initializer stays pure (StrictMode double-invokes
+    // useState initializers in dev).
+    const [{ resolvedInitialOpenTab, initialOpenTabWarning }] = useState<{
+        resolvedInitialOpenTab: DiagnosticsTabId | undefined;
+        initialOpenTabWarning: string | null;
+    }>(() => {
+        if (initialOpenTab === undefined) {
+            return {
+                resolvedInitialOpenTab: undefined,
+                initialOpenTabWarning: null,
+            };
+        }
+        const tabEnabled =
+            initialOpenTab === "responses" ? showResponses : showDiagnostics;
+        if (!tabEnabled) {
+            return {
+                resolvedInitialOpenTab: undefined,
+                initialOpenTabWarning: `DoenetEditor: initialOpenTab="${initialOpenTab}" is not enabled (showDiagnostics=${showDiagnostics}, showResponses=${showResponses}); falling back to default.`,
+            };
+        }
+        return {
+            resolvedInitialOpenTab: initialOpenTab,
+            initialOpenTabWarning: null,
+        };
+    });
+
+    useEffect(() => {
+        if (initialOpenTabWarning) {
+            console.warn(initialOpenTabWarning);
+        }
+    }, []);
 
     const [infoPanelIsOpen, setInfoPanelIsOpen] = useState(
         resolvedInitialOpenTab !== undefined,

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -165,8 +165,9 @@ export const EditorViewer = React.forwardRef<
     });
 
     // Resolve `initialOpenTab` once at mount: if the requested tab is disabled
-    // by `showDiagnostics={false}` / `showResponses={false}` (and inferring
-    // `showResponses` from `showViewer` above), warn and fall back to default.
+    // by `showDiagnostics={false}` / `showResponses={false}` (with
+    // `showResponses` forced to `false` by `showViewer={false}` above), warn
+    // and fall back to default.
     const [resolvedInitialOpenTab] = useState<DiagnosticsTabId | undefined>(
         () => {
             if (initialOpenTab === undefined) {

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -20,6 +20,14 @@ import { VirtualKeyboard } from "@doenet/virtual-keyboard";
 import "@doenet/virtual-keyboard/style.css";
 import "@doenet/ui-components/style.css";
 import { EditorViewer } from "./EditorViewer/EditorViewer.js";
+import type {
+    DiagnosticsTabId,
+    DoenetEditorHandle,
+} from "./EditorViewer/DiagnosticsResponseTabs";
+export type {
+    DiagnosticsTabId,
+    DoenetEditorHandle,
+} from "./EditorViewer/DiagnosticsResponseTabs";
 import VariantSelect from "./EditorViewer/VariantSelect";
 import { useIsOnPage } from "./utils/visibility";
 import { Provider as ReduxProvider } from "react-redux";
@@ -317,38 +325,7 @@ export function DoenetViewer({
     );
 }
 
-export function DoenetEditor({
-    doenetML,
-    activityId = "a",
-    prefixForIds = "",
-    addVirtualKeyboard = true,
-    externalVirtualKeyboardProvided = false,
-    doenetViewerUrl,
-    darkMode = "light",
-    showAnswerResponseButton = false,
-    answerResponseCounts = {},
-    width,
-    height,
-    viewerLocation,
-    backgroundColor,
-    showViewer,
-    doenetmlChangeCallback,
-    immediateDoenetmlChangeCallback,
-    documentStructureCallback,
-    diagnosticsSummaryCallback,
-    id,
-    readOnly = false,
-    showFormatter = true,
-    showDiagnostics,
-    showErrorsWarnings,
-    showResponses = true,
-    border = "1px solid",
-    initialDiagnostics = EMPTY_INITIAL_DIAGNOSTICS,
-    initialErrors,
-    initialWarnings,
-    fetchExternalDoenetML,
-    docsURL,
-}: {
+type DoenetEditorProps = {
     doenetML: string;
     activityId?: string;
     prefixForIds?: string;
@@ -381,7 +358,53 @@ export function DoenetEditor({
     initialWarnings?: WarningRecord[];
     fetchExternalDoenetML?: (arg: string) => Promise<string>;
     docsURL?: string;
-}) {
+    /**
+     * If set, the diagnostics/responses panel mounts open on the given tab.
+     * Reactive changes after mount are ignored — use the imperative ref handle
+     * (`openDiagnosticsTab` / `closeDiagnosticsPanel`) for runtime control.
+     */
+    initialOpenTab?: DiagnosticsTabId;
+};
+
+export const DoenetEditor = React.forwardRef<
+    DoenetEditorHandle,
+    DoenetEditorProps
+>(function DoenetEditor(
+    {
+        doenetML,
+        activityId = "a",
+        prefixForIds = "",
+        addVirtualKeyboard = true,
+        externalVirtualKeyboardProvided = false,
+        doenetViewerUrl,
+        darkMode = "light",
+        showAnswerResponseButton = false,
+        answerResponseCounts = {},
+        width,
+        height,
+        viewerLocation,
+        backgroundColor,
+        showViewer,
+        doenetmlChangeCallback,
+        immediateDoenetmlChangeCallback,
+        documentStructureCallback,
+        diagnosticsSummaryCallback,
+        id,
+        readOnly = false,
+        showFormatter = true,
+        showDiagnostics,
+        showErrorsWarnings,
+        showResponses = true,
+        border = "1px solid",
+        initialDiagnostics = EMPTY_INITIAL_DIAGNOSTICS,
+        initialErrors,
+        initialWarnings,
+        fetchExternalDoenetML,
+        docsURL,
+        initialOpenTab,
+    },
+    ref,
+) {
     const normalizedShowDiagnostics =
         showDiagnostics ?? showErrorsWarnings ?? true;
 
@@ -434,6 +457,7 @@ export function DoenetEditor({
 
     const editor = (
         <EditorViewer
+            ref={ref}
             doenetML={doenetML}
             activityId={activityId}
             prefixForIds={prefixForIds}
@@ -458,6 +482,7 @@ export function DoenetEditor({
             initialDiagnostics={normalizedInitialDiagnostics}
             fetchExternalDoenetML={fetchExternalDoenetML}
             docsURL={docsURL}
+            initialOpenTab={initialOpenTab}
         />
     );
 
@@ -475,7 +500,7 @@ export function DoenetEditor({
             </MathJaxContext>
         </ReduxProvider>
     );
-}
+});
 
 /**
  * Component that wraps its children and provides a VirtualKeyboard

--- a/packages/doenetml/src/index.ts
+++ b/packages/doenetml/src/index.ts
@@ -1,4 +1,5 @@
 export { DoenetViewer, DoenetEditor } from "./doenetml";
+export type { DiagnosticsTabId, DoenetEditorHandle } from "./doenetml";
 
 export {
     mathjaxConfig,

--- a/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticsPanelRef.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticsPanelRef.cy.tsx
@@ -1,6 +1,7 @@
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import {
     DoenetEditor,
+    type DiagnosticsTabId,
     type DoenetEditorHandle,
 } from "../../../src/doenetml-inline-worker";
 
@@ -11,7 +12,7 @@ function Harness() {
     return (
         <div style={{ height: "500px", width: "900px" }}>
             <button
-                data-cy="open-accessibility"
+                data-test="open-accessibility"
                 onClick={() =>
                     editorRef.current?.openDiagnosticsTab("accessibility")
                 }
@@ -19,7 +20,7 @@ function Harness() {
                 Open accessibility
             </button>
             <button
-                data-cy="open-warnings"
+                data-test="open-warnings"
                 onClick={() =>
                     editorRef.current?.openDiagnosticsTab("warnings")
                 }
@@ -27,7 +28,7 @@ function Harness() {
                 Open warnings
             </button>
             <button
-                data-cy="close"
+                data-test="close"
                 onClick={() => editorRef.current?.closeDiagnosticsPanel()}
             >
                 Close
@@ -50,7 +51,7 @@ describe("DoenetEditor imperative ref handle", () => {
             "is-open",
         );
 
-        cy.get('[data-cy="open-accessibility"]').click();
+        cy.get('[data-test="open-accessibility"]').click();
         cy.get(".diagnostics-response-tabs-container").should(
             "have.class",
             "is-open",
@@ -65,13 +66,13 @@ describe("DoenetEditor imperative ref handle", () => {
     it("closes the panel via closeDiagnosticsPanel", () => {
         cy.mount(<Harness />);
 
-        cy.get('[data-cy="open-accessibility"]').click();
+        cy.get('[data-test="open-accessibility"]').click();
         cy.get(".diagnostics-response-tabs-container").should(
             "have.class",
             "is-open",
         );
 
-        cy.get('[data-cy="close"]').click();
+        cy.get('[data-test="close"]').click();
         cy.get(".diagnostics-response-tabs-container").should(
             "not.have.class",
             "is-open",
@@ -82,21 +83,21 @@ describe("DoenetEditor imperative ref handle", () => {
         cy.mount(<Harness />);
 
         // open via ref
-        cy.get('[data-cy="open-accessibility"]').click();
+        cy.get('[data-test="open-accessibility"]').click();
         cy.get(".diagnostics-response-tabs-container").should(
             "have.class",
             "is-open",
         );
 
         // user clicks the panel's internal close button
-        cy.get(".close-button").click();
+        cy.get('[data-test="diagnostics-panel-close"]').click();
         cy.get(".diagnostics-response-tabs-container").should(
             "not.have.class",
             "is-open",
         );
 
         // ref handle reopens the same tab
-        cy.get('[data-cy="open-accessibility"]').click();
+        cy.get('[data-test="open-accessibility"]').click();
         cy.get(".diagnostics-response-tabs-container").should(
             "have.class",
             "is-open",
@@ -111,18 +112,97 @@ describe("DoenetEditor imperative ref handle", () => {
     it("switches between tabs", () => {
         cy.mount(<Harness />);
 
-        cy.get('[data-cy="open-accessibility"]').click();
+        cy.get('[data-test="open-accessibility"]').click();
         cy.get('[id="accessibility"][role="tab"]').should(
             "have.attr",
             "aria-selected",
             "true",
         );
 
-        cy.get('[data-cy="open-warnings"]').click();
+        cy.get('[data-test="open-warnings"]').click();
         cy.get('[id="warnings"][role="tab"]').should(
             "have.attr",
             "aria-selected",
             "true",
+        );
+    });
+});
+
+// Mirrors the README "lazy-mount / link in a different panel" pattern:
+// before the editor is mounted, set `initialOpenTab` to the requested tab;
+// once mounted, subsequent clicks drive the panel via the ref handle.
+function LazyMountHarness() {
+    const [showEditor, setShowEditor] = useState(false);
+    const [pendingTab, setPendingTab] = useState<DiagnosticsTabId | undefined>(
+        undefined,
+    );
+    const editorRef = useRef<DoenetEditorHandle>(null);
+
+    function onLinkClick(tab: DiagnosticsTabId) {
+        if (showEditor && editorRef.current) {
+            editorRef.current.openDiagnosticsTab(tab);
+        } else {
+            setShowEditor(true);
+            setPendingTab(tab);
+        }
+    }
+
+    return (
+        <div style={{ height: "500px", width: "900px" }}>
+            <button
+                data-test="link-accessibility"
+                onClick={() => onLinkClick("accessibility")}
+            >
+                Open accessibility
+            </button>
+            <button
+                data-test="link-warnings"
+                onClick={() => onLinkClick("warnings")}
+            >
+                Open warnings
+            </button>
+            {showEditor && (
+                <DoenetEditor
+                    ref={editorRef}
+                    doenetML={SAMPLE_DOENETML}
+                    initialOpenTab={pendingTab}
+                    addVirtualKeyboard={false}
+                />
+            )}
+        </div>
+    );
+}
+
+describe("DoenetEditor lazy-mount with initialOpenTab + ref handle", () => {
+    it("first click mounts the editor with the requested tab open; subsequent clicks switch tabs via ref", () => {
+        cy.mount(<LazyMountHarness />);
+
+        // Editor is not mounted yet.
+        cy.get(".diagnostics-response-tabs-container").should("not.exist");
+
+        // First click: mount with `initialOpenTab` set to "accessibility".
+        cy.get('[data-test="link-accessibility"]').click();
+        cy.get(".diagnostics-response-tabs-container").should(
+            "have.class",
+            "is-open",
+        );
+        cy.get('[id="accessibility"][role="tab"]').should(
+            "have.attr",
+            "aria-selected",
+            "true",
+        );
+
+        // Second click on a different link: editor is already mounted, so
+        // this must take the ref-handle branch and switch tabs in place.
+        cy.get('[data-test="link-warnings"]').click();
+        cy.get('[id="warnings"][role="tab"]').should(
+            "have.attr",
+            "aria-selected",
+            "true",
+        );
+        cy.get(".diagnostics-response-tabs-container").should(
+            "have.class",
+            "is-open",
         );
     });
 });

--- a/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticsPanelRef.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.diagnosticsPanelRef.cy.tsx
@@ -1,0 +1,128 @@
+import React, { useRef } from "react";
+import {
+    DoenetEditor,
+    type DoenetEditorHandle,
+} from "../../../src/doenetml-inline-worker";
+
+const SAMPLE_DOENETML = "<p>hello</p>";
+
+function Harness() {
+    const editorRef = useRef<DoenetEditorHandle>(null);
+    return (
+        <div style={{ height: "500px", width: "900px" }}>
+            <button
+                data-cy="open-accessibility"
+                onClick={() =>
+                    editorRef.current?.openDiagnosticsTab("accessibility")
+                }
+            >
+                Open accessibility
+            </button>
+            <button
+                data-cy="open-warnings"
+                onClick={() =>
+                    editorRef.current?.openDiagnosticsTab("warnings")
+                }
+            >
+                Open warnings
+            </button>
+            <button
+                data-cy="close"
+                onClick={() => editorRef.current?.closeDiagnosticsPanel()}
+            >
+                Close
+            </button>
+            <DoenetEditor
+                ref={editorRef}
+                doenetML={SAMPLE_DOENETML}
+                addVirtualKeyboard={false}
+            />
+        </div>
+    );
+}
+
+describe("DoenetEditor imperative ref handle", () => {
+    it("opens a tab via openDiagnosticsTab", () => {
+        cy.mount(<Harness />);
+
+        cy.get(".diagnostics-response-tabs-container").should(
+            "not.have.class",
+            "is-open",
+        );
+
+        cy.get('[data-cy="open-accessibility"]').click();
+        cy.get(".diagnostics-response-tabs-container").should(
+            "have.class",
+            "is-open",
+        );
+        cy.get('[id="accessibility"][role="tab"]').should(
+            "have.attr",
+            "aria-selected",
+            "true",
+        );
+    });
+
+    it("closes the panel via closeDiagnosticsPanel", () => {
+        cy.mount(<Harness />);
+
+        cy.get('[data-cy="open-accessibility"]').click();
+        cy.get(".diagnostics-response-tabs-container").should(
+            "have.class",
+            "is-open",
+        );
+
+        cy.get('[data-cy="close"]').click();
+        cy.get(".diagnostics-response-tabs-container").should(
+            "not.have.class",
+            "is-open",
+        );
+    });
+
+    it("re-opens after the user closes the panel", () => {
+        cy.mount(<Harness />);
+
+        // open via ref
+        cy.get('[data-cy="open-accessibility"]').click();
+        cy.get(".diagnostics-response-tabs-container").should(
+            "have.class",
+            "is-open",
+        );
+
+        // user clicks the panel's internal close button
+        cy.get(".close-button").click();
+        cy.get(".diagnostics-response-tabs-container").should(
+            "not.have.class",
+            "is-open",
+        );
+
+        // ref handle reopens the same tab
+        cy.get('[data-cy="open-accessibility"]').click();
+        cy.get(".diagnostics-response-tabs-container").should(
+            "have.class",
+            "is-open",
+        );
+        cy.get('[id="accessibility"][role="tab"]').should(
+            "have.attr",
+            "aria-selected",
+            "true",
+        );
+    });
+
+    it("switches between tabs", () => {
+        cy.mount(<Harness />);
+
+        cy.get('[data-cy="open-accessibility"]').click();
+        cy.get('[id="accessibility"][role="tab"]').should(
+            "have.attr",
+            "aria-selected",
+            "true",
+        );
+
+        cy.get('[data-cy="open-warnings"]').click();
+        cy.get('[id="warnings"][role="tab"]').should(
+            "have.attr",
+            "aria-selected",
+            "true",
+        );
+    });
+});

--- a/packages/doenetml/test/cypress/component/DoenetEditor.initialOpenTab.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.initialOpenTab.cy.tsx
@@ -72,4 +72,28 @@ describe("DoenetEditor initialOpenTab", () => {
         );
         cy.get("@consoleWarn").should("have.been.called");
     });
+
+    it("falls back to default and warns when initialOpenTab='responses' but showResponses={false}", () => {
+        const warnSpy = cy.stub().as("consoleWarn");
+        cy.window().then((win) => {
+            cy.stub(win.console, "warn").callsFake(warnSpy);
+        });
+
+        cy.mount(
+            <div style={{ height: "500px", width: "900px" }}>
+                <DoenetEditor
+                    doenetML={SAMPLE_DOENETML}
+                    initialOpenTab="responses"
+                    showResponses={false}
+                    addVirtualKeyboard={false}
+                />
+            </div>,
+        );
+
+        cy.get(".diagnostics-response-tabs-container").should(
+            "not.have.class",
+            "is-open",
+        );
+        cy.get("@consoleWarn").should("have.been.called");
+    });
 });

--- a/packages/doenetml/test/cypress/component/DoenetEditor.initialOpenTab.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.initialOpenTab.cy.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { DoenetEditor } from "../../../src/doenetml-inline-worker";
+
+const SAMPLE_DOENETML = "<p>hello</p>";
+
+describe("DoenetEditor initialOpenTab", () => {
+    it("opens the diagnostics panel on the requested tab when initialOpenTab is set", () => {
+        cy.mount(
+            <div style={{ height: "500px", width: "900px" }}>
+                <DoenetEditor
+                    doenetML={SAMPLE_DOENETML}
+                    initialOpenTab="accessibility"
+                    addVirtualKeyboard={false}
+                />
+            </div>,
+        );
+
+        cy.get(".diagnostics-response-tabs-container").should(
+            "have.class",
+            "is-open",
+        );
+        cy.get('[id="accessibility"][role="tab"]').should(
+            "have.attr",
+            "aria-selected",
+            "true",
+        );
+    });
+
+    it("opens on errors when initialOpenTab='errors'", () => {
+        cy.mount(
+            <div style={{ height: "500px", width: "900px" }}>
+                <DoenetEditor
+                    doenetML={SAMPLE_DOENETML}
+                    initialOpenTab="errors"
+                    addVirtualKeyboard={false}
+                />
+            </div>,
+        );
+
+        cy.get(".diagnostics-response-tabs-container").should(
+            "have.class",
+            "is-open",
+        );
+        cy.get('[id="errors"][role="tab"]').should(
+            "have.attr",
+            "aria-selected",
+            "true",
+        );
+    });
+
+    it("falls back to default and warns when initialOpenTab refers to a disabled tab", () => {
+        const warnSpy = cy.stub().as("consoleWarn");
+        cy.window().then((win) => {
+            cy.stub(win.console, "warn").callsFake(warnSpy);
+        });
+
+        cy.mount(
+            <div style={{ height: "500px", width: "900px" }}>
+                <DoenetEditor
+                    doenetML={SAMPLE_DOENETML}
+                    initialOpenTab="accessibility"
+                    showDiagnostics={false}
+                    addVirtualKeyboard={false}
+                />
+            </div>,
+        );
+
+        // panel should NOT auto-open (no diagnostics tabs available, falls back)
+        cy.get(".diagnostics-response-tabs-container").should(
+            "not.have.class",
+            "is-open",
+        );
+        cy.get("@consoleWarn").should("have.been.called");
+    });
+});

--- a/packages/doenetml/test/cypress/support/component-index.html
+++ b/packages/doenetml/test/cypress/support/component-index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Cypress Component Testing - DoenetML</title>
+    </head>
+    <body>
+        <div data-cy-root></div>
+    </body>
+</html>

--- a/packages/doenetml/test/cypress/support/component.ts
+++ b/packages/doenetml/test/cypress/support/component.ts
@@ -1,0 +1,12 @@
+// Cypress component support file for DoenetML tests.
+import { mount } from "cypress/react";
+
+declare global {
+    namespace Cypress {
+        interface Chainable {
+            mount: typeof mount;
+        }
+    }
+}
+
+Cypress.Commands.add("mount", mount);

--- a/packages/doenetml/test/tsconfig.json
+++ b/packages/doenetml/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../../tsconfig.build.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "../",
+        "types": ["cypress", "node"]
+    },
+    "include": ["../**/*.ts", "../**/*.tsx"],
+    "exclude": ["node_modules", "./vite.config.ts"],
+    "references": []
+}

--- a/packages/doenetml/test/tsconfig.json
+++ b/packages/doenetml/test/tsconfig.json
@@ -6,6 +6,6 @@
         "types": ["cypress", "node"]
     },
     "include": ["../**/*.ts", "../**/*.tsx"],
-    "exclude": ["node_modules", "./vite.config.ts"],
+    "exclude": ["node_modules", "../vite.config.ts", "../cypress.config.ts"],
     "references": []
 }

--- a/packages/doenetml/tsconfig.json
+++ b/packages/doenetml/tsconfig.json
@@ -14,6 +14,8 @@
     ],
     "exclude": [
         "vite.config.ts",
+        "cypress.config.ts",
+        "test/cypress/**",
         "node_modules",
         "runner-results",
         ".wireit",

--- a/packages/standalone/README.md
+++ b/packages/standalone/README.md
@@ -49,6 +49,31 @@ For example,
 </div>
 ```
 
+## Editor control handle
+
+`renderDoenetEditorToContainer` (also exposed as a global) returns a small
+control handle so the host page can drive the editor's diagnostics/responses
+panel. Calls made before the editor finishes mounting are queued and replayed
+on first commit.
+
+```html
+<script type="module">
+    const handle = renderDoenetEditorToContainer(
+        document.querySelector(".doenetml-editor"),
+    );
+    document
+        .querySelector("#open-accessibility")
+        .addEventListener("click", () =>
+            handle.openDiagnosticsTab("accessibility"),
+        );
+    document
+        .querySelector("#close-panel")
+        .addEventListener("click", () => handle.closeDiagnosticsPanel());
+</script>
+```
+
+Valid tab IDs: `"errors" | "warnings" | "info" | "accessibility" | "responses"`.
+
 ## Development
 
 Run

--- a/packages/standalone/src/index.tsx
+++ b/packages/standalone/src/index.tsx
@@ -9,6 +9,10 @@ import {
     DoenetViewer,
     DoenetEditor,
 } from "@doenet/doenetml/doenetml-inline-worker.js";
+import type {
+    DiagnosticsTabId,
+    DoenetEditorHandle,
+} from "@doenet/doenetml/doenetml-inline-worker.js";
 import "@doenet/doenetml/style.css";
 import "./pretext-compat.css";
 import { ResizeWatcher } from "./resize-watcher";
@@ -119,13 +123,47 @@ export function renderDoenetEditorToContainer(
     // DoenetEditor doesn't accept flags, so only attribute using is addVirtualKeyboard
     const { addVirtualKeyboard } = attrs;
 
+    // Hold pending control actions until the inner DoenetEditor commits
+    // (callback ref fires). React commits asynchronously after `createRoot.render`,
+    // so a synchronous caller cannot rely on the ref being populated immediately
+    // — queue and replay on mount.
+    let mountedHandle: DoenetEditorHandle | null = null;
+    const pendingHandleActions: ((h: DoenetEditorHandle) => void)[] = [];
+    function refCallback(h: DoenetEditorHandle | null) {
+        mountedHandle = h;
+        if (h) {
+            const queued = pendingHandleActions.splice(0);
+            for (const action of queued) {
+                action(h);
+            }
+        }
+    }
+
     ReactDOM.createRoot(container).render(
         <DoenetEditor
+            ref={refCallback}
             doenetML={doenetMLSource}
             addVirtualKeyboard={addVirtualKeyboard}
             {...config}
         />,
     );
+
+    return {
+        openDiagnosticsTab(tabId: DiagnosticsTabId) {
+            if (mountedHandle) {
+                mountedHandle.openDiagnosticsTab(tabId);
+            } else {
+                pendingHandleActions.push((h) => h.openDiagnosticsTab(tabId));
+            }
+        },
+        closeDiagnosticsPanel() {
+            if (mountedHandle) {
+                mountedHandle.closeDiagnosticsPanel();
+            } else {
+                pendingHandleActions.push((h) => h.closeDiagnosticsPanel());
+            }
+        },
+    };
 }
 
 function normalizeBooleanAttr(attr: string | undefined | null) {

--- a/packages/standalone/src/index.tsx
+++ b/packages/standalone/src/index.tsx
@@ -136,6 +136,11 @@ export function renderDoenetEditorToContainer(
             for (const action of queued) {
                 action(h);
             }
+        } else {
+            // On unmount, drop any actions that were queued after the editor
+            // detached so we don't replay them against a stale handle if the
+            // editor is ever re-mounted into the same container.
+            pendingHandleActions.length = 0;
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #1081. Adds programmatic control of the `<DoenetEditor>` diagnostics/responses panel so embedding apps can deep-link into a specific tab (e.g. open the **accessibility** tab from a link elsewhere on the page).

- **`initialOpenTab` prop** — when set (`"errors" | "warnings" | "info" | "accessibility" | "responses"`), the panel mounts open on that tab. Used for the "click a link, mount the editor with the tab open" case.
- **Imperative ref handle** (`DoenetEditorHandle`) exposing `openDiagnosticsTab(tabId)` and `closeDiagnosticsPanel()`. Each call is independent, so re-clicking the link after the user closes the panel reopens it without consumer state management.
- **Iframe-aware**: works through `@doenet/doenetml-iframe`. Calls made before the iframe finishes loading are queued in the outer wrapper and replayed on `iframeReady`. The standalone uses a callback ref + queue so the inner React commit timing is also handled.

## Usage

**Direct `<DoenetEditor>` from `@doenet/doenetml` (or `@doenet/doenetml-iframe`):**

```tsx
import { useRef } from "react";
import { DoenetEditor, type DoenetEditorHandle } from "@doenet/doenetml";

function App() {
    const editorRef = useRef<DoenetEditorHandle>(null);
    return (
        <>
            <button onClick={() => editorRef.current?.openDiagnosticsTab("accessibility")}>
                Show accessibility violations
            </button>
            <button onClick={() => editorRef.current?.closeDiagnosticsPanel()}>
                Close panel
            </button>
            <DoenetEditor ref={editorRef} doenetML="..." />
        </>
    );
}
```

**Mount-time form** (panel opens on the requested tab on first paint):

```tsx
<DoenetEditor doenetML="..." initialOpenTab="accessibility" />
```

**Cross-panel link / lazy mount** (the link is on a different panel of the host app from the editor; clicking should mount the editor and open the tab):

```tsx
const [showEditor, setShowEditor] = useState(false);
const [pendingTab, setPendingTab] = useState<DiagnosticsTabId | undefined>(undefined);
const editorRef = useRef<DoenetEditorHandle>(null);

function onLinkClick(tab: DiagnosticsTabId) {
    if (showEditor && editorRef.current) {
        editorRef.current.openDiagnosticsTab(tab);
    } else {
        setShowEditor(true);
        setPendingTab(tab);
    }
}

return showEditor && (
    <DoenetEditor ref={editorRef} doenetML="..." initialOpenTab={pendingTab} />
);
```

**Standalone (`@doenet/standalone`)** — `renderDoenetEditorToContainer` returns the same control handle:

```html
<script type="module">
    const handle = renderDoenetEditorToContainer(document.querySelector(".doenetml-editor"));
    document.querySelector("#open-accessibility").addEventListener("click", () =>
        handle.openDiagnosticsTab("accessibility"),
    );
</script>
```

## Implementation

- `@doenet/doenetml`: `DoenetEditor` and `EditorViewer` now `forwardRef` to a `DoenetEditorHandle`. New `initialOpenTab` prop and `useImperativeHandle` plumbing live alongside the existing tab state in `EditorViewer.tsx`.
- `@doenet/standalone`: `renderDoenetEditorToContainer` returns a `{ openDiagnosticsTab, closeDiagnosticsPanel }` control object backed by a callback-ref queue.
- `@doenet/doenetml-iframe`: outer wrapper queues actions until ComLink ready; inner bridge exposes the two methods via `ComlinkEditor.expose` and forwards to the standalone's handle.
- READMEs for `@doenet/doenetml`, `@doenet/doenetml-iframe`, and `@doenet/standalone` updated with usage examples.

## Tests

Set up new Cypress component-test infrastructure in `@doenet/doenetml` (mirroring `@doenet/codemirror`'s setup). Two specs cover the new surface:

- `DoenetEditor.initialOpenTab.cy.tsx` — opens on requested tab; falls back + warns on disabled tabs.
- `DoenetEditor.diagnosticsPanelRef.cy.tsx` — open/close via ref; re-open after user closes; switch between tabs.

Run with `npm run test:doenetml-cypress`.

## Test plan

- [x] Cypress component tests pass (7/7) — `npm run test:doenetml-cypress`
- [x] `tsc --noEmit` clean across `@doenet/doenetml`, `@doenet/standalone`, `@doenet/doenetml-iframe`
- [x] All three packages build cleanly
- [x] Manual: deep-link from outside the editor opens the accessibility tab; closing then re-firing the link reopens it
- [x] Manual: same flow through `@doenet/doenetml-iframe` (cross-iframe ComLink round trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)