### PR TITLE
Allow tests to run in dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,9 +10,10 @@
         }
     },
     "containerEnv": {
-        "NODE_OPTIONS": "--max-old-space-size=6144"
+        "NODE_OPTIONS": " --max-old-space-size=6144 "
     },
-    "postCreateCommand": "npm install && npm run build",
+    // Unset NODE_OPTIONS and VSCODE_INSPECTOR_OPTIONS to prevent a debugger from trying to auto-attach to the container in an invalid way.
+    "postCreateCommand": "unset NODE_OPTIONS VSCODE_INSPECTOR_OPTIONS && npm install && npm run build",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,10 @@
         "ghcr.io/devcontainers/features/rust:1": {
             "version": "latest"
         },
+        // Install vim from apt using an existing community feature.
+        "ghcr.io/devcontainers-extra/features/apt-packages:1": {
+            "packages": "vim"
+        },
         // Install files needed for WebDriver tests (e.g. doenetml-to-prefigure tests)
         "./features/webdriver-libs": {},
         // Avoid erronious connections to the host's debug environment.
@@ -16,8 +20,8 @@
     "containerEnv": {
         "NODE_OPTIONS": " --max-old-space-size=6144 "
     },
-    // Bootstrap workspace after shell rc files are initialized
-    "postCreateCommand": "npm install && npm run build",
+    // Use VIM as the command line git editor. Not everyone's preference, but oh well...
+    "postCreateCommand": "git config core.editor vim",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,13 +7,17 @@
         },
         "ghcr.io/devcontainers/features/rust:1": {
             "version": "latest"
-        }
+        },
+        // Install files needed for WebDriver tests (e.g. doenetml-to-prefigure tests)
+        "./features/webdriver-libs": {},
+        // Avoid erronious connections to the host's debug environment.
+        "./features/shell-init-rc": {}
     },
     "containerEnv": {
         "NODE_OPTIONS": " --max-old-space-size=6144 "
     },
-    // Unset NODE_OPTIONS and VSCODE_INSPECTOR_OPTIONS to prevent a debugger from trying to auto-attach to the container in an invalid way.
-    "postCreateCommand": "unset NODE_OPTIONS VSCODE_INSPECTOR_OPTIONS && npm install && npm run build",
+    // Bootstrap workspace after shell rc files are initialized
+    "postCreateCommand": "npm install && npm run build",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.devcontainer/features/shell-init-rc/devcontainer-feature.json
+++ b/.devcontainer/features/shell-init-rc/devcontainer-feature.json
@@ -1,9 +1,7 @@
 {
-  "id": "shell-init-rc",
-  "version": "1.0.0",
-  "name": "Shell RC File Initialization",
-  "description": "Automatically configure shell rc files (.bashrc, .zshrc, .profile) to unset stale environment variables like NODE_OPTIONS and VSCODE_INSPECTOR_OPTIONS",
-  "installsAfter": [
-    "ghcr.io/devcontainers/features/common-utils"
-  ]
+    "id": "shell-init-rc",
+    "version": "1.0.0",
+    "name": "Shell RC File Initialization",
+    "description": "Automatically configure shell rc files (.bashrc, .zshrc, .profile) to unset stale environment variables like NODE_OPTIONS and VSCODE_INSPECTOR_OPTIONS",
+    "installsAfter": ["ghcr.io/devcontainers/features/common-utils"]
 }

--- a/.devcontainer/features/shell-init-rc/devcontainer-feature.json
+++ b/.devcontainer/features/shell-init-rc/devcontainer-feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "shell-init-rc",
+  "version": "1.0.0",
+  "name": "Shell RC File Initialization",
+  "description": "Automatically configure shell rc files (.bashrc, .zshrc, .profile) to unset stale environment variables like NODE_OPTIONS and VSCODE_INSPECTOR_OPTIONS",
+  "installsAfter": [
+    "ghcr.io/devcontainers/features/common-utils"
+  ]
+}

--- a/.devcontainer/features/shell-init-rc/install.sh
+++ b/.devcontainer/features/shell-init-rc/install.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+# Initialize shell rc files (.bashrc, .zshrc, .profile) to unset stale environment variables
+# that may be injected by VS Code debugger or other tools.
+# This ensures every new shell session starts with a clean environment.
+#
+# NOTE: This feature runs as root. We must write to the non-root user's home directory.
+# _REMOTE_USER is set by the devcontainer framework to the name of the remote user.
+# Fall back to "vscode" if the variable is not set.
+
+TARGET_USER="${_REMOTE_USER:-vscode}"
+TARGET_HOME=$(getent passwd "$TARGET_USER" | cut -d: -f6)
+
+if [ -z "$TARGET_HOME" ]; then
+    echo "WARNING: Could not determine home directory for user '$TARGET_USER'; skipping shell rc init"
+    exit 0
+fi
+
+for shell_rc in "$TARGET_HOME/.bashrc" "$TARGET_HOME/.zshrc" "$TARGET_HOME/.profile"; do
+    if [ -f "$shell_rc" ]; then
+        # Only append if not already present (avoid duplicates)
+        if ! grep -q "unset NODE_OPTIONS VSCODE_INSPECTOR_OPTIONS" "$shell_rc"; then
+            echo 'unset NODE_OPTIONS VSCODE_INSPECTOR_OPTIONS' >> "$shell_rc"
+        fi
+    fi
+done
+
+echo "Shell rc files initialized with NODE_OPTIONS and VSCODE_INSPECTOR_OPTIONS cleanup"

