### PR TITLE
Ensure *.map files are cached by wireit

### DIFF
--- a/packages/codemirror/package.json
+++ b/packages/codemirror/package.json
@@ -41,6 +41,7 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "dist/**/*.map",
                 "dist/**/*.css",
                 "dist/**/*.d.ts",
                 "dist/**/*.json"

--- a/packages/debug-hooks/package.json
+++ b/packages/debug-hooks/package.json
@@ -32,6 +32,7 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "dist/**/*.map",
                 "dist/**/*.d.ts",
                 "dist/**/*.json"
             ],

--- a/packages/docs-nextra/package.json
+++ b/packages/docs-nextra/package.json
@@ -44,6 +44,7 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "dist/**/*.map",
                 "dist/**/*.d.ts",
                 "dist/**/*.json"
             ],

--- a/packages/doenetml-prototype/package.json
+++ b/packages/doenetml-prototype/package.json
@@ -36,7 +36,8 @@
                 "test/utils/vite.dast-to-flat-dast.config.ts"
             ],
             "output": [
-                "test/utils/dist/dast-to-flat-dast/**/*.js"
+                "test/utils/dist/dast-to-flat-dast/**/*.js",
+                "test/utils/dist/dast-to-flat-dast/**/*.map"
             ],
             "dependencies": [
                 "../doenetml-worker:build",
@@ -50,7 +51,8 @@
                 "test/utils/vite.run.config.ts"
             ],
             "output": [
-                "test/utils/dist/run/**/*.js"
+                "test/utils/dist/run/**/*.js",
+                "test/utils/dist/run/**/*.map"
             ],
             "dependencies": [
                 "build:test1"
@@ -67,6 +69,7 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "dist/**/*.map",
                 "dist/**/*.css",
                 "dist/**/*.d.ts",
                 "dist/**/*.json"

--- a/packages/doenetml-to-pretext/package.json
+++ b/packages/doenetml-to-pretext/package.json
@@ -42,7 +42,8 @@
                 "test/utils/vite.dast-to-flat-dast.config.ts"
             ],
             "output": [
-                "test/utils/dist/dast-to-flat-dast/**/*.js"
+                "test/utils/dist/dast-to-flat-dast/**/*.js",
+                "test/utils/dist/dast-to-flat-dast/**/*.map"
             ],
             "dependencies": [
                 "../doenetml-worker:build",
@@ -56,7 +57,8 @@
                 "test/utils/vite.run.config.ts"
             ],
             "output": [
-                "test/utils/dist/run/**/*.js"
+                "test/utils/dist/run/**/*.js",
+                "test/utils/dist/run/**/*.map"
             ],
             "dependencies": [
                 "build:test1"
@@ -73,6 +75,7 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "dist/**/*.map",
                 "dist/**/*.css",
                 "dist/**/*.d.ts",
                 "dist/**/*.json"

--- a/packages/doenetml-worker-javascript/package.json
+++ b/packages/doenetml-worker-javascript/package.json
@@ -39,6 +39,7 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "dist/**/*.map",
                 "dist/**/*.d.ts",
                 "dist/**/*.json"
             ],

--- a/packages/doenetml-worker-rust/package.json
+++ b/packages/doenetml-worker-rust/package.json
@@ -68,6 +68,7 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "dist/**/*.map",
                 "dist/**/*.d.ts",
                 "dist/**/*.json",
                 "dist/**/*.wasm*"

--- a/packages/doenetml-worker/package.json
+++ b/packages/doenetml-worker/package.json
@@ -42,6 +42,7 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "dist/**/*.map",
                 "dist/**/*.d.ts",
                 "dist/**/*.json",
                 "dist/**/*.wasm*"

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -46,6 +46,7 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "dist/**/*.map",
                 "dist/**/*.d.ts",
                 "dist/**/*.css",
                 "dist/**/*.json",

--- a/packages/lsp-tools/package.json
+++ b/packages/lsp-tools/package.json
@@ -32,6 +32,7 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "dist/**/*.map",
                 "dist/**/*.d.ts",
                 "dist/**/*.json"
             ],

--- a/packages/lsp/package.json
+++ b/packages/lsp/package.json
@@ -34,6 +34,7 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "dist/**/*.map",
                 "dist/**/*.d.ts",
                 "dist/**/*.json"
             ],

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -44,6 +44,7 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "dist/**/*.map",
                 "dist/**/*.d.ts",
                 "dist/**/*.json"
             ],

--- a/packages/prefigure/package.json
+++ b/packages/prefigure/package.json
@@ -48,6 +48,7 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "dist/**/*.map",
                 "dist/**/*.d.ts",
                 "dist/**/*.json",
                 "dist/assets/**/*"

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -39,6 +39,7 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "dist/**/*.map",
                 "dist/**/*.d.ts",
                 "dist/**/*.json",
                 "dist/**/*.css",

--- a/packages/static-assets/package.json
+++ b/packages/static-assets/package.json
@@ -56,6 +56,7 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "dist/**/*.map",
                 "dist/**/*.d.ts",
                 "dist/**/*.json"
             ]

--- a/packages/test-viewer/package.json
+++ b/packages/test-viewer/package.json
@@ -26,6 +26,7 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "dist/**/*.map",
                 "dist/**/*.d.ts",
                 "dist/**/*.json"
             ],

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -39,6 +39,7 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "dist/**/*.map",
                 "dist/**/*.d.ts",
                 "dist/**/*.css",
                 "dist/**/*.json"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -38,6 +38,7 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "dist/**/*.map",
                 "dist/**/*.d.ts",
                 "dist/**/*.json"
             ],

--- a/packages/v06-to-v07/package.json
+++ b/packages/v06-to-v07/package.json
@@ -38,6 +38,7 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "dist/**/*.map",
                 "dist/**/*.d.ts",
                 "dist/**/*.json"
             ],

--- a/packages/virtual-keyboard/package.json
+++ b/packages/virtual-keyboard/package.json
@@ -40,6 +40,7 @@
             ],
             "output": [
                 "dist/**/*.js",
+                "dist/**/*.map",
                 "dist/**/*.css",
                 "dist/**/*.d.ts",
                 "dist/**/*.json"


### PR DESCRIPTION
Looking at the CI build logs, there are many warnings about missing `.map` files. These warnings are because wireit wasn't caching them, so when we restore from the wrireit cache, it wasn't the same as having run `npm run build`.

This PR adds the map files to the wireit cache.