### PR TITLE
fix(editor): stabilize consumer callback identity with ref mirrors

### DIFF
--- a/.changeset/stabilize-editor-callback-identity.md
+++ b/.changeset/stabilize-editor-callback-identity.md
@@ -1,0 +1,9 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Stabilize `<DoenetEditor>` callback identity. The `doenetmlChangeCallback`, `immediateDoenetmlChangeCallback`, and `documentStructureCallback` props are now routed through ref mirrors, so the editor's internal `useCallback` hooks (and the imperative handle exposed via `ref`) no longer churn when consumers pass inline arrow functions. Also fixes a stale-closure bug where the unmount cleanup could fire the original `doenetmlChangeCallback` instead of the latest one.

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -303,7 +303,9 @@ export const EditorViewer = React.forwardRef<
             if (lastReportedDoenetML.current !== editorDoenetMLRef.current) {
                 lastReportedDoenetML.current = editorDoenetMLRef.current;
                 if (!showViewer) {
-                    doenetmlChangeCallback?.(editorDoenetMLRef.current);
+                    doenetmlChangeCallbackRef.current?.(
+                        editorDoenetMLRef.current,
+                    );
                 }
             }
             setCodeChanged(false);
@@ -313,7 +315,7 @@ export const EditorViewer = React.forwardRef<
             // above excludes the both-false case).
             setViewerResetNum((n) => n + 1);
         }
-    }, [showViewer, doenetmlChangeCallback]);
+    }, [showViewer]);
 
     useImperativeHandle(
         ref,
@@ -387,13 +389,34 @@ export const EditorViewer = React.forwardRef<
         [initialDiagnostics, diagnostics],
     );
 
-    // Hold the latest `diagnosticsSummaryCallback` in a ref so inline callbacks
-    // (whose identity changes every parent render) don't retrigger the effect below
-    // and cause unbounded recursion when the consumer stores the summary in state.
+    // Hold consumer-supplied callbacks in refs so inline-callback identity
+    // churn (the common case) doesn't invalidate the `useCallback`/`useEffect`
+    // deps below — which would otherwise re-identify `useImperativeHandle`'s
+    // output on every parent render. Routing through `*Ref.current` also
+    // avoids stale-closure bugs in hooks with empty dep arrays (e.g. the
+    // unmount cleanup below).
     const diagnosticsSummaryCallbackRef = useRef(diagnosticsSummaryCallback);
     useEffect(() => {
         diagnosticsSummaryCallbackRef.current = diagnosticsSummaryCallback;
     }, [diagnosticsSummaryCallback]);
