### PR TITLE
feat(editor): programmatic updateRenderedView() on DoenetEditorHandle

### DIFF
--- a/.changeset/programmatic-update-rendered-view.md
+++ b/.changeset/programmatic-update-rendered-view.md
@@ -1,0 +1,7 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+`DoenetEditorHandle` (the imperative ref handle on `<DoenetEditor>`) now exposes `updateRenderedView()`, the programmatic equivalent of clicking the editor's "Update" button. Consumers can call it before reading diagnostics to flush any pending edits from the editor buffer to the viewer, ensuring the next `diagnosticsSummaryCallback` reflects the current source rather than stale state. The method is a no-op when there is nothing to update (matching the visually-disabled button), and warns when invoked with `showViewer={false}`. The new method is plumbed through `@doenet/standalone`'s `renderDoenetEditorToContainer` handle and across the `@doenet/doenetml-iframe` ComLink boundary, including the same queue-and-replay treatment used for the existing `openDiagnosticsTab` / `closeDiagnosticsPanel` methods.

--- a/packages/doenetml-iframe/README.md
+++ b/packages/doenetml-iframe/README.md
@@ -49,6 +49,20 @@ Valid tab IDs: `"errors" | "warnings" | "info" | "accessibility" | "responses"`.
 See the `@doenet/doenetml` README for usage patterns including the lazy-mount
 "link in a different panel" scenario.
 
+### Programmatically updating the rendered view
+
+The handle also exposes `updateRenderedView()`, which forwards across the
+iframe to "press" the editor's Update button. Pair it with
+`diagnosticsSummaryCallback` (which receives the source the viewer
+rendered against as its second argument) to ensure diagnostics reflect the
+latest editor buffer:
+
+```tsx
+<button onClick={() => editorRef.current?.updateRenderedView()}>
+    Update viewer
+</button>
+```
+
 > **Note:** The handle methods are fire-and-forget across the iframe boundary.
 > Although they share the same `DoenetEditorHandle` type as the in-process
 > editor (so consumers can swap implementations), the iframe variant cannot

--- a/packages/doenetml-iframe/src/iframe-editor-index.ts
+++ b/packages/doenetml-iframe/src/iframe-editor-index.ts
@@ -61,6 +61,15 @@ ComlinkEditor.expose(
             }
             editorControlHandle.closeDiagnosticsPanel();
         },
+        updateRenderedView() {
+            if (!editorControlHandle) {
+                console.warn(
+                    "iframe DoenetEditor: updateRenderedView arrived before renderEditorWithFunctionProps completed — likely a bug in the iframe wrapper's queue/replay sequencing.",
+                );
+                return;
+            }
+            editorControlHandle.updateRenderedView();
+        },
     },
     ComlinkEditor.windowEndpoint(globalThis.parent),
 );

--- a/packages/doenetml-iframe/src/index.tsx
+++ b/packages/doenetml-iframe/src/index.tsx
@@ -311,6 +311,7 @@ type EditorIframeRemote = Comlink.Remote<{
     renderEditorWithFunctionProps: (...args: (string | Function)[]) => void;
     openDiagnosticsTab: (tabId: DiagnosticsTabId) => void;
     closeDiagnosticsPanel: () => void;
+    updateRenderedView: () => void;
 }>;
 
 // ComLink RPC calls return Promises, but the imperative handle methods are
@@ -372,6 +373,18 @@ export const DoenetEditor = React.forwardRef<
                     remote
                         .closeDiagnosticsPanel()
                         .catch(logComlinkError("closeDiagnosticsPanel"));
