### PR TITLE
Use schema descriptions in generated documentation

### DIFF
--- a/.changeset/doc-descriptions-and-schema-attribute-types.md
+++ b/.changeset/doc-descriptions-and-schema-attribute-types.md
@@ -8,7 +8,7 @@
 
 Use schema descriptions in the generated documentation and give schema attributes their own type.
 
-Each schema attribute now carries a `type` derived from its own declaration: `createComponentOfType`/`createPrimitiveOfType` (with the `string` primitive surfaced as `text`), `keyword` when the attribute enumerates valid values, and `reference` for reference-creating attributes. Previously an attribute's type was inferred only from a same-named property, so attributes without one (e.g. `<answer>`'s `type`, `showCorrectness`, `colorCorrectness`) had no type.
+Each schema attribute now carries a `type` derived from its own declaration: `createComponentOfType`/`createPrimitiveOfType` (with the `string` primitive surfaced as `text`), `keyword` when the attribute enumerates valid values, and `reference` for reference-creating attributes — or `referenceOrText` when such an attribute also sets `allowStrings` (e.g. `<ref to>`, which accepts a URL string in addition to a component reference). Previously an attribute's type was inferred only from a same-named property, so attributes without one (e.g. `<answer>`'s `type`, `showCorrectness`, `colorCorrectness`) had no type.
 
 The reference documentation now renders the attribute, property, and attribute-value descriptions (and component summaries) that were already used for editor context-help and autocomplete.
 

--- a/.changeset/doc-descriptions-and-schema-attribute-types.md
+++ b/.changeset/doc-descriptions-and-schema-attribute-types.md
@@ -1,0 +1,15 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Use schema descriptions in the generated documentation and give schema attributes their own type.
+
+Each schema attribute now carries a `type` derived from its own declaration: `createComponentOfType`/`createPrimitiveOfType` (with the `string` primitive surfaced as `text`), `keyword` when the attribute enumerates valid values, and `reference` for reference-creating attributes. Previously an attribute's type was inferred only from a same-named property, so attributes without one (e.g. `<answer>`'s `type`, `showCorrectness`, `colorCorrectness`) had no type.
+
+The reference documentation now renders the attribute, property, and attribute-value descriptions (and component summaries) that were already used for editor context-help and autocomplete.
+
+The unused `description` attribute of `<answer>` is excluded from the schema, so it no longer appears in autocomplete or RelaxNG validation.

--- a/packages/docs-nextra/components/component-display.tsx
+++ b/packages/docs-nextra/components/component-display.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+export type ComponentInfo = {
+    /** Name of the DoenetML component */
+    name: string;
+    /** One-sentence summary of what the component does */
+    summary: string;
+};
+
+/**
+ * Displays schema-derived information about a DoenetML component. Currently
+ * just the component summary; the `name`/`summary` props are filled in at
+ * build time by the `autoInsertAttrPropDescriptions` remark plugin from the
+ * `name` attribute, so reference pages only need `<ComponentDisplay name='…'/>`.
+ */
+export function ComponentDisplay({
+    name,
+    summary,
+    children,
+}: React.PropsWithChildren<{ name: string; summary?: string }>) {
+    if (!summary && !children) {
+        return null;
+    }
+    return (
+        <div
+            className="component-summary"
+            id="component-summary"
+            data-name={name}
+        >
+            {children || summary}
+        </div>
+    );
+}

--- a/packages/docs-nextra/components/index.ts
+++ b/packages/docs-nextra/components/index.ts
@@ -1,3 +1,4 @@
 export * from "./doenet-example";
 export * from "./props-display";
+export * from "./component-display";
 export * from "./doenet";

--- a/packages/docs-nextra/components/props-display.tsx
+++ b/packages/docs-nextra/components/props-display.tsx
@@ -7,6 +7,7 @@ export type KnownPropAttrType =
     | "text"
     | "keyword"
     | "reference"
+    | "referenceOrText"
     | "boolean"
     | "math"
     | "integer"
