### PR TITLE
ci: bump all GitHub Actions to latest major versions across workflows

### DIFF
--- a/.github/workflows/changesets-version-pr.yml
+++ b/.github/workflows/changesets-version-pr.yml
@@ -20,10 +20,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v6
 
             - name: Use Node.js 24
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 24.x
                   cache: "npm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
     cancel-in-progress: true
 
-env:
-    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
     changes:
         name: Detect Changed Paths
@@ -21,8 +18,8 @@ jobs:
         outputs:
             prefigure: ${{ steps.filter.outputs.prefigure }}
         steps:
-            - uses: actions/checkout@v3
-            - uses: dorny/paths-filter@v3
+            - uses: actions/checkout@v6
+            - uses: dorny/paths-filter@v4
               id: filter
               with:
                   filters: |
@@ -39,9 +36,9 @@ jobs:
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v6
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "npm"
@@ -62,7 +59,7 @@ jobs:
 
             # upload all the .wireit directories so that the test job can use them.
             - name: Upload build artifacts
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: build-artifacts
                   include-hidden-files: true
@@ -81,15 +78,15 @@ jobs:
                 node-version: [24.x]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v6
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "npm"
             - run: npm ci
             - name: Download build artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: build-artifacts
 
@@ -119,15 +116,15 @@ jobs:
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
                 test-group: [group1, group2, group3, group4]
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v6
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "npm"
             - run: npm ci
             - name: Download build artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: build-artifacts
 
@@ -166,15 +163,15 @@ jobs:
                         doenetml-cypress,
                     ]
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v6
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "npm"
             - run: npm ci
             - name: Download build artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: build-artifacts
 
@@ -216,7 +213,7 @@ jobs:
 
             - name: Upload screenshots on failure
               if: failure()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: cypress-screenshots-${{ matrix.test-group }}
                   path: ./packages/test-cypress/cypress/screenshots
@@ -230,16 +227,16 @@ jobs:
             matrix:
                 node-version: [24.x]
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v6
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "npm"
             - run: npm ci
 
             - name: Download build artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: build-artifacts
 
@@ -259,7 +256,7 @@ jobs:
 
         steps:
             - name: Checkout sources
-              uses: actions/checkout@v3
+              uses: actions/checkout@v6
 
             - name: Install toolchain
               run: |
@@ -286,16 +283,16 @@ jobs:
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v6
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "npm"
             - run: npm ci
 
             - name: Download build artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: build-artifacts
 
@@ -331,9 +328,9 @@ jobs:
 
         steps:
             - name: Checkout sources
-              uses: actions/checkout@v3
+              uses: actions/checkout@v6
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "npm"
@@ -352,15 +349,15 @@ jobs:
                 node-version: [24.x]
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v6
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "npm"
             - run: npm ci
             - name: Download build artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: build-artifacts
 

--- a/.github/workflows/gh-pages-docs.yml
+++ b/.github/workflows/gh-pages-docs.yml
@@ -21,9 +21,6 @@ concurrency:
     group: "pages"
     cancel-in-progress: false
 
-env:
-    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
     build-docs:
         runs-on: ubuntu-latest
@@ -34,9 +31,9 @@ jobs:
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v6
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "npm"
@@ -48,12 +45,12 @@ jobs:
                   npm run build
                   npm run build:docs
             - name: Setup Pages
-              uses: actions/configure-pages@v5
+              uses: actions/configure-pages@v6
             - name: Upload artifact
-              uses: actions/upload-pages-artifact@v3
+              uses: actions/upload-pages-artifact@v5
               with:
                   # Upload built static site
                   path: "packages/docs-nextra/out"
             - name: Deploy to GitHub Pages
               id: deployment
-              uses: actions/deploy-pages@v4
+              uses: actions/deploy-pages@v5

--- a/.github/workflows/publish-prefigure.yml
+++ b/.github/workflows/publish-prefigure.yml
@@ -18,9 +18,6 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
     cancel-in-progress: false
 
-env:
-    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
     publish-prefigure:
         name: Publish Prefigure
@@ -32,7 +29,7 @@ jobs:
             id-token: write
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v6
               with:
                   fetch-depth: 0
 
@@ -49,7 +46,7 @@ jobs:
                   fi
 
             - name: Use Node.js 24
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 24.x
                   registry-url: https://registry.npmjs.org

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,9 +30,6 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref || github.run_id }}
     cancel-in-progress: false
 
-env:
-    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
     dev-release:
         name: Dev Release
@@ -48,7 +45,7 @@ jobs:
             contents: read
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v6
               with:
                   ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
@@ -57,7 +54,7 @@ jobs:
               run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
             - name: Use Node.js 24
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 24.x
                   registry-url: https://registry.npmjs.org
@@ -115,7 +112,7 @@ jobs:
             contents: read
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v6
               with:
                   ref: ${{ github.event_name == 'release' && github.event.release.tag_name || (inputs.tag != '' && inputs.tag || github.ref) }}
                   fetch-depth: 0
@@ -125,7 +122,7 @@ jobs:
               run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
             - name: Use Node.js 24
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 24.x
                   registry-url: https://registry.npmjs.org


### PR DESCRIPTION
## Summary

Closes #1087.

Workflow-wide refresh of action pins so we drop the Node 16 deprecation warnings from `actions/checkout@v3` and stay aligned with GitHub's runner upgrade. Every JavaScript action now declares `runs.using: node24` natively, so the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` env override is also removed from each workflow that set it (`ci.yml`, `publish.yml`, `gh-pages-docs.yml`, `publish-prefigure.yml`).

Pin changes:

- `actions/checkout@v3` → `@v6` (15 usages)
- `actions/setup-node@v4` → `@v6` (13 usages)
- `actions/upload-artifact@v4` → `@v7` (2 usages)
- `actions/download-artifact@v4` → `@v8` (6 usages)
- `actions/configure-pages@v5` → `@v6`
- `actions/deploy-pages@v4` → `@v5`
- `actions/upload-pages-artifact@v3` → `@v5`
- `dorny/paths-filter@v3` → `@v4`
- `changesets/action@v1` left as-is (still current)

The migration concerns spelled out in #1087 (setup-node v6 cache opt-in, download-artifact v5 path unification, upload-pages-artifact v4+ pairing with deploy-pages v4+, checkout v6 credential persistence, upload-artifact v4 hidden-files exclusion) are all already satisfied by current usage, so this PR is a pure pin sweep with no source code changes.

## Test plan

- [ ] CI workflow runs green across all matrix legs on this PR
- [ ] No Node 16 / Node 20 deprecation warnings appear in any run
- [ ] After merge: `gh-pages-docs.yml` runs on `main` and the deployed docs site renders correctly (spot-check that the `upload-pages-artifact@v5` hidden-files exclusion did not drop anything required)
- [ ] After merge: `publish.yml` dev-release path runs from a `main` push (or `workflow_dispatch` with `dry_run: true`) and completes end-to-end
- [ ] After merge: `changesets-version-pr.yml` runs successfully on the next changeset version PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)