+                };
+                if (editorIframeRef.current) {
+                    action(editorIframeRef.current);
+                } else {
+                    pendingActions.current.push(action);
+                }
+            },
+            updateRenderedView() {
+                const action = (remote: EditorIframeRemote) => {
+                    remote
+                        .updateRenderedView()
+                        .catch(logComlinkError("updateRenderedView"));
                 };
                 if (editorIframeRef.current) {
                     action(editorIframeRef.current);

--- a/packages/doenetml-iframe/src/test-main.tsx
+++ b/packages/doenetml-iframe/src/test-main.tsx
@@ -89,6 +89,9 @@ function App() {
                 >
                     Close panel
                 </button>
+                <button onClick={() => editorRef.current?.updateRenderedView()}>
+                    Update view
+                </button>
             </div>
             <DoenetEditor
                 ref={editorRef}

--- a/packages/doenetml/README.md
+++ b/packages/doenetml/README.md
@@ -91,6 +91,38 @@ return (
 );
 ```
 
+### Programmatically updating the rendered view
+
+The same ref handle exposes `updateRenderedView()`, the programmatic
+equivalent of clicking the editor's "Update" button. Use it to flush any
+pending edits to the viewer so the next `diagnosticsSummaryCallback`
+reflects the current editor buffer rather than stale state. If the source
+hasn't changed and the document hasn't been interacted with, the call is a
+no-op (matching the visually-disabled button). When `showViewer={false}`,
+the call is ignored with a `console.warn`.
+
+```tsx
+function App() {
+    const editorRef = useRef<DoenetEditorHandle>(null);
+    return (
+        <>
+            <button onClick={() => editorRef.current?.updateRenderedView()}>
+                Update viewer
+            </button>
+            <DoenetEditor
+                ref={editorRef}
+                doenetML="..."
+                diagnosticsSummaryCallback={(summary, doenetML) => {
+                    // `doenetML` here is the source the viewer rendered against,
+                    // so you can correlate the summary with what the user typed
+                    // before pressing your "Update" trigger.
+                }}
+            />
+        </>
+    );
+}
+```
+
 ## Quick Start
 
 In the project folder:

--- a/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
+++ b/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
@@ -56,6 +56,23 @@ export type DoenetEditorHandle = {
     openDiagnosticsTab: (tabId: DiagnosticsTabId) => void;
     /** Close the diagnostics/responses panel. */
     closeDiagnosticsPanel: () => void;
+    /**
+     * Programmatic equivalent of clicking the editor's "Update" button: flush
+     * any pending edits to the viewer so the next `diagnosticsSummaryCallback`
+     * reflects the current editor buffer rather than stale state.
+     *
+     * Behavior mirrors the button:
+     * - If the editor has unsaved edits, the viewer is re-rendered with the
+     *   current source and any pending `doenetmlChangeCallback` debounce is
+     *   flushed.
+     * - If the source is unchanged but the document has been interacted with,
+     *   the viewer is remounted (clearing answer/work state).
+     * - If neither condition holds, the call is a no-op.
+     *
+     * Ignored with a `console.warn` when `showViewer={false}` (no viewer to
+     * update).
+     */
+    updateRenderedView: () => void;
 };
 
 /** Human-readable label for diagnostic source line, when position exists. */

--- a/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
+++ b/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
@@ -46,35 +46,6 @@ export type DiagnosticsTabId =
     | "accessibility"
     | "responses";
 
-/** Imperative handle exposed by `<DoenetEditor>` for programmatic panel control. */
-export type DoenetEditorHandle = {
-    /**
-     * Switch the diagnostics/responses panel to `tabId` and open it.
-     * If `tabId` references a tab disabled by `showDiagnostics={false}` or
-     * `showResponses={false}`, the call is ignored with a `console.warn`.
-     */
-    openDiagnosticsTab: (tabId: DiagnosticsTabId) => void;
-    /** Close the diagnostics/responses panel. */
-    closeDiagnosticsPanel: () => void;
-    /**
-     * Programmatic equivalent of clicking the editor's "Update" button: flush
-     * any pending edits to the viewer so the next `diagnosticsSummaryCallback`
-     * reflects the current editor buffer rather than stale state.
-     *
-     * Behavior mirrors the button:
-     * - If the editor has unsaved edits, the viewer is re-rendered with the
-     *   current source and any pending `doenetmlChangeCallback` debounce is
-     *   flushed.
-     * - If the source is unchanged but the document has been interacted with,
-     *   the viewer is remounted (clearing answer/work state).
-     * - If neither condition holds, the call is a no-op.
-     *
-     * Ignored with a `console.warn` when `showViewer={false}` (no viewer to
-     * update).
-     */
-    updateRenderedView: () => void;
-};
-
 /** Human-readable label for diagnostic source line, when position exists. */
 function diagnosticLocationLabel(diagnostic: {
     position?: { start: { line: number } };

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -250,11 +250,12 @@ export const EditorViewer = React.forwardRef<
         setInfoPanelIsOpen(true);
     }
 
-    // Shared between the "Update" button click and the imperative
-    // `updateRenderedView()` ref method. Mirrors the Ctrl/Cmd-S keyboard
-    // handler's defensive form (reads via refs, gates the viewer-reset on
-    // `documentInteractedRef`) so the programmatic call is a true no-op when
-    // there is nothing to update.
+    // Shared between the "Update" button click, the Ctrl/Cmd-S keyboard
+    // shortcut, and the imperative `updateRenderedView()` ref method. Reads
+    // via refs and gates the viewer-reset on `documentInteractedRef` so the
+    // programmatic call is a true no-op when there is nothing to update.
+    // For the button this gating is invisible (the button is disabled when
+    // both `codeChanged` and `documentInteracted` are false).
     const updateViewer = useCallback(() => {
         setDocumentInteracted(false);
         setResponses([]);
@@ -563,29 +564,7 @@ export const EditorViewer = React.forwardRef<
             ) {
                 event.preventDefault();
                 event.stopPropagation();
-                window.clearTimeout(updateValueTimer.current ?? undefined);
-                updateValueTimer.current = null;
-
-                setDocumentInteracted(false);
-                setResponses([]);
-
-                if (codeChangedRef.current) {
-                    setViewerDoenetML(editorDoenetMLRef.current);
-                    if (
-                        lastReportedDoenetML.current !==
-                        editorDoenetMLRef.current
-                    ) {
-                        lastReportedDoenetML.current =
-                            editorDoenetMLRef.current;
-                        if (!showViewer) {
-                            doenetmlChangeCallback?.(editorDoenetMLRef.current);
-                        }
-                    }
-
-                    setCodeChanged(false);
-                } else if (documentInteractedRef.current) {
-                    setViewerResetNum((n) => n + 1);
-                }
+                updateViewer();
             }
         };
 
@@ -603,7 +582,7 @@ export const EditorViewer = React.forwardRef<
                 handleEditorKeyDown,
             );
         };
-    }, [showViewer, id]);
+    }, [showViewer, id, updateViewer]);
 
     useEffect(() => {
         return () => {

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -250,6 +250,31 @@ export const EditorViewer = React.forwardRef<
         setInfoPanelIsOpen(true);
     }
 
+    // Shared between the "Update" button click and the imperative
+    // `updateRenderedView()` ref method. Mirrors the Ctrl/Cmd-S keyboard
+    // handler's defensive form (reads via refs, gates the viewer-reset on
+    // `documentInteractedRef`) so the programmatic call is a true no-op when
+    // there is nothing to update.
+    const updateViewer = useCallback(() => {
+        setDocumentInteracted(false);
+        setResponses([]);
+
+        if (codeChangedRef.current) {
+            setViewerDoenetML(editorDoenetMLRef.current);
+            window.clearTimeout(updateValueTimer.current ?? undefined);
+            if (lastReportedDoenetML.current !== editorDoenetMLRef.current) {
+                lastReportedDoenetML.current = editorDoenetMLRef.current;
+                if (!showViewer) {
+                    doenetmlChangeCallback?.(editorDoenetMLRef.current);
+                }
+            }
+            setCodeChanged(false);
+            updateValueTimer.current = null;
+        } else if (documentInteractedRef.current) {
+            setViewerResetNum((n) => n + 1);
+        }
+    }, [showViewer, doenetmlChangeCallback]);
+
     useImperativeHandle(
         ref,
         () => ({
@@ -268,8 +293,17 @@ export const EditorViewer = React.forwardRef<
             closeDiagnosticsPanel() {
                 setInfoPanelIsOpen(false);
             },
+            updateRenderedView() {
+                if (!showViewer) {
+                    console.warn(
+                        "DoenetEditor: updateRenderedView() ignored — showViewer is false; nothing to update.",
+                    );
+                    return;
+                }
+                updateViewer();
+            },
         }),
-        [tabStore, showDiagnostics, showResponses],
+        [tabStore, showDiagnostics, showResponses, showViewer, updateViewer],
     );
 
     /** Receives diagnostics from DocViewer and stores them for panel/LSP sync. */
@@ -701,33 +735,7 @@ export const EditorViewer = React.forwardRef<
                 documentInteracted={documentInteracted}
                 platform={platform as "Mac" | "Win" | "Linux"}
                 updateWord={updateWord}
-                onUpdateViewer={() => {
-                    setDocumentInteracted(false);
-                    setResponses([]);
-
-                    if (!codeChanged) {
-                        setViewerResetNum((n) => n + 1);
-                    } else {
-                        setViewerDoenetML(editorDoenetMLRef.current);
-                        window.clearTimeout(
-                            updateValueTimer.current ?? undefined,
-                        );
-                        if (
-                            lastReportedDoenetML.current !==
-                            editorDoenetMLRef.current
-                        ) {
-                            lastReportedDoenetML.current =
-                                editorDoenetMLRef.current;
-                            if (!showViewer) {
-                                doenetmlChangeCallback?.(
-                                    editorDoenetMLRef.current,
-                                );
-                            }
-                        }
-                        setCodeChanged(false);
-                        updateValueTimer.current = null;
-                    }
-                }}
+                onUpdateViewer={updateViewer}
                 variants={variants}
                 setVariants={setVariants}
                 showDiagnostics={showDiagnostics}

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -283,11 +283,15 @@ export const EditorViewer = React.forwardRef<
 
     // Shared between the "Update" button click, the Ctrl/Cmd-S keyboard
     // shortcut, and the imperative `updateRenderedView()` ref method. Reads
-    // via refs and gates the viewer-reset on `documentInteractedRef` so the
-    // programmatic call is a true no-op when there is nothing to update.
-    // For the button this gating is invisible (the button is disabled when
-    // both `codeChanged` and `documentInteracted` are false).
+    // via refs and early-returns when nothing has changed so the programmatic
+    // call is a true no-op (no spurious `setResponses([])` re-render). For
+    // the button this guard is invisible (the button is disabled when both
+    // `codeChanged` and `documentInteracted` are false).
     const updateViewer = useCallback(() => {
+        if (!codeChangedRef.current && !documentInteractedRef.current) {
+            return;
+        }
+
         setDocumentInteracted(false);
         setResponses([]);
 
@@ -302,7 +306,9 @@ export const EditorViewer = React.forwardRef<
             }
             setCodeChanged(false);
             updateValueTimer.current = null;
-        } else if (documentInteractedRef.current) {
+        } else {
+            // documentInteractedRef.current is true here (the early-return
+            // above excludes the both-false case).
             setViewerResetNum((n) => n + 1);
         }
     }, [showViewer, doenetmlChangeCallback]);

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -65,8 +65,10 @@ export type DoenetEditorHandle = {
      *
      * Behavior mirrors the button:
      * - If the editor has unsaved edits, the viewer is re-rendered with the
-     *   current source and any pending `doenetmlChangeCallback` debounce is
-     *   flushed.
+     *   current source and the pending `doenetmlChangeCallback` debounce
+     *   timer is cancelled. (The callback still fires indirectly via the
+     *   viewer's normal change-reporting path once it parses the new
+     *   source.)
      * - If the source is unchanged but the document has been interacted with,
      *   the viewer is remounted (clearing answer/work state).
      * - If neither condition holds, the call is a no-op.

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -15,10 +15,7 @@ import {
     DiagnosticsResponseTabContents,
     DiagnosticsResponseTabstrip,
 } from "./DiagnosticsResponseTabs";
-import type {
-    DiagnosticsTabId,
-    DoenetEditorHandle,
-} from "./DiagnosticsResponseTabs";
+import type { DiagnosticsTabId } from "./DiagnosticsResponseTabs";
 import { DiagnosticRecord, nanInfinityReviver } from "@doenet/utils";
 import { nanoid } from "nanoid";
 import { prettyPrint } from "@doenet/parser/pretty-printer";
@@ -45,6 +42,40 @@ const HELP_NONE: HelpContent = { kind: "none" };
 // stable across renders. A parameter default `= []` would create a fresh array
 // each render, refiring every effect/memo that depends on `initialDiagnostics`.
 const EMPTY_INITIAL_DIAGNOSTICS: DiagnosticRecord[] = [];
+
+/**
+ * Imperative handle exposed on the ref of `<DoenetEditor>`. Provides
+ * programmatic access to editor actions that would otherwise require user
+ * interaction with the UI — switching the diagnostics/responses panel, and
+ * flushing pending edits to the rendered view.
+ */
+export type DoenetEditorHandle = {
+    /**
+     * Switch the diagnostics/responses panel to `tabId` and open it.
+     * If `tabId` references a tab disabled by `showDiagnostics={false}` or
+     * `showResponses={false}`, the call is ignored with a `console.warn`.
+     */
+    openDiagnosticsTab: (tabId: DiagnosticsTabId) => void;
+    /** Close the diagnostics/responses panel. */
+    closeDiagnosticsPanel: () => void;
+    /**
+     * Programmatic equivalent of clicking the editor's "Update" button: flush
+     * any pending edits to the viewer so the next `diagnosticsSummaryCallback`
+     * reflects the current editor buffer rather than stale state.
+     *
+     * Behavior mirrors the button:
+     * - If the editor has unsaved edits, the viewer is re-rendered with the
+     *   current source and any pending `doenetmlChangeCallback` debounce is
+     *   flushed.
+     * - If the source is unchanged but the document has been interacted with,
+     *   the viewer is remounted (clearing answer/work state).
+     * - If neither condition holds, the call is a no-op.
+     *
+     * Ignored with a `console.warn` when `showViewer={false}` (no viewer to
+     * update).
+     */
+    updateRenderedView: () => void;
+};
 
 type EditorViewerProps = {
     doenetML: string;

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -20,14 +20,10 @@ import { VirtualKeyboard } from "@doenet/virtual-keyboard";
 import "@doenet/virtual-keyboard/style.css";
 import "@doenet/ui-components/style.css";
 import { EditorViewer } from "./EditorViewer/EditorViewer.js";
-import type {
-    DiagnosticsTabId,
-    DoenetEditorHandle,
-} from "./EditorViewer/DiagnosticsResponseTabs";
-export type {
-    DiagnosticsTabId,
-    DoenetEditorHandle,
-} from "./EditorViewer/DiagnosticsResponseTabs";
+import type { DoenetEditorHandle } from "./EditorViewer/EditorViewer";
+import type { DiagnosticsTabId } from "./EditorViewer/DiagnosticsResponseTabs";
+export type { DoenetEditorHandle } from "./EditorViewer/EditorViewer";
+export type { DiagnosticsTabId } from "./EditorViewer/DiagnosticsResponseTabs";
 import VariantSelect from "./EditorViewer/VariantSelect";
 import { useIsOnPage } from "./utils/visibility";
 import { Provider as ReduxProvider } from "react-redux";

--- a/packages/doenetml/test/cypress/component/DoenetEditor.updateRenderedViewRef.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.updateRenderedViewRef.cy.tsx
@@ -122,6 +122,11 @@ describe("DoenetEditor updateRenderedView ref method", () => {
     });
 
     it("warns and does not throw when showViewer is false", () => {
+        // Stub console.warn before mount: Cypress queues commands, so the
+        // `cy.window().then(...)` chain runs before `cy.mount(...)` and the
+        // component sees the stubbed warn from its first render onward. If
+        // anyone reorders these, the assertion below will silently miss the
+        // warn call.
         const warnSpy = cy.stub().as("consoleWarn");
         cy.window().then((win) => {
             cy.stub(win.console, "warn").callsFake(warnSpy);

--- a/packages/doenetml/test/cypress/component/DoenetEditor.updateRenderedViewRef.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.updateRenderedViewRef.cy.tsx
@@ -1,0 +1,139 @@
+import React, { useRef, useState } from "react";
+import {
+    DoenetEditor,
+    type DoenetEditorHandle,
+} from "../../../src/doenetml-inline-worker";
+
+const SAMPLE_DOENETML = "<p>hello</p>";
+
+type DiagnosticsCall = {
+    summary: {
+        warningsCount: number;
+        errorsCount: number;
+        infosCount: number;
+        accessibilityLevel1Count: number;
+        accessibilityLevel2Count: number;
+    };
+    doenetML: string;
+};
+
+function Harness({ showViewer = true }: { showViewer?: boolean }) {
+    const editorRef = useRef<DoenetEditorHandle>(null);
+    const [calls, setCalls] = useState<DiagnosticsCall[]>([]);
+
+    return (
+        <div style={{ height: "500px", width: "900px" }}>
+            <button
+                data-test="trigger-update"
+                onClick={() => editorRef.current?.updateRenderedView()}
+            >
+                Trigger update
+            </button>
+            <div data-test="call-count">{calls.length}</div>
+            <div data-test="last-source">
+                {calls.length > 0 ? calls[calls.length - 1].doenetML : ""}
+            </div>
+            <DoenetEditor
+                ref={editorRef}
+                doenetML={SAMPLE_DOENETML}
+                addVirtualKeyboard={false}
+                showViewer={showViewer}
+                diagnosticsSummaryCallback={(summary, doenetML) => {
+                    setCalls((prev) => [...prev, { summary, doenetML }]);
+                }}
+            />
+        </div>
+    );
+}
+
+describe("DoenetEditor updateRenderedView ref method", () => {
+    it("flushes pending edits and fires diagnosticsSummaryCallback with the new source", () => {
+        cy.mount(<Harness />);
+
+        // Wait for the initial diagnostics callback (from the first viewer render).
+        cy.get('[data-test="call-count"]').should("not.have.text", "0");
+        cy.get('[data-test="last-source"]').should(
+            "have.text",
+            SAMPLE_DOENETML,
+        );
+
+        // Capture the call count after initial settle so we can assert that
+        // typing alone (debounced) does NOT trigger a new viewer render.
+        cy.get('[data-test="call-count"]')
+            .invoke("text")
+            .then((initialCountText) => {
+                const initialCount = Number(initialCountText);
+
+                // Type into CodeMirror — this changes the editor buffer but,
+                // because there's a 3s debounce, does NOT immediately update
+                // the viewer or fire the diagnostics callback. Append plain
+                // text (no `<` or `=`) so we don't trigger DoenetML
+                // autocomplete and end up with a buffer different from what
+                // we typed.
+                // Two `.type()` calls so the Ctrl modifier is released after
+                // jumping to the end — otherwise ` EXTRA` gets typed as
+                // Ctrl-chord characters (e.g. Ctrl+A selects all).
+                cy.get(".cm-content")
+                    .click()
+                    .type("{ctrl}{end}", { force: true })
+                    .type(" EXTRA", { force: true });
+
+                // Programmatically click "Update".
+                cy.get('[data-test="trigger-update"]').click();
+
+                // Callback should fire with the new source.
+                cy.get('[data-test="last-source"]').should("contain", "EXTRA");
+                cy.get('[data-test="call-count"]')
+                    .invoke("text")
+                    .then((finalCountText) => {
+                        expect(Number(finalCountText)).to.be.greaterThan(
+                            initialCount,
+                        );
+                    });
+            });
+    });
+
+    it("is a no-op when nothing has changed", () => {
+        cy.mount(<Harness />);
+
+        // Wait for initial settle.
+        cy.get('[data-test="last-source"]').should(
+            "have.text",
+            SAMPLE_DOENETML,
+        );
+
+        cy.get('[data-test="call-count"]')
+            .invoke("text")
+            .then((countAfterInitialText) => {
+                const countAfterInitial = Number(countAfterInitialText);
+
+                // Click trigger without any edits or interaction.
+                cy.get('[data-test="trigger-update"]').click();
+
+                // Give React a couple of ticks; the call count must NOT grow.
+                // Using `.should` with a duration check by re-asserting after wait.
+                cy.wait(500);
+                cy.get('[data-test="call-count"]')
+                    .invoke("text")
+                    .should((text) => {
+                        expect(Number(text)).to.equal(countAfterInitial);
+                    });
+            });
+    });
+
+    it("warns and does not throw when showViewer is false", () => {
+        const warnSpy = cy.stub().as("consoleWarn");
+        cy.window().then((win) => {
+            cy.stub(win.console, "warn").callsFake(warnSpy);
+        });
+
+        cy.mount(<Harness showViewer={false} />);
+
+        // No viewer to update — clicking should warn and be a no-op.
+        cy.get('[data-test="trigger-update"]').click();
+        cy.get("@consoleWarn").should(
+            "have.been.calledWithMatch",
+            /showViewer/,
+        );
+    });
+});

--- a/packages/standalone/README.md
+++ b/packages/standalone/README.md
@@ -69,10 +69,19 @@ on first commit.
     document
         .querySelector("#close-panel")
         .addEventListener("click", () => handle.closeDiagnosticsPanel());
+    document
+        .querySelector("#update-viewer")
+        .addEventListener("click", () => handle.updateRenderedView());
 </script>
 ```
 
 Valid tab IDs: `"errors" | "warnings" | "info" | "accessibility" | "responses"`.
+
+`handle.updateRenderedView()` programmatically presses the editor's "Update"
+button: it flushes any pending edits to the viewer so the next
+`diagnosticsSummaryCallback` reflects the current editor buffer. It's a
+no-op when nothing has changed, and warns when there is no viewer
+(`showViewer={false}`).
 
 ## Development
 

--- a/packages/standalone/src/index.tsx
+++ b/packages/standalone/src/index.tsx
@@ -168,6 +168,13 @@ export function renderDoenetEditorToContainer(
                 pendingHandleActions.push((h) => h.closeDiagnosticsPanel());
             }
         },
+        updateRenderedView() {
+            if (mountedHandle) {
+                mountedHandle.updateRenderedView();
+            } else {
+                pendingHandleActions.push((h) => h.updateRenderedView());
+            }
+        },
     };
 }
 


