### PR TITLE
chore(tests): silence CI test-output noise; route variant logs to info diagnostics

### DIFF
--- a/.changeset/variant-info-diagnostics.md
+++ b/.changeset/variant-info-diagnostics.md
@@ -1,0 +1,9 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Surface variant-time validation messages as `info` diagnostics instead of writing them to the browser console. When a document can't compute unique variants (e.g. a `<select>` with `selectWeight` or `selectForVariants`, a `<selectFromSequence>` with non-integer `numToSelect`, or a `requestedVariantIndex` that isn't a finite integer), the explanation now appears in the editor's diagnostics panel and flows through `diagnosticsSummaryCallback` / `setDiagnosticsCallback` like any other info record, rather than being dropped into `console.log` where authors couldn't see it. The `<select>` component's messages also no longer claim to be from `selectFromSequence`.

--- a/packages/doenetml-to-pretext/src/renderers/pretext-xml/jsxgraph/listeners.ts
+++ b/packages/doenetml-to-pretext/src/renderers/pretext-xml/jsxgraph/listeners.ts
@@ -27,30 +27,24 @@ export function attachStandardGraphListeners<T extends JSG.GeometryElement>(
         ) {
             interactionState.dragActive = true;
         }
-        console.log("dragging", obj.elType, { interactionState, obj });
     });
     obj.on("down", function (_e) {
         const e = _e as MouseEvent;
         interactionState.pointerAtDown = [e.x, e.y];
-        console.log("down", obj.elType, { interactionState, obj });
     });
     obj.on("hit", function (_e) {
         interactionState.dragActive = false;
-        console.log("hit", obj.elType, { interactionState, obj });
     });
     obj.on("up", function (_e) {
         interactionState.dragActive = false;
-        console.log("up", obj.elType, { interactionState, obj });
     });
     obj.on("keyfocusout", function (_e) {
         interactionState.dragActive = false;
-        console.log("keyfocusout", obj.elType, { interactionState, obj });
     });
     obj.on("keydown", function (_e) {
         const e = _e as KeyboardEvent;
         if (e.key === "Enter") {
             interactionState.dragActive = false;
         }
-        console.log("keydown", obj.elType, { interactionState, obj });
     });
 }

