### PR TITLE
feat(schema): require descriptions on components, attributes, and properties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,35 @@ jobs:
             - name: Prettier Check
               run: npx prettier . --check --ignore-path ./.prettierignore --ignore-path ./.prettierignoreci
 
+    schema-freshness:
+        name: Verify schema regenerated
+        runs-on: ubuntu-latest
+
+        strategy:
+            matrix:
+                node-version: [24.x]
+
+        steps:
+            - uses: actions/checkout@v6
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v6
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: "npm"
+            - run: npm ci
+
+            # Regenerates packages/static-assets/src/generated/* from
+            # componentInfoObjects (read by vite-node). build:schema is
+            # not wireit-wrapped, so a fresh run always executes.
+            # The runtime guards in get-schema.ts also throw here if any
+            # component/attribute/property/attribute-value description is
+            # missing.
+            - name: Regenerate schema
+              run: npm run build:schema -w packages/static-assets
+
+            - name: Assert committed schema is up to date
+              run: git diff --exit-code -- packages/static-assets/src/generated/
+
     check-docs-coverage:
         name: Check Reference Docs Coverage
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,7 @@ jobs:
     schema-freshness:
         name: Verify schema regenerated
         runs-on: ubuntu-latest
+        needs: build
 
         strategy:
             matrix:
@@ -355,6 +356,20 @@ jobs:
                   node-version: ${{ matrix.node-version }}
                   cache: "npm"
             - run: npm ci
+            - name: Download build artifacts
+              uses: actions/download-artifact@v8
+              with:
+                  name: build-artifacts
+
+            # build:schema imports componentInfoObjects from source, which
+            # transitively requires @doenet/utils (and friends) to be built.
+            # Matches the check-docs-coverage cached-build pattern.
+            - name: Build (cached)
+              run: |
+                  export NODE_OPTIONS="--max_old_space_size=6114"
+                  npm run build:all-no-docs
+              env:
+                  WIREIT_CACHE: "local"
 
             # Regenerates packages/static-assets/src/generated/* from
             # componentInfoObjects (read by vite-node). build:schema is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,6 +383,18 @@ jobs:
             - name: Assert committed schema is up to date
               run: git diff --exit-code -- packages/static-assets/src/generated/
 
+            # `git diff` only catches tracked-file drift. If build:schema
+            # ever starts emitting a new generated artifact, it'd land
+            # here as untracked and silently pass the diff above.
+            - name: Assert no untracked generated files
+              run: |
+                  untracked=$(git ls-files --others --exclude-standard -- packages/static-assets/src/generated/)
+                  if [ -n "$untracked" ]; then
+                      echo "Untracked generated files:"
+                      echo "$untracked"
+                      exit 1
+                  fi
+
     check-docs-coverage:
         name: Check Reference Docs Coverage
         runs-on: ubuntu-latest