### PR DESCRIPTION
Closes #1105. Adds an `updateRenderedView()` method to the imperative ref handle on `<DoenetEditor>`, letting embedding apps programmatically "press the Update button" before reading diagnostics. Combined with #1108's `(summary, doenetML)` callback signature, consumers (DoenetTools) can now flush pending edits and receive a `diagnosticsSummaryCallback` whose second argument matches the source they intend to validate against — eliminating the race between user typing and diagnostic reads.

## Summary

- **`updateRenderedView()` on `DoenetEditorHandle`** — programmatic equivalent of clicking the editor's "Update" button. No-op when nothing has changed (matching the visually-disabled button); warns and ignores when `showViewer={false}`.
- **Plumbed through three packages** following the same pattern established by #1094:
  - `@doenet/doenetml`: extends `DoenetEditorHandle` and `useImperativeHandle` in `EditorViewer`.
  - `@doenet/standalone`: extends the handle returned by `renderDoenetEditorToContainer`, with the same callback-ref + queue used for the existing methods.
  - `@doenet/doenetml-iframe`: extends `EditorIframeRemote`, the outer wrapper's queued imperative handle, and the inner bridge's `ComlinkEditor.expose`. Calls made before `iframeReady` are queued and replayed.
- **Internal cleanup**: the "Update" button, the Ctrl/Cmd-S keyboard shortcut, and the new imperative method now all route through a single `updateViewer` `useCallback`, replacing the inline arrow the button used to pass to `ViewerControlsBar` and the near-duplicate body inside the keydown handler.

  Note one silent behavior alignment: the consolidated path gates the no-code-changed branch on `documentInteractedRef.current` (so a programmatic call when nothing has changed is a true no-op). For the **button** this is invisible — `ViewerControlsBar` already disables the button when both `codeChanged` and `documentInteracted` are false, so the previously-reachable inline-arrow behavior was unreachable from the UI. For **Ctrl/Cmd-S** this matches the keydown handler's pre-existing form (it already had the `documentInteractedRef` gate), so there is no user-visible change there either.

