### PR TITLE
fix(editor): include doenetML source in diagnosticsSummaryCallback

### DIFF
--- a/.changeset/diagnostics-summary-callback-doenetml-arg.md
+++ b/.changeset/diagnostics-summary-callback-doenetml-arg.md
@@ -6,4 +6,4 @@
 "doenet-vscode-extension": patch
 ---
 
-`diagnosticsSummaryCallback` on `DoenetEditor` now receives a second argument, `doenetML`, containing the source string the viewer was rendering when those diagnostics were produced. Consumers can use this to correlate diagnostics with the document version that triggered them rather than the (potentially newer) editor buffer. `setDiagnosticsCallback` on `DoenetViewer` is also widened to accept an optional `doenetML` source as its second argument; existing single-argument consumers remain valid.
+`diagnosticsSummaryCallback` on `DoenetEditor` and `setDiagnosticsCallback` on `DoenetViewer` now receive a second argument, `doenetML`, containing the source string the viewer was rendering when those diagnostics were produced. Consumers can use this to correlate diagnostics with the document version that triggered them rather than the (potentially newer) editor buffer. Existing single-argument consumers remain valid — passing a callback with fewer parameters than the declared signature is still allowed by TypeScript.

--- a/.changeset/diagnostics-summary-callback-doenetml-arg.md
+++ b/.changeset/diagnostics-summary-callback-doenetml-arg.md
@@ -1,0 +1,9 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+`diagnosticsSummaryCallback` on `DoenetEditor` now receives a second argument, `doenetML`, containing the source string the viewer was rendering when those diagnostics were produced. Consumers can use this to correlate diagnostics with the document version that triggered them rather than the (potentially newer) editor buffer. `setDiagnosticsCallback` on `DoenetViewer` is also widened to accept an optional `doenetML` source as its second argument; existing single-argument consumers remain valid.

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -340,18 +340,14 @@ export const EditorViewer = React.forwardRef<
             },
             diagnosticsSource,
         );
-        // Fire once per `diagnostics`/`initialDiagnostics` change rather than per
+        // Fire once per viewer-generated `diagnostics` change rather than per
         // count change — the consumer should treat this as an event, not a memoized value.
-        // `diagnosticsSource` is the DoenetML the viewer was rendering when these
-        // diagnostics were produced; note that `initialDiagnostics` may have been
-        // computed by the parent against an earlier snapshot, so the source pairing
-        // is only authoritative for the viewer-generated portion.
-    }, [
-        diagnostics,
-        initialDiagnostics,
-        receivedDiagnosticsFromViewer,
-        diagnosticsSource,
-    ]);
+        // `initialDiagnostics` is intentionally excluded from the deps: those are
+        // owned by the parent, which already knows the source they were computed
+        // against, so re-firing on their identity change would only emit a
+        // `diagnosticsSource` paired with viewer-generated diagnostics that didn't
+        // actually change.
+    }, [diagnostics, receivedDiagnosticsFromViewer, diagnosticsSource]);
 
     const [responses, setResponses] = useState<
         {

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -63,6 +63,7 @@ type EditorViewerProps = {
     documentStructureCallback?: Function;
     diagnosticsSummaryCallback?: (
         diagnosticsSummary: DiagnosticsSummary,
+        doenetML: string,
     ) => void;
     id?: string;
     readOnly?: boolean;
@@ -205,6 +206,10 @@ export const EditorViewer = React.forwardRef<
     );
 
     const [diagnostics, setDiagnostics] = useState<DiagnosticRecord[]>([]);
+    // Snapshot of the DoenetML the viewer was rendering when it last reported
+    // diagnostics, captured at callback time so a later edit/save can't make
+    // the source disagree with the diagnostics it produced.
+    const [diagnosticsSource, setDiagnosticsSource] = useState(initialDoenetML);
     // Track whether we've received diagnostics from the viewer at least once.
     // This is used to gate when we call the diagnosticsSummaryCallback to avoid sending
     // just the initial diagnostics on load, which would be misleading since that
@@ -268,8 +273,12 @@ export const EditorViewer = React.forwardRef<
     );
 
     /** Receives diagnostics from DocViewer and stores them for panel/LSP sync. */
