### PR TITLE
Enable Doenet to run over HTTP

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,9 +10,10 @@
         }
     },
     "containerEnv": {
-        "NODE_OPTIONS": "--max-old-space-size=6144"
+        "NODE_OPTIONS": " --max-old-space-size=6144 "
     },
-    "postCreateCommand": "npm install && npm run build",
+    // Unset NODE_OPTIONS and VSCODE_INSPECTOR_OPTIONS to prevent a debugger from trying to auto-attach to the container in an invalid way.
+    "postCreateCommand": "unset NODE_OPTIONS VSCODE_INSPECTOR_OPTIONS && npm install && npm run build",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -567,7 +567,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
             "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.5",
@@ -1646,7 +1645,6 @@
             "integrity": "sha512-XcE9fcnkHCbWkjeKyi0lllwXmBLtyYb5dt89dJyx23I9+LSh5vZDIuk7OLG4VM1lgrXZQcY6cxyZyk5WVPRv/A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@codemirror/state": "^6.5.0",
                 "crelt": "^1.0.6",
@@ -2565,7 +2563,6 @@
             "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@fortawesome/fontawesome-common-types": "6.7.2"
             },
@@ -4596,7 +4593,6 @@
             "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -5768,7 +5764,6 @@
             "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -6394,7 +6389,6 @@
             "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
             "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/ms": "*"
             }
@@ -6523,7 +6517,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.1.tgz",
             "integrity": "sha512-czWPzKIAXucn9PtsttxmumiQ9N0ok9FrBwgRWrwmVLlp86BrMExzvXRLFYRJ+Ex3g6yqj+KuaxfX1JTgV2lpfg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~7.16.0"
             }
@@ -6562,7 +6555,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
             "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -6619,6 +6611,16 @@
             "integrity": "sha512-TY1eezMU2zH2ozQoAFAQFOPpvP15g+ZgSfTZt31AUUH/Rxtnz3H+A/Sv1Snw2/amp//omibc+AEkTaA8KUeOLQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/sha256": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@types/sha256/-/sha256-0.2.2.tgz",
+            "integrity": "sha512-uKMaDzyzfcDYGEwTgLh+hmgDMxXWyIVodY8T+qt7A+NYvikW0lmGLMGbQ7BipCB8dzXHa55C9g+Ii/3Lgt1KmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/sinonjs__fake-timers": {
             "version": "8.1.1",
@@ -7865,7 +7867,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -8602,7 +8603,6 @@
             "integrity": "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==",
             "dev": true,
             "license": "MPL-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -9277,7 +9277,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.8.25",
                 "caniuse-lite": "^1.0.30001754",
@@ -9583,6 +9582,7 @@
             "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 16"
             }
@@ -10314,7 +10314,6 @@
             "resolved": "https://registry.npmjs.org/compromise/-/compromise-13.11.4.tgz",
             "integrity": "sha512-nBITcNdqIHSVDDluaG6guyFFCSNXN+Hu87fU8VlhkE5Z0PwTZN1nro2O7a8JcUH88nB5EOzrxd9zKfXLSNFqcg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "efrt-unpack": "2.2.0"
             },
@@ -10374,11 +10373,23 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/convert-hex": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/convert-hex/-/convert-hex-0.1.0.tgz",
+            "integrity": "sha512-w20BOb1PiR/sEJdS6wNrUjF5CSfscZFUp7R9NSlXH8h2wynzXVEPFPJECAnkNylZ+cvf3p7TyRUHggDmrwXT9A==",
+            "dev": true
+        },
         "node_modules/convert-source-map": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
             "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
             "license": "MIT"
+        },
+        "node_modules/convert-string": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/convert-string/-/convert-string-0.1.0.tgz",
+            "integrity": "sha512-1KX9ESmtl8xpT2LN2tFnKSbV4NiarbVi8DVb39ZriijvtTklyrT+4dT1wsGMHKD3CJUjXgvJzstm9qL9ICojGA==",
+            "dev": true
         },
         "node_modules/cookies": {
             "version": "0.9.1",
@@ -10677,7 +10688,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@cypress/request": "^3.0.10",
                 "@cypress/xvfb": "^1.2.4",
@@ -10735,7 +10745,6 @@
             "integrity": "sha512-zzJpvAAjauEB3GZl0KYXb8i3w6MztWAt2WM3czYTFyNVC30alDmqCm9E7GwZ4bgkldZJlmHakaVEyu73R5St4w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -10750,6 +10759,7 @@
             "integrity": "sha512-5ReXlNE7C/9/rpDI3z0tAJbPXsTHK7P3ogvUtBntQlmctRQ+sSMts7dIQY5MTb0XfBSge3CuwvNvaoqtw90KSQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "debug": "^4.4.0",
                 "lodash": "^4.17.21",
@@ -10768,6 +10778,7 @@
             "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -11061,7 +11072,6 @@
             "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10"
             }