+
+    const doenetmlChangeCallbackRef = useRef(doenetmlChangeCallback);
+    useEffect(() => {
+        doenetmlChangeCallbackRef.current = doenetmlChangeCallback;
+    }, [doenetmlChangeCallback]);
+
+    const immediateDoenetmlChangeCallbackRef = useRef(
+        immediateDoenetmlChangeCallback,
+    );
+    useEffect(() => {
+        immediateDoenetmlChangeCallbackRef.current =
+            immediateDoenetmlChangeCallback;
+    }, [immediateDoenetmlChangeCallback]);
+
+    const documentStructureCallbackRef = useRef(documentStructureCallback);
+    useEffect(() => {
+        documentStructureCallbackRef.current = documentStructureCallback;
+    }, [documentStructureCallback]);
 
     useEffect(() => {
         // On initial load of the editor, don't call `diagnosticsSummaryCallback`
@@ -506,61 +529,50 @@ export const EditorViewer = React.forwardRef<
     // call documentStructure callback followed by doenetmlChangeCallback
     // so that one can have access to the document structure before a
     // save in response to doenetmlChangeCallback
-    const documentStructureThenChangeCallback = useCallback(
-        (obj: unknown) => {
-            documentStructureCallback?.(obj);
-            doenetmlChangeCallback?.(editorDoenetMLRef.current);
-        },
-        [documentStructureCallback, doenetmlChangeCallback],
-    );
+    const documentStructureThenChangeCallback = useCallback((obj: unknown) => {
+        documentStructureCallbackRef.current?.(obj);
+        doenetmlChangeCallbackRef.current?.(editorDoenetMLRef.current);
+    }, []);
 
-    const onEditorChange = useCallback(
-        (value: string) => {
-            if (editorDoenetMLRef.current !== value) {
-                editorDoenetMLRef.current = value;
-                completerRef.current.setSource(value);
+    const onEditorChange = useCallback((value: string) => {
+        if (editorDoenetMLRef.current !== value) {
+            editorDoenetMLRef.current = value;
+            completerRef.current.setSource(value);
 
-                if (!codeChangedRef.current) {
-                    setCodeChanged(true);
-                    setUpdateWord("Update");
-                }
-
-                immediateDoenetmlChangeCallback?.(value);
-
-                // Debounce update value at 3 seconds
-                clearTimeout(updateValueTimer.current ?? undefined);
-
-                //TODO: when you try to leave the page before it saved you will lose work
-                //so prompt the user on page leave
-                updateValueTimer.current = window.setTimeout(function () {
-                    if (
-                        lastReportedDoenetML.current !==
-                        editorDoenetMLRef.current
-                    ) {
-                        lastReportedDoenetML.current =
-                            editorDoenetMLRef.current;
-                        doenetmlChangeCallback?.(editorDoenetMLRef.current);
-                    }
-                    updateValueTimer.current = null;
-                }, 3000); //3 seconds
+            if (!codeChangedRef.current) {
+                setCodeChanged(true);
+                setUpdateWord("Update");
             }
-        },
-        [immediateDoenetmlChangeCallback, doenetmlChangeCallback],
-    );
+
+            immediateDoenetmlChangeCallbackRef.current?.(value);
+
+            // Debounce update value at 3 seconds
+            clearTimeout(updateValueTimer.current ?? undefined);
+
+            //TODO: when you try to leave the page before it saved you will lose work
+            //so prompt the user on page leave
+            updateValueTimer.current = window.setTimeout(function () {
+                if (
+                    lastReportedDoenetML.current !== editorDoenetMLRef.current
+                ) {
+                    lastReportedDoenetML.current = editorDoenetMLRef.current;
+                    doenetmlChangeCallbackRef.current?.(
+                        editorDoenetMLRef.current,
+                    );
+                }
+                updateValueTimer.current = null;
+            }, 3000); //3 seconds
+        }
+    }, []);
 
     const onBlur = useCallback(() => {
         window.clearTimeout(updateValueTimer.current ?? undefined);
         if (lastReportedDoenetML.current !== editorDoenetMLRef.current) {
             lastReportedDoenetML.current = editorDoenetMLRef.current;
-            doenetmlChangeCallback?.(editorDoenetMLRef.current);
+            doenetmlChangeCallbackRef.current?.(editorDoenetMLRef.current);
         }
         updateValueTimer.current = null;
-    }, [
-        doenetmlChangeCallback,
-        updateValueTimer,
-        lastReportedDoenetML,
-        editorDoenetMLRef,
-    ]);
+    }, []);
 
     const onCursorChange = useCallback((selection: EditorSelection) => {
         const offset = selection.main.head;
@@ -631,7 +643,13 @@ export const EditorViewer = React.forwardRef<
                     lastReportedDoenetML.current !== editorDoenetMLRef.current
                 ) {
                     lastReportedDoenetML.current = editorDoenetMLRef.current;
-                    doenetmlChangeCallback?.(editorDoenetMLRef.current);
+                    // Routed through the ref mirror so the *latest* callback
+                    // fires at unmount, not whichever one was passed on
+                    // initial render. (The empty dep array would otherwise
+                    // capture a stale closure.)
+                    doenetmlChangeCallbackRef.current?.(
+                        editorDoenetMLRef.current,
+                    );
                 }
             }
             // Cancel pending help-debounce so its callback can't fire

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -392,31 +392,22 @@ export const EditorViewer = React.forwardRef<
     // Hold consumer-supplied callbacks in refs so inline-callback identity
     // churn (the common case) doesn't invalidate the `useCallback`/`useEffect`
     // deps below — which would otherwise re-identify `useImperativeHandle`'s
-    // output on every parent render. Routing through `*Ref.current` also
-    // avoids stale-closure bugs in hooks with empty dep arrays (e.g. the
-    // unmount cleanup below).
+    // output on every parent render. Sync happens at render time (not in a
+    // `useEffect`) so `*Ref.current` always holds the latest prop, even if a
+    // callback fires from a parent `useLayoutEffect` between commit and
+    // effect flush; this also lets the unmount cleanup (empty-dep `useEffect`
+    // below) read the latest value rather than a stale closure.
     const diagnosticsSummaryCallbackRef = useRef(diagnosticsSummaryCallback);
-    useEffect(() => {
-        diagnosticsSummaryCallbackRef.current = diagnosticsSummaryCallback;
-    }, [diagnosticsSummaryCallback]);
-
+    diagnosticsSummaryCallbackRef.current = diagnosticsSummaryCallback;
     const doenetmlChangeCallbackRef = useRef(doenetmlChangeCallback);
-    useEffect(() => {
-        doenetmlChangeCallbackRef.current = doenetmlChangeCallback;
-    }, [doenetmlChangeCallback]);
-
+    doenetmlChangeCallbackRef.current = doenetmlChangeCallback;
     const immediateDoenetmlChangeCallbackRef = useRef(
         immediateDoenetmlChangeCallback,
     );
-    useEffect(() => {
-        immediateDoenetmlChangeCallbackRef.current =
-            immediateDoenetmlChangeCallback;
-    }, [immediateDoenetmlChangeCallback]);
-
+    immediateDoenetmlChangeCallbackRef.current =
+        immediateDoenetmlChangeCallback;
     const documentStructureCallbackRef = useRef(documentStructureCallback);
-    useEffect(() => {
-        documentStructureCallbackRef.current = documentStructureCallback;
-    }, [documentStructureCallback]);
+    documentStructureCallbackRef.current = documentStructureCallback;
 
     useEffect(() => {
         // On initial load of the editor, don't call `diagnosticsSummaryCallback`


### PR DESCRIPTION
## Summary

- Route `doenetmlChangeCallback`, `immediateDoenetmlChangeCallback`, and `documentStructureCallback` through ref mirrors in `EditorViewer.tsx`, mirroring the existing `diagnosticsSummaryCallbackRef` pattern. Inline-callback identity churn (the common case for consumers) no longer invalidates the editor's internal `useCallback` deps, so `useImperativeHandle`'s output is stable across parent re-renders and the Ctrl/Cmd-S `keydown` listener no longer re-binds on every render.
- Fix a stale-closure bug in the unmount cleanup: it had an empty dep array and read `doenetmlChangeCallback` directly, so it would fire the *initial* callback at unmount even if the consumer had since swapped the prop. Now routes through `doenetmlChangeCallbackRef.current` and fires the latest one.
- `DocViewer.tsx` is intentionally untouched. Audited every callback prop reference there — `generatedVariantCallback`, `setDiagnosticsCallback`, `reportScoreAndStateCallback`, `documentStructureCallback`, `initializedCallback` — and none sit inside a hook body with the callback in its dep array. They live in plain function definitions (`initializeRenderers`, `updateRenderers`, `startCore`) or `Comlink.proxy()` arguments. The issue's stated rule scopes them out.

Closes #1110.

## Test plan

- [x] `npm run build -w @doenet/doenetml` passes (TS + Vite).
- [x] `npx prettier --check` clean on the edited file.
- [ ] `npm run test:e2e-group1` (and any other editor-touching groups) — please run on CI; the existing editor Cypress suite exercises the typing → `immediateDoenetmlChangeCallback`, debounce/blur → `doenetmlChangeCallback`, and structure-update → `documentStructureCallback` paths, so any invocation regression would surface there.
- [ ] Manual ref-stability check: wrap `<DoenetEditor>` in a parent that forces re-renders; `useEffect(() => { console.log("churn"); }, [editorRef.current])` should fire once on mount, not per parent render.
- [ ] Manual stale-closure check: mount with `doenetmlChangeCallback={v => log("v1", v)}`, edit text (starting the 3s debounce), swap parent to render with `doenetmlChangeCallback={v => log("v2", v)}`, then unmount. Expect `"v2"` in the log; pre-fix this would log `"v1"`.

## Out of scope

- Latent staleness in `DocViewer.tsx`'s `Comlink.proxy(reportScoreAndStateCallback)` (line 1063) and `documentStructureCallback` passed to `initializeCoreWorker` (lines 438/1038/1293). These capture the prop value at proxy-creation time and would not pick up later swaps; defer to a follow-up since they need a different mechanism (stable proxy wrappers, not just refs).
- Memoization advice for consumers — they shouldn't have to memoize.
- Extracting a `useLatestRef` / `useEvent` utility — the issue explicitly defers this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)