--- a/packages/doenetml-to-pretext/src/state/redux-slices/global/thunks.ts
+++ b/packages/doenetml-to-pretext/src/state/redux-slices/global/thunks.ts
@@ -21,7 +21,6 @@ export const globalThunks = {
     setDarkMode: createLoggingAsyncThunk(
         "global/setDarkMode",
         async (darkMode: boolean, { dispatch }) => {
-            console.log("setDarkMode", darkMode);
             document.querySelector("html")?.classList.toggle("dark", darkMode);
             dispatch(_globalReducerActions._setDarkMode(darkMode));
         },

--- a/packages/doenetml-to-pretext/src/utils/pretext/ensure-pretext-tag.ts
+++ b/packages/doenetml-to-pretext/src/utils/pretext/ensure-pretext-tag.ts
@@ -40,9 +40,6 @@ export function ensurePretextTag(
         flatDast.children = [{ id, annotation: "original" }];
     }
 
-    if (!pretextElement.children) {
-        console.log("No children", pretextElement);
-    }
     // Ensure that a <book> or <article> tag is immediately inside the <pretext> tag
     // There may be a <docinfo> tag that is a sibling of the division tag.
     const hasDivisionTag = pretextElement.children.find(

--- a/packages/doenetml-worker-javascript/src/Core.ts
+++ b/packages/doenetml-worker-javascript/src/Core.ts
@@ -462,6 +462,10 @@ export default class Core {
 
         this.unmatchedChildren = {};
 
+        // No `infoDiagnostics` buffer: info diagnostics were already emitted
+        // and pushed into `preliminaryDiagnostics` during the earlier
+        // `returnAllPossibleVariants` call in `CoreWorker.initializeWorker`.
+        // Passing one here would duplicate those records.
         let numVariants = getNumVariants({
             serializedComponent: serializedComponents[0],
             componentInfoObjects: this.componentInfoObjects,

--- a/packages/doenetml-worker-javascript/src/CoreWorker.ts
+++ b/packages/doenetml-worker-javascript/src/CoreWorker.ts
@@ -165,9 +165,14 @@ export class PublicDoenetMLCore {
 
         this.initialized = true;
 
+        // `returnAllPossibleVariants` walks the variant tree before Core
+        // exists, so any info-typed diagnostics emitted along the way are
+        // appended to the same `diagnostics` array that becomes
+        // `preliminaryDiagnostics` when Core is constructed.
         let allPossibleVariants = await returnAllPossibleVariants(
             this.coreBaseArgs.serializedDocument,
             this.coreBaseArgs.componentInfoObjects,
+            diagnostics,
         );
 
         // count the number of occurrences of each component type from the document's immediate children

--- a/packages/doenetml-worker-javascript/src/components/ChoiceInput.js
+++ b/packages/doenetml-worker-javascript/src/components/ChoiceInput.js
@@ -1649,11 +1649,13 @@ export default class Choiceinput extends Input {
     static determineNumberOfUniqueVariants({
         serializedComponent,
         componentInfoObjects,
+        infoDiagnostics,
     }) {
         if (!serializedComponent.attributes?.shuffleOrder?.primitive.value) {
             return super.determineNumberOfUniqueVariants({
                 serializedComponent,
                 componentInfoObjects,
+                infoDiagnostics,
             });
         }
 
@@ -1705,6 +1707,7 @@ export default class Choiceinput extends Input {
         let result = super.determineNumberOfUniqueVariants({
             serializedComponent,
             componentInfoObjects,
+            infoDiagnostics,
         });
 
         if (!result.success) {

--- a/packages/doenetml-worker-javascript/src/components/Document.js
+++ b/packages/doenetml-worker-javascript/src/components/Document.js
@@ -748,7 +748,7 @@ export default class Document extends BaseComponent {
             if (desiredVariant.index !== undefined) {
                 let desiredVariantIndex = Number(desiredVariant.index);
                 if (!Number.isFinite(desiredVariantIndex)) {
-                    core?.addDiagnostic({
+                    core.addDiagnostic({
                         type: "info",
                         message:
                             "Variant index " +
@@ -760,7 +760,7 @@ export default class Document extends BaseComponent {
                     variantIndex = 1;
                 } else {
                     if (!Number.isInteger(desiredVariantIndex)) {
-                        core?.addDiagnostic({
+                        core.addDiagnostic({
                             type: "info",
                             message:
                                 "Variant index " +

--- a/packages/doenetml-worker-javascript/src/components/Document.js
+++ b/packages/doenetml-worker-javascript/src/components/Document.js
@@ -735,6 +735,7 @@ export default class Document extends BaseComponent {
         serializedComponent,
         sharedParameters,
         descendantVariantComponents,
+        core,
     }) {
         // console.log("****Variant for document*****")
 
@@ -747,19 +748,27 @@ export default class Document extends BaseComponent {
             if (desiredVariant.index !== undefined) {
                 let desiredVariantIndex = Number(desiredVariant.index);
                 if (!Number.isFinite(desiredVariantIndex)) {
-                    console.warn(
-                        "Variant index " +
+                    core?.addDiagnostic({
+                        type: "info",
+                        message:
+                            "Variant index " +
                             desiredVariant.index +
                             " must be a number",
-                    );
+                        position: serializedComponent.position,
+                        sourceDoc: serializedComponent.sourceDoc,
+                    });
                     variantIndex = 1;
                 } else {
                     if (!Number.isInteger(desiredVariantIndex)) {
-                        console.warn(
-                            "Variant index " +
+                        core?.addDiagnostic({
+                            type: "info",
+                            message:
+                                "Variant index " +
                                 desiredVariant.index +
                                 " must be an integer",
-                        );
+                            position: serializedComponent.position,
+                            sourceDoc: serializedComponent.sourceDoc,
+                        });
                         desiredVariantIndex = Math.round(desiredVariantIndex);
                     }
                     let indexFrom0 = (desiredVariantIndex - 1) % numVariants;
@@ -821,11 +830,13 @@ export default class Document extends BaseComponent {
     static determineNumberOfUniqueVariants({
         serializedComponent,
         componentInfoObjects,
+        infoDiagnostics,
     }) {
         return determineVariantsForSection({
             serializedComponent,
             componentInfoObjects,
             isDocument: true,
+            infoDiagnostics,
         });
     }
 
@@ -850,8 +861,6 @@ export default class Document extends BaseComponent {
         });
 
         if (!result.success) {
-            console.log("Failed to get unique variant for document.");
-
             return { success: false };
         }
 

--- a/packages/doenetml-worker-javascript/src/components/PretzelArranger.js
+++ b/packages/doenetml-worker-javascript/src/components/PretzelArranger.js
@@ -635,6 +635,7 @@ export default class PretzelArranger extends CompositeComponent {
     static determineNumberOfUniqueVariants({
         serializedComponent,
         componentInfoObjects,
+        infoDiagnostics,
     }) {
         let numProblems = 0;
         const mode = normalizePretzelMode(
@@ -677,6 +678,7 @@ export default class PretzelArranger extends CompositeComponent {
         let result = super.determineNumberOfUniqueVariants({
             serializedComponent,
             componentInfoObjects,
+            infoDiagnostics,
         });
 
         if (!result.success) {

--- a/packages/doenetml-worker-javascript/src/components/Repeat.js
+++ b/packages/doenetml-worker-javascript/src/components/Repeat.js
@@ -670,6 +670,7 @@ export default class Repeat extends CompositeComponent {
     static determineNumberOfUniqueVariants({
         serializedComponent,
         componentInfoObjects,
+        infoDiagnostics,
     }) {
         let numVariants = serializedComponent.variants?.numVariants;
 
@@ -691,6 +692,7 @@ export default class Repeat extends CompositeComponent {
             let result = descendantClass.determineNumberOfUniqueVariants({
                 serializedComponent: descendant,
                 componentInfoObjects,
+                infoDiagnostics,
             });
             if (!result.success) {
                 return { success: false };

--- a/packages/doenetml-worker-javascript/src/components/RepeatForSequence.js
+++ b/packages/doenetml-worker-javascript/src/components/RepeatForSequence.js
@@ -659,6 +659,7 @@ export default class RepeatForSequence extends CompositeComponent {
     static determineNumberOfUniqueVariants({
         serializedComponent,
         componentInfoObjects,
+        infoDiagnostics,
     }) {
         let numVariants = serializedComponent.variants?.numVariants;
 
@@ -680,6 +681,7 @@ export default class RepeatForSequence extends CompositeComponent {
             let result = descendantClass.determineNumberOfUniqueVariants({
                 serializedComponent: descendant,
                 componentInfoObjects,
+                infoDiagnostics,
             });
             if (!result.success) {
                 return { success: false };

--- a/packages/doenetml-worker-javascript/src/components/SamplePrimeNumbers.js
+++ b/packages/doenetml-worker-javascript/src/components/SamplePrimeNumbers.js
@@ -374,6 +374,7 @@ export default class SamplePrimeNumbers extends CompositeComponent {
     static determineNumberOfUniqueVariants({
         serializedComponent,
         componentInfoObjects,
+        infoDiagnostics,
     }) {
         let variantDeterminesSeed =
             serializedComponent.attributes.variantDeterminesSeed.primitive
@@ -385,6 +386,7 @@ export default class SamplePrimeNumbers extends CompositeComponent {
             return super.determineNumberOfUniqueVariants({
                 serializedComponent,
                 componentInfoObjects,
+                infoDiagnostics,
             });
         }
     }

--- a/packages/doenetml-worker-javascript/src/components/SampleRandomNumbers.js
+++ b/packages/doenetml-worker-javascript/src/components/SampleRandomNumbers.js
@@ -822,6 +822,7 @@ export default class SampleRandomNumbers extends CompositeComponent {
     static determineNumberOfUniqueVariants({
         serializedComponent,
         componentInfoObjects,
+        infoDiagnostics,
     }) {
         let variantDeterminesSeed =
             serializedComponent.attributes.variantDeterminesSeed.primitive
@@ -833,6 +834,7 @@ export default class SampleRandomNumbers extends CompositeComponent {
             return super.determineNumberOfUniqueVariants({
                 serializedComponent,
                 componentInfoObjects,
+                infoDiagnostics,
             });
         }
     }

--- a/packages/doenetml-worker-javascript/src/components/Select.js
+++ b/packages/doenetml-worker-javascript/src/components/Select.js
@@ -699,7 +699,7 @@ export default class Select extends CompositeComponent {
                 if (!(Number.isInteger(numToSelect) && numToSelect >= 0)) {
                     pushVariantInfo(
                         infoDiagnostics,
-                        `cannot determine unique variants of selectFromSequence as numToSelect isn't a non-negative integer.`,
+                        `cannot determine unique variants of select as numToSelect isn't a non-negative integer.`,
                         serializedComponent,
                     );
                     return { success: false };
@@ -707,7 +707,7 @@ export default class Select extends CompositeComponent {
             } else {
                 pushVariantInfo(
                     infoDiagnostics,
-                    `cannot determine unique variants of selectFromSequence as numToSelect isn't constant number.`,
+                    `cannot determine unique variants of select as numToSelect isn't constant number.`,
                     serializedComponent,
                 );
                 return { success: false };
@@ -735,7 +735,7 @@ export default class Select extends CompositeComponent {
                 } else {
                     pushVariantInfo(
                         infoDiagnostics,
-                        `cannot determine unique variants of selectFromSequence as withReplacement isn't constant boolean.`,
+                        `cannot determine unique variants of select as withReplacement isn't constant boolean.`,
                         serializedComponent,
                     );
                     return { success: false };
@@ -743,7 +743,7 @@ export default class Select extends CompositeComponent {
             } else {
                 pushVariantInfo(
                     infoDiagnostics,
-                    `cannot determine unique variants of selectFromSequence as withReplacement isn't constant boolean.`,
+                    `cannot determine unique variants of select as withReplacement isn't constant boolean.`,
                     serializedComponent,
                 );
                 return { success: false };

--- a/packages/doenetml-worker-javascript/src/components/Select.js
+++ b/packages/doenetml-worker-javascript/src/components/Select.js
@@ -4,7 +4,7 @@ import {
     enumerateSelectionCombinations,
     enumerateCombinations,
 } from "@doenet/utils";
-import { gatherVariantComponents } from "../utils/variants";
+import { gatherVariantComponents, pushVariantInfo } from "../utils/variants";
 import { createNewComponentIndices } from "../utils/componentIndices";
 
 export default class Select extends CompositeComponent {
@@ -674,6 +674,7 @@ export default class Select extends CompositeComponent {
     static determineNumberOfUniqueVariants({
         serializedComponent,
         componentInfoObjects,
+        infoDiagnostics,
     }) {
         let numVariants = serializedComponent.variants?.numVariants;
 
@@ -696,14 +697,18 @@ export default class Select extends CompositeComponent {
                 numToSelect = Number(numToSelectComponent.children[0]);
 
                 if (!(Number.isInteger(numToSelect) && numToSelect >= 0)) {
-                    console.log(
+                    pushVariantInfo(
+                        infoDiagnostics,
                         `cannot determine unique variants of selectFromSequence as numToSelect isn't a non-negative integer.`,
+                        serializedComponent,
                     );
                     return { success: false };
                 }
             } else {
-                console.log(
+                pushVariantInfo(
+                    infoDiagnostics,
                     `cannot determine unique variants of selectFromSequence as numToSelect isn't constant number.`,
+                    serializedComponent,
                 );
                 return { success: false };
             }
@@ -728,14 +733,18 @@ export default class Select extends CompositeComponent {
                 ) {
                     withReplacement = withReplacementComponent.state.value;
                 } else {
-                    console.log(
+                    pushVariantInfo(
+                        infoDiagnostics,
                         `cannot determine unique variants of selectFromSequence as withReplacement isn't constant boolean.`,
+                        serializedComponent,
                     );
                     return { success: false };
                 }
             } else {
-                console.log(
+                pushVariantInfo(
+                    infoDiagnostics,
                     `cannot determine unique variants of selectFromSequence as withReplacement isn't constant boolean.`,
+                    serializedComponent,
                 );
                 return { success: false };
             }
@@ -747,8 +756,10 @@ export default class Select extends CompositeComponent {
                 child.attributes?.selectForVariants
             ) {
                 // uniqueVariants disabled if have a child with selectWeight or selectForVariants specified
-                console.log(
+                pushVariantInfo(
+                    infoDiagnostics,
                     `Unique variants for select disabled if have an option with selectWeight or selectForVariants specified`,
+                    serializedComponent,
                 );
                 return { success: false };
             }
@@ -775,6 +786,7 @@ export default class Select extends CompositeComponent {
             let result = descendantClass.determineNumberOfUniqueVariants({
                 serializedComponent: descendant,
                 componentInfoObjects,
+                infoDiagnostics,
             });
             if (!result.success) {
                 return { success: false };

--- a/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
@@ -9,7 +9,10 @@ import { lettersToNumber, enumerateSelectionCombinations } from "@doenet/utils";
 import { convertUnresolvedAttributesForComponentType } from "../utils/dast/convertNormalizedDast";
 import { returnNumberDisplayAttributes } from "../utils/numberDisplay";
 import { textToMathFactory } from "../utils/math";
-import { extractConstantSortAttribute } from "../utils/variants";
+import {
+    extractConstantSortAttribute,
+    pushVariantInfo,
+} from "../utils/variants";
 import {
     checkForExcludedCombination,
     estimateNumberOfDuplicateCombinations,
@@ -396,7 +399,12 @@ export default class SelectFromSequence extends Sequence {
         return { replacementChanges: [], nComponents };
     }
 
-    static determineNumberOfUniqueVariants({ serializedComponent }) {
+    static determineNumberOfUniqueVariants({
+        serializedComponent,
+        infoDiagnostics,
+    }) {
+        const info = (message) =>
+            pushVariantInfo(infoDiagnostics, message, serializedComponent);
         let numToSelect = 1,
             withReplacement = false;
 
@@ -414,13 +422,13 @@ export default class SelectFromSequence extends Sequence {
                 numToSelect = Number(numToSelectComponent.children[0]);
 
                 if (!(Number.isInteger(numToSelect) && numToSelect >= 0)) {
-                    console.log(
+                    info(
                         `cannot determine unique variants of selectFromSequence as numToSelect isn't a non-negative integer.`,
                     );
                     return { success: false };
                 }
             } else {
-                console.log(
+                info(
                     `cannot determine unique variants of selectFromSequence as numToSelect isn't constant number.`,
                 );
                 return { success: false };
@@ -443,7 +451,7 @@ export default class SelectFromSequence extends Sequence {
                         .toLowerCase() === "false"
                 )
             ) {
-                console.log(
+                info(
                     `cannot determine unique variants of selectFromSequence as cannot determine coprime is always false.`,
                 );
                 return { success: false };
@@ -469,13 +477,13 @@ export default class SelectFromSequence extends Sequence {
                 ) {
                     withReplacement = withReplacementComponent.state.value;
                 } else {
-                    console.log(
+                    info(
                         `cannot determine unique variants of selectFromSequence as withReplacement isn't constant boolean.`,
                     );
                     return { success: false };
                 }
             } else {
-                console.log(
+                info(
                     `cannot determine unique variants of selectFromSequence as withReplacement isn't constant boolean.`,
                 );
                 return { success: false };
@@ -503,7 +511,7 @@ export default class SelectFromSequence extends Sequence {
                 if (sequenceType === "number") {
                     from = Number(fromComponent2.children[0]);
                     if (!Number.isFinite(from)) {
-                        console.log(
+                        info(
                             `cannot determine unique variants of selectFromSequence of number type as from isn't a number.`,
                         );
                         return { success: false };
@@ -511,7 +519,7 @@ export default class SelectFromSequence extends Sequence {
                 } else if (sequenceType === "letters") {
                     from = lettersToNumber(fromComponent2.children[0]);
                     if (!Number.isFinite(from)) {
-                        console.log(
+                        info(
                             `cannot determine unique variants of selectFromSequence of letters type as from isn't a combination of letters.`,
                         );
                         return { success: false };
@@ -523,7 +531,7 @@ export default class SelectFromSequence extends Sequence {
                     try {
                         from = fromText(fromComponent2.children[0]);
                     } catch (e) {
-                        console.log(
+                        info(
                             `cannot determine unique variants of selectFromSequence of math type as from isn't a valid math expression.`,
                         );
                         return { success: false };
@@ -531,7 +539,7 @@ export default class SelectFromSequence extends Sequence {
                 }
                 sequencePars.from = from;
             } else {
-                console.log(
+                info(
                     `cannot determine unique variants of selectFromSequence as from isn't a constant.`,
                 );
                 return { success: false };
@@ -552,7 +560,7 @@ export default class SelectFromSequence extends Sequence {
                 if (sequenceType === "number") {
                     to = Number(toComponent2.children[0]);
                     if (!Number.isFinite(to)) {
-                        console.log(
+                        info(
                             `cannot determine unique variants of selectFromSequence of number type as to isn't a number.`,
                         );
                         return { success: false };
@@ -560,7 +568,7 @@ export default class SelectFromSequence extends Sequence {
                 } else if (sequenceType === "letters") {
                     to = lettersToNumber(toComponent2.children[0]);
                     if (!Number.isFinite(to)) {
-                        console.log(
+                        info(
                             `cannot determine unique variants of selectFromSequence of letters type as to isn't a combination of letters.`,
                         );
                         return { success: false };
@@ -572,7 +580,7 @@ export default class SelectFromSequence extends Sequence {
                     try {
                         to = fromText(toComponent2.children[0]);
                     } catch (e) {
-                        console.log(
+                        info(
                             `cannot determine unique variants of selectFromSequence of math type as to isn't a valid math expression.`,
                         );
                         return { success: false };
@@ -580,7 +588,7 @@ export default class SelectFromSequence extends Sequence {
                 }
                 sequencePars.to = to;
             } else {
-                console.log(
+                info(
                     `cannot determine unique variants of selectFromSequence as to isn't a constant.`,
                 );
                 return { success: false };
@@ -599,7 +607,7 @@ export default class SelectFromSequence extends Sequence {
                 if (sequenceType === "number") {
                     step = Number(stepComponent.children[0]);
                     if (!Number.isFinite(step)) {
-                        console.log(
+                        info(
                             `cannot determine unique variants of selectFromSequence of number type as step isn't a number.`,
                         );
                         return { success: false };
@@ -607,7 +615,7 @@ export default class SelectFromSequence extends Sequence {
                 } else if (sequenceType === "letters") {
                     step = Number(stepComponent.children[0]);
                     if (!Number.isInteger(step)) {
-                        console.log(
+                        info(
                             `cannot determine unique variants of selectFromSequence of letters type as step isn't an integer.`,
                         );
                         return { success: false };
@@ -619,7 +627,7 @@ export default class SelectFromSequence extends Sequence {
                     try {
                         step = fromText(stepComponent.children[0]);
                     } catch (e) {
-                        console.log(
+                        info(
                             `cannot determine unique variants of selectFromSequence of math type as step isn't a valid math expression.`,
                         );
                         return { success: false };
@@ -627,7 +635,7 @@ export default class SelectFromSequence extends Sequence {
                 }
                 sequencePars.step = step;
             } else {
-                console.log(
+                info(
                     `cannot determine unique variants of selectFromSequence as step isn't a constant.`,
                 );
                 return { success: false };
@@ -643,14 +651,14 @@ export default class SelectFromSequence extends Sequence {
             ) {
                 let length = Number(lengthComponent.children[0]);
                 if (!Number.isInteger(length)) {
-                    console.log(
+                    info(
                         `cannot determine unique variants of selectFromSequence as length isn't an integer.`,
                     );
                     return { success: false };
                 }
                 sequencePars.length = length;
             } else {
-                console.log(
+                info(
                     `cannot determine unique variants of selectFromSequence as length isn't a constant.`,
                 );
                 return { success: false };
@@ -658,7 +666,7 @@ export default class SelectFromSequence extends Sequence {
         }
 
         if (serializedComponent.attributes.excludeCombinations) {
-            console.log(
+            info(
                 "have not implemented unique variants of a selectFromSequence with excludeCombinations",
             );
             return { success: false };
@@ -670,7 +678,7 @@ export default class SelectFromSequence extends Sequence {
             serializedComponent.attributes.exclude?.component;
         if (excludeComponent) {
             if (sequenceType === "math") {
-                console.log(
+                info(
                     "have not implemented unique variants of a selectFromSequence of type math with exclude",
                 );
                 return { success: false };
@@ -682,7 +690,7 @@ export default class SelectFromSequence extends Sequence {
                         typeof x.children[0] === "string",
                 )
             ) {
-                console.log(
+                info(
                     "have not implemented unique variants of a selectFromSequence with non-constant exclude",
                 );
                 return { success: false };
@@ -698,7 +706,7 @@ export default class SelectFromSequence extends Sequence {
             }
 
             if (!excludes.every(Number.isFinite)) {
-                console.log(
+                info(
                     "have not implemented unique variants of a selectFromSequence with non-constant exclude",
                 );
                 return { success: false };
@@ -709,6 +717,7 @@ export default class SelectFromSequence extends Sequence {
             serializedComponent,
             "selectFromSequence",
             numToSelect,
+            infoDiagnostics,
         );
         if (!sortResult.success) {
             return { success: false };

--- a/packages/doenetml-worker-javascript/src/components/SelectPrimeNumbers.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectPrimeNumbers.js
@@ -1,5 +1,8 @@
 import { enumerateSelectionCombinations } from "@doenet/utils";
-import { extractConstantSortAttribute } from "../utils/variants";
+import {
+    extractConstantSortAttribute,
+    pushVariantInfo,
+} from "../utils/variants";
 import {
     checkForExcludedCombination,
     estimateNumberOfDuplicateCombinations,
@@ -339,7 +342,12 @@ export default class SelectPrimeNumbers extends CompositeComponent {
         return { replacementChanges: [], nComponents };
     }
 
-    static determineNumberOfUniqueVariants({ serializedComponent }) {
+    static determineNumberOfUniqueVariants({
+        serializedComponent,
+        infoDiagnostics,
+    }) {
+        const info = (message) =>
+            pushVariantInfo(infoDiagnostics, message, serializedComponent);
         let numToSelect = 1,
             withReplacement = false;
 
@@ -355,13 +363,13 @@ export default class SelectPrimeNumbers extends CompositeComponent {
                 numToSelect = Number(numToSelectComponent.children[0]);
 
                 if (!(Number.isInteger(numToSelect) && numToSelect >= 0)) {
-                    console.log(
+                    info(
                         `cannot determine unique variants of selectPrimeNumbers as numToSelect isn't a non-negative integer.`,
                     );
                     return { success: false };
                 }
             } else {
-                console.log(
+                info(
                     `cannot determine unique variants of selectPrimeNumbers as numToSelect isn't constant number.`,
                 );
                 return { success: false };
@@ -387,13 +395,13 @@ export default class SelectPrimeNumbers extends CompositeComponent {
                 ) {
                     withReplacement = withReplacementComponent.state.value;
                 } else {
-                    console.log(
+                    info(
                         `cannot determine unique variants of selectPrimeNumbers as withReplacement isn't constant boolean.`,
                     );
                     return { success: false };
                 }
             } else {
-                console.log(
+                info(
                     `cannot determine unique variants of selectPrimeNumbers as withReplacement isn't constant boolean.`,
                 );
                 return { success: false };
@@ -411,14 +419,14 @@ export default class SelectPrimeNumbers extends CompositeComponent {
             ) {
                 let from = Number(fromComponent.children[0]);
                 if (!Number.isFinite(from)) {
-                    console.log(
+                    info(
                         `cannot determine unique variants of selectPrimeNumbers as from isn't a number.`,
                     );
                     return { success: false };
                 }
                 primePars.from = from;
             } else {
-                console.log(
+                info(
                     `cannot determine unique variants of selectPrimeNumbers as from isn't a constant.`,
                 );
                 return { success: false };
@@ -434,14 +442,14 @@ export default class SelectPrimeNumbers extends CompositeComponent {
             ) {
                 let to = Number(toComponent.children[0]);
                 if (!Number.isFinite(to)) {
-                    console.log(
+                    info(
                         `cannot determine unique variants of selectPrimeNumbers as to isn't a number.`,
                     );
                     return { success: false };
                 }
                 primePars.to = to;
             } else {
-                console.log(
+                info(
                     `cannot determine unique variants of selectPrimeNumbers as to isn't a constant.`,
                 );
                 return { success: false };
@@ -449,7 +457,7 @@ export default class SelectPrimeNumbers extends CompositeComponent {
         }
 
         if (serializedComponent.attributes.excludeCombinations) {
-            console.log(
+            info(
                 "have not implemented unique variants of a selectPrimeNumbers with excludeCombinations",
             );
             return { success: false };
@@ -465,7 +473,7 @@ export default class SelectPrimeNumbers extends CompositeComponent {
                         typeof x.children[0] === "string",
                 )
             ) {
-                console.log(
+                info(
                     "have not implemented unique variants of a selectPrimeNumbers with non-constant exclude",
                 );
                 return { success: false };
@@ -475,7 +483,7 @@ export default class SelectPrimeNumbers extends CompositeComponent {
             );
 
             if (!exclude.every(Number.isFinite)) {
-                console.log(
+                info(
                     "have not implemented unique variants of a selectPrimeNumbers with non-constant exclude",
                 );
                 return { success: false };
@@ -487,6 +495,7 @@ export default class SelectPrimeNumbers extends CompositeComponent {
             serializedComponent,
             "selectPrimeNumbers",
             numToSelect,
+            infoDiagnostics,
         );
         if (!sortResult.success) {
             return { success: false };

--- a/packages/doenetml-worker-javascript/src/components/Shuffle.js
+++ b/packages/doenetml-worker-javascript/src/components/Shuffle.js
@@ -462,6 +462,7 @@ export default class Shuffle extends CompositeComponent {
     static determineNumberOfUniqueVariants({
         serializedComponent,
         componentInfoObjects,
+        infoDiagnostics,
     }) {
         let numComponents = 0;
 
@@ -506,6 +507,7 @@ export default class Shuffle extends CompositeComponent {
         let result = super.determineNumberOfUniqueVariants({
             serializedComponent,
             componentInfoObjects,
+            infoDiagnostics,
         });
 
         if (!result.success) {

--- a/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
@@ -1848,6 +1848,7 @@ export default class BaseComponent {
     static determineNumberOfUniqueVariants({
         serializedComponent,
         componentInfoObjects,
+        infoDiagnostics,
     }) {
         let numVariants = serializedComponent.variants?.numVariants;
 
@@ -1884,6 +1885,7 @@ export default class BaseComponent {
             let result = descendantClass.determineNumberOfUniqueVariants({
                 serializedComponent: descendant,
                 componentInfoObjects,
+                infoDiagnostics,
             });
             if (!result.success) {
                 return { success: false };

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -1153,6 +1153,7 @@ export class SectioningComponent extends BlockComponent {
         serializedComponent,
         sharedParameters,
         descendantVariantComponents,
+        core,
     }) {
         if (!serializedComponent.variants?.allPossibleVariants) {
             // no variant control child
@@ -1178,19 +1179,27 @@ export class SectioningComponent extends BlockComponent {
             if (desiredVariant.index !== undefined) {
                 let desiredVariantIndex = Number(desiredVariant.index);
                 if (!Number.isFinite(desiredVariantIndex)) {
-                    console.warn(
-                        "Variant index " +
+                    core?.addDiagnostic({
+                        type: "info",
+                        message:
+                            "Variant index " +
                             desiredVariant.index +
                             " must be a number",
-                    );
+                        position: serializedComponent.position,
+                        sourceDoc: serializedComponent.sourceDoc,
+                    });
                     variantIndex = 1;
                 } else {
                     if (!Number.isInteger(desiredVariantIndex)) {
-                        console.warn(
-                            "Variant index " +
+                        core?.addDiagnostic({
+                            type: "info",
+                            message:
+                                "Variant index " +
                                 desiredVariant.index +
                                 " must be an integer",
-                        );
+                            position: serializedComponent.position,
+                            sourceDoc: serializedComponent.sourceDoc,
+                        });
                         desiredVariantIndex = Math.round(desiredVariantIndex);
                     }
                     let indexFrom0 = (desiredVariantIndex - 1) % numVariants;
@@ -1255,10 +1264,12 @@ export class SectioningComponent extends BlockComponent {
     static determineNumberOfUniqueVariants({
         serializedComponent,
         componentInfoObjects,
+        infoDiagnostics,
     }) {
         return determineVariantsForSection({
             serializedComponent,
             componentInfoObjects,
+            infoDiagnostics,
         });
     }
 
@@ -1301,8 +1312,6 @@ export class SectioningComponent extends BlockComponent {
         });
 
         if (!result.success) {
-            console.log("Failed to get unique variant for section.");
-
             return { success: false };
         }
 

--- a/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/SectioningComponent.js
@@ -1179,7 +1179,7 @@ export class SectioningComponent extends BlockComponent {
             if (desiredVariant.index !== undefined) {
                 let desiredVariantIndex = Number(desiredVariant.index);
                 if (!Number.isFinite(desiredVariantIndex)) {
-                    core?.addDiagnostic({
+                    core.addDiagnostic({
                         type: "info",
                         message:
                             "Variant index " +
@@ -1191,7 +1191,7 @@ export class SectioningComponent extends BlockComponent {
                     variantIndex = 1;
                 } else {
                     if (!Number.isInteger(desiredVariantIndex)) {
-                        core?.addDiagnostic({
+                        core.addDiagnostic({
                             type: "info",
                             message:
                                 "Variant index " +

--- a/packages/doenetml-worker-javascript/src/core/ComponentBuilder.ts
+++ b/packages/doenetml-worker-javascript/src/core/ComponentBuilder.ts
@@ -407,6 +407,7 @@ export async function createChildrenThenComponent({
                 serializedComponent,
                 sharedParameters,
                 descendantVariantComponents,
+                core,
             });
         }
 

--- a/packages/doenetml-worker-javascript/src/test/diagnostics/warningsInfos.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/diagnostics/warningsInfos.test.ts
@@ -854,4 +854,86 @@ describe("Warning Tests @group4", async () => {
             );
         }
     });
+
+    // The variant-time diagnostics below cover code paths that previously
+    // emitted raw console.log/console.warn. They are now routed through
+    // `preliminaryDiagnostics` (variant resolution) or `core.addDiagnostic`
+    // (`setUpVariant`), so they surface to the user as info records instead
+    // of polluting test output.
+    it("`selectWeight` on an option produces an info: unique variants disabled", async () => {
+        const { core } = await createTestCore({
+            doenetML: `
+<select name="s">
+  <option selectWeight="1"><text>a</text></option>
+  <option selectWeight="2"><text>b</text></option>
+</select>
+            `,
+        });
+
+        const diagnosticsByType = getDiagnosticsByType(core);
+
+        expect(diagnosticsByType.errors.length).eq(0);
+        expect(
+            diagnosticsByType.infos.some((info) =>
+                info.message.includes(
+                    "Unique variants for select disabled if have an option with selectWeight or selectForVariants specified",
+                ),
+            ),
+        ).eq(true);
+    });
+
+    it("non-integer `numToSelect` on selectFromSequence produces an info", async () => {
+        const { core } = await createTestCore({
+            doenetML: `
+<selectFromSequence from="1" to="10" numToSelect="2.5" />
+            `,
+        });
+
+        const diagnosticsByType = getDiagnosticsByType(core);
+
+        expect(diagnosticsByType.errors.length).eq(0);
+        expect(
+            diagnosticsByType.infos.some((info) =>
+                info.message.includes(
+                    "cannot determine unique variants of selectFromSequence as numToSelect isn't a non-negative integer",
+                ),
+            ),
+        ).eq(true);
+    });
+
+    it("non-integer requested variant index produces an info", async () => {
+        const { core } = await createTestCore({
+            doenetML: `<text>hi</text>`,
+            requestedVariantIndex: 2.5,
+        });
+
+        const diagnosticsByType = getDiagnosticsByType(core);
+
+        expect(diagnosticsByType.errors.length).eq(0);
+        expect(
+            diagnosticsByType.infos.some(
+                (info) =>
+                    info.message.includes("Variant index") &&
+                    info.message.includes("must be an integer"),
+            ),
+        ).eq(true);
+    });
+
+    it("non-numeric requested variant index produces an info", async () => {
+        const { core } = await createTestCore({
+            doenetML: `<text>hi</text>`,
+            requestedVariantIndex: NaN,
+        });
+
+        const diagnosticsByType = getDiagnosticsByType(core);
+
+        expect(diagnosticsByType.errors.length).eq(0);
+        expect(
+            diagnosticsByType.infos.some(
+                (info) =>
+                    info.message.includes("Variant index") &&
+                    info.message.includes("must be a number"),
+            ),
+        ).eq(true);
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/utils/test-core.ts
+++ b/packages/doenetml-worker-javascript/src/test/utils/test-core.ts
@@ -64,7 +64,7 @@ export async function createTestCore({
         ),
     );
 
-    await init(wasmBuffer);
+    await init({ module_or_path: wasmBuffer });
 
     const rustCore = PublicDoenetMLCoreRust.new();
 

--- a/packages/doenetml-worker-javascript/src/utils/returnAllPossibleVariants.js
+++ b/packages/doenetml-worker-javascript/src/utils/returnAllPossibleVariants.js
@@ -4,10 +4,12 @@ import { getNumVariants } from "./variants";
 export async function returnAllPossibleVariants(
     serializedDocument,
     componentInfoObjects,
+    infoDiagnostics,
 ) {
     let results = getNumVariants({
         serializedComponent: serializedDocument,
         componentInfoObjects,
+        infoDiagnostics,
     });
 
     let numVariants = results.numVariants;

--- a/packages/doenetml-worker-javascript/src/utils/variants.ts
+++ b/packages/doenetml-worker-javascript/src/utils/variants.ts
@@ -1,4 +1,5 @@
 import { numberToLetters, enumerateCombinations } from "@doenet/utils";
+import type { DiagnosticRecord } from "@doenet/utils";
 import seedrandom from "seedrandom";
 
 // getVariantsForDescendantsForUniqueVariants: only needed in worker
@@ -200,7 +201,11 @@ export function getNumVariants({
     serializedComponent,
     componentInfoObjects,
     infoDiagnostics,
-}: any): any {
+}: {
+    serializedComponent: any;
+    componentInfoObjects: any;
+    infoDiagnostics?: DiagnosticRecord[];
+}): any {
     // get number of variants from document (or other sectioning component)
 
     if (!serializedComponent.variants) {
@@ -292,7 +297,7 @@ export function determineVariantsForSection({
     serializedComponent: any;
     componentInfoObjects: any;
     isDocument: boolean;
-    infoDiagnostics?: any[];
+    infoDiagnostics?: DiagnosticRecord[];
 }) {
     if (serializedComponent.variants === undefined) {
         serializedComponent.variants = {};
@@ -578,7 +583,7 @@ export function extractConstantSortAttribute(
     serializedComponent: any,
     componentName: string,
     numToSelect: number,
-    infoDiagnostics?: any[],
+    infoDiagnostics?: DiagnosticRecord[],
 ): { success: boolean; sort?: string } {
     let sort;
 
@@ -627,7 +632,7 @@ export function extractConstantSortAttribute(
  * drains it into `preliminaryDiagnostics` when it's constructed.
  */
 export function pushVariantInfo(
-    infoDiagnostics: any[] | undefined,
+    infoDiagnostics: DiagnosticRecord[] | undefined,
     message: string,
     serializedComponent: any,
 ) {

--- a/packages/doenetml-worker-javascript/src/utils/variants.ts
+++ b/packages/doenetml-worker-javascript/src/utils/variants.ts
@@ -296,7 +296,7 @@ export function determineVariantsForSection({
 }: {
     serializedComponent: any;
     componentInfoObjects: any;
-    isDocument: boolean;
+    isDocument?: boolean;
     infoDiagnostics?: DiagnosticRecord[];
 }) {
     if (serializedComponent.variants === undefined) {

--- a/packages/doenetml-worker-javascript/src/utils/variants.ts
+++ b/packages/doenetml-worker-javascript/src/utils/variants.ts
@@ -199,6 +199,7 @@ export function gatherVariantComponents({
 export function getNumVariants({
     serializedComponent,
     componentInfoObjects,
+    infoDiagnostics,
 }: any): any {
     // get number of variants from document (or other sectioning component)
 
@@ -240,6 +241,7 @@ export function getNumVariants({
             let results = getNumVariants({
                 serializedComponent: sectionChild,
                 componentInfoObjects,
+                infoDiagnostics,
             });
 
             if (results.success) {
@@ -272,6 +274,7 @@ export function getNumVariants({
         serializedComponent,
         componentInfoObjects,
         isDocument,
+        infoDiagnostics,
     });
 }
 
@@ -284,10 +287,12 @@ export function determineVariantsForSection({
     serializedComponent,
     componentInfoObjects,
     isDocument = false,
+    infoDiagnostics,
 }: {
     serializedComponent: any;
     componentInfoObjects: any;
     isDocument: boolean;
+    infoDiagnostics?: any[];
 }) {
     if (serializedComponent.variants === undefined) {
         serializedComponent.variants = {};
@@ -319,6 +324,7 @@ export function determineVariantsForSection({
         return BaseComponent.determineNumberOfUniqueVariants({
             serializedComponent,
             componentInfoObjects,
+            infoDiagnostics,
         });
     }
 
@@ -459,6 +465,7 @@ export function determineVariantsForSection({
         uniqueResult = BaseComponent.determineNumberOfUniqueVariants({
             serializedComponent,
             componentInfoObjects,
+            infoDiagnostics,
         }) as { success: boolean; numVariants: number };
 
         if (
@@ -571,6 +578,7 @@ export function extractConstantSortAttribute(
     serializedComponent: any,
     componentName: string,
     numToSelect: number,
+    infoDiagnostics?: any[],
 ): { success: boolean; sort?: string } {
     let sort;
 
@@ -589,8 +597,10 @@ export function extractConstantSortAttribute(
         ) {
             sort = sortComponent.state.value.trim().toLowerCase();
         } else {
-            console.log(
+            pushVariantInfo(
+                infoDiagnostics,
                 `cannot determine unique variants of ${componentName} as sort isn't a constant.`,
+                serializedComponent,
             );
             return { success: false };
         }
@@ -599,11 +609,35 @@ export function extractConstantSortAttribute(
     }
 
     if (sort !== "unsorted" && numToSelect > 1) {
-        console.log(
+        pushVariantInfo(
+            infoDiagnostics,
             `have not implemented unique variants of a ${componentName} with sort`,
+            serializedComponent,
         );
         return { success: false };
     }
 
     return { success: true, sort };
+}
+
+/**
+ * Append an info-typed diagnostic record describing a reason that unique
+ * variant determination failed. Variant code runs during DAST serialization,
+ * before Core exists, so the caller chains pass this buffer down and Core
+ * drains it into `preliminaryDiagnostics` when it's constructed.
+ */
+export function pushVariantInfo(
+    infoDiagnostics: any[] | undefined,
+    message: string,
+    serializedComponent: any,
+) {
+    if (!infoDiagnostics) {
+        return;
+    }
+    infoDiagnostics.push({
+        type: "info",
+        message,
+        position: serializedComponent?.position,
+        sourceDoc: serializedComponent?.sourceDoc,
+    });
 }

--- a/packages/doenetml-worker/src/CoreWorker.ts
+++ b/packages/doenetml-worker/src/CoreWorker.ts
@@ -118,7 +118,7 @@ export class CoreWorker {
 
         try {
             if (!this.wasm_initialized) {
-                await init(wasmBlobUrl);
+                await init({ module_or_path: wasmBlobUrl });
                 this.wasm_initialized = true;
             }
 
@@ -156,7 +156,7 @@ export class CoreWorker {
         await isProcessingPromise;
 
         if (!this.wasm_initialized) {
-            await init(wasmBlobUrl);
+            await init({ module_or_path: wasmBlobUrl });
             this.wasm_initialized = true;
         }
 
@@ -339,10 +339,7 @@ export class CoreWorker {
             if (this.core_type === "javascript") {
                 return await this.returnFlatDastFromJS();
             } else {
-                let flat_dast = this.doenetCore.return_dast();
-
-                console.log("flat_data from rust core", flat_dast);
-                return flat_dast;
+                return this.doenetCore.return_dast();
             }
         } catch (err) {
             console.error(err);
@@ -423,26 +420,15 @@ export class CoreWorker {
             }
         };
 
-        // Stub these callbacks for now, which aren't needed if we don't have interactivity
-        const reportScoreAndStateCallback = (args: any) => {
-            console.log("reportScoreAndStateCallback", args);
-        };
-        const requestAnimationFrame = (args: any) => {
-            console.log("requestAnimationFrame", args);
-        };
-        const cancelAnimationFrame = (args: any) => {
-            console.log("cancelAnimationFrame", args);
-        };
-        const copyToClipboard = (args: any) => {
-            console.log("copyToClipboard", args);
-        };
-        const sendEvent = (args: any) => {
-            console.log("sendEvent", args);
-        };
-        const requestSolutionView = (args: any) => {
-            console.log("requestSolutionView", args);
-            return Promise.resolve({ allowView: true });
-        };
+        // No-op stubs for callbacks that aren't needed in non-interactive contexts
+        // (e.g. pretext export). The core requires these to be functions.
+        const reportScoreAndStateCallback = (_args: any) => {};
+        const requestAnimationFrame = (_args: any) => {};
+        const cancelAnimationFrame = (_args: any) => {};
+        const copyToClipboard = (_args: any) => {};
+        const sendEvent = (_args: any) => {};
+        const requestSolutionView = (_args: any) =>
+            Promise.resolve({ allowView: true });
 
         const coreResult = await this.javascriptCore.createCoreGenerateDast(
             args,

--- a/packages/lsp-tools/src/auto-completer/index.ts
+++ b/packages/lsp-tools/src/auto-completer/index.ts
@@ -585,10 +585,9 @@ export class AutoCompleter {
                 snippet.element,
             );
             if (normalizedElement === "UNKNOWN_NAME") {
-                // Skip snippets for unknown elements
-                console.warn(
-                    `Skipping snippet "${key}": invalid element name "${snippet.element}".`,
-                );
+                // Skip snippets whose element isn't in the active schema.
+                // Tests intentionally supply reduced schemas, so unknown
+                // here is normal — not a misconfiguration.
                 return;
             }
 

--- a/packages/lsp-tools/test/rust-resolver-integration.test.ts
+++ b/packages/lsp-tools/test/rust-resolver-integration.test.ts
@@ -27,7 +27,7 @@ try {
         "../../doenetml-worker-rust/dist/lib_doenetml_worker_bg.wasm",
     );
     const wasmBytes = fs.readFileSync(wasmPath);
-    mod.initSync(wasmBytes);
+    mod.initSync({ module: wasmBytes });
     PublicDoenetMLCore = mod.PublicDoenetMLCore;
     wasmAvailable = true;
 } catch (e) {

--- a/packages/lsp/src/rust-core.ts
+++ b/packages/lsp/src/rust-core.ts
@@ -49,7 +49,7 @@ function getNodeProcess(): NodeProcessLike | undefined {
 
 async function initWasmWithNodePathWorkaround(): Promise<void> {
     try {
-        await init(wasmBlobUrl);
+        await init({ module_or_path: wasmBlobUrl });
         return;
     } catch (error) {
         function stripQueryAndHash(value: string) {
@@ -109,7 +109,7 @@ async function initWasmWithNodePathWorkaround(): Promise<void> {
         for (const wasmPath of candidatePaths) {
             try {
                 const wasmBytes = await fs.readFile(wasmPath);
-                await init(wasmBytes);
+                await init({ module_or_path: wasmBytes });
                 return;
             } catch {
                 // Try the next candidate path.

--- a/packages/v06-to-v07/src/core-info/core.ts
+++ b/packages/v06-to-v07/src/core-info/core.ts
@@ -57,7 +57,7 @@ export async function createCoreForLookup({ dast }: { dast: DastRoot }) {
     const wasmBuffer = (
         await import("@doenet/doenetml-worker/lib_doenetml_worker_bg.wasm?arraybuffer&base64")
     ).default;
-    await init(wasmBuffer);
+    await init({ module_or_path: wasmBuffer });
 
     const rustCore = PublicDoenetMLCoreRust.new();
 


### PR DESCRIPTION
## Summary

The CI test runs (Test Main + four Test Worker JS shards) emitted thousands of lines of console output that obscured real failures. Three categories of cleanup:

1. **wasm-bindgen `init()` deprecation** — switched all 6 callers (and the `initSync` test caller in `lsp-tools`) to the `{ module_or_path }` / `{ module }` form. The auto-generated wasm bindings were warning on every legacy positional call.

2. **Dead debug logs** — removed leftover `console.log`/`console.warn` in `CoreWorker` stub callbacks (the pretext-export path that produced the giant `reportScoreAndStateCallback` dumps), JSXGraph listeners, redux `setDarkMode`, `ensurePretextTag`, the LSP `Skipping snippet` warning (which fired 1200× per Test Main run because tests pass reduced schemas), and a couple of `Failed to get unique variant` / `flat_data from rust core` debug lines.

3. **Real validation messages → info diagnostics** — variant-time messages like `cannot determine unique variants of selectFromSequence as …` and `Unique variants for select disabled if have an option with selectWeight or selectForVariants specified` were being `console.log`'d from static methods that run before `Core` exists. Threaded an `infoDiagnostics: DiagnosticRecord[]` buffer from `CoreWorker.initializeWorker` through `returnAllPossibleVariants` → `getNumVariants` → `determineVariantsForSection` → every `Component.determineNumberOfUniqueVariants` override. The buffer drains into the existing `preliminaryDiagnostics` channel and surfaces through `DiagnosticsManager`. Separately, `ComponentBuilder` now passes `core` to `setUpVariant`, so the `Variant index … must be a (number|integer)` warnings route through `core.addDiagnostic({ type: "info" })`.

### Files of note
- `packages/doenetml-worker-javascript/src/utils/variants.ts` — new `pushVariantInfo` helper; `infoDiagnostics` parameter threaded through `getNumVariants`, `determineVariantsForSection`, and `extractConstantSortAttribute`.
- `packages/doenetml-worker-javascript/src/components/{Select,SelectFromSequence,SelectPrimeNumbers,ChoiceInput,Shuffle,Repeat,RepeatForSequence,PretzelArranger,SampleRandomNumbers,SamplePrimeNumbers,Document}.js` and `abstract/{BaseComponent,SectioningComponent}.js` — `determineNumberOfUniqueVariants` and (where relevant) `setUpVariant` updated to accept and forward the buffer.
- `packages/doenetml-worker-javascript/src/core/ComponentBuilder.ts` — passes `core` to `setUpVariant`.
- `packages/doenetml-worker/src/CoreWorker.ts` — stub callbacks no-op'd; `init({ module_or_path })`.

## Test plan

- [x] `npm run build` succeeds for `doenetml-worker-javascript`, `doenetml-worker`, `lsp-tools`, `doenetml-to-pretext`.
- [x] `specifySingleVariant.test.ts` (22 tests) — passes, 0 noise patterns.
- [x] `select.test.ts` (44 tests) — passes, 0 noise patterns.
- [x] All `variants/` tests (59 tests) — pass, 0 noise patterns.
- [x] All `diagnostics/` tests (46 tests) — pass.
- [x] `pretext-export.test.ts` — passes, 0 `reportScoreAndStateCallback` lines.
- [x] `doenet-auto-complete.test.ts` (94 tests) — passes, 0 `Skipping snippet` lines.
- [x] `rust-resolver-integration.test.ts` (38 tests) — passes, 0 `initSync` deprecation lines.
- [x] **New** unit tests added in `warningsInfos.test.ts` covering: `selectWeight` on an option produces an info; non-integer `numToSelect` on `selectFromSequence` produces an info; non-integer / non-numeric `requestedVariantIndex` produces an info. All 4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)