### PR TITLE
Fix Dev Container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,9 +10,10 @@
         }
     },
     "containerEnv": {
-        "NODE_OPTIONS": "--max-old-space-size=6144"
+        "NODE_OPTIONS": " --max-old-space-size=6144 "
     },
-    "postCreateCommand": "npm install && npm run build",
+    // Unset NODE_OPTIONS and VSCODE_INSPECTOR_OPTIONS to prevent a debugger from trying to auto-attach to the container in an invalid way.
+    "postCreateCommand": "unset NODE_OPTIONS VSCODE_INSPECTOR_OPTIONS && npm install && npm run build",
     "customizations": {
         "vscode": {
             "extensions": [


### PR DESCRIPTION
Make sure the dev container doesn't try to connect to the debugger of the parent vscode instance.


Another question:

Should the dev container block access to the host system's git? I am using the dev container to sandbox an AI. At the moment, it could force push over all my branches, if it felt like it, because by default git gets permissions from the host.

If git access is blocked, you would have to push from the host (though you should still be able to commit from inside the container?). I don't know if this would be math codespaces would become unusable, since you'd be running directly in the container without access to the host...