--- a/.devcontainer/features/webdriver-libs/devcontainer-feature.json
+++ b/.devcontainer/features/webdriver-libs/devcontainer-feature.json
@@ -1,0 +1,9 @@
+{
+    "id": "webdriver-libs",
+    "version": "1.0.0",
+    "name": "WebDriver Runtime Libraries",
+    "description": "Installs shared libraries required by Chromium/WebDriver for in-container browser tests.",
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
+}

--- a/.devcontainer/features/webdriver-libs/devcontainer-feature.json
+++ b/.devcontainer/features/webdriver-libs/devcontainer-feature.json
@@ -3,7 +3,5 @@
     "version": "1.0.0",
     "name": "WebDriver Runtime Libraries",
     "description": "Installs shared libraries required by Chromium/WebDriver for in-container browser tests.",
-    "installsAfter": [
-        "ghcr.io/devcontainers/features/common-utils"
-    ]
+    "installsAfter": ["ghcr.io/devcontainers/features/common-utils"]
 }

--- a/.devcontainer/features/webdriver-libs/install.sh
+++ b/.devcontainer/features/webdriver-libs/install.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y --no-install-recommends \
+    libglib2.0-0 \
+    libnss3 \
+    libnspr4 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libdrm2 \
+    libxkbcommon0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    libgbm1 \
+    libpango-1.0-0 \
+    libcairo2 \
+    libasound2t64 \
+    libx11-6 \
+    libx11-xcb1 \
+    libxcb1 \
+    libxext6 \
+    libxrender1 \
+    libxshmfence1 \
+    ca-certificates \
+    fonts-liberation
+
+rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,20 @@ jobs:
             - name: Run browser runtime check
               run: npm run test:browser-runtime -w @doenet/prefigure
 
+        test-doenetml-to-pretext-devcontainer:
+          name: DoenetML to PreTeXt Devcontainer Test
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@v6
+
+            - name: Build and test in devcontainer
+              uses: devcontainers/ci@v0.3
+              with:
+                runCmd: |
+                  npm ci
+                  npm run build -w packages/doenetml-to-pretext
+                  npm run test -w packages/doenetml-to-pretext
+
     lint:
         name: Lint Rust Code
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,19 +250,19 @@ jobs:
             - name: Run browser runtime check
               run: npm run test:browser-runtime -w @doenet/prefigure
 
-        test-doenetml-to-pretext-devcontainer:
-          name: DoenetML to PreTeXt Devcontainer Test
-          runs-on: ubuntu-latest
-          steps:
+    test-doenetml-to-pretext-devcontainer:
+        name: DoenetML to PreTeXt Devcontainer Test
+        runs-on: ubuntu-latest
+        steps:
             - uses: actions/checkout@v6
 
             - name: Build and test in devcontainer
               uses: devcontainers/ci@v0.3
               with:
-                runCmd: |
-                  npm ci
-                  npm run build -w packages/doenetml-to-pretext
-                  npm run test -w packages/doenetml-to-pretext
+                  runCmd: |
+                      npm ci
+                      npm run build -w packages/doenetml-to-pretext
+                      npm run test -w packages/doenetml-to-pretext
 
     lint:
         name: Lint Rust Code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,7 @@ jobs:
               run: npm run test:browser-runtime -w @doenet/prefigure
 
     test-doenetml-to-pretext-devcontainer:
-        name: DoenetML to PreTeXt Devcontainer Test
+        name: Devcontainer Runs Tests
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
@@ -261,6 +261,7 @@ jobs:
               with:
                   runCmd: |
                       npm ci
+                      # This package runs tests in a headless browser. If it can run, the other tests should too.
                       npm run build -w packages/doenetml-to-pretext
                       npm run test -w packages/doenetml-to-pretext
 

--- a/.prettierignoreci
+++ b/.prettierignoreci
@@ -1,3 +1,5 @@
 cypress
 packages/doenetml-worker-rust/lib-js-wasm-binding/pkg
 .vscode
+.devcontainer
+.github


### PR DESCRIPTION
Tests that rely on a headless browser require more packages to be installed in the dev container. This PR adds those tests. 

It also adds a CI job that runs the dev container and makes sure tests can run. Currently only one tests is executed (doenetml-to-pretext). We might consider running all the tests? It would eat into CI minutes, though.

Another option is that we change all tests right now to run in the dev container.