## Usage

**Direct `<DoenetEditor>` from `@doenet/doenetml` (or `@doenet/doenetml-iframe`):**

```tsx
import { useRef } from "react";
import { DoenetEditor, type DoenetEditorHandle } from "@doenet/doenetml";

function App() {
    const editorRef = useRef<DoenetEditorHandle>(null);
    return (
        <>
            <button onClick={() => editorRef.current?.updateRenderedView()}>
                Update viewer
            </button>
            <DoenetEditor
                ref={editorRef}
                doenetML="..."
                diagnosticsSummaryCallback={(summary, doenetML) => {
                    // `doenetML` here is the source the viewer rendered
                    // against — correlate the summary with what the user
                    // typed before pressing your "Update" trigger.
                }}
            />
        </>
    );
}
```

**Standalone:**

```html
<script type="module">
    const handle = renderDoenetEditorToContainer(document.querySelector(".doenetml-editor"));
    document.querySelector("#update-viewer").addEventListener("click", () =>
        handle.updateRenderedView(),
    );
</script>
```

## Tests

New Cypress component spec `DoenetEditor.updateRenderedViewRef.cy.tsx` (3 tests):
- Typing into CodeMirror, then `updateRenderedView()`, fires `diagnosticsSummaryCallback` with the new source as its second argument.
- With unchanged source, `updateRenderedView()` is a no-op (no extra callback).
- With `showViewer={false}`, `updateRenderedView()` warns and does not throw.

## Test plan

- [x] `tsc --noEmit` clean across `@doenet/doenetml`, `@doenet/standalone`, `@doenet/doenetml-iframe`
- [x] All three packages build cleanly
- [x] Cypress component tests pass — 12/12 (`npm run test:doenetml-cypress`), including the 3 new + 9 existing
- [x] Manual: in a small harness page, type into the editor, then click an out-of-editor button that calls `editorRef.current.updateRenderedView()` — confirm the viewer rerenders and `diagnosticsSummaryCallback` fires with the just-typed source as the second argument
- [x] Manual via `@doenet/doenetml-iframe` (cross-iframe ComLink round trip), including the queue path: invoke `updateRenderedView()` immediately after mount (before `iframeReady`) to confirm it's queued and replayed
- [x] Manual via `@doenet/standalone`'s `renderDoenetEditorToContainer` handle
- [x] Manual: confirm Ctrl/Cmd-S still flushes pending edits as before (now routes through the consolidated `updateViewer`)

## Related

- Builds on #1094 (programmatic control of the diagnostics panel — same handle, same plumbing pattern).
- Composes with #1108 (the `(summary, doenetML)` callback signature) to give consumers a deterministic "flush + read" workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