@@ -280,7 +281,12 @@ function formatType(typeName?: PropAttrType, isArray?: boolean) {
     if (!typeName) {
         return null;
     }
-    return isArray ? `[ ${typeName} ]` : typeName;
+    // `referenceOrText` marks an attribute (e.g. `<ref to>`) that accepts a
+    // URL string in addition to a component reference; spell it out so the
+    // docs don't imply a plain string is invalid.
+    const label =
+        typeName === "referenceOrText" ? "reference or text" : typeName;
+    return isArray ? `[ ${label} ]` : label;
 }
 
 /**

--- a/packages/docs-nextra/components/props-display.tsx
+++ b/packages/docs-nextra/components/props-display.tsx
@@ -4,12 +4,21 @@ import React from "react";
 export type PropAttrType =
     | "title"
     | "text"
+    | "keyword"
     | "boolean"
     | "math"
     | "integer"
     | "number"
     | "textList"
     | "point";
+
+/** A single value an attribute may take, with an optional description. */
+export type AttrValueInfo = {
+    /** The literal value */
+    value: string;
+    /** Human-readable description of what the value does */
+    description?: string;
+};
 
 export type AttrInfo = {
     /** Name of the attribute */
@@ -18,8 +27,12 @@ export type AttrInfo = {
     type?: PropAttrType;
     /** Whether this attribute is common to all components (like `hide`) */
     common: boolean;
+    /** Author-facing description of the attribute */
+    description: string;
+    /** Default value of the attribute, if it declares one */
+    defaultValue?: unknown;
     /** Explicit values that the attribute may take */
-    values?: string[];
+    values?: AttrValueInfo[];
     /** Whether the attribute accepts an array of values */
     isArray?: boolean;
 };
@@ -31,6 +44,8 @@ export type PropInfo = {
     type: PropAttrType;
     /** Whether this prop is common to all components (like `hide`) */
     common: boolean;
+    /** Author-facing description of the prop */
+    description: string;
     /** Whether the prop accepts an array of values */
     isArray?: boolean;
 };
@@ -46,12 +61,11 @@ export function AttrDisplay({
     links?: Record<string, string>;
 }>) {
     attrs.sort((a, b) => a.name.localeCompare(b.name));
-    const commonAttrs = attrs.filter((attr) => attr.common);
     const componentAttrs = attrs.filter((attr) => !attr.common);
 
     return (
-        <table className="attr-table" id="attr-list">
-            <caption>
+        <div className="attr-list" id="attr-list">
+            <h3 className="attr-list-caption">
                 Attributes for{" "}
                 {children || (
                     <code>
@@ -60,47 +74,89 @@ export function AttrDisplay({
                         {">"}
                     </code>
                 )}
-            </caption>
-            <thead>
-                <tr>
-                    <th>Attribute</th>
-                    <th>Type</th>
-                    <th>Values</th>
-                </tr>
-            </thead>
-            <tbody>
-                {componentAttrs.map((attr) => {
-                    const linkTarget = links[attr.name];
-                    const nameElm = linkTarget ? (
-                        <Link href={linkTarget}>{attr.name}</Link>
-                    ) : (
-                        attr.name
-                    );
-                    return (
-                        <tr key={attr.name}>
-                            <td>
-                                <code>
-                                    <span className="attr-name">{nameElm}</span>
-                                     = "…"
-                                </code>
-                            </td>
-                            <td className="attr-type">
-                                {formatType(attr.type, attr.isArray)}
-                            </td>
-                            <td className="attr-values">
-                                {attr.values?.map((v) => (
-                                    <React.Fragment key={v}>
-                                        <code className="attr-value">
-                                            "{v}"
-                                        </code>{" "}
-                                    </React.Fragment>
-                                )) || ""}
-                            </td>
-                        </tr>
-                    );
-                })}
-            </tbody>
-        </table>
+            </h3>
+            {componentAttrs.map((attr) => {
+                const linkTarget = links[attr.name];
+                const nameElm = linkTarget ? (
+                    <Link href={linkTarget}>{attr.name}</Link>
+                ) : (
+                    attr.name
+                );
+                const typeLabel = formatType(attr.type, attr.isArray);
+                const isKeyword = attr.type === "keyword";
+                const defaultStr = formatDefaultValue(attr.defaultValue);
+                // `boolean` attributes only ever take true/false, so the
+                // value table would be noise — skip it for them.
+                const showValues =
+                    attr.type !== "boolean" &&
+                    attr.values != null &&
+                    attr.values.length > 0;
+                return (
+                    <div className="attr-item" key={attr.name}>
+                        <div>
+                            <code className="attr-name attr-name-box">
+                                {nameElm}
+                            </code>
+                        </div>
+                        <p className="attr-detail">
+                            {typeLabel ? (
+                                <>
+                                    <em className="attr-type">{typeLabel}</em>
+                                    .{" "}
+                                </>
+                            ) : null}
+                            {/* The default value follows the type, except for
+                                keyword attributes, where it is marked in the
+                                value list below. */}
+                            {!isKeyword && defaultStr !== null ? (
+                                <>
+                                    Default value:{" "}
+                                    <code className="attr-default">
+                                        {defaultStr}
+                                    </code>
+                                    .{" "}
+                                </>
+                            ) : null}
+                            {attr.description}
+                        </p>
+                        {showValues ? (
+                            <table className="attr-value-table">
+                                <thead>
+                                    <tr>
+                                        <th>Value</th>
+                                        <th>Description</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {attr.values!.map((v) => {
+                                        const isDefault =
+                                            attr.defaultValue != null &&
+                                            String(attr.defaultValue) ===
+                                                v.value;
+                                        return (
+                                            <tr key={v.value}>
+                                                <td>
+                                                    <code className="attr-value-chip">
+                                                        {v.value}
+                                                    </code>
+                                                    {isDefault ? (
+                                                        <span className="attr-default-marker">
+                                                            {" "}
+                                                            (default)
+                                                        </span>
+                                                    ) : null}
+                                                </td>
+                                                <td>{v.description || ""}</td>
+                                            </tr>
+                                        );
+                                    })}
+                                </tbody>
+                            </table>
+                        ) : null}
+                    </div>
+                );
+            })}
+        </div>
     );
 }
 
@@ -115,13 +171,12 @@ export function PropDisplay({
     links?: Record<string, string>;
 }>) {
     props.sort((a, b) => a.name.localeCompare(b.name));
-    const commonProps = props.filter((attr) => attr.common);
-    const componentProps = props.filter((attr) => !attr.common);
+    const componentProps = props.filter((prop) => !prop.common);
     const refName = name.charAt(0).toLowerCase();
 
     return (
-        <table className="prop-table" id="prop-list">
-            <caption>
+        <div className="prop-list" id="prop-list">
+            <h3 className="prop-list-caption">
                 Props for{" "}
                 {children || (
                     <code>
@@ -129,37 +184,82 @@ export function PropDisplay({
                         {name} name="{refName}"{">"}
                     </code>
                 )}
-            </caption>
-            <thead>
-                <tr>
-                    <th>Property</th>
-                    <th>Type</th>
-                </tr>
-            </thead>
-            <tbody>
-                {componentProps.map((prop) => {
-                    const linkTarget = links[prop.name];
-                    const nameElm = linkTarget ? (
-                        <Link href={linkTarget}>{prop.name}</Link>
-                    ) : (
-                        prop.name
-                    );
-                    return (
-                        <tr key={prop.name}>
-                            <td>
-                                <code>
-                                    ${refName}.
-                                    <span className="prop-name">{nameElm}</span>
-                                </code>
-                            </td>
-                            <td className="prop-type">
-                                {formatType(prop.type, prop.isArray)}
-                            </td>
-                        </tr>
-                    );
-                })}
-            </tbody>
-        </table>
+            </h3>
+            {componentProps.map((prop) => {
+                const linkTarget = links[prop.name];
+                const nameElm = linkTarget ? (
+                    <Link href={linkTarget}>{prop.name}</Link>
+                ) : (
+                    prop.name
+                );
+                const typeLabel = formatType(prop.type, prop.isArray);
+                return (
+                    <div className="prop-item" key={prop.name}>
+                        <div>
+                            <code className="prop-name-box">
+                                ${refName}.
+                                <span className="prop-name">{nameElm}</span>
+                            </code>
+                        </div>
+                        <p className="prop-detail">
+                            {typeLabel ? (
+                                <>
+                                    <em className="prop-type">{typeLabel}</em>
+                                    .{" "}
+                                </>
+                            ) : null}
+                            {prop.description}
+                        </p>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}
+
+/**
+ * Renders the body of an "Attributes and Properties" section: the attribute
+ * list and the property list, substituting a short message for either one
+ * when the component has none. The section heading itself is emitted as a
+ * real Markdown heading by the `autoInsertAttrPropDescriptions` remark plugin.
+ */
+export function AttrPropDisplay({
+    name,
+    attrs = [],
+    props = [],
+    links = {},
+}: {
+    name: string;
+    attrs?: AttrInfo[];
+    props?: PropInfo[];
+    links?: Record<string, string>;
+}) {
+    const hasAttrs = attrs.some((attr) => !attr.common);
+    const hasProps = props.some((prop) => !prop.common);
+    const nameCode = (
+        <code>
+            {"<"}
+            {name}
+            {">"}
+        </code>
+    );
+
+    if (!hasAttrs && !hasProps) {
+        return <p>The {nameCode} component has no attributes or properties.</p>;
+    }
+    return (
+        <>
+            {hasAttrs ? (
+                <AttrDisplay name={name} attrs={attrs} links={links} />
+            ) : (
+                <p>The {nameCode} component has no attributes.</p>
+            )}
+            {hasProps ? (
+                <PropDisplay name={name} props={props} links={links} />
+            ) : (
+                <p>The {nameCode} component has no properties.</p>
+            )}
+        </>
     );
 }
 
@@ -171,4 +271,26 @@ function formatType(typeName?: PropAttrType, isArray?: boolean) {
         return null;
     }
     return isArray ? `[ ${typeName} ]` : typeName;
+}
+
+/**
+ * Format an attribute's default value for display. Returns `null` when there
+ * is no meaningful default (`null`/`undefined`), so callers can omit it.
+ */
+function formatDefaultValue(value: unknown): string | null {
+    if (value == null) {
+        return null;
+    }
+    if (typeof value === "string") {
+        // An empty-string default carries no useful information.
+        return value === "" ? null : value;
+    }
+    if (Array.isArray(value)) {
+        // An empty-array default carries no useful information.
+        return value.length === 0 ? null : JSON.stringify(value);
+    }
+    if (typeof value === "boolean" || typeof value === "number") {
+        return String(value);
+    }
+    return JSON.stringify(value);
 }

--- a/packages/docs-nextra/components/props-display.tsx
+++ b/packages/docs-nextra/components/props-display.tsx
@@ -1,16 +1,26 @@
 import { Link } from "nextra-theme-docs";
 import React from "react";
 
-export type PropAttrType =
+/** Types the rendering code special-cases. */
+export type KnownPropAttrType =
     | "title"
     | "text"
     | "keyword"
+    | "reference"
     | "boolean"
     | "math"
     | "integer"
     | "number"
     | "textList"
     | "point";
+
+/**
+ * An attribute/prop type. The known types above are special-cased by the
+ * rendering code, but the value is ultimately derived from `createComponentOfType`,
+ * which is open-ended — so any other component type string is also valid. The
+ * `(string & {})` keeps editor autocomplete for the known literals.
+ */
+export type PropAttrType = KnownPropAttrType | (string & {});
 
 /** A single value an attribute may take, with an optional description. */
 export type AttrValueInfo = {
@@ -41,7 +51,7 @@ export type PropInfo = {
     /** Name of the prop */
     name: string;
     /** Type of the prop */
-    type: PropAttrType;
+    type?: PropAttrType;
     /** Whether this prop is common to all components (like `hide`) */
     common: boolean;
     /** Author-facing description of the prop */
@@ -60,7 +70,7 @@ export function AttrDisplay({
     attrs: AttrInfo[];
     links?: Record<string, string>;
 }>) {
-    attrs.sort((a, b) => a.name.localeCompare(b.name));
+    // `attrs` arrives already sorted by name from computeOptimizedSchema.
     const componentAttrs = attrs.filter((attr) => !attr.common);
 
     return (
@@ -170,7 +180,7 @@ export function PropDisplay({
     props: PropInfo[];
     links?: Record<string, string>;
 }>) {
-    props.sort((a, b) => a.name.localeCompare(b.name));
+    // `props` arrives already sorted by name from computeOptimizedSchema.
     const componentProps = props.filter((prop) => !prop.common);
     const refName = name.charAt(0).toLowerCase();
 

--- a/packages/docs-nextra/pages/reference/Sample_Component.mdx
+++ b/packages/docs-nextra/pages/reference/Sample_Component.mdx
@@ -1,14 +1,11 @@
-import { DoenetViewer, DoenetEditor, DoenetExample, AttrDisplay, PropDisplay } from "../../components"
+import { DoenetViewer, DoenetEditor, DoenetExample, AttrPropDisplay } from "../../components"
 
 # `<Sample>`
 
 ## What it does
 The `<Sample>` component does this stuff
 
-## Attributes and Properties
-<AttrDisplay name='math'/>
-
-<PropDisplay name='math'/>
+<AttrPropDisplay name='math'/>
 
 ## Examples
 1. [Render the absolute value of a math expression](#math-ex)

--- a/packages/docs-nextra/pages/reference/abs.mdx
+++ b/packages/docs-nextra/pages/reference/abs.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <abs>{:dn}`
@@ -10,9 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 the absolute value of the enclosed math.
 
 
-## Attributes and Properties 
- <AttrDisplay name='abs'/> 
- <PropDisplay name='abs'/>
+<AttrPropDisplay name='abs'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/alert.mdx
+++ b/packages/docs-nextra/pages/reference/alert.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <alert>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <alert>{:dn}` is a [Paragraph Markup](../document_structure/essentialConcepts#component-types) component which 
 renders the enclosed text in bold font.
 
-## Attributes and Properties 
-The ` <alert>{:dn}` component has no attributes.
- <PropDisplay name='alert'/>
+<AttrPropDisplay name='alert'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/and.mdx
+++ b/packages/docs-nextra/pages/reference/and.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 
@@ -10,8 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <and>{:dn}` is a [Logic](../document_structure/essentialConcepts#component-types) component
 which checks to see whether all enclosed ` <boolean>{:dn}` references are `true`.
 
-## Attributes and Properties 
-The `<and>{:dn}` component has no attributes or properties.
+<AttrPropDisplay name='and'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/angle.mdx
+++ b/packages/docs-nextra/pages/reference/angle.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <angle>{:dn}`
@@ -10,9 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 which renders a geometric angle when nested inside a [` <graph>{:dn}`](graph.mdx) component.
 
 
-## Attributes and Properties 
- <AttrDisplay name='angle'/> 
- <PropDisplay name='angle'/>
+<AttrPropDisplay name='angle'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/animateFromSequence.mdx
+++ b/packages/docs-nextra/pages/reference/animateFromSequence.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <animateFromSequence/>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <animateFromSequence/>{:dn}` is a [General Operator](../document_structure/essentialConcepts#component-types) component
 that renders an animation of a changing component over a specified interval of uniform steps.
 
-## Attributes and Properties 
- <AttrDisplay name='animateFromSequence'/> 
- <PropDisplay name='animateFromSequence'/>
+<AttrPropDisplay name='animateFromSequence'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/aside.mdx
+++ b/packages/docs-nextra/pages/reference/aside.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <aside>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 renders a collapsible, boxed section of content that is expanded when the user clicks the banner 
 to display supplementary material.
 
-## Attributes and Properties 
- <AttrDisplay name='aside'/> 
- <PropDisplay name='aside'/>
+<AttrPropDisplay name='aside'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/atom.mdx
+++ b/packages/docs-nextra/pages/reference/atom.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <atom>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <atom>{:dn}` is a [Subject-specific](../document_structure/essentialConcepts#component-types) 
 component that renders the atomic symbol for an element, and contains numerous built-in chemical properties.
 
-## Attributes and Properties 
- <AttrDisplay name='atom'/> 
- <PropDisplay name='atom'/>
+<AttrPropDisplay name='atom'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/attr.mdx
+++ b/packages/docs-nextra/pages/reference/attr.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <attr>{:dn}`
@@ -10,8 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component which renders the enclosed 
 text in the default font for component attributes.
 
-## Attributes and Properties 
-` <attr>{:dn}` does not have any attributes or properties.
+<AttrPropDisplay name='attr'/>
 
 
 

--- a/packages/docs-nextra/pages/reference/attractTo.mdx
+++ b/packages/docs-nextra/pages/reference/attractTo.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <attractTo>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <attractTo>{:dn}` is a [Graphical](../document_structure/essentialConcepts#component-types) component that 
 is used to within a ` <point>{:dn}` to attract it to a specified reference component.
 
-## Attributes and Properties 
- <AttrDisplay name='attractTo'/> 
- <PropDisplay name='attractTo'/>
+<AttrPropDisplay name='attractTo'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/attractToGrid.mdx
+++ b/packages/docs-nextra/pages/reference/attractToGrid.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <attractToGrid/>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <attractToGrid>{:dn}` is a [Graphical](../document_structure/essentialConcepts#component-types) component that 
 is used to within a ` <point>{:dn}` to attract it to a specified grid.
 
-## Attributes and Properties 
- <AttrDisplay name='attractToGrid'/> 
- <PropDisplay name='attractToGrid'/>
+<AttrPropDisplay name='attractToGrid'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/award.mdx
+++ b/packages/docs-nextra/pages/reference/award.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <award>{:dn}`
@@ -20,9 +20,7 @@ control the behavior of just that ` <award>{:dn}`.
 The following examples illustrate some of the basic award forms.  
 See the following pages for additional examples on using the attributes and properties.
 
-## Attributes and Properties 
- <AttrDisplay name='award'/> 
- <PropDisplay name='award'/>
+<AttrPropDisplay name='award'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/bestFitLine.mdx
+++ b/packages/docs-nextra/pages/reference/bestFitLine.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <bestFitLine>{:dn}`
@@ -10,9 +10,7 @@ component computes a linear regression through a list of points.
 When nested inside a [` <graph>{:dn}`](graph.mdx), the ` <bestFitLine>{:dn}` component displays a line.  
 The equation for the line of best fit can be rendered by accessing the `equation` property.
 
-## Attributes and Properties 
- <AttrDisplay name='bestFitLine'/> 
- <PropDisplay name='bestFitLine'/>
+<AttrPropDisplay name='bestFitLine'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/bezierControls.mdx
+++ b/packages/docs-nextra/pages/reference/bezierControls.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <bezierControls>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component. It is always the child of a ` <curve>{:dn}` component and provides a means to 
 specify the control vectors at each bezier curve control point.
 
-## Attributes and Properties 
- <AttrDisplay name='bezierControls'/> 
- <PropDisplay name='bezierControls'/>
+<AttrPropDisplay name='bezierControls'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/boolean.mdx
+++ b/packages/docs-nextra/pages/reference/boolean.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <boolean>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <boolean>{:dn}` is a [Logic](../document_structure/essentialConcepts#component-types) 
 component that renders the boolean value of `true` or `false` of the enclosed expression.
 
-## Attributes and Properties 
- <AttrDisplay name='boolean'/> 
- <PropDisplay name='boolean'/>
+<AttrPropDisplay name='boolean'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/booleanInput.mdx
+++ b/packages/docs-nextra/pages/reference/booleanInput.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 # ` <booleanInput>{:dn}`
 
@@ -10,9 +10,7 @@ component that renders a checkbox. If the box is checked by the user, Doenet
 stores the boolean value `true` in the named ` <booleanInput>{:dn}`.
 
 
-## Attributes and Properties 
- <AttrDisplay name='booleanInput'/> 
- <PropDisplay name='booleanInput'/>
+<AttrPropDisplay name='booleanInput'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/booleanList.mdx
+++ b/packages/docs-nextra/pages/reference/booleanList.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <booleanList>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <booleanList>{:dn}` is a [Logic](../document_structure/essentialConcepts#component-types)
 component that stores multiple [` <boolean>{:dn}`](boolean.mdx) components within a list.
 
-## Attributes and Properties 
- <AttrDisplay name='booleanList'/> 
- <PropDisplay name='booleanList'/>
+<AttrPropDisplay name='booleanList'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/c.mdx
+++ b/packages/docs-nextra/pages/reference/c.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <c>{:dn}`
@@ -9,8 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <c>{:dn}` is a [Paragraph Markup](../document_structure/essentialConcepts#component-types) component 
 which renders the enclosed text in the default font for illustrating code examples.
 
-## Attributes and Properties 
-The ` <c>{:dn}` component does not have any attributes or properties.
+<AttrPropDisplay name='c'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/callAction.mdx
+++ b/packages/docs-nextra/pages/reference/callAction.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <callAction>{:dn}`
@@ -21,9 +21,7 @@ available actions are:
 - `navigateToTarget`: Navigates to a specified target, such as a reference link.
 - `copyDoenetMLToClipboard`: Copies the DoenetML of the target component to the clipboard.
 
-## Attributes and Properties 
- <AttrDisplay name='callAction'/> 
- <PropDisplay name='callAction'/>
+<AttrPropDisplay name='callAction'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/caption.mdx
+++ b/packages/docs-nextra/pages/reference/caption.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <caption>{:dn}`
@@ -10,9 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that renders a caption attached to an 
 ` <image/>{:dn}` or ` <video/>{:dn}` when nested inside a ` <figure>{:dn}`.
 
-## Attributes and Properties 
-The ` <caption>{:dn}` component has no attributes.
- <PropDisplay name='caption'/>
+<AttrPropDisplay name='caption'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/case.mdx
+++ b/packages/docs-nextra/pages/reference/case.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <case>{:dn}`
@@ -10,9 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that defines an individual block of content triggered when 
 the its condition is met within a ` <conditionalContent>{:dn}`.
 
-## Attributes and Properties 
- <AttrDisplay name='case'/> 
- <PropDisplay name='case'/>
+<AttrPropDisplay name='case'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/ceil.mdx
+++ b/packages/docs-nextra/pages/reference/ceil.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 
@@ -13,9 +13,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that renders the result of the $\text{ceiling}$ function applied to the enclosed math.  
 The $\text{ceiling}$ function returns the least integer greater than or equal to a given rational number.
 
-## Attributes and Properties 
- <AttrDisplay name='ceil'/> 
- <PropDisplay name='ceil'/>
+<AttrPropDisplay name='ceil'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/cell.mdx
+++ b/packages/docs-nextra/pages/reference/cell.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <cell>{:dn}`
@@ -10,9 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component. It is the smallest element of a ` <tabular>{:dn}` block of text or 
 data inside a ` <table>{:dn}`.
 
-## Attributes and Properties 
- <AttrDisplay name='cell'/> 
- <PropDisplay name='cell'/>
+<AttrPropDisplay name='cell'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/choice.mdx
+++ b/packages/docs-nextra/pages/reference/choice.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <choice>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that defines an individual choice when nested 
 within an [` <answer>{:dn}`](answer.mdx) block for multiple choice questions.
 
-## Attributes and Properties 
- <AttrDisplay name='choice'/> 
- <PropDisplay name='choice'/>
+<AttrPropDisplay name='choice'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/choiceInput.mdx
+++ b/packages/docs-nextra/pages/reference/choiceInput.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <choiceInput>{:dn}`
@@ -10,9 +10,7 @@ component that defines a block of code for multiple choice questions.
 It serves as a container element for the individual 
 ` <choice>{:dn}` components that are nested within.
 
-## Attributes and Properties 
- <AttrDisplay name='choiceInput'/> 
- <PropDisplay name='choiceInput'/>
+<AttrPropDisplay name='choiceInput'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/circle.mdx
+++ b/packages/docs-nextra/pages/reference/circle.mdx
@@ -1,17 +1,16 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { ComponentDisplay, AttrPropDisplay } from "../../components"
 
 
 # ` <circle>{:dn}`
 
+<ComponentDisplay name='circle'/>
 
 ` <circle>{:dn}` is a [Graphical](../document_structure/essentialConcepts#component-types)
 component that renders a circle when nested inside a ` <graph>{:dn}`.
 
-## Attributes and Properties 
- <AttrDisplay name='circle'/> 
- <PropDisplay name='circle'/>
+<AttrPropDisplay name='circle'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/clampNumber.mdx
+++ b/packages/docs-nextra/pages/reference/clampNumber.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <clampNumber>{:dn}`
@@ -12,9 +12,7 @@ endpoints of a specified interval if the number is outside
 the range of that interval. The default interval is $[0,1]$.
 
 
-## Attributes and Properties 
- <AttrDisplay name='clampNumber'/> 
- <PropDisplay name='clampNumber'/>
+<AttrPropDisplay name='clampNumber'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/collect.mdx
+++ b/packages/docs-nextra/pages/reference/collect.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <collect>{:dn}`
@@ -10,9 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that gathers discrete component data from a graph or 
 sectional component and stores it in an array.
 
-## Attributes and Properties 
- <AttrDisplay name='collect'/> 
- <PropDisplay name='collect'/>
+<AttrPropDisplay name='collect'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/conditionalContent.mdx
+++ b/packages/docs-nextra/pages/reference/conditionalContent.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <conditionalContent>{:dn}`
@@ -13,8 +13,7 @@ Conditions may be defined directly on the ` <conditionalContent>{:dn}` tag using
 Alternatively, one can use one or more [` <case>{:dn}`](case.mdx) children with an 
 optional [` <else>{:dn}`](else.mdx) child.
 
-## Attributes and Properties 
-The ` <conditionalContent>{:dn}` component has no attributes or properties.
+<AttrPropDisplay name='conditionalContent'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/considerAsResponses.mdx
+++ b/packages/docs-nextra/pages/reference/considerAsResponses.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 
@@ -27,8 +27,7 @@ However, it is good practice to use the ` <considerAsResponses>{:dn}` in the fol
 
 
 
-## Attributes and Properties 
-The ` <considerAsResponses>{:dn}` component has no attributes or properties.
+<AttrPropDisplay name='considerAsResponses'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/constrainTo.mdx
+++ b/packages/docs-nextra/pages/reference/constrainTo.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <constrainTo>{:dn}`
@@ -10,9 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
  to constrain a ` <point>{:dn}` to 
  another named graphical component (such as a ` <line>{:dn}` or a ` <function>{:dn}`).
 
-## Attributes and Properties 
- <AttrDisplay name='constrainTo'/> 
- <PropDisplay name='constrainTo'/>
+<AttrPropDisplay name='constrainTo'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/constrainToGraph.mdx
+++ b/packages/docs-nextra/pages/reference/constrainToGraph.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <constrainToGraph>{:dn}`
@@ -10,9 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component to keep constrained ` <point>{:dn}` 
 components within the confines of the graphing window.
 
-## Attributes and Properties 
- <AttrDisplay name='constrainToGraph'/> 
- <PropDisplay name='constrainToGraph'/>
+<AttrPropDisplay name='constrainToGraph'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/constrainToGrid.mdx
+++ b/packages/docs-nextra/pages/reference/constrainToGrid.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <constrainToGrid/>{:dn}`
@@ -11,9 +11,7 @@ component that is used to constrain a ` <point>{:dn}` to a grid. The grid can be
 
 ` <constrainToGrid/>{:dn}` forces points to snap to gridline locations.
 
-## Attributes and Properties 
- <AttrDisplay name='constrainToGrid'/> 
- <PropDisplay name='constrainToGrid'/>
+<AttrPropDisplay name='constrainToGrid'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/constraintUnion.mdx
+++ b/packages/docs-nextra/pages/reference/constraintUnion.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <constraintUnion>{:dn}`
@@ -11,9 +11,7 @@ component that delineates
 a block of code for defining the union of one or more constraint components 
 associated with a ` <point>{:dn}`.
 
-## Attributes and Properties 
-The ` <constraintUnion>{:dn}` component has no attributes.
- <PropDisplay name='constraintUnion'/>
+<AttrPropDisplay name='constraintUnion'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/controlVectors.mdx
+++ b/packages/docs-nextra/pages/reference/controlVectors.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <controlVectors>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that is used to specify the direction(s) of the bezier curve 
 handles at each through point within a ` <curve>{:dn}` component.
 
-## Attributes and Properties 
- <AttrDisplay name='controlVectors'/> 
- <PropDisplay name='controlVectors'/>
+<AttrPropDisplay name='controlVectors'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/coords.mdx
+++ b/packages/docs-nextra/pages/reference/coords.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 
 ` <coords>{:dn}` is a math component that renders a set of coordinates.
 
-## Attributes and Properties 
- <AttrDisplay name='coords'/> 
- <PropDisplay name='coords'/>
+<AttrPropDisplay name='coords'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/count.mdx
+++ b/packages/docs-nextra/pages/reference/count.mdx
@@ -1,15 +1,13 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 # ` <count>{:dn}`
 
 ` <count>{:dn}` renders the length of a list of items.
 
 
-## Attributes and Properties 
- <AttrDisplay name='count'/> 
- <PropDisplay name='count'/>
+<AttrPropDisplay name='count'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/curve.mdx
+++ b/packages/docs-nextra/pages/reference/curve.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <curve>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <curve>{:dn}` is a [Graphical](../document_structure/essentialConcepts#component-types)
 component that renders a spline within a ` <graph>{:dn}`.
 
-## Attributes and Properties 
- <AttrDisplay name='curve'/> 
- <PropDisplay name='curve'/>
+<AttrPropDisplay name='curve'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/derivative.mdx
+++ b/packages/docs-nextra/pages/reference/derivative.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <derivative>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that renders the derivative of basic elementary functions 
 (including polynomial, exponential, and trigonometric functions.)
 
-## Attributes and Properties 
- <AttrDisplay name='derivative'/> 
- <PropDisplay name='derivative'/>
+<AttrPropDisplay name='derivative'/>
 
 
 

--- a/packages/docs-nextra/pages/reference/div.mdx
+++ b/packages/docs-nextra/pages/reference/div.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <div>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <div>{:dn}` is a [Sectional](../document_structure/essentialConcepts#component-types) 
 component that groups doenetML content into an unformatted container that can be named.
 
-## Attributes and Properties 
-The ` <div>{:dn}` component does not have attributes.
- <PropDisplay name='div'/>
+<AttrPropDisplay name='div'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/document.mdx
+++ b/packages/docs-nextra/pages/reference/document.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <document>{:dn}`
@@ -11,9 +11,7 @@ structure and content. If not explicitly included by the author,
 it is automatically added by the DoenetML compiler.
 
 
-## Attributes and Properties 
- <AttrDisplay name='document'/> 
- <PropDisplay name='document'/>
+<AttrPropDisplay name='document'/>
 
 
 

--- a/packages/docs-nextra/pages/reference/ellipsis.mdx
+++ b/packages/docs-nextra/pages/reference/ellipsis.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 # ` <ellipsis>{:dn}`
 
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <ellipsis/>{:dn}` is a [Paragraph Markup](../document_structure/essentialConcepts#component-types) 
 component that renders an ellipsis symbol consisting of three closely spaced dots.
 
-## Attributes and Properties 
-The ` <ellipsis>{:dn}` component does not have attributes.
- <PropDisplay name='ellipsis'/>
+<AttrPropDisplay name='ellipsis'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/else.mdx
+++ b/packages/docs-nextra/pages/reference/else.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <else>{:dn}`
@@ -10,8 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that is used with the ` <conditionalContent>{:dn}`
 component in creating logical statements with DoenetML.
 
-## Attributes and Properties 
-The ` <else>{:dn}` does not have attributes or properties.
+<AttrPropDisplay name='else'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/em.mdx
+++ b/packages/docs-nextra/pages/reference/em.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <em>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 The ` <em>{:dn}` component is a [Paragraph Markup](../document_structure/essentialConcepts#component-types) 
 component which renders the enclosed text in emphasized, or italicized, font.
 
-## Attributes and Properties 
-The ` <em>{:dn}` component does not have attributes.
- <PropDisplay name='em'/>
+<AttrPropDisplay name='em'/>
 
 ### Example: ` <em>{:dn}` in a paragraph
 

--- a/packages/docs-nextra/pages/reference/endpoint.mdx
+++ b/packages/docs-nextra/pages/reference/endpoint.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <endpoint>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <endpoint>{:dn}` is a [Graphical](../document_structure/essentialConcepts#component-types) 
 component that renders a point that can be switched from open to closed (or unfilled to filled).
 
-## Attributes and Properties 
- <AttrDisplay name='endpoint'/> 
- <PropDisplay name='endpoint'/>
+<AttrPropDisplay name='endpoint'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/evaluate.mdx
+++ b/packages/docs-nextra/pages/reference/evaluate.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <evaluate/>{:dn}`
@@ -11,9 +11,7 @@ This is a self-closing tag; it's tempting to try to nest the function within ope
 incorrect -- the function to be evaluated 
 must instead be specified within the `function` attribute directly.
 
-## Attributes and Properties 
- <AttrDisplay name='evaluate'/> 
- <PropDisplay name='evaluate'/>
+<AttrPropDisplay name='evaluate'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/example.mdx
+++ b/packages/docs-nextra/pages/reference/example.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <example>{:dn}`
@@ -11,9 +11,7 @@ component which renders an auto-numbered block of content. Inline components suc
 and other components can be nested within an ` <example>{:dn}` to group and order content. Some 
 examples are: another ` <example>{:dn}`, a ` <section>{:dn}`, a ` <figure>{:dn}`, or a ` <problem>{:dn}`.
 
-## Attributes and Properties 
- <AttrDisplay name='example'/> 
- <PropDisplay name='example'/>
+<AttrPropDisplay name='example'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/exercise.mdx
+++ b/packages/docs-nextra/pages/reference/exercise.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <exercise>{:dn}`
@@ -13,9 +13,7 @@ and order content. Some examples are: another ` <exercise>{:dn}`, a ` <section>{
 a ` <figure>{:dn}`, or a ` <problem>{:dn}`.
 
 
-## Attributes and Properties 
- <AttrDisplay name='exercise'/> 
- <PropDisplay name='exercise'/>
+<AttrPropDisplay name='exercise'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/extractMath.mdx
+++ b/packages/docs-nextra/pages/reference/extractMath.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <extractMath>{:dn}`
@@ -20,9 +20,7 @@ The types of data that can be extracted with ` <extractMath>{:dn}` are:
 
 
 
-## Attributes and Properties 
- <AttrDisplay name='extractMath'/> 
- <PropDisplay name='extractMath'/>
+<AttrPropDisplay name='extractMath'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/feedback.mdx
+++ b/packages/docs-nextra/pages/reference/feedback.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <feedback>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <feedback>{:dn}` is an [Evaluation](../document_structure/essentialConcepts#component-types) 
 component that renders a boxed section of content that can be triggered by predefined user interactions. 
 
-## Attributes and Properties 
- <AttrDisplay name='feedback'/> 
- <PropDisplay name='feedback'/>
+<AttrPropDisplay name='feedback'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/figure.mdx
+++ b/packages/docs-nextra/pages/reference/figure.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <figure>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <figure>{:dn}` is a [Sectional](../document_structure/essentialConcepts#component-types) 
 component which acts as a container for an ` <image/>{:dn}` or ` <video/>{:dn}`.
 
-## Attributes and Properties 
- <AttrDisplay name='figure'/> 
- <PropDisplay name='figure'/>
+<AttrPropDisplay name='figure'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/floor.mdx
+++ b/packages/docs-nextra/pages/reference/floor.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <floor>{:dn}`
@@ -10,9 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that renders the result of the $\text{floor}$ function applied to the enclosed numerical expression or 
 math input.  The $\text{floor}$ function returns the greatest integer less than or equal to a given rational number.
 
-## Attributes and Properties 
- <AttrDisplay name='floor'/> 
- <PropDisplay name='floor'/>
+<AttrPropDisplay name='floor'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/footnote.mdx
+++ b/packages/docs-nextra/pages/reference/footnote.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <footnote>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <footnote>{:dn}` is a [Paragraph Markup](../document_structure/essentialConcepts#component-types) 
 component that renders a numbered footnote above and to the right of the content it is adjacent to.
 
-## Attributes and Properties 
-The  ` <footnote>{:dn}` component does not have attributes.
- <PropDisplay name='footnote'/>
+<AttrPropDisplay name='footnote'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/functionIterates.mdx
+++ b/packages/docs-nextra/pages/reference/functionIterates.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <functionIterates>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <functionIterates>{:dn}` is a [Math Operator](../document_structure/essentialConcepts#component-types)
 component that evaluates a function over a specified number of iterations of its argument.
 
-## Attributes and Properties 
- <AttrDisplay name='functionIterates'/> 
- <PropDisplay name='functionIterates'/>
+<AttrPropDisplay name='functionIterates'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/gcd.mdx
+++ b/packages/docs-nextra/pages/reference/gcd.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <gcd>{:dn}`
@@ -10,9 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that accepts a list of integer values separated by spaces and returns the 
 greatest common divisor of those integers.
 
-## Attributes and Properties 
- <AttrDisplay name='gcd'/> 
- <PropDisplay name='gcd'/>
+<AttrPropDisplay name='gcd'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/graph.mdx
+++ b/packages/docs-nextra/pages/reference/graph.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <graph>{:dn}`  is a [Graphical](../document_structure/essentialConcepts#component-types) 
 component that renders a 2D cartesian graph.
 
-## Attributes and Properties 
- <AttrDisplay name='graph'/> 
- <PropDisplay name='graph'/>
+<AttrPropDisplay name='graph'/>
 
 ---
 ## Examples Page 1

--- a/packages/docs-nextra/pages/reference/group.mdx
+++ b/packages/docs-nextra/pages/reference/group.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <group>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <group>{:dn}` is a [General Operator](../document_structure/essentialConcepts#component-types)
 component that collects individual DoenetML components into a single named element.
 
-## Attributes and Properties 
- <AttrDisplay name='group'/> 
- <PropDisplay name='group'/>
+<AttrPropDisplay name='group'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/hasSameFactoring.mdx
+++ b/packages/docs-nextra/pages/reference/hasSameFactoring.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <hasSameFactoring>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that returns the boolean value of `true` or `false` depending on 
 whether the two enclosed ` <math>{:dn}` or math references are factored in the same way.
 
-## Attributes and Properties 
- <AttrDisplay name='hasSameFactoring'/> 
- <PropDisplay name='hasSameFactoring'/>
+<AttrPropDisplay name='hasSameFactoring'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/hint.mdx
+++ b/packages/docs-nextra/pages/reference/hint.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 # ` <hint>{:dn}`
 
@@ -11,9 +11,7 @@ component that renders a hidden block of content that can be expanded when its b
 or can be rendered visible only when triggered by specific user interactions.
 
 
-## Attributes and Properties 
-The ` <hint>{:dn}` does not have attributes.
- <PropDisplay name='hint'/>
+<AttrPropDisplay name='hint'/>
 
 
 

--- a/packages/docs-nextra/pages/reference/image.mdx
+++ b/packages/docs-nextra/pages/reference/image.mdx
@@ -1,15 +1,13 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 # ` <image/>{:dn}`
 
 ` <image/>{:dn}` is a [Sectional](../document_structure/essentialConcepts/#componentTypes) 
 component that renders an image from a hyperlink or an uploaded file.
 
-## Attributes and Properties 
- <AttrDisplay name='image'/> 
- <PropDisplay name='image'/>
+<AttrPropDisplay name='image'/>
 
 
 

--- a/packages/docs-nextra/pages/reference/intComma.mdx
+++ b/packages/docs-nextra/pages/reference/intComma.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <intComma>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <intComma>{:dn}` is a [Math Operator](../document_structure/essentialConcepts#component-types) 
 component which inserts commas into a large integer when rendering. 
 
-## Attributes and Properties 
- <AttrDisplay name='intComma'/> 
- <PropDisplay name='intComma'/>
+<AttrPropDisplay name='intComma'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/integer.mdx
+++ b/packages/docs-nextra/pages/reference/integer.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 
@@ -10,9 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <integer>{:dn}` is a [Math](../document_structure/essentialConcepts#component-types) 
 component that defines an integer value.
 
-## Attributes and Properties 
- <AttrDisplay name='integer'/> 
- <PropDisplay name='integer'/>
+<AttrPropDisplay name='integer'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/intersection.mdx
+++ b/packages/docs-nextra/pages/reference/intersection.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <intersection>{:dn}`
@@ -12,9 +12,7 @@ component that determines the intersection point of a pair of graphical objects.
 The ` <intersection>{:dn}` component renders a point (or points in the case of multiple intersections) 
 when nested inside a ` <graph>{:dn}` component, and renders a coordinate pair (or a list of coordinate pairs) otherwise.
 
-## Attributes and Properties 
- <AttrDisplay name='intersection'/> 
- The ` <intersection>{:dn}` component shares properties with the `<point>{:dn}` component
+<AttrPropDisplay name='intersection'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/interval.mdx
+++ b/packages/docs-nextra/pages/reference/interval.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <interval>{:dn}` is a [Math](../document_structure/essentialConcepts#component-types) 
 component that renders an interval.
 
-## Attributes and Properties 
- <AttrDisplay name='interval'/> 
- <PropDisplay name='interval'/>
+<AttrPropDisplay name='interval'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/intervalList.mdx
+++ b/packages/docs-nextra/pages/reference/intervalList.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <intervalList>{:dn}` is a [Math](../document_structure/essentialConcepts#component-types)
 component that renders a list of intervals.
 
-## Attributes and Properties 
- <AttrDisplay name='intervalList'/> 
- <PropDisplay name='intervalList'/>
+<AttrPropDisplay name='intervalList'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/isBetween.mdx
+++ b/packages/docs-nextra/pages/reference/isBetween.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <isBetween>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <isBetween>{:dn}` is a [Logic](../document_structure/essentialConcepts#component-types) component
 that returns the boolean value of `true` or `false` depending on whether a value is enclosed in a specified interval.
 
-## Attributes and Properties 
- <AttrDisplay name='isBetween'/> 
- <PropDisplay name='isBetween'/>
+<AttrPropDisplay name='isBetween'/>
  
 ---
 

--- a/packages/docs-nextra/pages/reference/isInteger.mdx
+++ b/packages/docs-nextra/pages/reference/isInteger.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <isInteger>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <isInteger>{:dn}` is a [Logic](../document_structure/essentialConcepts#component-types) 
 component that returns the boolean value of `true` or `false` depending on whether the value enclosed is an integer.
 
-## Attributes and Properties 
- <AttrDisplay name='isInteger'/> 
- <PropDisplay name='isInteger'/>
+<AttrPropDisplay name='isInteger'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/isNumber.mdx
+++ b/packages/docs-nextra/pages/reference/isNumber.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <isNumber>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <isNumber>{:dn}` is a [Logic](../document_structure/essentialConcepts#component-types)
 component that returns the boolean value of `true` or `false` depending on whether the value enclosed is a real number.
 
-## Attributes and Properties 
- <AttrDisplay name='isNumber'/> 
- <PropDisplay name='isNumber'/>
+<AttrPropDisplay name='isNumber'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/label.mdx
+++ b/packages/docs-nextra/pages/reference/label.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <label>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <label>{:dn}` is a [Graphical](../document_structure/essentialConcepts#component-types)
 component that renders a label on a ` <graph>{:dn}`, button, or checkbox.
 
-## Attributes and Properties 
- <AttrDisplay name='label'/> 
- <PropDisplay name='label'/>
+<AttrPropDisplay name='label'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/legend.mdx
+++ b/packages/docs-nextra/pages/reference/legend.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <legend>{:dn}`
@@ -12,9 +12,7 @@ component that renders a legend when nested inside a ` <graph>{:dn}`. Individual
 legend entries are defined with the ` <label>{:dn}` component.
 
 
-## Attributes and Properties 
- <AttrDisplay name='legend'/> 
- <PropDisplay name='legend'/>
+<AttrPropDisplay name='legend'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/li.mdx
+++ b/packages/docs-nextra/pages/reference/li.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <li>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <li>{:dn}` is a [Sectional](../document_structure/essentialConcepts#component-types) component
 that defines an item in either an ordered list, ` <ol>{:dn}`, or an unordered list, ` <ul>{:dn}`.
 
-## Attributes and Properties 
- The ` <li>{:dn}` component does not have attributes.
- <PropDisplay name='li'/>
+<AttrPropDisplay name='li'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/line.mdx
+++ b/packages/docs-nextra/pages/reference/line.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 
@@ -17,9 +17,7 @@ Current functionality supports generation of lines in $\mathbb{R^2}$ through use
 3. with an equation, or ` <function>{:dn}`
 
 
-## Attributes and Properties 
- <AttrDisplay name='line'/> 
- <PropDisplay name='line'/>
+<AttrPropDisplay name='line'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/lineSegment.mdx
+++ b/packages/docs-nextra/pages/reference/lineSegment.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <lineSegment>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <lineSegment>{:dn}` is a [Graphical](../document_structure/essentialConcepts#component-types)
 component that renders a line segment when nested within a [` <graph>{:dn}`](graph.mdx) component.
 
-## Attributes and Properties 
- <AttrDisplay name='lineSegment'/> 
- <PropDisplay name='lineSegment'/>
+<AttrPropDisplay name='lineSegment'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/lorem.mdx
+++ b/packages/docs-nextra/pages/reference/lorem.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # `<lorem/>{:dn}`
@@ -10,9 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that renders random lorem-ipsum filler text.  The amount of text generated is controlled by attribute specification of the number of words, sentences, and paragraphs.
 
 
-## Attributes and Properties 
- <AttrDisplay name='lorem'/> 
- <PropDisplay name='lorem'/>
+<AttrPropDisplay name='lorem'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/m.mdx
+++ b/packages/docs-nextra/pages/reference/m.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 
@@ -15,9 +15,7 @@ For displaying mathematics alone on a line by itself, see ` <me>{:dn}`, ` <men>{
 or ` <md>{:dn}`,` <mdn>{:dn}` (for aligned mathematics). See also ` <math>{:dn}`
 for mathematical manipulations using a computer algebra system.
 
-## Attributes and Properties 
- <AttrDisplay name='m'/> 
- <PropDisplay name='m'/>
+<AttrPropDisplay name='m'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/matchesPattern.mdx
+++ b/packages/docs-nextra/pages/reference/matchesPattern.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <matchesPattern>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that returns the boolean value of `true` or `false` depending on whether the enclosed 
 math (often a referenced ` <mathInput/>{:dn}`) conforms to the specified `pattern` template.
 
-## Attributes and Properties 
- <AttrDisplay name='matchesPattern'/> 
- <PropDisplay name='matchesPattern'/>
+<AttrPropDisplay name='matchesPattern'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/math.mdx
+++ b/packages/docs-nextra/pages/reference/math.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <math>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <math>{:dn}` is a [Math](../document_structure/essentialConcepts#component-types)
 component that defines a symbolic or numerical math expression that can be rendered and used in computations.
 
-## Attributes and Properties 
- <AttrDisplay name='math'/> 
- <PropDisplay name='math'/>
+<AttrPropDisplay name='math'/>
 
 ## Examples Page 1
 

--- a/packages/docs-nextra/pages/reference/mathInput.mdx
+++ b/packages/docs-nextra/pages/reference/mathInput.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <mathInput/>{:dn}`
@@ -11,9 +11,7 @@ component that renders a user-input field that stores mathematical content.
 When referenced, a named ` <mathInput/>{:dn}` can be used in computations in the same manner 
 as a ` <math>{:dn}` component.
 
-## Attributes and Properties 
- <AttrDisplay name='mathInput'/> 
- <PropDisplay name='mathInput'/>
+<AttrPropDisplay name='mathInput'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/mathList.mdx
+++ b/packages/docs-nextra/pages/reference/mathList.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <mathList>{:dn}`
@@ -11,9 +11,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that defines a collection, or list, of [` <math>{:dn}`](math.mdx) components. 
 Some components that accept a ` <mathList>{:dn}` as an input include functions, repeats, and awards.
 
-## Attributes and Properties 
- <AttrDisplay name='mathList'/> 
- <PropDisplay name='mathList'/>
+<AttrPropDisplay name='mathList'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/matrix.mdx
+++ b/packages/docs-nextra/pages/reference/matrix.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <matrix>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <matrix>{:dn}` is a [Math](../document_structure/essentialConcepts#component-types)
 component that defines/renders a matrix for use in computations.
 
-## Attributes and Properties 
- <AttrDisplay name='matrix'/> 
- <PropDisplay name='matrix'/>
+<AttrPropDisplay name='matrix'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/matrixInput.mdx
+++ b/packages/docs-nextra/pages/reference/matrixInput.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <matrixInput/>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <matrixInput/>{:dn}` is an [Input](../document_structure/essentialConcepts#component-types)
 component renders an empty matrix with blanks for user-input of entries.
 
-## Attributes and Properties 
- <AttrDisplay name='matrixInput'/> 
- <PropDisplay name='matrixInput'/>
+<AttrPropDisplay name='matrixInput'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/max.mdx
+++ b/packages/docs-nextra/pages/reference/max.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <max>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <max>{:dn}` is a [Math Operator](../document_structure/essentialConcepts#component-types)
 component that renders the maximum value in a list of numbers separated by spaces.
 
-## Attributes and Properties 
- <AttrDisplay name='max'/> 
- <PropDisplay name='max'/>
+<AttrPropDisplay name='max'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/md.mdx
+++ b/packages/docs-nextra/pages/reference/md.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <md>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that renders a block of aligned display mathematics when used in combination 
 with the ` <mrow>{:dn}` component.
 
-## Attributes and Properties 
- <AttrDisplay name='md'/> 
- <PropDisplay name='md'/>
+<AttrPropDisplay name='md'/>
  
 ---
 

--- a/packages/docs-nextra/pages/reference/mdn.mdx
+++ b/packages/docs-nextra/pages/reference/mdn.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <mdn>{:dn}`
@@ -10,9 +10,7 @@ The ` <mdn>{:dn}` is a [Display Math](../document_structure/essentialConcepts#co
 component that renders a block of numbered, aligned display mathematics when used in 
 combination with the ` <mrow/>{:dn}` component.
 
-## Attributes and Properties 
- <AttrDisplay name='mdn'/> 
- <PropDisplay name='mdn'/>
+<AttrPropDisplay name='mdn'/>
  
 ---
 

--- a/packages/docs-nextra/pages/reference/me.mdx
+++ b/packages/docs-nextra/pages/reference/me.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <me>{:dn}`
@@ -11,9 +11,7 @@ component that renders the math expression centered within the page.
 ` <me>{:dn}` can be used with [` <men>{:dn}`](men.mdx) to number the equation, and can also be used with 
 mathematical expression created by [` <m>{:dn}`](m.mdx)and [` <md>{:dn}`](md.mdx)/[` <mdn>{:dn}`](mdn.mdx).
 
-## Attributes and Properties 
- <AttrDisplay name='me'/> 
- <PropDisplay name='me'/>
+<AttrPropDisplay name='me'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/mean.mdx
+++ b/packages/docs-nextra/pages/reference/mean.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <mean>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <mean>{:dn}` is a [Math Operator](../document_structure/essentialConcepts#component-types) 
 component which renders the arithmetic mean of the enclosed values.
 
-## Attributes and Properties 
- <AttrDisplay name='mean'/> 
- <PropDisplay name='mean'/>
+<AttrPropDisplay name='mean'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/median.mdx
+++ b/packages/docs-nextra/pages/reference/median.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 # ` <median>{:dn}`
 
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component which renders the median of the enclosed values.
 
 
-## Attributes and Properties 
- <AttrDisplay name='median'/> 
- <PropDisplay name='median'/>
+<AttrPropDisplay name='median'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/men.mdx
+++ b/packages/docs-nextra/pages/reference/men.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 # ` <men>{:dn}`
 
@@ -9,9 +9,7 @@ component that renders auto-numbered, mathematical display text centered within 
 component accepts DoenetML mathematical content as well as LaTeX.
 
 
-## Attributes and Properties 
- <AttrDisplay name='men'/> 
- <PropDisplay name='men'/>
+<AttrPropDisplay name='men'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/min.mdx
+++ b/packages/docs-nextra/pages/reference/min.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <min>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <min>{:dn}` is a [Math Operator](../document_structure/essentialConcepts#component-types)
 component that renders the minimum value in a list of numbers separated by spaces.
 
-## Attributes and Properties 
- <AttrDisplay name='min'/> 
- <PropDisplay name='min'/>
+<AttrPropDisplay name='min'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/mod.mdx
+++ b/packages/docs-nextra/pages/reference/mod.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <mod>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that accepts a list of two numerical inputs $a$ and $b$ (separated by a space) and 
 returns the value of $a \bmod b$.
 
-## Attributes and Properties 
- <AttrDisplay name='mod'/> 
- <PropDisplay name='mod'/>
+<AttrPropDisplay name='mod'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/module.mdx
+++ b/packages/docs-nextra/pages/reference/module.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <module>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that provides a way to organize a sequence of repeatable content. It is similar to creating
 a macro that can be reused multiple times within a DoenetML document.
 
-## Attributes and Properties 
- <AttrDisplay name='module'/> 
- <PropDisplay name='module'/>
+<AttrPropDisplay name='module'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/moduleAttributes.mdx
+++ b/packages/docs-nextra/pages/reference/moduleAttributes.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <moduleAttributes>{:dn}`
@@ -11,9 +11,7 @@ Similar to the attributes of a built-in DoenetML component, the user-defined att
 are then listed in the opening tag of the custom ` <module>{:dn}` component.
 
 
-## Attributes and Properties 
- <AttrDisplay name='module'/> 
- <PropDisplay name='module'/>
+<AttrPropDisplay name='module'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/mrow.mdx
+++ b/packages/docs-nextra/pages/reference/mrow.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <mrow>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that renders a single line within a block of aligned display mathematics when 
 nested within the ` <md>{:dn}` or the ` <mdn>{:dn}` component.
 
-## Attributes and Properties 
- <AttrDisplay name='mrow'/> 
- <PropDisplay name='mrow'/>
+<AttrPropDisplay name='mrow'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/nbsp.mdx
+++ b/packages/docs-nextra/pages/reference/nbsp.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 # `<nbsp/>{:dn}`
 
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that renders white space in a paragraph.
 
 
-## Attributes and Properties 
-The `<nbsp/>{:dn}` component does not have attributes.
- <PropDisplay name='nbsp'/>
+<AttrPropDisplay name='nbsp'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/not.mdx
+++ b/packages/docs-nextra/pages/reference/not.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <not>{:dn}` is a [Logic](../document_structure/essentialConcepts#component-types) 
 component that can be used in place of typing `not` or using the symbol `!` to construct boolean conditions.
 
-## Attributes and Properties 
- <AttrDisplay name='not'/> 
- <PropDisplay name='not'/>
+<AttrPropDisplay name='not'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/number.mdx
+++ b/packages/docs-nextra/pages/reference/number.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <number>{:dn}`
@@ -13,9 +13,7 @@ and displays the result as text.
 The default precision for display is either: (1) rounded to three significant digits or (2) rounded 
 two decimal places, whichever has more digits.
 
-## Attributes and Properties 
- <AttrDisplay name='number'/> 
- <PropDisplay name='number'/>
+<AttrPropDisplay name='number'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/numberList.mdx
+++ b/packages/docs-nextra/pages/reference/numberList.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <numberList>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 components that accept a ` <numberList>{:dn}` as an input include ` <function>{:dn}`, ` <repeat>{:dn}`, 
 and ` <award>{:dn}`.
 
-## Attributes and Properties 
- <AttrDisplay name='numberList'/> 
- <PropDisplay name='numberList'/>
+<AttrPropDisplay name='numberList'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/odeSystem.mdx
+++ b/packages/docs-nextra/pages/reference/odeSystem.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <odeSystem>{:dn}`
@@ -8,9 +8,8 @@ import { AttrDisplay, PropDisplay } from "../../components"
 
 ` <odeSystem>{:dn}` computes a numerical solution to a system of ordinary differential equations. The following are required attributes: `variables` and `initialConditions`. The opening ` <odeSystem>{:dn}` tag defines a block in which to enter one or more ` <rightHandSide>{:dn}` children, representing the successive RHS's of the equations defining the system.
 
-## Attributes and Properties 
- <AttrDisplay name='odeSystem'/> 
- <PropDisplay name='odeSystem'/>
+<AttrPropDisplay name='odeSystem'/>
+
 ---
 
 ### Example: Single ODE system with user-input

--- a/packages/docs-nextra/pages/reference/ol.mdx
+++ b/packages/docs-nextra/pages/reference/ol.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <ol>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <ol>{:dn}` is a [Sectional](../document_structure/essentialConcepts#component-types)
 component that defines an ordered (numbered) list.  List items are nested within using an ` <li>{:dn}` tag.
 
-## Attributes and Properties 
- <AttrDisplay name='ol'/> 
- <PropDisplay name='ol'/>
+<AttrPropDisplay name='ol'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/option.mdx
+++ b/packages/docs-nextra/pages/reference/option.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <option>{:dn}`
@@ -17,9 +17,7 @@ When varying component types are used as options, such as
 a ` <text>{:dn}`, ` <function>{:dn}`, 
 or ` <number>{:dn}`, these tags are nested within the ` <option>{:dn}` tag.
 
-## Attributes and Properties 
- <AttrDisplay name='option'/> 
- <PropDisplay name='option'/>
+<AttrPropDisplay name='option'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/or.mdx
+++ b/packages/docs-nextra/pages/reference/or.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 
@@ -10,9 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that functions as the boolean operator `or` and checks to see whether any of 
 the enclosed ` <boolean>{:dn}` references are `true`.
 
-## Attributes and Properties 
- <AttrDisplay name='or'/> 
- <PropDisplay name='or'/>
+<AttrPropDisplay name='or'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/orbitalDiagramInput.mdx
+++ b/packages/docs-nextra/pages/reference/orbitalDiagramInput.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <orbitalDiagramInput/>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <orbitalDiagramInput/>{:dn}` is a [Subject-Specific](../document_structure/essentialConcepts#component-types)
 component that renders an interactive tool for student entry of orbital diagrams.
 
-## Attributes and Properties 
- <AttrDisplay name='orbitalDiagramInput'/> 
- <PropDisplay name='orbitalDiagramInput'/>
+<AttrPropDisplay name='orbitalDiagramInput'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/p.mdx
+++ b/packages/docs-nextra/pages/reference/p.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 
@@ -13,9 +13,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that renders a paragraph of text.
 
 
-## Attributes and Properties 
- The ` <p>{:dn}` component has no attributes.
- <PropDisplay name='p'/>
+<AttrPropDisplay name='p'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/paginator.mdx
+++ b/packages/docs-nextra/pages/reference/paginator.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <paginator>{:dn}`
@@ -10,9 +10,7 @@ component that organizes content into discrete pages, allowing users to navigate
 To create navigation buttons for the paginator, this component is typically used in conjunction with the 
 `<paginatorControls>{:dn}` component.
 
-## Attributes and Properties 
- <AttrDisplay name='paginator'/> 
- <PropDisplay name='paginator'/>
+<AttrPropDisplay name='paginator'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/paginatorControls.mdx
+++ b/packages/docs-nextra/pages/reference/paginatorControls.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <paginatorControls>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that works alongside the `<paginator>{:dn}` component to provide navigation buttons.
 
 
-## Attributes and Properties 
- <AttrDisplay name='paginatorControls'/> 
- <PropDisplay name='paginatorControls'/>
+<AttrPropDisplay name='paginatorControls'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/parabola.mdx
+++ b/packages/docs-nextra/pages/reference/parabola.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <parabola>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <parabola>{:dn}` is a [Graphical](../document_structure/essentialConcepts#component-types)
 component that renders a parabola when nested inside a [` <graph>{:dn}`](graph.mdx) component.
 
-## Attributes and Properties 
- <AttrDisplay name='parabola'/> 
- <PropDisplay name='parabola'/>
+<AttrPropDisplay name='parabola'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/piecewiseFunction.mdx
+++ b/packages/docs-nextra/pages/reference/piecewiseFunction.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <piecewiseFunction>{:dn}`
@@ -19,9 +19,7 @@ set to `false`, to force numerical evaluation.
 Individual ` <function>{:dn}` children need to be differentiated independently. Open and closed 
 endpoints must also be graphed as independent components (see [` <endpoint>{:dn}`](endpoint.mdx).)
 
-## Attributes and Properties 
- <AttrDisplay name='piecewiseFunction'/> 
- <PropDisplay name='piecewiseFunction'/>
+<AttrPropDisplay name='piecewiseFunction'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/point.mdx
+++ b/packages/docs-nextra/pages/reference/point.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 # ` <point>{:dn}`
 
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that renders a point on a ` <graph>{:dn}`.
 
 
-## Attributes and Properties 
- <AttrDisplay name='point'/> 
- <PropDisplay name='point'/>
+<AttrPropDisplay name='point'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/polygon.mdx
+++ b/packages/docs-nextra/pages/reference/polygon.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <polygon>{:dn}`
@@ -11,9 +11,8 @@ component that renders a general polygon when nested inside a [` <graph>{:dn}`](
 component. The ` <polygon>{:dn}` tag is self-closing and the `vertices` attribute is required.
 (See also, [`<regularPolygon>{:dn}`](regularPolygon.mdx).)
 
-## Attributes and Properties 
- <AttrDisplay name='polygon'/> 
- <PropDisplay name='polygon'/>
+<AttrPropDisplay name='polygon'/>
+
 ---
 
 ### Example: Default ` <polygon>{:dn}` from vertices

--- a/packages/docs-nextra/pages/reference/polyline.mdx
+++ b/packages/docs-nextra/pages/reference/polyline.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 # ` <polyline>{:dn}`
 
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that renders a polyline when nested inside a [` <graph>{:dn}`](graph.mdx) component.
 
 
-## Attributes and Properties 
- <AttrDisplay name='polyline'/> 
- <PropDisplay name='polyline'/>
+<AttrPropDisplay name='polyline'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/pre.mdx
+++ b/packages/docs-nextra/pages/reference/pre.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <pre>{:dn}`
@@ -10,9 +10,7 @@ The ` <pre>{:dn}` is a [Paragraph Markup](../document_structure/essentialConcept
 component that renders a block of text that preserves the formatting of the text directly as 
 input into the editor, including line spacing, font and indentation.
 
-## Attributes and Properties 
-The ` <pre>{:dn}` component has no attributes.
- <PropDisplay name='pre'/>
+<AttrPropDisplay name='pre'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/pretzel.mdx
+++ b/packages/docs-nextra/pages/reference/pretzel.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <pretzel>{:dn}`
@@ -15,9 +15,7 @@ If the pretzel contains any distractor, neither the statement nor the answer of 
 Each ` <problem>{:dn}` in a pretzel should contain one ` <statement>{:dn}` and one ` <answer>{:dn}`.
 
 
-## Attributes and Properties
- <AttrDisplay name='pretzel'/>
- <PropDisplay name='pretzel'/>
+<AttrPropDisplay name='pretzel'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/problem.mdx
+++ b/packages/docs-nextra/pages/reference/problem.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 # ` <problem>{:dn}`
 
@@ -11,9 +11,7 @@ component that renders an auto-numbered block of content. Inline components such
 content. Some examples are: another ` <problem>{:dn}`, a ` <section>{:dn}`, a ` <figure>{:dn}`, or 
 an ` <example>{:dn}`.
 
-## Attributes and Properties 
- <AttrDisplay name='problem'/> 
- <PropDisplay name='problem'/>
+<AttrPropDisplay name='problem'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/product.mdx
+++ b/packages/docs-nextra/pages/reference/product.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <product>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <product>{:dn}` is a [Math Operator](../document_structure/essentialConcepts#component-types)
 component that renders the product of its arguments.
 
-## Attributes and Properties 
- <AttrDisplay name='product'/> 
- <PropDisplay name='product'/>
+<AttrPropDisplay name='product'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/proof.mdx
+++ b/packages/docs-nextra/pages/reference/proof.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <proof>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 A ` <proof>{:dn}` is a [Sectional](../document_structure/essentialConcepts#component-types)
 component. It is unnumbered and collapsible. Its rendered appearance is similar to an ` <aside>{:dn}`.
 
-## Attributes and Properties 
- <AttrDisplay name='proof'/> 
- <PropDisplay name='proof'/>
+<AttrPropDisplay name='proof'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/ray.mdx
+++ b/packages/docs-nextra/pages/reference/ray.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 # ` <ray>{:dn}`
 
@@ -14,9 +14,7 @@ A ` <ray>{:dn}` may be specified with:
 1. the `endpoint` and the `through` attributes
 2. the `endpoint` and the `direction` attributes
 
-## Attributes and Properties 
- <AttrDisplay name='ray'/> 
- <PropDisplay name='ray'/>
+<AttrPropDisplay name='ray'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/rectangle.mdx
+++ b/packages/docs-nextra/pages/reference/rectangle.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 # ` <rectangle>{:dn}`
 
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <rectangle>{:dn}` is a [Graphical](../document_structure/essentialConcepts#component-types) 
 component that renders a rectangle when nested inside a [` <graph>{:dn}`](graph.mdx) component.
 
-## Attributes and Properties 
- <AttrDisplay name='rectangle'/> 
- <PropDisplay name='rectangle'/>
+<AttrPropDisplay name='rectangle'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/ref.mdx
+++ b/packages/docs-nextra/pages/reference/ref.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 
 The ` <ref>{:dn}` component renders a link to another Doenet document or to an external website.
 
-## Attributes and Properties 
- <AttrDisplay name='ref'/> 
- <PropDisplay name='ref'/>
+<AttrPropDisplay name='ref'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/regionBetweenCurveXAxis.mdx
+++ b/packages/docs-nextra/pages/reference/regionBetweenCurveXAxis.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 # ` <regionBetweenCurveXAxis>{:dn}`
 
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
  component that renders a shaded region on a graph between a specified function and the $x$-axis.
 
 
-## Attributes and Properties 
- <AttrDisplay name='regionBetweenCurveXAxis'/> 
- <PropDisplay name='regionBetweenCurveXAxis'/>
+<AttrPropDisplay name='regionBetweenCurveXAxis'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/regionBetweenCurves.mdx
+++ b/packages/docs-nextra/pages/reference/regionBetweenCurves.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 # ` <regionBetweenCurves>{:dn}`
 
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
  component that renders a shaded region on a graph between a specified function and the $x$-axis.
 
 
-## Attributes and Properties 
- <AttrDisplay name='regionBetweenCurves'/> 
- <PropDisplay name='regionBetweenCurves'/>
+<AttrPropDisplay name='regionBetweenCurves'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/regularPolygon.mdx
+++ b/packages/docs-nextra/pages/reference/regularPolygon.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <regularPolygon>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <regularPolygon>{:dn}` is a [Graphical](../document_structure/essentialConcepts#component-types)
 component that renders a regular polygon on a ` <graph>{:dn}`.
 
-## Attributes and Properties 
- <AttrDisplay name='regularPolygon'/> 
- <PropDisplay name='regularPolygon'/>
+<AttrPropDisplay name='regularPolygon'/>
 
 ## Examples Page 1
 

--- a/packages/docs-nextra/pages/reference/repeat.mdx
+++ b/packages/docs-nextra/pages/reference/repeat.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <repeat>{:dn}`
@@ -13,9 +13,7 @@ use the [` <repeatForSequence>{:dn}`](repeatForSequence.mdx) component.
 The behavior of the ` <repeat>{:dn}` component is similar to a for loop in other programming languages. 
 
 
-## Attributes and Properties 
- <AttrDisplay name='repeat'/> 
-` <repeat>{:dn}` does not have any properties.
+<AttrPropDisplay name='repeat'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/repeatForSequence.mdx
+++ b/packages/docs-nextra/pages/reference/repeatForSequence.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <repeatForSequence>{:dn}`
@@ -13,9 +13,7 @@ Its behavior is similar to a for loop in other programming languages.
 ---
 
 
-## Attributes and Properties 
- <AttrDisplay name='repeatForSequence'/> 
-` <repeatForSequence>{:dn}` does not have any properties.
+<AttrPropDisplay name='repeatForSequence'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/round.mdx
+++ b/packages/docs-nextra/pages/reference/round.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 `<round>{:dn}` is a [Math Operator](../document_structure/essentialConcepts#component-types)
 component that renders a numerical value rounded to the user-specified number of decimal places or digits.  Default rounding is to the nearest integer.
 
-## Attributes and Properties 
- <AttrDisplay name='round'/> 
- <PropDisplay name='round'/>
+<AttrPropDisplay name='round'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/row_matrix.mdx
+++ b/packages/docs-nextra/pages/reference/row_matrix.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <row>{:dn}` (in a matrix)
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <row>{:dn}` is a [Math](../document_structure/essentialConcepts#component-types)
 component that defines the individual row entries in a ` <matrix>{:dn}`.
 
-## Attributes and Properties 
- <AttrDisplay name='row'/> 
- <PropDisplay name='row'/>
+<AttrPropDisplay name='row'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/row_table.mdx
+++ b/packages/docs-nextra/pages/reference/row_table.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 
@@ -10,9 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <row>{:dn}` is a [Sectional](../document_structure/essentialConcepts#component-types)
 component that functions as a container element for the individual [` <cell>{:dn}`](cell.mdx) elements of  a [` <tabular>{:dn}`](tabular.mdx). 
 
-## Attributes and Properties 
- <AttrDisplay name='row'/> 
- <PropDisplay name='row'/>
+<AttrPropDisplay name='row'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/samplePrimeNumbers.mdx
+++ b/packages/docs-nextra/pages/reference/samplePrimeNumbers.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <samplePrimeNumbers/>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 `<samplePrimeNumbers/>{:dn}` is a [Math](../document_structure/essentialConcepts#component-types)
 component that generates random prime numbers from a specified range of values.
 
-## Attributes and Properties 
- <AttrDisplay name='samplePrimeNumbers'/> 
- <PropDisplay name='samplePrimeNumbers'/>
+<AttrPropDisplay name='samplePrimeNumbers'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/sampleRandomNumbers.mdx
+++ b/packages/docs-nextra/pages/reference/sampleRandomNumbers.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 
@@ -15,9 +15,7 @@ component's attributes. The primary application of the ` <sampleRandomNumbers/>{
 is for use in simulations involving random numbers.
 
 
-## Attributes and Properties 
- <AttrDisplay name='sampleRandomNumbers'/> 
- <PropDisplay name='sampleRandomNumbers'/>
+<AttrPropDisplay name='sampleRandomNumbers'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/sbsGroup.mdx
+++ b/packages/docs-nextra/pages/reference/sbsGroup.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <sbsGroup>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <sbsGroup>{:dn}` is a [Sectional](../document_structure/essentialConcepts#component-types)
 component that serves as a container element for multiple ` <sideBySide>{:dn}` components.
 
-## Attributes and Properties 
- <AttrDisplay name='sbsGroup'/> 
- <PropDisplay name='sbsGroup'/>
+<AttrPropDisplay name='sbsGroup'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/section.mdx
+++ b/packages/docs-nextra/pages/reference/section.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 # ` <section>{:dn}`
 
@@ -12,9 +12,7 @@ group and order content. Some examples are: another ` <section>{:dn}`,
 a ` <figure>{:dn}`, or a `<problem>{:dn}`.
 
 
-## Attributes and Properties 
- <AttrDisplay name='section'/> 
- <PropDisplay name='section'/>
+<AttrPropDisplay name='section'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/select.mdx
+++ b/packages/docs-nextra/pages/reference/select.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <select>{:dn}`
@@ -10,9 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that selects values from a list or from a group of 
 nested [` <option>{:dn}`](option.mdx) components at random. Selections generate variants of the document.
 
-## Attributes and Properties 
- <AttrDisplay name='select'/> 
- <PropDisplay name='select'/>
+<AttrPropDisplay name='select'/>
  
 ---
 

--- a/packages/docs-nextra/pages/reference/selectFromSequence.mdx
+++ b/packages/docs-nextra/pages/reference/selectFromSequence.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <selectFromSequence>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <selectFromSequence>{:dn}` is a [Math](../document_structure/essentialConcepts#component-types)
 component that creates named variants from a user-defined range of numerical (or alphabetical) values. Selections generate variants of the document.
 
-## Attributes and Properties 
- <AttrDisplay name='selectFromSequence'/> 
- <PropDisplay name='selectFromSequence'/>
+<AttrPropDisplay name='selectFromSequence'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/selectPrimeNumbers.mdx
+++ b/packages/docs-nextra/pages/reference/selectPrimeNumbers.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <selectPrimeNumbers/>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <selectPrimeNumbers/>{:dn}` is a [Math](../document_structure/essentialConcepts#component-types) 
 component that selects a prime number at random from a specified range. Selections generate variants of the document.
 
-## Attributes and Properties 
- <AttrDisplay name='selectPrimeNumbers'/> 
- <PropDisplay name='selectPrimeNumbers'/>
+<AttrPropDisplay name='selectPrimeNumbers'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/selectRandomNumbers.mdx
+++ b/packages/docs-nextra/pages/reference/selectRandomNumbers.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # `<selectRandomNumbers/>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that generates document variants by selecting random numbers from a specified range of 
 values or within a normal distribution around a specified mean.
 
-## Attributes and Properties 
- <AttrDisplay name='selectRandomNumbers'/> 
- <PropDisplay name='selectRandomNumbers'/>
+<AttrPropDisplay name='selectRandomNumbers'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/sequence.mdx
+++ b/packages/docs-nextra/pages/reference/sequence.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <sequence>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <sequence>{:dn}` is a [Math](../document_structure/essentialConcepts#component-types)
 component that defines a sequence of numerical (or alphabetical) values.
 
-## Attributes and Properties 
- <AttrDisplay name='sequence'/> 
-The `<sequence>{:dn}` component does not have properties.
+<AttrPropDisplay name='sequence'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/setSmallToZero.mdx
+++ b/packages/docs-nextra/pages/reference/setSmallToZero.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <setSmallToZero>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <setSmallToZero>{:dn}` is a [Math Operator](../document_structure/essentialConcepts#component-types) component 
 that replaces very small floating point numbers that arise during numerical computations to a precise zero value.
 
-## Attributes and Properties 
- <AttrDisplay name='setSmallToZero'/> 
- <PropDisplay name='setSmallToZero'/>
+<AttrPropDisplay name='setSmallToZero'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/setup.mdx
+++ b/packages/docs-nextra/pages/reference/setup.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <setup>{:dn}`
@@ -11,9 +11,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 acts as a container element for defining other components. Content defined within the ` <setup>{:dn}` 
 portion will not be rendered.
 
-## Attributes and Properties 
-
-The ` <setup>{:dn}` component has no attributes or properties.
+<AttrPropDisplay name='setup'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/shuffle.mdx
+++ b/packages/docs-nextra/pages/reference/shuffle.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <shuffle>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <shuffle>{:dn}` is a [Math Operator](../document_structure/essentialConcepts/#componentTypes)
 component that re-orders a list of referenced components and creates document variants based on the different possible orders.
 
-## Attributes and Properties 
- <AttrDisplay name='shuffle'/> 
-The ` <shuffle>{:dn}` component has no properties.
+<AttrPropDisplay name='shuffle'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/sideBySide.mdx
+++ b/packages/docs-nextra/pages/reference/sideBySide.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <sideBySide>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <sideBySide>{:dn}` is a [Sectional](../document_structure/essentialConcepts/#componentTypes) 
 component that takes enclosed sectional components and renders them in a side-by-side horizontal format.
 
-## Attributes and Properties 
- <AttrDisplay name='sideBySide'/> 
- <PropDisplay name='sideBySide'/>
+<AttrPropDisplay name='sideBySide'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/sign.mdx
+++ b/packages/docs-nextra/pages/reference/sign.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <sign>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <sign>{:dn}` is a [Math Operator](../document_structure/essentialConcepts#component-types)
 component that renders the result of the $\text{sign}$ or the $\text{signum}$ function on the enclosed argument.
 
-## Attributes and Properties 
- <AttrDisplay name='sign'/> 
- <PropDisplay name='sign'/>
+<AttrPropDisplay name='sign'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/slider.mdx
+++ b/packages/docs-nextra/pages/reference/slider.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
  
@@ -11,9 +11,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <slider>{:dn}` is an [Input](../document_structure/essentialConcepts#component-types)
 component that renders a draggable selection bar for graphical user input of a single value.
 
-## Attributes and Properties 
- <AttrDisplay name='slider'/> 
- <PropDisplay name='slider'/>
+<AttrPropDisplay name='slider'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/solution.mdx
+++ b/packages/docs-nextra/pages/reference/solution.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <solution>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 
 ` <solution>{:dn}` is a [Sectional](../document/essentialConcepts/#componentTypes) component whose function is to display an explanation or problem solution.
 
-## Attributes and Properties 
-The ` <solution>{:dn}` component has no attributes.
- <PropDisplay name='solution'/>
+<AttrPropDisplay name='solution'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/sort.mdx
+++ b/packages/docs-nextra/pages/reference/sort.mdx
@@ -1,15 +1,13 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <sort>{:dn}`
 
 ` <sort>{:dn}` is an [General Operator](../document/essentialConcepts/#componentTypes) component that reorders a list of components based on given criteria.
 
-## Attributes and Properties 
- <AttrDisplay name='sort'/> 
- <PropDisplay name='sort'/>
+<AttrPropDisplay name='sort'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/split.mdx
+++ b/packages/docs-nextra/pages/reference/split.mdx
@@ -1,8 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
-
-## Attributes and Properties 
+import { AttrPropDisplay } from "../../components"
 
 # ` <split>{:dn}`
 
@@ -10,8 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <split>{:dn}` is an [General Operator](../document_structure/essentialConcepts/#componentTypes) 
 component that splits a numerical value or a text string into separate characters.
 
-<AttrDisplay name='split'/> 
-The ` <split>{:dn}` component has no properties.
+<AttrPropDisplay name='split'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/spreadsheet.mdx
+++ b/packages/docs-nextra/pages/reference/spreadsheet.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <spreadsheet>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <spreadsheet>{:dn}` is a [General Operator](../document_structure/essentialConcepts/#componentTypes) 
 component that renders a basic embedded spreadsheet tool.
 
-## Attributes and Properties 
- <AttrDisplay name='spreadsheet'/> 
- <PropDisplay name='spreadsheet'/>
+<AttrPropDisplay name='spreadsheet'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/stack.mdx
+++ b/packages/docs-nextra/pages/reference/stack.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <stack>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <stack>{:dn}` is a [Sectional](../document_structure/essentialConcepts/#componentTypes) 
 component that groups content vertically. It is used with a ` <sideBySide>{:dn}` to organize elements on a page.
 
-## Attributes and Properties 
-The ` <stack>{:dn}` component has no attributes.
- <PropDisplay name='stack'/>
+<AttrPropDisplay name='stack'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/standardDeviation.mdx
+++ b/packages/docs-nextra/pages/reference/standardDeviation.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <standardDeviation>{:dn}`
@@ -21,9 +21,7 @@ standard deviation is calculated.  If instead, the `population` attribute is spe
 $$\sigma(x) = \sqrt{\frac{\sum_{i=1}^n (x_{i} - \bar x)^2}{n}}$$
 
 
-## Attributes and Properties 
- <AttrDisplay name='standardDeviation'/> 
- <PropDisplay name='standardDeviation'/>
+<AttrPropDisplay name='standardDeviation'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/styleDefinition.mdx
+++ b/packages/docs-nextra/pages/reference/styleDefinition.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <styleDefinition>{:dn}`
@@ -12,9 +12,7 @@ component that allows the user to define custom styles for an individual documen
 
 These new styles are assigned unique numbers that can be used locally in that document.
 
-## Attributes and Properties 
- <AttrDisplay name='styleDefinition'/> 
- <PropDisplay name='styleDefinition'/>
+<AttrPropDisplay name='styleDefinition'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/subsetOfReals.mdx
+++ b/packages/docs-nextra/pages/reference/subsetOfReals.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 # ` <subsetOfReals>{:dn}`
 
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <subsetOfReals>{:dn}` is a [Math](../document_structure/essentialConcepts/#componentTypes)
 component that defines an interval or a subset on the number line.
 
-## Attributes and Properties 
- <AttrDisplay name='subsetOfReals'/> 
- <PropDisplay name='subsetOfReals'/>
+<AttrPropDisplay name='subsetOfReals'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/substitute.mdx
+++ b/packages/docs-nextra/pages/reference/substitute.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <substitute>{:dn}`
@@ -12,9 +12,7 @@ component that replaces one character or string from a math or a text with anoth
 
 Note that substitution is used for variables in math expressions, not numerical values. Doenet ignores requests for substitution of strict numerical values in math expressions.
 
-## Attributes and Properties 
- <AttrDisplay name='substitute'/> 
- <PropDisplay name='substitute'/>
+<AttrPropDisplay name='substitute'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/sum.mdx
+++ b/packages/docs-nextra/pages/reference/sum.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 # ` <sum>{:dn}`
 
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that renders the sum of its arguments.
 
 
-## Attributes and Properties 
- <AttrDisplay name='sum'/> 
- <PropDisplay name='sum'/>
+<AttrPropDisplay name='sum'/>
  
 
 ---

--- a/packages/docs-nextra/pages/reference/table.mdx
+++ b/packages/docs-nextra/pages/reference/table.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 # ` <table>{:dn}`
 
@@ -10,9 +10,7 @@ component that serves as a container element for data rendered
 in a `<tabular>{:dn}` format.  Much of the DoenetML for customizing the appearance 
 of a table occurs in its ` <tabular>{:dn}`, ` <row>{:dn}`, or ` <cell>{:dn}` children.
 
-## Attributes and Properties 
- <AttrDisplay name='table'/> 
- <PropDisplay name='table'/>
+<AttrPropDisplay name='table'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/tabular.mdx
+++ b/packages/docs-nextra/pages/reference/tabular.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <tabular>{:dn}`
@@ -12,9 +12,7 @@ inside a ` <tabular>{:dn}` component are the [` <row>{:dn}`](row.mdx) and [` <ce
 components. 
 
 
-## Attributes and Properties 
- <AttrDisplay name='tabular'/> 
- <PropDisplay name='tabular'/>
+<AttrPropDisplay name='tabular'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/tag.mdx
+++ b/packages/docs-nextra/pages/reference/tag.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # `<tag>{:dn}`, ` <tage/>{:dn}`
@@ -12,9 +12,7 @@ Similarly, a `<tage/>{:dn}` component may be used to render
 a self-closing tag (i.e. `< componentName />`).  Use of ` <tag>{:dn}` and ` <tage/>{:dn}` will prevent errors with 
 rendering these symbols, allowing them to be used for display rather than as functional components within the document.
 
-## Attributes and Properties 
- 
-The ` <tag>{:dn}` and ` <tage/>{:dn}` components do not have any attributes or properties.
+<AttrPropDisplay name='tag'/>
 
 
 

--- a/packages/docs-nextra/pages/reference/term.mdx
+++ b/packages/docs-nextra/pages/reference/term.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <term>{:dn}`
@@ -10,9 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that renders the enclosed text in the emphasized 
 styling associated with a defined vocabulary word.
 
-## Attributes and Properties 
-The ` <term>{:dn}` component does not have any attributes.
- <PropDisplay name='term'/>
+<AttrPropDisplay name='term'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/text.mdx
+++ b/packages/docs-nextra/pages/reference/text.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <text>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <text>{:dn}` is a [Text](../document_structure/essentialConcepts/#componentTypes)
 component that defines a string variable for use in evaluations and boolean expressions, or to store a value for future rendering.
 
-## Attributes and Properties 
- <AttrDisplay name='text'/> 
- <PropDisplay name='text'/>
+<AttrPropDisplay name='text'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/textInput.mdx
+++ b/packages/docs-nextra/pages/reference/textInput.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 # ` <textInput/>{:dn}`
 
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <textInput/>{:dn}` is an [Input](../document_structure/essentialConcepts/#componentTypes)
 component that renders a form input field for text responses from the user.
 
-## Attributes and Properties 
- <AttrDisplay name='textInput'/> 
- <PropDisplay name='textInput'/>
+<AttrPropDisplay name='textInput'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/textList.mdx
+++ b/packages/docs-nextra/pages/reference/textList.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <textList>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 The ` <textList>{:dn}` is a [Text](../document_structure/essentialConcepts/#componentTypes)
 component that stores multiple [` <text>{:dn}`](text.mdx) components within a list.
 
-## Attributes and Properties 
- <AttrDisplay name='textList'/> 
- <PropDisplay name='textList'/>
+<AttrPropDisplay name='textList'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/title.mdx
+++ b/packages/docs-nextra/pages/reference/title.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <title>{:dn}`
@@ -11,9 +11,7 @@ component that renders a title with default formatting to match the heierarchy o
 associated sectional component. A ` <title>{:dn}` placed at the top of the document 
 creates a document title.
 
-## Attributes and Properties 
- The ` <title>{:dn}` component has no attributes.
- <PropDisplay name='title'/>
+<AttrPropDisplay name='title'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/triangle.mdx
+++ b/packages/docs-nextra/pages/reference/triangle.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <triangle>{:dn}`
@@ -10,9 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <triangle>{:dn}` is a [Graphical](../document_structure/essentialConcepts/#componentTypes)
 component that renders a triangle when nested inside a [` <graph>{:dn}`](graph.mdx) component.
 
-## Attributes and Properties 
- <AttrDisplay name='triangle'/> 
- <PropDisplay name='triangle'/>
+<AttrPropDisplay name='triangle'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/triggerSet.mdx
+++ b/packages/docs-nextra/pages/reference/triggerSet.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <triggerSet>{:dn}`
@@ -10,9 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that combines the actions of multiple ` <updateValue>{:dn}`, ` <triggerSet>{:dn}` and/or ` <callAction>{:dn}` components and allows them to be triggered by a single button click interaction or boolean condition.
 
 
-## Attributes and Properties 
- <AttrDisplay name='triggerSet'/> 
- <PropDisplay name='triggerSet'/>
+<AttrPropDisplay name='triggerSet'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/ul.mdx
+++ b/packages/docs-nextra/pages/reference/ul.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <ul>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that renders an unordered (bulleted) list. The ` <ul>{:dn}` component can only take [`<li>{:dn}`](li.mdx) 
 components (list items) as children.
 
-## Attributes and Properties 
- <AttrDisplay name='ul'/> 
- <PropDisplay name='ul'/>
+<AttrPropDisplay name='ul'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/updateValue.mdx
+++ b/packages/docs-nextra/pages/reference/updateValue.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <updateValue>{:dn}`
@@ -10,9 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that changes the value or property of a named component based on a button click interaction or a boolean condition.
 
 
-## Attributes and Properties 
- <AttrDisplay name='updateValue'/> 
- <PropDisplay name='updateValue'/>
+<AttrPropDisplay name='updateValue'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/variance.mdx
+++ b/packages/docs-nextra/pages/reference/variance.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <variance>{:dn}`
@@ -22,9 +22,7 @@ becomes:
 $$\mathbf{Var}(x) = \frac{\sum_{i=1}^n (x_{i} - \bar x)^2}{n}$$
 
 
-## Attributes and Properties 
- <AttrDisplay name='variance'/> 
- <PropDisplay name='variance'/>
+<AttrPropDisplay name='variance'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/vector.mdx
+++ b/packages/docs-nextra/pages/reference/vector.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <vector>{:dn}`
@@ -8,9 +8,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <vector>{:dn}` is a [Graphical](../document_structure/essentialConcepts/#componentTypes)
 component that renders a vector when nested within a [` <graph>{:dn}`](graph.mdx). Outside a graph, it can be used in vector computations.
 
-## Attributes and Properties 
- <AttrDisplay name='vector'/> 
- <PropDisplay name='vector'/>
+<AttrPropDisplay name='vector'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/video.mdx
+++ b/packages/docs-nextra/pages/reference/video.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <video/>{:dn}` 
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that renders an embedded video.
 
 
-## Attributes and Properties 
- <AttrDisplay name='video'/> 
- <PropDisplay name='video'/>
+<AttrPropDisplay name='video'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/when.mdx
+++ b/packages/docs-nextra/pages/reference/when.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <when>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <when>{:dn}` is an [Evaluation](../document_structure/essentialConcepts/#componentTypes)
 component that is used for creating boolean conditions within an [` <award>{:dn}`](award.mdx).
 
-## Attributes and Properties 
- <AttrDisplay name='when'/> 
- <PropDisplay name='when'/>
+<AttrPropDisplay name='when'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/wrapNumberPeriodic.mdx
+++ b/packages/docs-nextra/pages/reference/wrapNumberPeriodic.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <wrapNumberPeriodic>{:dn}`
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <wrapNumberPeriodic>{:dn}` is a [Math Operator](../document_structure/essentialConcepts/#componentTypes) 
 component that wraps a number line around a circle.
 
-## Attributes and Properties 
- <AttrDisplay name='wrapNumberPeriodic'/> 
- <PropDisplay name='wrapNumberPeriodic'/>
+<AttrPropDisplay name='wrapNumberPeriodic'/>
 
 
 ---

--- a/packages/docs-nextra/pages/reference/xLabel.mdx
+++ b/packages/docs-nextra/pages/reference/xLabel.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 # ` <xLabel>{:dn}`
@@ -10,9 +10,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that specifies a label for the horizontal axis on a ` <graph>{:dn}`.
 
 
-## Attributes and Properties 
- <AttrDisplay name='xLabel'/> 
- <PropDisplay name='xLabel'/>
+<AttrPropDisplay name='xLabel'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/xor.mdx
+++ b/packages/docs-nextra/pages/reference/xor.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 
@@ -11,9 +11,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 component that functions as the exclusive `or` boolean operator, and checks to see whether one and 
 only one of the enclosed ` <boolean>{:dn}` references are `true`.
 
-## Attributes and Properties 
- <AttrDisplay name='xor'/> 
- <PropDisplay name='xor'/>
+<AttrPropDisplay name='xor'/>
 
 ---
 

--- a/packages/docs-nextra/pages/reference/yLabel.mdx
+++ b/packages/docs-nextra/pages/reference/yLabel.mdx
@@ -1,6 +1,6 @@
 import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
 
-import { AttrDisplay, PropDisplay } from "../../components"
+import { AttrPropDisplay } from "../../components"
 
 
 
@@ -9,9 +9,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 ` <yLabel>{:dn}` is a [Graphical](../document_structure/essentialConcepts/#componentTypes)
 component that specifies a label for the vertical axis on a ` <graph>{:dn}`.
 
-## Attributes and Properties 
- <AttrDisplay name='yLabel'/> 
- <PropDisplay name='yLabel'/>
+<AttrPropDisplay name='yLabel'/>
 
  ---
 

--- a/packages/docs-nextra/pages/style.css
+++ b/packages/docs-nextra/pages/style.css
@@ -9,41 +9,7 @@
     margin-top: 1.5rem;
 }
 
-.attr-table,
-.prop-table {
-    margin-left: auto;
-    margin-right: auto;
-    border: 1px solid rgb(229, 231, 235);
-    border-radius: 6px;
-    background-color: white;
-    padding: 10px;
-    padding-left: 0;
-    padding-right: 0;
-}
-:is(html[class~="dark"] .nextra-content) .attr-table,
-:is(html[class~="dark"] .nextra-content) .prop-table {
-    background-color: rgb(31, 41, 55);
-    border: 1px solid rgb(31, 41, 55);
-}
-.attr-table td,
-.attr-table th,
-.prop-table td,
-.prop-table th {
-    border-bottom: 1px solid rgb(229, 231, 235);
-}
-.attr-table tr:last-child td,
-.prop-table tr:last-child td {
-    border-bottom: none;
-}
-
-.attr-table td,
-.prop-table td {
-    padding: 0.25em 1em;
-}
-.attr-table caption,
-.prop-table caption {
-    margin: 1em 0;
-}
+/* Attribute and property names highlighted in blue. */
 .attr-name,
 .prop-name {
     color: rgb(29, 85, 197);
@@ -52,21 +18,99 @@
 :is(html[class~="dark"] .nextra-content) .prop-name {
     color: rgb(0, 122, 255);
 }
-.attr-value {
-    color: rgb(194, 31, 138);
-    margin-right: 1ex;
-}
-.attr-value:last-child {
-    margin-right: 0;
-}
+
+/* Type label that leads each indented detail paragraph. */
 .attr-type,
 .prop-type {
     font-style: italic;
 }
 
-.attr-table caption p,
-.prop-table caption p {
-    margin: unset;
-    padding: unset;
-    display: inline;
+/* Non-tabular attribute and property lists rendered by
+   <AttrDisplay> / <PropDisplay>. */
+.attr-list,
+.prop-list {
+    margin: 1em 0;
+}
+
+/* List captions rendered as headings. */
+.attr-list-caption,
+.prop-list-caption {
+    margin: 1.5em 0 0.75em;
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.attr-item,
+.prop-item {
+    margin: 1.25em 0;
+}
+
+/* Gray pill around the attribute/property name, mirroring the editor
+   help panel. */
+.attr-name-box,
+.prop-name-box {
+    display: inline-block;
+    background-color: rgb(229, 231, 235);
+    border-radius: 0.25rem;
+    padding: 0.1rem 0.45rem;
+}
+:is(html[class~="dark"] .nextra-content) .attr-name-box,
+:is(html[class~="dark"] .nextra-content) .prop-name-box {
+    background-color: rgb(55, 65, 81);
+}
+
+/* Indented type + description paragraph under each name. */
+.attr-detail,
+.prop-detail {
+    margin: 0.35em 0 0.35em 1.75em;
+}
+
+/* Default value shown immediately after the type. */
+.attr-default {
+    background-color: rgb(243, 244, 246);
+    border-radius: 0.25rem;
+    padding: 0.05rem 0.35rem;
+}
+:is(html[class~="dark"] .nextra-content) .attr-default {
+    background-color: rgb(55, 65, 81);
+}
+
+/* Keyword value rendered as a pill (no surrounding quotes). */
+.attr-value-chip {
+    display: inline-block;
+    background-color: rgb(229, 231, 235);
+    border-radius: 0.6rem;
+    padding: 0.05rem 0.5rem;
+}
+:is(html[class~="dark"] .nextra-content) .attr-value-chip {
+    background-color: rgb(55, 65, 81);
+}
+
+/* "(default)" marker after the default keyword value. */
+.attr-default-marker {
+    font-style: italic;
+    color: rgb(107, 114, 128);
+}
+
+/* Small Value/Description table for enumerated (non-boolean) attributes. */
+.attr-value-table {
+    margin: 0.5em 0 0.5em 1.75em;
+    border-collapse: collapse;
+}
+.attr-value-table th,
+.attr-value-table td {
+    border: 1px solid rgb(229, 231, 235);
+    padding: 0.2em 0.7em;
+    text-align: left;
+}
+:is(html[class~="dark"] .nextra-content) .attr-value-table th,
+:is(html[class~="dark"] .nextra-content) .attr-value-table td {
+    border-color: rgb(55, 65, 81);
+}
+
+/* Component summary rendered by <ComponentDisplay>. */
+.component-summary {
+    margin-top: 0.5em;
+    margin-bottom: 1em;
+    font-style: italic;
 }

--- a/packages/docs-nextra/scripts/auto-insert-attr-prop-descriptions.ts
+++ b/packages/docs-nextra/scripts/auto-insert-attr-prop-descriptions.ts
@@ -2,9 +2,12 @@ import { visit } from "unist-util-visit";
 import { Plugin } from "unified";
 import { computeOptimizedSchema } from "./compute-optimized-schema";
 import { parseModule, Program as EstreeProgram } from "esprima";
-import { Root as MdastRoot } from "mdast";
+import { Heading, Root as MdastRoot } from "mdast";
 // Importing this automatically imports all the types from `mdast-util-mdx-jsx`.
 import "mdast-util-mdx-jsx";
+import type { MdxJsxFlowElement } from "mdast-util-mdx-jsx";
+
+type OptimizedInfo = ReturnType<typeof computeOptimizedSchema>[string];
 
 export const autoInsertAttrPropDescriptions: Plugin<
     void[],
@@ -15,11 +18,16 @@ export const autoInsertAttrPropDescriptions: Plugin<
     return (tree, file) => {
         file.data.extraSearchData = {};
 
-        visit(tree, (node) => {
+        visit(tree, (node, index, parent) => {
             if (node?.type !== "mdxJsxFlowElement") {
                 return;
             }
-            if (node.name !== "AttrDisplay" && node.name !== "PropDisplay") {
+            if (
+                node.name !== "AttrDisplay" &&
+                node.name !== "PropDisplay" &&
+                node.name !== "ComponentDisplay" &&
+                node.name !== "AttrPropDisplay"
+            ) {
                 return;
             }
             const nameAttr = node.attributes.find(
@@ -32,65 +40,125 @@ export const autoInsertAttrPropDescriptions: Plugin<
                 return;
             }
 
-            if (
-                node.name === "AttrDisplay" &&
-                !node.attributes.find(
-                    (attr) =>
-                        attr.type === "mdxJsxAttribute" &&
-                        attr.name === "attrs",
-                )
-            ) {
-                // Info has all the schema information for this element. We need to insert it into the node.
-                node.attributes.push({
-                    type: "mdxJsxAttribute",
-                    name: "attrs",
-                    value: {
-                        type: "mdxJsxAttributeValueExpression",
-                        value: JSON.stringify(info.attrs),
-                        data: {
-                            estree: objectToEstree(info.attrs),
-                        },
-                    },
-                });
-
-                // Add some data that will be used for search
-                // @ts-ignore
-                file.data.extraSearchData["attr-list#Attribute"] = info.attrs
-                    .filter((attr) => !attr.common)
-                    .map((attr) => attr.name)
-                    .join("\n");
+            if (node.name === "AttrDisplay") {
+                injectAttrs(node, info, file);
+            }
+            if (node.name === "PropDisplay") {
+                injectProps(node, info, file);
+            }
+            if (node.name === "ComponentDisplay") {
+                injectSummary(node, info, file);
             }
             if (
-                node.name === "PropDisplay" &&
-                !node.attributes.find(
-                    (attr) =>
-                        attr.type === "mdxJsxAttribute" &&
-                        attr.name === "props",
-                )
+                node.name === "AttrPropDisplay" &&
+                parent &&
+                typeof index === "number"
             ) {
-                // Info has all the schema information for this element. We need to insert it into the node.
-                node.attributes.push({
-                    type: "mdxJsxAttribute",
-                    name: "props",
-                    value: {
-                        type: "mdxJsxAttributeValueExpression",
-                        value: JSON.stringify(info.props),
-                        data: {
-                            estree: objectToEstree(info.props),
-                        },
-                    },
-                });
-
-                // Add some data that will be used for search
-                // @ts-ignore
-                file.data.extraSearchData["prop-list#Property"] = info.props
-                    .filter((prop) => !prop.common)
-                    .map((prop) => prop.name)
-                    .join("\n");
+                // <AttrPropDisplay> renders the attribute and property
+                // sections (or "no attributes/properties" messages), so it
+                // needs both data sets.
+                injectAttrs(node, info, file);
+                injectProps(node, info, file);
+                // Emit the section heading as a real Markdown heading so it
+                // picks up the theme's heading styling, anchor, and TOC entry.
+                const heading: Heading = {
+                    type: "heading",
+                    depth: 2,
+                    children: [
+                        { type: "text", value: "Attributes and Properties" },
+                    ],
+                };
+                parent.children.splice(index, 0, heading);
+                // Continue past the inserted heading and this node.
+                return index + 2;
             }
         });
     };
 };
+
+/** Whether `node` already carries an attribute named `attrName`. */
+function hasAttribute(node: MdxJsxFlowElement, attrName: string): boolean {
+    return node.attributes.some(
+        (attr) => attr.type === "mdxJsxAttribute" && attr.name === attrName,
+    );
+}
+
+/** Inject the schema `attrs` data onto an `<AttrDisplay>`/`<AttrPropDisplay>`. */
+function injectAttrs(
+    node: MdxJsxFlowElement,
+    info: OptimizedInfo,
+    file: { data: Record<string, any> },
+): void {
+    if (hasAttribute(node, "attrs")) {
+        return;
+    }
+    node.attributes.push({
+        type: "mdxJsxAttribute",
+        name: "attrs",
+        value: {
+            type: "mdxJsxAttributeValueExpression",
+            value: JSON.stringify(info.attrs),
+            data: {
+                estree: objectToEstree(info.attrs),
+            },
+        },
+    });
+
+    // Add some data that will be used for search. Include the descriptions
+    // so searches match the explanatory text too.
+    file.data.extraSearchData["attr-list#Attribute"] = info.attrs
+        .filter((attr) => !attr.common)
+        .map((attr) => `${attr.name}: ${attr.description}`)
+        .join("\n");
+}
+
+/** Inject the schema `props` data onto a `<PropDisplay>`/`<AttrPropDisplay>`. */
+function injectProps(
+    node: MdxJsxFlowElement,
+    info: OptimizedInfo,
+    file: { data: Record<string, any> },
+): void {
+    if (hasAttribute(node, "props")) {
+        return;
+    }
+    node.attributes.push({
+        type: "mdxJsxAttribute",
+        name: "props",
+        value: {
+            type: "mdxJsxAttributeValueExpression",
+            value: JSON.stringify(info.props),
+            data: {
+                estree: objectToEstree(info.props),
+            },
+        },
+    });
+
+    // Add some data that will be used for search. Include the descriptions
+    // so searches match the explanatory text too.
+    file.data.extraSearchData["prop-list#Property"] = info.props
+        .filter((prop) => !prop.common)
+        .map((prop) => `${prop.name}: ${prop.description}`)
+        .join("\n");
+}
+
+/** Inject the schema `summary` onto a `<ComponentDisplay>`. */
+function injectSummary(
+    node: MdxJsxFlowElement,
+    info: OptimizedInfo,
+    file: { data: Record<string, any> },
+): void {
+    if (hasAttribute(node, "summary")) {
+        return;
+    }
+    node.attributes.push({
+        type: "mdxJsxAttribute",
+        name: "summary",
+        value: info.summary,
+    });
+
+    // Add the summary to the search data.
+    file.data.extraSearchData["component-summary#Description"] = info.summary;
+}
 
 /**
  * Turn a plain JS object into an ESTree object suitable for including in a `mdxJsxAttributeValueExpression`.

--- a/packages/docs-nextra/scripts/auto-insert-attr-prop-descriptions.ts
+++ b/packages/docs-nextra/scripts/auto-insert-attr-prop-descriptions.ts
@@ -49,18 +49,27 @@ export const autoInsertAttrPropDescriptions: Plugin<
             if (node.name === "ComponentDisplay") {
                 injectSummary(node, info, file);
             }
-            if (
-                node.name === "AttrPropDisplay" &&
-                parent &&
-                typeof index === "number"
-            ) {
+            if (node.name === "AttrPropDisplay") {
                 // <AttrPropDisplay> renders the attribute and property
                 // sections (or "no attributes/properties" messages), so it
-                // needs both data sets.
+                // needs both data sets. This injection does not depend on the
+                // node's position, so it always runs.
                 injectAttrs(node, info, file);
                 injectProps(node, info, file);
+
                 // Emit the section heading as a real Markdown heading so it
                 // picks up the theme's heading styling, anchor, and TOC entry.
+                // A flow element should always have a parent and numeric
+                // index; if it does not, the tree is malformed — surface a
+                // warning rather than silently dropping the heading.
+                if (!parent || typeof index !== "number") {
+                    file.message(
+                        `<AttrPropDisplay name="${name}"> has no parent node; ` +
+                            `the "Attributes and Properties" heading was not inserted.`,
+                        node,
+                    );
+                    return;
+                }
                 const heading: Heading = {
                     type: "heading",
                     depth: 2,

--- a/packages/docs-nextra/scripts/compute-optimized-schema.ts
+++ b/packages/docs-nextra/scripts/compute-optimized-schema.ts
@@ -4,15 +4,29 @@ import { AttrInfo, PropAttrType, PropInfo } from "../components";
 const SCHEMA: {
     elements: {
         name: string;
+        summary: string;
         children: string[];
-        attributes: { name: string; values?: string[] }[];
-        properties: { name: string; type?: string; isArray: boolean }[];
+        attributes: {
+            name: string;
+            type?: string;
+            description: string;
+            defaultValue?: unknown;
+            values?: string[];
+            autocompleteValues?: { value: string; description: string }[];
+        }[];
+        properties: {
+            name: string;
+            type?: string;
+            isArray: boolean;
+            description: string;
+        }[];
         acceptsStringChildren: boolean;
         top: boolean;
     }[];
 } = doenetSchema;
 
 type OptimizedSchemaItem = {
+    summary: string;
     children: string[];
     parents: string[];
     attrs: AttrInfo[];
@@ -27,7 +41,13 @@ export function computeOptimizedSchema() {
         Object.fromEntries(
             SCHEMA.elements.map((element) => [
                 element.name,
-                { children: [], parents: [], attrs: [], props: [] },
+                {
+                    summary: element.summary,
+                    children: [],
+                    parents: [],
+                    attrs: [],
+                    props: [],
+                },
             ]),
         );
 
@@ -87,17 +107,27 @@ function getAttrInfo(element: (typeof SCHEMA)["elements"][number]) {
         const info: AttrInfo = {
             name: attr.name,
             common: false,
+            description: attr.description,
         };
-        if (attr.values) {
-            info.values = attr.values;
+        // The type comes from the attribute's own schema entry.
+        if (attr.type) {
+            info.type = attr.type as PropAttrType;
         }
-        if (correspondingProp) {
-            if (correspondingProp.type) {
-                info.type = correspondingProp.type as PropAttrType;
-            }
-            if (correspondingProp.isArray) {
-                info.isArray = true;
-            }
+        if (attr.defaultValue !== undefined) {
+            info.defaultValue = attr.defaultValue;
+        }
+        if (attr.autocompleteValues) {
+            // Prefer the author-facing values, which carry per-value descriptions.
+            info.values = attr.autocompleteValues.map((v) => ({
+                value: v.value,
+                description: v.description,
+            }));
+        } else if (attr.values) {
+            info.values = attr.values.map((value) => ({ value }));
+        }
+        // `isArray` is still cross-referenced from a same-named property.
+        if (correspondingProp?.isArray) {
+            info.isArray = true;
         }
 
         attrInfo.push(info);
@@ -115,6 +145,7 @@ function getPropInfo(element: (typeof SCHEMA)["elements"][number]) {
             name: prop.name,
             type: prop.type as PropAttrType,
             common: false,
+            description: prop.description,
         };
         if (prop.isArray) {
             info.isArray = true;

--- a/packages/docs-nextra/scripts/compute-optimized-schema.ts
+++ b/packages/docs-nextra/scripts/compute-optimized-schema.ts
@@ -1,5 +1,5 @@
 import { doenetSchema } from "@doenet/static-assets/schema";
-import { AttrInfo, PropAttrType, PropInfo } from "../components";
+import { AttrInfo, PropInfo } from "../components";
 
 const SCHEMA: {
     elements: {
@@ -111,7 +111,7 @@ function getAttrInfo(element: (typeof SCHEMA)["elements"][number]) {
         };
         // The type comes from the attribute's own schema entry.
         if (attr.type) {
-            info.type = attr.type as PropAttrType;
+            info.type = attr.type;
         }
         if (attr.defaultValue !== undefined) {
             info.defaultValue = attr.defaultValue;
@@ -132,6 +132,8 @@ function getAttrInfo(element: (typeof SCHEMA)["elements"][number]) {
 
         attrInfo.push(info);
     }
+    // Sort by name once here so the display components don't have to.
+    attrInfo.sort((a, b) => a.name.localeCompare(b.name));
     return attrInfo;
 }
 
@@ -143,15 +145,19 @@ function getPropInfo(element: (typeof SCHEMA)["elements"][number]) {
     for (const prop of element.properties) {
         const info: PropInfo = {
             name: prop.name,
-            type: prop.type as PropAttrType,
             common: false,
             description: prop.description,
         };
+        if (prop.type) {
+            info.type = prop.type;
+        }
         if (prop.isArray) {
             info.isArray = true;
         }
 
         propInfo.push(info);
     }
+    // Sort by name once here so the display components don't have to.
+    propInfo.sort((a, b) => a.name.localeCompare(b.name));
     return propInfo;
 }

--- a/packages/doenetml-worker-javascript/src/components/Answer.js
+++ b/packages/doenetml-worker-javascript/src/components/Answer.js
@@ -314,14 +314,18 @@ export default class Answer extends InlineComponent {
                 "Whether the answer's submitted-response panel is expanded by default.",
         };
 
+        // TODO: deprecate this attribute. It is currently unused — the
+        // renderer reads an accessible description from a `<description>`
+        // child, not from this attribute. Once a deprecation mechanism
+        // exists, emit an authoring warning when it is used.
         attributes.description = {
             createComponentOfType: "text",
             createStateVariable: "description",
             defaultValue: "",
             public: true,
             forRenderer: true,
-            description:
-                "An accessible description of what this answer asks for.",
+            excludeFromSchema: true,
+            description: "Currently unused",
         };
 
         attributes.showPreview = {

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -81,6 +81,7 @@ type AttributeObject = {
     createPrimitiveOfType: string;
     createStateVariable: string;
     createComponentOfType: string;
+    createReferences?: boolean;
     defaultValue: unknown;
     public: boolean;
     excludeFromSchema: boolean;
@@ -240,6 +241,12 @@ type PublicStateVariableDescription = {
 
 type SchemaAttribute = {
     name: string;
+    /**
+     * The attribute's own type, derived from its `createComponentOfType` /
+     * `createPrimitiveOfType` declaration (`string` is normalized to `text`).
+     * An attribute with a list of valid values has type `keyword`.
+     */
+    type?: string;
     /** Values accepted by validation/schema checks. */
     values?: string[];
     /**
@@ -581,6 +588,24 @@ export function getSchema(
                 attrDef.createComponentOfType === "boolean"
             ) {
                 attrSpec.values = ["true", "false"];
+            }
+
+            // The attribute's type comes from its own declaration, not from a
+            // mapping to a same-named property. A `string` primitive is
+            // surfaced as `text`; an attribute that enumerates valid values is
+            // surfaced as `keyword`; a reference-creating attribute is
+            // surfaced as `reference`.
+            if (attrDef.validValues) {
+                attrSpec.type = "keyword";
+            } else if (attrDef.createReferences) {
+                attrSpec.type = "reference";
+            } else {
+                const rawType =
+                    attrDef.createComponentOfType ??
+                    attrDef.createPrimitiveOfType;
+                if (rawType) {
+                    attrSpec.type = rawType === "string" ? "text" : rawType;
+                }
             }
 
             attributes.push(attrSpec);

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -82,6 +82,7 @@ type AttributeObject = {
     createStateVariable: string;
     createComponentOfType: string;
     createReferences?: boolean;
+    allowStrings?: boolean;
     defaultValue: unknown;
     public: boolean;
     excludeFromSchema: boolean;
@@ -594,11 +595,15 @@ export function getSchema(
             // mapping to a same-named property. A `string` primitive is
             // surfaced as `text`; an attribute that enumerates valid values is
             // surfaced as `keyword`; a reference-creating attribute is
-            // surfaced as `reference`.
+            // surfaced as `reference` — or `referenceOrText` when it also sets
+            // `allowStrings` (e.g. `<ref to>`, which accepts a URL string in
+            // addition to a component reference).
             if (attrDef.validValues) {
                 attrSpec.type = "keyword";
             } else if (attrDef.createReferences) {
-                attrSpec.type = "reference";
+                attrSpec.type = attrDef.allowStrings
+                    ? "referenceOrText"
+                    : "reference";
             } else {
                 const rawType =
                     attrDef.createComponentOfType ??

--- a/packages/static-assets/test/schema-help.test.ts
+++ b/packages/static-assets/test/schema-help.test.ts
@@ -13,6 +13,8 @@ describe("generated schema help fields", () => {
     const when = elementsByName.when;
     const point = elementsByName.point;
     const fn = elementsByName.function;
+    const ref = elementsByName.ref;
+    const collect = elementsByName.collect;
 
     it("has the piloted components present in the generated schema", () => {
         // Asserted up front so later tests don't fail with confusing
@@ -22,6 +24,22 @@ describe("generated schema help fields", () => {
         expect(when).toBeDefined();
         expect(point).toBeDefined();
         expect(fn).toBeDefined();
+        expect(ref).toBeDefined();
+        expect(collect).toBeDefined();
+    });
+
+    it("types a plain reference-creating attribute as `reference`", () => {
+        const from = collect.attributes.find(
+            (attribute) => attribute.name === "from",
+        );
+        expect(from?.type).toBe("reference");
+    });
+
+    it("types a reference attribute that allows strings as `referenceOrText`", () => {
+        // `<ref to>` sets `createReferences` and `allowStrings`, so it accepts
+        // a URL string in addition to a component reference.
+        const to = ref.attributes.find((attribute) => attribute.name === "to");
+        expect(to?.type).toBe("referenceOrText");
     });
 
     it("populates element summary from static componentDocs", () => {


### PR DESCRIPTION
## Summary

Surface the component, attribute, property, and attribute-value descriptions — already used for editor context-help and autocomplete — in the generated reference documentation.

## Schema changes (`get-schema.ts`)

- Each attribute now carries its own `type`, derived from `createComponentOfType`/`createPrimitiveOfType` (the `string` primitive is surfaced as `text`), `keyword` when it enumerates valid values, and `reference` for reference-creating attributes. Previously the docs inferred an attribute's type only from a same-named property, so attributes without one (e.g. `<answer>`'s `type`, `showCorrectness`, `colorCorrectness`) had no type.
- ⚠️ The unused `description` attribute of `<answer>` is now `excludeFromSchema`. It no longer appears in autocomplete or RelaxNG validation, so `<answer description="…">` will be flagged as an unknown attribute by the editor. This is an intentional first step toward deprecating it (the renderer reads an accessible description from a `<description>` child, not this attribute); a TODO in `Answer.js` marks it for a proper deprecation warning once a mechanism exists.

## Documentation changes (`docs-nextra`)

- `<AttrDisplay>` / `<PropDisplay>` reformatted from tables to a list: the name as a gray pill, then an indented paragraph with the type, default value, and description. Enumerated `keyword` values render as chips in a Value/Description table, with the default value marked.
- New `<ComponentDisplay>` renders the component summary.
- New `<AttrPropDisplay>` emits the "Attributes and Properties" heading (as a real Markdown heading, so it keeps the anchor and TOC entry) plus both sections, substituting a short message when a component has no attributes and/or properties. All 171 reference pages with the hand-written section now use it.
- Descriptions are also fed into the docs search index.

### Note on visible doc changes

Some pages had **stale hand-written text** that the schema contradicts — `<AttrPropDisplay>` now shows the truth. For example `and.mdx` claimed "no attributes or properties", but `<and>` actually has inherited comparison attributes/properties, which now render. `intersection.mdx` lost a custom "shares properties with `<point>`" note in favor of the schema-driven list.

## Testing

- `static-assets` schema tests (22) pass.
- `lsp-tools` tests (192) pass.
- `docs-nextra` full build (`build:pre` + `next build`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)