@@ -11500,7 +11510,6 @@
             "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -11769,6 +11778,7 @@
             "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -14019,7 +14029,6 @@
             "integrity": "sha512-bivyvW41RKT3SNIo+f2SOgvV376NbtTkfWYYRCSTOW/bx6EnjH4S2Pl4vfVpFPRQLOFPGTEWniuXLg8b1VkpBQ==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.txt",
-            "peer": true,
             "dependencies": {
                 "@types/pikaday": "1.7.4",
                 "core-js": "^3.0.0",
@@ -15396,7 +15405,6 @@
             "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "jiti": "bin/jiti.js"
             }
@@ -15905,7 +15913,6 @@
             "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@chevrotain/cst-dts-gen": "11.0.3",
                 "@chevrotain/gast": "11.0.3",
@@ -18272,7 +18279,6 @@
             "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "browser-stdout": "^1.3.1",
                 "chokidar": "^4.0.1",
@@ -19930,6 +19936,7 @@
             "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 14.16"
             }
@@ -20071,7 +20078,6 @@
             "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "playwright-core": "1.57.0"
             },
@@ -20179,7 +20185,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -20798,7 +20803,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
             "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -20854,7 +20858,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -20935,7 +20938,6 @@
             "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/use-sync-external-store": "^0.0.6",
                 "use-sync-external-store": "^1.4.0"
@@ -21378,8 +21380,7 @@
             "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
             "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/redux-thunk": {
             "version": "3.1.0",
@@ -22122,7 +22123,6 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
             "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -22757,6 +22757,16 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/sha256": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/sha256/-/sha256-0.2.0.tgz",
+            "integrity": "sha512-kTWMJUaez5iiT9CcMv8jSq6kMhw3ST0uRdcIWl3D77s6AsLXNXRp3heeqqfu5+Dyfu4hwpQnMzhqHh8iNQxw0w==",
+            "dev": true,
+            "dependencies": {
+                "convert-hex": "~0.1.0",
+                "convert-string": "~0.1.0"
+            }
+        },
         "node_modules/sharp": {
             "version": "0.34.5",
             "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
@@ -22844,7 +22854,6 @@
             "integrity": "sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@shikijs/core": "1.29.2",
                 "@shikijs/engine-javascript": "1.29.2",
@@ -23687,6 +23696,7 @@
             "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "js-tokens": "^9.0.1"
             },
