### PR TITLE
Load local standalone in docs-nextra dev server; fix iframe React duplication

### DIFF
--- a/.changeset/iframe-externalize-react-mathjax.md
+++ b/.changeset/iframe-externalize-react-mathjax.md
@@ -1,9 +1,5 @@
 ---
-"@doenet/doenetml": patch
-"@doenet/standalone": patch
 "@doenet/doenetml-iframe": patch
-"@doenet/vscode-extension": patch
-"doenet-vscode-extension": patch
 ---
 
 Fix `dispatcher.getOwner is not a function` when an `@doenet/doenetml-iframe`

--- a/.changeset/iframe-externalize-react-mathjax.md
+++ b/.changeset/iframe-externalize-react-mathjax.md
@@ -1,0 +1,17 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Fix `dispatcher.getOwner is not a function` when an `@doenet/doenetml-iframe`
+`DoenetEditor`/`DoenetViewer` first renders inside a host React app. The iframe
+package's library build only externalized the exact strings `react` and `react-dom`,
+so the subpaths `react/jsx-runtime`, `react/jsx-dev-runtime`, and `react-dom/client`
+— along with `better-react-mathjax` — were bundled into `dist/component/index.js`.
+The bundled copy carried its own React dispatcher state, conflicting with the host's
+React. The build now externalizes those subpaths and `better-react-mathjax`, so the
+consuming app always supplies a single React instance. `better-react-mathjax` is now
+a peer dependency of the published package.

--- a/packages/docs-nextra/components/doenet-iframe.tsx
+++ b/packages/docs-nextra/components/doenet-iframe.tsx
@@ -1,0 +1,9 @@
+/**
+ * Re-exports the `@doenet/doenetml-iframe` components from a standalone module.
+ *
+ * `doenet.tsx` loads this module via `next/dynamic` with `ssr: false`. Keeping the
+ * `@doenet/doenetml-iframe` import in its own file means it is only pulled into the
+ * lazily-loaded client chunk. A `next/dynamic` import of the package directly fails
+ * webpack's `exports`-map resolution, so the dynamic import must target a local file.
+ */
+export { DoenetViewer, DoenetEditor } from "@doenet/doenetml-iframe";