-    function setDiagnosticsCallback(newDiagnostics: DiagnosticRecord[]) {
+    function setDiagnosticsCallback(
+        newDiagnostics: DiagnosticRecord[],
+        source: string,
+    ) {
         setDiagnostics(newDiagnostics);
+        setDiagnosticsSource(source);
         setReceivedDiagnosticsFromViewer(true);
     }
 
@@ -321,16 +330,28 @@ export const EditorViewer = React.forwardRef<
             return;
         }
 
-        diagnosticsSummaryCallbackRef.current?.({
-            warningsCount,
-            errorsCount,
-            infosCount,
-            accessibilityLevel1Count,
-            accessibilityLevel2Count,
-        });
+        diagnosticsSummaryCallbackRef.current?.(
+            {
+                warningsCount,
+                errorsCount,
+                infosCount,
+                accessibilityLevel1Count,
+                accessibilityLevel2Count,
+            },
+            diagnosticsSource,
+        );
         // Fire once per `diagnostics`/`initialDiagnostics` change rather than per
         // count change — the consumer should treat this as an event, not a memoized value.
-    }, [diagnostics, initialDiagnostics, receivedDiagnosticsFromViewer]);
+        // `diagnosticsSource` is the DoenetML the viewer was rendering when these
+        // diagnostics were produced; note that `initialDiagnostics` may have been
+        // computed by the parent against an earlier snapshot, so the source pairing
+        // is only authoritative for the viewer-generated portion.
+    }, [
+        diagnostics,
+        initialDiagnostics,
+        receivedDiagnosticsFromViewer,
+        diagnosticsSource,
+    ]);
 
     const [responses, setResponses] = useState<
         {

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -82,7 +82,10 @@ export function DocViewer({
     flags: DoenetMLFlags;
     requestedVariantIndex: number;
     initialState?: Record<string, any> | null;
-    setDiagnosticsCallback?: (diagnostics: DiagnosticRecord[]) => void;
+    setDiagnosticsCallback?: (
+        diagnostics: DiagnosticRecord[],
+        source: string,
+    ) => void;
     reportScoreAndStateCallback?: (data: {
         score: number;
         state: unknown;
@@ -744,7 +747,7 @@ export function DocViewer({
     }) {
         if (newDiagnostics) {
             diagnostics.current = newDiagnostics;
-            setDiagnosticsCallback?.(diagnostics.current);
+            setDiagnosticsCallback?.(diagnostics.current, doenetML);
             if (
                 init &&
                 newDiagnostics.some((diagnostic) => diagnostic.type === "error")
@@ -1092,7 +1095,7 @@ export function DocViewer({
                 ) {
                     setHasInitialError(true);
                 }
-                setDiagnosticsCallback?.(diagnostics.current);
+                setDiagnosticsCallback?.(diagnostics.current, doenetML);
             }
         } else {
             setIsInErrorState?.(true);

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -121,7 +121,7 @@ export function DoenetViewer({
     initializedCallback?: Function;
     setDiagnosticsCallback?: (
         diagnostics: DiagnosticRecord[],
-        source?: string,
+        source: string,
     ) => void;
     /**
      * @deprecated Use `setDiagnosticsCallback` instead.

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -119,7 +119,10 @@ export function DoenetViewer({
     generatedVariantCallback?: Function;
     documentStructureCallback?: Function;
     initializedCallback?: Function;
-    setDiagnosticsCallback?: (diagnostics: DiagnosticRecord[]) => void;
+    setDiagnosticsCallback?: (
+        diagnostics: DiagnosticRecord[],
+        source?: string,
+    ) => void;
     /**
      * @deprecated Use `setDiagnosticsCallback` instead.
      */
@@ -194,8 +197,8 @@ export function DoenetViewer({
     }, []);
 
     const effectiveDiagnosticsCallback = setErrorsAndWarningsCallback
-        ? (diagnostics: DiagnosticRecord[]) => {
-              setDiagnosticsCallback?.(diagnostics);
+        ? (diagnostics: DiagnosticRecord[], source: string) => {
+              setDiagnosticsCallback?.(diagnostics, source);
               setErrorsAndWarningsCallback({
                   errors: diagnostics.filter(isErrorRecord),
                   warnings: diagnostics.filter(isWarningRecord),
@@ -345,6 +348,7 @@ type DoenetEditorProps = {
     documentStructureCallback?: Function;
     diagnosticsSummaryCallback?: (
         diagnosticsSummary: DiagnosticsSummary,
+        doenetML: string,
     ) => void;
     id?: string;
     readOnly?: boolean;

--- a/packages/test-cypress/cypress/e2e/EditorViewer/editorViewerAccessibilityReport.cy.js
+++ b/packages/test-cypress/cypress/e2e/EditorViewer/editorViewerAccessibilityReport.cy.js
@@ -156,7 +156,8 @@ describe(
         });
 
         it("diagnosticsSummaryCallback fires on each diagnostics update, including when counts are unchanged", () => {
-            postDoenetML(`<textInput /><text name="t">hello</text>`);
+            const sourceA = `<textInput /><text name="t">hello</text>`;
+            postDoenetML(sourceA);
 
             cy.get("#t").should("contain.text", "hello");
 
@@ -164,7 +165,8 @@ describe(
             cy.window().should((win) => {
                 const calls = win.returnDiagnosticsSummaryCallbackCalls();
                 expect(calls).to.have.length(1);
-                expect(calls[0].accessibilityLevel1Count).to.eq(1);
+                expect(calls[0].summary.accessibilityLevel1Count).to.eq(1);
+                expect(calls[0].doenetML).to.eq(sourceA);
             });
 
             // Type at the end of the editor and force a viewer update.
@@ -176,7 +178,8 @@ describe(
             cy.window().should((win) => {
                 const calls = win.returnDiagnosticsSummaryCallbackCalls();
                 expect(calls).to.have.length(2);
-                expect(calls[1].accessibilityLevel1Count).to.eq(1);
+                expect(calls[1].summary.accessibilityLevel1Count).to.eq(1);
+                expect(calls[1].doenetML).to.eq(sourceA + "abc");
             });
 
             // Add a second unlabeled input and update again.
@@ -189,8 +192,11 @@ describe(
             cy.window().should((win) => {
                 const calls = win.returnDiagnosticsSummaryCallbackCalls();
                 expect(calls).to.have.length(3);
-                expect(calls[2].accessibilityLevel1Count).to.be.greaterThan(
-                    calls[1].accessibilityLevel1Count,
+                expect(
+                    calls[2].summary.accessibilityLevel1Count,
+                ).to.be.greaterThan(calls[1].summary.accessibilityLevel1Count);
+                expect(calls[2].doenetML).to.eq(
+                    sourceA + "abc" + "<mathInput />",
                 );
             });
 
@@ -206,6 +212,44 @@ describe(
             cy.window().should((win) => {
                 const calls = win.returnDiagnosticsSummaryCallbackCalls();
                 expect(calls).to.have.length(3);
+            });
+        });
+
+        it("diagnosticsSummaryCallback's doenetML pairs with the source the viewer rendered, not the editor buffer", () => {
+            const sourceA = `<textInput /><text name="t">hello</text>`;
+            postDoenetML(sourceA);
+
+            cy.get("#t").should("contain.text", "hello");
+
+            // First call: viewer just rendered sourceA, so doenetML must be sourceA.
+            cy.window().should((win) => {
+                const calls = win.returnDiagnosticsSummaryCallbackCalls();
+                expect(calls).to.have.length(1);
+                expect(calls[0].doenetML).to.eq(sourceA);
+            });
+
+            // Type into the editor WITHOUT clicking the viewer update button.
+            // The viewer is still rendering sourceA, so any callback that fires
+            // now must report sourceA — not the (newer) editor buffer.
+            const appended = "<mathInput />";
+            cy.get(".cm-content")
+                .click()
+                .type("{ctrl+end}" + appended, { delay: 10 });
+            cy.wait(300);
+            cy.window().should((win) => {
+                const calls = win.returnDiagnosticsSummaryCallbackCalls();
+                for (const call of calls) {
+                    expect(call.doenetML).to.eq(sourceA);
+                }
+            });
+
+            // Now click the viewer update button: viewer re-renders with the
+            // buffer, and the next callback's doenetML must be the new source.
+            cy.get('[data-test="Viewer Update Button"]').click();
+            cy.window().should((win) => {
+                const calls = win.returnDiagnosticsSummaryCallbackCalls();
+                const last = calls[calls.length - 1];
+                expect(last.doenetML).to.eq(sourceA + appended);
             });
         });
 

--- a/packages/test-cypress/src/CypressTest.tsx
+++ b/packages/test-cypress/src/CypressTest.tsx
@@ -111,7 +111,9 @@ export function CypressTest() {
         testSettings.includeVariantSelector,
     );
     const diagnosticsSummaryRef = useRef<Record<string, number> | null>(null);
-    const diagnosticsSummaryCallsRef = useRef<Record<string, number>[]>([]);
+    const diagnosticsSummaryCallsRef = useRef<
+        { summary: Record<string, number>; doenetML: string }[]
+    >([]);
 
     useEffect(() => {
         (window as any).returnDiagnosticsSummaryCallbackValue = (): Record<
@@ -120,10 +122,10 @@ export function CypressTest() {
         > | null => {
             return diagnosticsSummaryRef.current;
         };
-        (window as any).returnDiagnosticsSummaryCallbackCalls = (): Record<
-            string,
-            number
-        >[] => {
+        (window as any).returnDiagnosticsSummaryCallbackCalls = (): {
+            summary: Record<string, number>;
+            doenetML: string;
+        }[] => {
             return diagnosticsSummaryCallsRef.current.slice();
         };
         return () => {
@@ -605,11 +607,13 @@ export function CypressTest() {
                 readOnly={readOnly}
                 diagnosticsSummaryCallback={(
                     nextDiagnosticsSummary: Record<string, number>,
+                    nextDoenetML: string,
                 ) => {
                     diagnosticsSummaryRef.current = nextDiagnosticsSummary;
-                    diagnosticsSummaryCallsRef.current.push(
-                        nextDiagnosticsSummary,
-                    );
+                    diagnosticsSummaryCallsRef.current.push({
+                        summary: nextDiagnosticsSummary,
+                        doenetML: nextDoenetML,
+                    });
                 }}
             />
         );


### PR DESCRIPTION
Closes #1106.

## Summary
- Thread the DoenetML source through `setDiagnosticsCallback` from DocViewer so the editor records the exact source the viewer rendered against, not the (potentially newer) editor buffer.
- `DoenetEditor.diagnosticsSummaryCallback` and `DoenetViewer.setDiagnosticsCallback` both now receive that source as a second argument (`doenetML: string`), required on the declared signature. Existing single-argument consumers continue to compile — TypeScript allows callbacks with fewer parameters than their declared type.
- The editor's callback effect fires only on viewer-generated diagnostic changes (not on `initialDiagnostics` identity changes), so the `doenetML` arg always pairs with the source the viewer actually rendered.

## Why threading the source vs. snapshotting in the parent
Reading `editorDoenetMLRef.current` (or even `viewerDoenetML`) inside the editor at the moment the callback fires is racy: between Ctrl+S (viewer loaded with source A) and the worker producing diagnostics, the user may have typed more characters, or even saved a second time (B). DocViewer is the only component that knows exactly which `doenetML` it ran the worker against, so it now passes that along.

## Test plan
- [x] Existing `editorViewerAccessibilityReport.cy.js` tests extended to assert on the new `doenetML` argument at each call.
- [x] New regression test: post source A, type into the editor without clicking Viewer Update (buffer ≠ viewer), assert any callback fired still reports A; then click Viewer Update and assert the next call reports the new buffer.
- [x] `npm run build -w @doenet/test-cypress` followed by headless run of `editorViewerAccessibilityReport.cy.js` — 17/17 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)