@@ -23699,7 +23709,8 @@
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
             "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/strnum": {
             "version": "2.1.1",
@@ -24346,7 +24357,8 @@
             "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
             "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/tinyglobby": {
             "version": "0.2.15",
@@ -24370,6 +24382,7 @@
             "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^18.0.0 || >=20.0.0"
             }
@@ -24756,7 +24769,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -25331,7 +25343,6 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.7.tgz",
             "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.5.0",
@@ -25496,7 +25507,6 @@
             "integrity": "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@vitest/expect": "4.0.15",
                 "@vitest/mocker": "4.0.15",
@@ -25912,7 +25922,6 @@
             "integrity": "sha512-7teaXajOuNdn2UyyKlqMLssJjf0vDEih+Lo+tE/gHOt/P+mB8CinZym4PGtsriZLcyt4xV+Cun3hDmXM+pL26A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/node": "^20.11.30",
                 "@types/sinonjs__fake-timers": "^8.1.5",
@@ -26787,7 +26796,6 @@
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -26838,6 +26846,8 @@
             "version": "0.7.16",
             "license": "AGPL-3.0-or-later",
             "dependencies": {
+                "@doenet/lsp-tools": "*",
+                "@doenet/static-assets": "*",
                 "dompurify": "^3.3.0"
             },
             "peerDependencies": {
@@ -26912,7 +26922,6 @@
             "integrity": "sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@testing-library/dom": "^10.4.0",
                 "@testing-library/user-event": "^14.6.1",
@@ -26949,6 +26958,7 @@
             "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/chai": "^5.2.2",
                 "@vitest/spy": "3.2.4",
@@ -27006,6 +27016,7 @@
             "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vitest/utils": "3.2.4",
                 "pathe": "^2.0.3",
@@ -27021,6 +27032,7 @@
             "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vitest/pretty-format": "3.2.4",
                 "magic-string": "^0.30.17",
@@ -27080,6 +27092,7 @@
             "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "assertion-error": "^2.0.1",
                 "check-error": "^2.1.1",
@@ -27230,6 +27243,7 @@
             "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cac": "^6.7.14",
                 "debug": "^4.4.1",
@@ -27454,7 +27468,9 @@
             },
             "devDependencies": {
                 "@types/color-name": "^2.0.0",
-                "@types/nearest-color": "^0.4.1"
+                "@types/nearest-color": "^0.4.1",
+                "@types/sha256": "^0.2.2",
+                "sha256": "^0.2.0"
             }
         },
         "packages/v06-to-v07": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -56,6 +56,8 @@
     },
     "devDependencies": {
         "@types/color-name": "^2.0.0",
-        "@types/nearest-color": "^0.4.1"
+        "@types/nearest-color": "^0.4.1",
+        "@types/sha256": "^0.2.2",
+        "sha256": "^0.2.0"
     }
 }

--- a/packages/utils/src/media/cid.ts
+++ b/packages/utils/src/media/cid.ts
@@ -7,8 +7,25 @@ export async function cidFromText(text: string) {
     return await cidFromArrayBuffer(data);
 }
 
-export async function cidFromArrayBuffer(data: ArrayBuffer) {
-    let hashBuffer = await crypto.subtle.digest("SHA-256", data);
+// Digest is set lazily. Since crpto.subtle is not available in `http` mode,
+// we fall back to a polyfill in that case
+let digest: typeof crypto.subtle.digest | null = null;
+
+export async function cidFromArrayBuffer(data: BufferSource) {
+    if (!digest) {
+        try {
+            await crypto.subtle.digest("SHA-256", new Uint8Array());
+            digest = (...args) => crypto.subtle.digest(...args);
+        } catch (e) {
+            // Fallback to a polyfill or alternative implementation if needed
+            const sha256 = (await import("sha256")).default;
+            digest = ((algorithm: string, data: Buffer) =>
+                sha256(data, {
+                    asBytes: true,
+                })) as unknown as typeof crypto.subtle.digest;
+        }
+    }
+    let hashBuffer = await digest("SHA-256", data);
 
     let cidArray = new Uint8Array(36);
 

--- a/packages/utils/src/media/cid.ts
+++ b/packages/utils/src/media/cid.ts
@@ -9,23 +9,26 @@ export async function cidFromText(text: string) {
 
 // Digest is set lazily. Since crpto.subtle is not available in `http` mode,
 // we fall back to a polyfill in that case
-let digest: typeof crypto.subtle.digest | null = null;
+let digest:
+    | ((data: BufferSource) => Promise<ArrayBuffer> | Array<number>)
+    | null = null;
 
 export async function cidFromArrayBuffer(data: BufferSource) {
     if (!digest) {
         try {
             await crypto.subtle.digest("SHA-256", new Uint8Array());
-            digest = (...args) => crypto.subtle.digest(...args);
+            digest = (data: BufferSource) =>
+                crypto.subtle.digest("SHA-256", data);
         } catch (e) {
             // Fallback to a polyfill or alternative implementation if needed
             const sha256 = (await import("sha256")).default;
-            digest = ((algorithm: string, data: Buffer) =>
-                sha256(data, {
+            digest = (data: BufferSource) =>
+                sha256(data as Buffer, {
                     asBytes: true,
-                })) as unknown as typeof crypto.subtle.digest;
+                });
         }
     }
-    let hashBuffer = await digest("SHA-256", data);
+    let hashBuffer = await digest(data);
 
     let cidArray = new Uint8Array(36);
 


### PR DESCRIPTION
Fixes #1102 By loading a JS-native sha256 algorithm as a fallback if crypto.subtle is not available.