--- a/packages/doenetml-worker-javascript/src/utils/dast/types.ts
+++ b/packages/doenetml-worker-javascript/src/utils/dast/types.ts
@@ -307,7 +307,7 @@ export type AttributeDefinition<T> = {
     /** When the value of this attribute is changed, call the action `triggerActionOnChange`. */
     triggerActionOnChange?: string;
     /** One-sentence description of the attribute, surfaced in editor help and docs. */
-    description?: string;
+    description: string;
     /** If `true`, attribute values are converted to lower case */
     toLowerCase?: boolean;
     /** If `true`, leave the attribute serialized when the component is created */

--- a/packages/static-assets/scripts/generate-schema.ts
+++ b/packages/static-assets/scripts/generate-schema.ts
@@ -1,10 +1,9 @@
 import * as fs from "node:fs/promises";
-import { getSchema, reportHelpCoverage } from "./get-schema";
+import { getSchema } from "./get-schema";
 
 const destUrl = new URL("../src/generated/doenet-schema.json", import.meta.url);
 
 const schema = getSchema();
-reportHelpCoverage(schema.elements);
 console.log(
     "Writing",
     schema.elements.length,

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -87,7 +87,7 @@ type AttributeObject = {
     validValues?: ValidValueEntry[];
     valueForTrue?: unknown;
     valueForFalse?: unknown;
-    description?: string;
+    description: string;
 };
 
 type ComponentClass = {
@@ -644,6 +644,7 @@ export function getSchema(
             const description = publicStateVariableDescriptions[varName];
             properties.push(
                 ...propFromDescription({
+                    parentType: type,
                     varName,
                     description,
                     arrayEntryPrefixes,
@@ -675,6 +676,7 @@ export function getSchema(
                 }
                 properties.push(
                     ...propFromDescription({
+                        parentType: type,
                         varName: aliasName,
                         description: aliasDescription,
                         arrayEntryPrefixes,
@@ -712,6 +714,7 @@ export function getSchema(
 
                         properties.push(
                             ...propFromDescription({
+                                parentType: type,
                                 varName: aliasName,
                                 description: arrayEntryDescription,
                                 arrayEntryPrefixes,
@@ -787,11 +790,13 @@ export function getSchema(
 }
 
 function propFromDescription({
+    parentType,
     varName,
     description,
     arrayEntryPrefixes,
     includeSchemaSubarrays,
 }: {
+    parentType: string;
     varName: string;
     description: PublicStateVariableDescription;
     arrayEntryPrefixes: Record<string, ArrayEntryPrefixDescription>;
@@ -799,6 +804,7 @@ function propFromDescription({
 }): PropertyDescription[] {
     const props = [
         singlePropFromDescription({
+            parentType,
             varName,
             description,
             arrayEntryPrefixes,
@@ -831,6 +837,7 @@ function propFromDescription({
 
             props.push(
                 singlePropFromDescription({
+                    parentType,
                     varName: subarrayName,
                     description: {
                         ...description,
@@ -859,10 +866,12 @@ function propFromDescription({
 }
 
 function singlePropFromDescription({
+    parentType,
     varName,
     description,
     arrayEntryPrefixes,
 }: {
+    parentType: string;
     varName: string;
     description: PublicStateVariableDescription;
     arrayEntryPrefixes: Record<string, ArrayEntryPrefixDescription>;
@@ -878,7 +887,7 @@ function singlePropFromDescription({
         description.description.trim() === ""
     ) {
         throw new Error(
-            `Invalid description for property \`${varName}\` (createComponentOfType=${componentType}): every public state variable, alias, or array-entry property feeding the schema must have a non-empty \`description\`. Got: ${JSON.stringify(description.description)}`,
+            `Invalid description for property \`${parentType}.${varName}\` (createComponentOfType=${componentType}): every public state variable, alias, or array-entry property feeding the schema must have a non-empty \`description\`. Got: ${JSON.stringify(description.description)}`,
         );
     }
 

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -149,7 +149,7 @@ type ComponentClass = {
     /** Class-level help metadata. */
     componentDocs?: {
         /** A one-sentence summary of the component. */
-        summary?: string;
+        summary: string;
         /**
          * Reference-page slug for this component, used to link from editor help.
          * - Undefined → default to the component type (e.g. "abs" → /reference/abs).
@@ -185,7 +185,7 @@ type PropertyDescription = {
     isArray: boolean;
     numDimensions?: number;
     indexedArrayDescription?: ArrayElementDescription[];
-    description?: string;
+    description: string;
     fromAttribute?: boolean;
 };
 
@@ -217,7 +217,7 @@ type StateVariableDescription = {
     wrappingComponents?: WrappingComponentElement[][];
     getArrayKeysFromVarName?: Function;
     arrayVarNameFromPropIndex?: Function;
-    description?: string;
+    description: string;
     fromAttribute?: boolean;
 };
 
@@ -230,7 +230,7 @@ type PublicStateVariableDescription = {
     wrappingComponents?: WrappingComponentElement[][];
     getArrayKeysFromVarName?: Function;
     arrayVarNameFromPropIndex?: Function;
-    description?: string;
+    description: string;
     fromAttribute?: boolean;
 };
 
@@ -246,7 +246,7 @@ type SchemaAttribute = {
      */
     autocompleteValues?: ValidValueEntry[];
     /** One-sentence description of the attribute, surfaced in editor help and docs. */
-    description?: string;
+    description: string;
     /** Default value for the attribute (if defined). */
     defaultValue?: unknown;
 };
@@ -267,7 +267,7 @@ type SchemaElement = {
     /** Whether descendants are accessible only via index */
     takesIndex: boolean;
     /** One-sentence summary of the component, surfaced in editor help and docs. */
-    summary?: string;
+    summary: string;
     /**
      * Reference-page slug for this component, or `null` when no docs page
      * exists for it. The generator always emits this field — either a string
@@ -292,7 +292,7 @@ type SchemaElement = {
  */
 type AliasedSchemaElement = {
     name: string;
-    summary?: string;
+    summary: string;
     docsSlug: string | null;
     attributes: SchemaAttribute[];
     properties: PropertyDescription[];
@@ -323,9 +323,9 @@ type AliasedSchemaElement = {
  *          where each element represents a component type with its full schema definition
  *          including name, children, attributes, properties, and string acceptance
  */
-export function getSchema() {
-    const componentInfoObjects =
-        createComponentInfoObjects() as ComponentInfoObjects;
+export function getSchema(
+    componentInfoObjects: ComponentInfoObjects = createComponentInfoObjects() as ComponentInfoObjects,
+) {
     // Work on a shallow copy so the schema filtering doesn't mutate the
     // shared registry (`publicStateVariableInfo` reads classes lazily from
     // it, so deletions break later property lookups for excluded classes
@@ -514,8 +514,21 @@ export function getSchema() {
             const attrDef = attrObj[attrName];
             if (attrDef.excludeFromSchema) continue;
 
-            const attrSpec: SchemaAttribute = { name: attrName };
-            if (attrDef.description) attrSpec.description = attrDef.description;
+            // Hard-fail on missing description. Mirrors the validValues
+            // guard below and the per-component summary guard further on.
+            if (
+                typeof attrDef.description !== "string" ||
+                attrDef.description.trim() === ""
+            ) {
+                throw new Error(
+                    `Invalid description for attribute \`${type}.${attrName}\`: every non-excluded attribute must declare a non-empty \`description\`. Got: ${JSON.stringify(attrDef.description)}`,
+                );
+            }
+
+            const attrSpec: SchemaAttribute = {
+                name: attrName,
+                description: attrDef.description,
+            };
             if (attrDef.defaultValue !== undefined) {
                 attrSpec.defaultValue = encodeDefaultValueForJson(
                     attrDef.defaultValue,
@@ -574,6 +587,17 @@ export function getSchema() {
             excludedStateVariableNames,
         );
 
+        // Hard-fail on missing summary. Fires for every class that reaches
+        // the schema, plus alias targets promoted via `childAliases`
+        // (e.g. `<row>` → `<matrixRow>`) — those are `excludeFromSchema`
+        // but still emit help payloads here.
+        const summary = cClass.componentDocs?.summary;
+        if (typeof summary !== "string" || summary.trim() === "") {
+            throw new Error(
+                `Invalid componentDocs.summary for \`${type}\`: every component reaching the schema must declare a non-empty \`static componentDocs = { summary: "..." }\`. Got: ${JSON.stringify(summary)}`,
+            );
+        }
+
         const out: Pick<
             SchemaElement,
             "attributes" | "properties" | "summary" | "docsSlug"
@@ -581,9 +605,8 @@ export function getSchema() {
             attributes,
             properties,
             docsSlug: null,
+            summary,
         };
-        const summary = cClass.componentDocs?.summary;
-        if (summary) out.summary = summary;
 
         const declaredSlug = getDeclaredDocsSlug(cClass.componentDocs, type);
         if (declaredSlug !== null && getExistingDocSlugs().has(declaredSlug)) {
@@ -723,8 +746,8 @@ export function getSchema() {
             acceptsStringChildren,
             takesIndex: cClass.takesIndex ?? false,
             docsSlug: helpPayload.docsSlug,
+            summary: helpPayload.summary,
         };
-        if (helpPayload.summary) element.summary = helpPayload.summary;
 
         elements.push(element);
     }
@@ -755,54 +778,12 @@ export function getSchema() {
                 attributes: payload.attributes,
                 properties: payload.properties,
                 docsSlug: payload.docsSlug,
-                ...(payload.summary !== undefined && {
-                    summary: payload.summary,
-                }),
+                summary: payload.summary,
             };
         }
     }
 
     return { elements, aliasedElements };
-}
-
-/**
- * Print aggregate coverage counts to stdout for schema elements, attributes,
- * and properties with help (`summary`/`description`) authored. Informational
- * only — never fails the build. Helps track authoring progress as
- * descriptions are backfilled across the ~200+ component classes.
- */
-export function reportHelpCoverage(
-    elements: ReturnType<typeof getSchema>["elements"],
-) {
-    let elementsWithSummary = 0;
-    let attributesWithDescription = 0;
-    let propertiesWithDescription = 0;
-    let totalAttributes = 0;
-    let totalProperties = 0;
-
-    for (const element of elements) {
-        if (element.summary) {
-            elementsWithSummary++;
-        }
-        for (const attr of element.attributes) {
-            totalAttributes++;
-            if (attr.description) {
-                attributesWithDescription++;
-            }
-        }
-        for (const prop of element.properties) {
-            totalProperties++;
-            if (prop.description) {
-                propertiesWithDescription++;
-            }
-        }
-    }
-
-    console.log(
-        `Help coverage: ${elementsWithSummary}/${elements.length} elements have summary, ` +
-            `${attributesWithDescription}/${totalAttributes} attributes have description, ` +
-            `${propertiesWithDescription}/${totalProperties} properties have description`,
-    );
 }
 
 function propFromDescription({
@@ -888,18 +869,32 @@ function singlePropFromDescription({
 }): PropertyDescription {
     const componentType = description.createComponentOfType;
 
+    // Hard-fail on missing description. Single choke point for direct
+    // state vars, aliases, and array-entry-prefix aliases — the existing
+    // fallback assembly (`aliasInfo.description ?? arrayStateVarDescription.description`)
+    // is preserved upstream, so this only fires when *every* candidate is empty.
+    if (
+        typeof description.description !== "string" ||
+        description.description.trim() === ""
+    ) {
+        throw new Error(
+            `Invalid description for property \`${varName}\` (createComponentOfType=${componentType}): every public state variable, alias, or array-entry property feeding the schema must have a non-empty \`description\`. Got: ${JSON.stringify(description.description)}`,
+        );
+    }
+
     const prop: PropertyDescription =
         componentType !== undefined
             ? {
                   name: varName,
                   type: componentType,
                   isArray: description.isArray,
+                  description: description.description,
               }
-            : { name: varName, isArray: description.isArray };
-
-    if (description.description) {
-        prop.description = description.description;
-    }
+            : {
+                  name: varName,
+                  isArray: description.isArray,
+                  description: description.description,
+              };
 
     if (description.fromAttribute) {
         prop.fromAttribute = true;

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -223,7 +223,11 @@ type StateVariableDescription = {
 
 type PublicStateVariableDescription = {
     public: boolean;
-    createComponentOfType: string;
+    /** Some public state variables (mainly array slots) don't declare a
+     * `createComponentOfType` — kept optional to match the underlying
+     * `StateVariableDescription`. The ternary in `singlePropFromDescription`
+     * is load-bearing for these cases. */
+    createComponentOfType?: string;
     isArray: boolean;
     numDimensions?: number;
     schemaSubarrays?: Record<string, SchemaSubarrayDescription>;

--- a/packages/static-assets/src/schema.ts
+++ b/packages/static-assets/src/schema.ts
@@ -18,7 +18,7 @@ export type SchemaProperty = {
     isArray: boolean;
     numDimensions?: number;
     indexedArrayDescription?: unknown[];
-    description?: string;
+    description: string;
     fromAttribute?: boolean;
 };
 

--- a/packages/static-assets/test/schema-enforcement.test.ts
+++ b/packages/static-assets/test/schema-enforcement.test.ts
@@ -107,7 +107,9 @@ describe("schema build enforcement", () => {
                 originalDescription;
         };
         expect(() => getSchema(infoObjects)).toThrow(
-            new RegExp(`Invalid description for property \`${varName}\``),
+            new RegExp(
+                `Invalid description for property \`point\\.${varName}\``,
+            ),
         );
     });
 });

--- a/packages/static-assets/test/schema-enforcement.test.ts
+++ b/packages/static-assets/test/schema-enforcement.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createComponentInfoObjects } from "../../doenetml-worker-javascript/src/utils/componentInfoObjects";
+import { getSchema } from "../scripts/get-schema";
+
+/**
+ * These tests use the real component registry and mutate one field per
+ * assertion to verify the schema-build hard-fails on missing summary/
+ * description. Each test restores its mutation in `afterEach` so the
+ * registry doesn't drift across tests.
+ */
+describe("schema build enforcement", () => {
+    const infoObjects = createComponentInfoObjects();
+    let restore: () => void = () => {};
+
+    afterEach(() => {
+        restore();
+        restore = () => {};
+    });
+
+    it("throws when a component's summary is missing", () => {
+        const cls = infoObjects.allComponentClasses.point as any;
+        const original = cls.componentDocs;
+        cls.componentDocs = { ...original, summary: undefined };
+        restore = () => {
+            cls.componentDocs = original;
+        };
+        expect(() => getSchema(infoObjects)).toThrow(
+            /Invalid componentDocs.summary for `point`/,
+        );
+    });
+
+    it("throws when a component's summary is an empty string", () => {
+        const cls = infoObjects.allComponentClasses.point as any;
+        const original = cls.componentDocs;
+        cls.componentDocs = { ...original, summary: "   " };
+        restore = () => {
+            cls.componentDocs = original;
+        };
+        expect(() => getSchema(infoObjects)).toThrow(
+            /Invalid componentDocs.summary for `point`/,
+        );
+    });
+
+    it("throws when an attribute's description is missing", () => {
+        const cls = infoObjects.allComponentClasses.point as any;
+        const originalCreate = cls.createAttributesObject;
+        cls.createAttributesObject = function () {
+            const attrs = originalCreate.call(this);
+            delete attrs.draggable.description;
+            return attrs;
+        };
+        restore = () => {
+            cls.createAttributesObject = originalCreate;
+        };
+        expect(() => getSchema(infoObjects)).toThrow(
+            /Invalid description for attribute `\w+\.draggable`/,
+        );
+    });
+
+    it("throws when an attribute's description is whitespace-only", () => {
+        const cls = infoObjects.allComponentClasses.point as any;
+        const originalCreate = cls.createAttributesObject;
+        cls.createAttributesObject = function () {
+            const attrs = originalCreate.call(this);
+            attrs.draggable = { ...attrs.draggable, description: "   " };
+            return attrs;
+        };
+        restore = () => {
+            cls.createAttributesObject = originalCreate;
+        };
+        expect(() => getSchema(infoObjects)).toThrow(
+            /Invalid description for attribute `\w+\.draggable`/,
+        );
+    });
+
+    it("does not throw when an attribute with no description is excludeFromSchema", () => {
+        const cls = infoObjects.allComponentClasses.point as any;
+        const originalCreate = cls.createAttributesObject;
+        cls.createAttributesObject = function () {
+            const attrs = originalCreate.call(this);
+            attrs.draggable = {
+                ...attrs.draggable,
+                description: undefined,
+                excludeFromSchema: true,
+            };
+            return attrs;
+        };
+        restore = () => {
+            cls.createAttributesObject = originalCreate;
+        };
+        expect(() => getSchema(infoObjects)).not.toThrow();
+    });
+
+    it("throws when a public state variable's description is missing", () => {
+        // Access the cached publicStateVariableInfo for `point` and remove
+        // the description on one state variable.
+        const info = infoObjects.publicStateVariableInfo.point as any;
+        const varName = Object.keys(info.stateVariableDescriptions).find(
+            (n) => info.stateVariableDescriptions[n].description,
+        )!;
+        const originalDescription =
+            info.stateVariableDescriptions[varName].description;
+        info.stateVariableDescriptions[varName].description = undefined;
+        restore = () => {
+            info.stateVariableDescriptions[varName].description =
+                originalDescription;
+        };
+        expect(() => getSchema(infoObjects)).toThrow(
+            new RegExp(`Invalid description for property \`${varName}\``),
+        );
+    });
+});

--- a/packages/static-assets/test/schema-help.test.ts
+++ b/packages/static-assets/test/schema-help.test.ts
@@ -25,8 +25,10 @@ describe("generated schema help fields", () => {
     });
 
     it("populates element summary from static componentDocs", () => {
-        expect(sequence.summary).toBeTruthy();
-        expect(selectFromSequence.summary).toBeTruthy();
+        expect(typeof sequence.summary).toBe("string");
+        expect(sequence.summary.length).toBeGreaterThan(0);
+        expect(typeof selectFromSequence.summary).toBe("string");
+        expect(selectFromSequence.summary.length).toBeGreaterThan(0);
     });
 
     it("populates description on a component's own attribute", () => {


### PR DESCRIPTION
## Summary
- Makes `componentDocs.summary`, `AttributeDefinition.description`, and `PublicStateVariableDescription.description` (plus the downstream `SchemaElement.summary` / `SchemaAttribute.description` / `SchemaProperty.description` shapes) **required** at the TS-type level, and adds matching runtime guards in `get-schema.ts` that hard-fail with a precise message identifying the offending `componentType[.attrName|.propName]`. Mirrors the pattern landed in #1098 for attribute values, so all four schema kinds (components, attributes, properties, attribute values) now enforce descriptions uniformly.
- Adds a `schema-freshness` CI job that re-runs `build:schema` and asserts `git diff --exit-code -- packages/static-assets/src/generated/`. A contributor who changes component metadata without rebuilding the schema (as happened with 838789b9a "fix the pretzel descriptions" — source updated, schema never regenerated) is now caught in CI. The regenerated schema JSON in this commit picks up that drift.
- Deletes `reportHelpCoverage` (now tautologically 100%) and its call site.

## Test plan
- [x] `npm run build:schema -w packages/static-assets` succeeds (proves runtime guards pass with current source)
- [x] `git diff -- packages/static-assets/src/generated/` is clean
- [x] `npx vitest run packages/static-assets/test/` — 22/22 pass, including 6 new enforcement tests in `schema-enforcement.test.ts`
- [x] Negative test: removing `summary` from `Point.js` throws ``Invalid componentDocs.summary for `point`: every component reaching the schema must declare a non-empty…``
- [x] Negative test: removing `draggable.description` throws ``Invalid description for attribute `equilibriumPoint.draggable`: every non-excluded attribute…``
- [x] `tsc --noEmit` clean in `packages/static-assets`, `packages/lsp-tools`, `packages/doenetml` (pre-existing 65-line tsc-error count in `doenetml-worker-javascript` unchanged)
- [x] `npm run check:docs-coverage -w packages/static-assets` exits 0
- [x] CI green on the new `schema-freshness` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)