--- a/packages/docs-nextra/components/doenet.tsx
+++ b/packages/docs-nextra/components/doenet.tsx
@@ -6,12 +6,52 @@ import {
 import "@doenet/virtual-keyboard/style.css";
 
 /**
+ * Which standalone DoenetML build the embedded examples load.
+ *
+ * In development (`next dev`), load the locally-built standalone bundle that the
+ * `build:pre-copy` task copies into `public/bundle/`. This lets doc examples exercise
+ * features that are new in the current PR, instead of the version published off `main`.
+ *
+ * In a production build (`next build`, used for the published docs), keep using the
+ * `dev` version from the CDN.
+ */
+const versionProps =
+    process.env.NODE_ENV === "development"
+        ? {
+              standaloneUrl: "/bundle/doenet-standalone.js",
+              cssUrl: "/bundle/style.css",
+              // Force the local bundle even if an example contains a
+              // <document xmlns=".../vX"> tag that would otherwise be auto-detected.
+              autodetectVersion: false as const,
+          }
+        : { doenetmlVersion: "dev" };
+
+/**
+ * `true` only after the component has mounted on the client.
+ *
+ * The iframe components generate a random per-instance id that is baked into the
+ * iframe's `srcDoc`, so they cannot be server-rendered without a hydration mismatch
+ * (server and client pick different ids), which leaves the example blank after a page
+ * reload. Gating on this renders nothing during SSR and the initial hydration pass,
+ * then mounts the real component client-side.
+ */
+function useClientOnly() {
+    const [mounted, setMounted] = React.useState(false);
+    React.useEffect(() => setMounted(true), []);
+    return mounted;
+}
+
+/**
  * Render DoenetML in an iframe so that its styling/state is completely isolated from the page.
  */
 export function DoenetViewer({
     source,
 }: React.PropsWithChildren<{ source: string }>) {
-    return <DoenetViewerOrig doenetML={source} doenetmlVersion="dev" />;
+    const mounted = useClientOnly();
+    if (!mounted) {
+        return null;
+    }
+    return <DoenetViewerOrig doenetML={source} {...versionProps} />;
 }
 
 export function DoenetEditor({
@@ -25,15 +65,18 @@ export function DoenetEditor({
     viewerLocation?: "left" | "right" | "top" | "bottom";
     height?: string;
 }>) {
+    const mounted = useClientOnly();
     return (
         <div className="doenet-editor-container">
-            <DoenetEditorOrig
-                doenetML={source}
-                showFormatter={showFormatter}
-                viewerLocation={viewerLocation}
-                height={height}
-                doenetmlVersion="dev"
-            />
+            {mounted ? (
+                <DoenetEditorOrig
+                    doenetML={source}
+                    showFormatter={showFormatter}
+                    viewerLocation={viewerLocation}
+                    height={height}
+                    {...versionProps}
+                />
+            ) : null}
         </div>
     );
 }

--- a/packages/docs-nextra/components/doenet.tsx
+++ b/packages/docs-nextra/components/doenet.tsx
@@ -20,9 +20,6 @@ const versionProps =
         ? {
               standaloneUrl: "/bundle/doenet-standalone.js",
               cssUrl: "/bundle/style.css",
-              // Force the local bundle even if an example contains a
-              // <document xmlns=".../vX"> tag that would otherwise be auto-detected.
-              autodetectVersion: false as const,
           }
         : { doenetmlVersion: "dev" };
 

--- a/packages/docs-nextra/components/doenet.tsx
+++ b/packages/docs-nextra/components/doenet.tsx
@@ -1,9 +1,22 @@
 import React from "react";
-import {
-    DoenetViewer as DoenetViewerOrig,
-    DoenetEditor as DoenetEditorOrig,
-} from "@doenet/doenetml-iframe";
+import dynamic from "next/dynamic";
 import "@doenet/virtual-keyboard/style.css";
+
+/**
+ * The iframe components generate a random per-instance id that is baked into the
+ * iframe's `srcDoc`, so they cannot be server-rendered without a hydration mismatch
+ * (server and client pick different ids), which leaves the example blank after a page
+ * reload. `next/dynamic` with `ssr: false` skips SSR entirely and mounts these
+ * client-side only. The root cause in `@doenet/doenetml-iframe` is tracked in #1139.
+ */
+const DoenetViewerOrig = dynamic(
+    () => import("./doenet-iframe").then((m) => m.DoenetViewer),
+    { ssr: false },
+);
+const DoenetEditorOrig = dynamic(
+    () => import("./doenet-iframe").then((m) => m.DoenetEditor),
+    { ssr: false },
+);
 
 /**
  * Which standalone DoenetML build the embedded examples load.
@@ -24,30 +37,11 @@ const versionProps =
         : { doenetmlVersion: "dev" };
 
 /**
- * `true` only after the component has mounted on the client.
- *
- * The iframe components generate a random per-instance id that is baked into the
- * iframe's `srcDoc`, so they cannot be server-rendered without a hydration mismatch
- * (server and client pick different ids), which leaves the example blank after a page
- * reload. Gating on this renders nothing during SSR and the initial hydration pass,
- * then mounts the real component client-side.
- */
-function useClientOnly() {
-    const [mounted, setMounted] = React.useState(false);
-    React.useEffect(() => setMounted(true), []);
-    return mounted;
-}
-
-/**
  * Render DoenetML in an iframe so that its styling/state is completely isolated from the page.
  */
 export function DoenetViewer({
     source,
 }: React.PropsWithChildren<{ source: string }>) {
-    const mounted = useClientOnly();
-    if (!mounted) {
-        return null;
-    }
     return <DoenetViewerOrig doenetML={source} {...versionProps} />;
 }
 
@@ -62,18 +56,15 @@ export function DoenetEditor({
     viewerLocation?: "left" | "right" | "top" | "bottom";
     height?: string;
 }>) {
-    const mounted = useClientOnly();
     return (
         <div className="doenet-editor-container">
-            {mounted ? (
-                <DoenetEditorOrig
-                    doenetML={source}
-                    showFormatter={showFormatter}
-                    viewerLocation={viewerLocation}
-                    height={height}
-                    {...versionProps}
-                />
-            ) : null}
+            <DoenetEditorOrig
+                doenetML={source}
+                showFormatter={showFormatter}
+                viewerLocation={viewerLocation}
+                height={height}
+                {...versionProps}
+            />
         </div>
     );
 }

--- a/packages/docs-nextra/next.config.mjs
+++ b/packages/docs-nextra/next.config.mjs
@@ -13,7 +13,12 @@ import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
 
-/** Resolve the directory of an installed package (so webpack aliases handle subpaths). */
+/**
+ * Returns the directory that contains a package. The `resolve.alias` entries below
+ * alias each package to its directory (rather than a specific file), which is what
+ * lets subpath imports such as `react/jsx-runtime` and `react-dom/client` keep
+ * resolving against the aliased copy.
+ */
 function packageDir(pkg) {
     return path.dirname(require.resolve(`${pkg}/package.json`));
 }

--- a/packages/docs-nextra/next.config.mjs
+++ b/packages/docs-nextra/next.config.mjs
@@ -8,6 +8,15 @@ import {
 } from "./dist/index.js";
 import { getHighlighter, bundledLanguages, bundledThemes } from "shiki";
 import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+/** Resolve the directory of an installed package (so webpack aliases handle subpaths). */
+function packageDir(pkg) {
+    return path.dirname(require.resolve(`${pkg}/package.json`));
+}
 
 const withNextra = nextraConfig({
     theme: "nextra-theme-docs",
@@ -154,7 +163,22 @@ fullConfig.webpack = (config, options) => {
     const newConfig = nextraWebpackConfig(config, options);
     newConfig.optimization.minimizer = [];
     newConfig.optimization.minimize = false;
-    return config;
+
+    // Force a single copy of React (and better-react-mathjax) so the
+    // `@doenet/doenetml-iframe` component shares the host page's React
+    // dispatcher. Without this, a duplicate React instance triggers
+    // `dispatcher.getOwner is not a function` when MathJaxContext renders.
+    // Alias to each package's directory so subpath imports
+    // (react/jsx-runtime, react-dom/client, ...) keep resolving.
+    newConfig.resolve = newConfig.resolve || {};
+    newConfig.resolve.alias = {
+        ...(newConfig.resolve.alias || {}),
+        react: packageDir("react"),
+        "react-dom": packageDir("react-dom"),
+        "better-react-mathjax": packageDir("better-react-mathjax"),
+    };
+
+    return newConfig;
 };
 
 export default fullConfig;

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -75,7 +75,8 @@
     },
     "peerDependencies": {
         "react": "^19.2.3",
-        "react-dom": "^19.2.3"
+        "react-dom": "^19.2.3",
+        "better-react-mathjax": "^3.0.0"
     },
     "dependencies": {},
     "devDependencies": {}

--- a/packages/doenetml-iframe/vite.config.ts
+++ b/packages/doenetml-iframe/vite.config.ts
@@ -5,14 +5,18 @@ import { createPackageJsonTransformer } from "../../scripts/transform-package-js
 import { version } from "./package.json";
 import { suppressLogPlugin } from "../../scripts/vite-plugins";
 
-// Bare package names that will not be bundled into the library. These become
-// peerDependencies in the published dist/component/package.json.
+/**
+ * Bare package names that will not be bundled into the library. These become
+ * peerDependencies in the published dist/component/package.json.
+ */
 const EXTERNAL_PACKAGES = ["react", "react-dom", "better-react-mathjax"];
 
-// Rollup `external` predicate. Unlike a plain string array, this also matches
-// subpath imports (e.g. react/jsx-runtime, react/jsx-dev-runtime, react-dom/client),
-// which must be externalized too so the consuming app provides a single React
-// instance. Bundling them causes a duplicate-React "dispatcher" mismatch.
+/**
+ * Rollup `external` predicate. Unlike a plain string array, this also matches
+ * subpath imports (e.g. react/jsx-runtime, react/jsx-dev-runtime, react-dom/client),
+ * which must be externalized too so the consuming app provides a single React
+ * instance. Bundling them causes a duplicate-React "dispatcher" mismatch.
+ */
 function isExternal(id: string): boolean {
     return EXTERNAL_PACKAGES.some(
         (pkg) => id === pkg || id.startsWith(pkg + "/"),

--- a/packages/doenetml-iframe/vite.config.ts
+++ b/packages/doenetml-iframe/vite.config.ts
@@ -5,8 +5,19 @@ import { createPackageJsonTransformer } from "../../scripts/transform-package-js
 import { version } from "./package.json";
 import { suppressLogPlugin } from "../../scripts/vite-plugins";
 
-// These are the dependencies that will not be bundled into the library.
-const EXTERNAL_DEPS = ["react", "react-dom"];
+// Bare package names that will not be bundled into the library. These become
+// peerDependencies in the published dist/component/package.json.
+const EXTERNAL_PACKAGES = ["react", "react-dom", "better-react-mathjax"];
+
+// Rollup `external` predicate. Unlike a plain string array, this also matches
+// subpath imports (e.g. react/jsx-runtime, react/jsx-dev-runtime, react-dom/client),
+// which must be externalized too so the consuming app provides a single React
+// instance. Bundling them causes a duplicate-React "dispatcher" mismatch.
+function isExternal(id: string): boolean {
+    return EXTERNAL_PACKAGES.some(
+        (pkg) => id === pkg || id.startsWith(pkg + "/"),
+    );
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -19,7 +30,7 @@ export default defineConfig({
                     src: "package.json",
                     dest: "./",
                     transform: createPackageJsonTransformer({
-                        externalDeps: EXTERNAL_DEPS,
+                        externalDeps: EXTERNAL_PACKAGES,
                         targetDir: "dist/component",
                     }),
                 },
@@ -40,12 +51,7 @@ export default defineConfig({
             cssFileName: "style",
         },
         rollupOptions: {
-            external: EXTERNAL_DEPS,
-            output: {
-                globals: Object.fromEntries(
-                    EXTERNAL_DEPS.map((dep) => [dep, dep]),
-                ),
-            },
+            external: isExternal,
         },
     },
     define: {


### PR DESCRIPTION
## Motivation

The `docs-nextra` package loaded `DoenetEditor`/`DoenetViewer` with `doenetmlVersion="dev"`, which resolves to the standalone build published off `main` via CDN. That is correct for the published docs (built in CI off `main`), but in local development it means doc examples cannot exercise a feature that is new in the current PR — which pushes contributors to write docs in a separate follow-up PR rather than the preferred single feature-plus-docs PR.

This PR makes the docs-nextra **dev server** point at the locally-built standalone, and fixes two bugs uncovered along the way.

## Changes

**1. Dev server loads the local standalone**
- `components/doenet.tsx`: in `next dev`, `DoenetEditor`/`DoenetViewer` now load `/bundle/doenet-standalone.js` + `/bundle/style.css` — the locally-built standalone that the existing `build:pre-copy` task already copies into `public/bundle/`. `next build` (published docs) keeps using the CDN `dev` version, unchanged.
- Version autodetection in `@doenet/doenetml-iframe` is left at its default (`true`). A doc example whose source contains an explicit `<document xmlns="…">` version tag therefore still resolves that version from the CDN rather than the local bundle; examples without a version tag (the common case) load the local bundle.

**2. Fix `dispatcher.getOwner is not a function`**
- `@doenet/doenetml-iframe`'s library build only externalized the exact strings `react` and `react-dom`, so the subpaths (`react/jsx-runtime`, `react-dom/client`, …) and `better-react-mathjax` were bundled into `dist/component/index.js`, creating a duplicate React instance that conflicted with the host's React.
- `doenetml-iframe/vite.config.ts` now externalizes those subpaths and `better-react-mathjax` via a predicate; `better-react-mathjax` is added as a peer dependency.
- `docs-nextra/next.config.mjs` adds a `resolve.alias` React-dedup as a belt-and-suspenders guarantee.

**3. Render the iframe components client-only in docs-nextra**
- Fixing `getOwner` exposed a latent SSR bug: the iframe components use a `Math.random()` id baked into the iframe `srcDoc`, so server and client disagree and hydration mismatches — leaving examples blank after a page reload. `components/doenet.tsx` now loads `DoenetEditor`/`DoenetViewer` via `next/dynamic` with `ssr: false`.
- `next/dynamic` cannot import `@doenet/doenetml-iframe` directly — the package's `exports` map only declares the `import` condition, so a dynamic `import()` of it fails webpack's exports-map resolution (`Package path . is not exported`). The dynamic import therefore targets a new thin re-export module, `components/doenet-iframe.tsx`, which does the (working) static package import.
- The root cause in `@doenet/doenetml-iframe` is tracked in #1139.

## Notes
- Doc examples are now client-rendered rather than SSR-prerendered (in both dev and the published build). This is necessary — the `Math.random()` hydration mismatch would otherwise break the published docs once `getOwner` is fixed.
- Follow-ups filed: #1138 (worker source-map 404s) and #1139 (make `doenetml-iframe` SSR-safe with `useId()`).

## Testing
- `@doenet/doenetml-iframe` library build: `dist/component/index.js` now imports `better-react-mathjax` externally (no inlined MathJax); the published `package.json` lists the new peer dependency.
- `docs-nextra` production build (`next build`) succeeds; prod export uses the CDN `dev` version, with no `/bundle/` reference.
- `docs-nextra` dev server serves `/bundle/doenet-standalone.js`; the rendered pages reference the local bundle, not the CDN.
- Verified in-browser: a page with `DoenetEditor`/`DoenetViewer` loads without the `getOwner` error and is no longer blank on reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
