### PR TITLE
fix(schema): surface state-variable defaults and render math defaults

### DIFF
--- a/.changeset/schema-attr-defaults-and-math-defaults.md
+++ b/.changeset/schema-attr-defaults-and-math-defaults.md
@@ -1,0 +1,12 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Surface state-variable defaults to attributes in the schema, and render math-expression defaults through MathJax.
+
+- Attributes whose resting value lives on a state variable rather than the attribute declaration (e.g. `padZeros`, `displayDigits`, `displayDecimals`, `displaySmallAsZero`, `avoidScientificNotation`) now carry their effective `defaultValue` in the schema, so the reference documentation and the editor's context-sensitive help panel show it. `BaseComponent.returnStateVariableInfo` surfaces each state def's `hasEssential` + `defaultValue` pair, and `get-schema.ts` falls back to that when an attribute does not declare its own default.
+- Math-expression defaults (e.g. the `<math>` `assumptions` attribute, which defaults to `me.fromAst("＿")`) are encoded as a `{ type: "math", latex }` sentinel instead of the opaque `{ objectType: "math-expression", tree }` JSON dump. The docs reference pages and the editor's context-help panel both render the sentinel through MathJax, so the LaTeX appears typeset rather than as a serialized object.

--- a/packages/docs-nextra/components/props-display.tsx
+++ b/packages/docs-nextra/components/props-display.tsx
@@ -1,23 +1,7 @@
 import { Link } from "nextra-theme-docs";
 import React from "react";
 import { MathJax, MathJaxContext } from "better-react-mathjax";
-
-/**
- * Sentinel emitted by `encodeDefaultValueForJson` in `get-schema.ts` for a
- * `math-expressions` default value. The schema generator converts each
- * `Expression` instance to this shape so the docs-nextra build doesn't have
- * to pull in `math-expressions` just to render the LaTeX.
- */
-type MathDefaultValue = { type: "math"; latex: string };
-
-function isMathDefaultValue(val: unknown): val is MathDefaultValue {
-    return (
-        typeof val === "object" &&
-        val !== null &&
-        (val as { type?: unknown }).type === "math" &&
-        typeof (val as { latex?: unknown }).latex === "string"
-    );
-}
+import { isMathDefaultValue } from "@doenet/static-assets/schema";
 
 /** Types the rendering code special-cases. */
 export type KnownPropAttrType =
@@ -143,13 +127,25 @@ export function AttrDisplay({
                                 ) : null}
                                 {/* The default value follows the type, except for
                                 keyword attributes, where it is marked in the
-                                value list below. */}
+                                value list below. Math defaults are typeset by
+                                MathJax, so we render them in a plain `<span>`
+                                instead of `<code>` — wrapping typeset math
+                                inside a monospace `<code>` block produces
+                                awkward mixed-typography output. */}
                                 {!isKeyword && defaultNode !== null ? (
                                     <>
                                         Default value:{" "}
-                                        <code className="attr-default">
-                                            {defaultNode}
-                                        </code>
+                                        {isMathDefaultValue(
+                                            attr.defaultValue,
+                                        ) ? (
+                                            <span className="attr-default attr-default-math">
+                                                {defaultNode}
+                                            </span>
+                                        ) : (
+                                            <code className="attr-default">
+                                                {defaultNode}
+                                            </code>
+                                        )}
                                         .{" "}
                                     </>
                                 ) : null}

--- a/packages/docs-nextra/components/props-display.tsx
+++ b/packages/docs-nextra/components/props-display.tsx
@@ -1,5 +1,23 @@
 import { Link } from "nextra-theme-docs";
 import React from "react";
+import { MathJax, MathJaxContext } from "better-react-mathjax";
+
+/**
+ * Sentinel emitted by `encodeDefaultValueForJson` in `get-schema.ts` for a
+ * `math-expressions` default value. The schema generator converts each
+ * `Expression` instance to this shape so the docs-nextra build doesn't have
+ * to pull in `math-expressions` just to render the LaTeX.
+ */
+type MathDefaultValue = { type: "math"; latex: string };
+
+function isMathDefaultValue(val: unknown): val is MathDefaultValue {
+    return (
+        typeof val === "object" &&
+        val !== null &&
+        (val as { type?: unknown }).type === "math" &&
+        typeof (val as { latex?: unknown }).latex === "string"
+    );
+}
 
 /** Types the rendering code special-cases. */
 export type KnownPropAttrType =
@@ -75,99 +93,109 @@ export function AttrDisplay({
     const componentAttrs = attrs.filter((attr) => !attr.common);
 
     return (
-        <div className="attr-list" id="attr-list">
-            <h3 className="attr-list-caption">
-                Attributes for{" "}
-                {children || (
-                    <code>
-                        {"<"}
-                        {name}
-                        {">"}
-                    </code>
-                )}
-            </h3>
-            {componentAttrs.map((attr) => {
-                const linkTarget = links[attr.name];
-                const nameElm = linkTarget ? (
-                    <Link href={linkTarget}>{attr.name}</Link>
-                ) : (
-                    attr.name
-                );
-                const typeLabel = formatType(attr.type, attr.isArray);
-                const isKeyword = attr.type === "keyword";
-                const defaultStr = formatDefaultValue(attr.defaultValue);
-                // `boolean` attributes only ever take true/false, so the
-                // value table would be noise — skip it for them.
-                const showValues =
-                    attr.type !== "boolean" &&
-                    attr.values != null &&
-                    attr.values.length > 0;
-                return (
-                    <div className="attr-item" key={attr.name}>
-                        <div>
-                            <code className="attr-name attr-name-box">
-                                {nameElm}
-                            </code>
-                        </div>
-                        <p className="attr-detail">
-                            {typeLabel ? (
-                                <>
-                                    <em className="attr-type">{typeLabel}</em>
-                                    .{" "}
-                                </>
-                            ) : null}
-                            {/* The default value follows the type, except for
+        <WithMathJaxIfNeeded
+            needed={componentAttrs.some((a) =>
+                isMathDefaultValue(a.defaultValue),
+            )}
+        >
+            <div className="attr-list" id="attr-list">
+                <h3 className="attr-list-caption">
+                    Attributes for{" "}
+                    {children || (
+                        <code>
+                            {"<"}
+                            {name}
+                            {">"}
+                        </code>
+                    )}
+                </h3>
+                {componentAttrs.map((attr) => {
+                    const linkTarget = links[attr.name];
+                    const nameElm = linkTarget ? (
+                        <Link href={linkTarget}>{attr.name}</Link>
+                    ) : (
+                        attr.name
+                    );
+                    const typeLabel = formatType(attr.type, attr.isArray);
+                    const isKeyword = attr.type === "keyword";
+                    const defaultNode = renderDefaultValue(attr.defaultValue);
+                    // `boolean` attributes only ever take true/false, so the
+                    // value table would be noise — skip it for them.
+                    const showValues =
+                        attr.type !== "boolean" &&
+                        attr.values != null &&
+                        attr.values.length > 0;
+                    return (
+                        <div className="attr-item" key={attr.name}>
+                            <div>
+                                <code className="attr-name attr-name-box">
+                                    {nameElm}
+                                </code>
+                            </div>
+                            <p className="attr-detail">
+                                {typeLabel ? (
+                                    <>
+                                        <em className="attr-type">
+                                            {typeLabel}
+                                        </em>
+                                        .{" "}
+                                    </>
+                                ) : null}
+                                {/* The default value follows the type, except for
                                 keyword attributes, where it is marked in the
                                 value list below. */}
-                            {!isKeyword && defaultStr !== null ? (
-                                <>
-                                    Default value:{" "}
-                                    <code className="attr-default">
-                                        {defaultStr}
-                                    </code>
-                                    .{" "}
-                                </>
+                                {!isKeyword && defaultNode !== null ? (
+                                    <>
+                                        Default value:{" "}
+                                        <code className="attr-default">
+                                            {defaultNode}
+                                        </code>
+                                        .{" "}
+                                    </>
+                                ) : null}
+                                {attr.description}
+                            </p>
+                            {showValues ? (
+                                <table className="attr-value-table">
+                                    <thead>
+                                        <tr>
+                                            <th>Value</th>
+                                            <th>Description</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {attr.values!.map((v) => {
+                                            const isDefault =
+                                                attr.defaultValue != null &&
+                                                String(attr.defaultValue) ===
+                                                    v.value;
+                                            return (
+                                                <tr key={v.value}>
+                                                    <td>
+                                                        <code className="attr-value-chip">
+                                                            {v.value}
+                                                        </code>
+                                                        {isDefault ? (
+                                                            <span className="attr-default-marker">
+                                                                {" "}
+                                                                (default)
+                                                            </span>
+                                                        ) : null}
+                                                    </td>
+                                                    <td>
+                                                        {v.description || ""}
+                                                    </td>
+                                                </tr>
+                                            );
+                                        })}
+                                    </tbody>
+                                </table>
                             ) : null}
-                            {attr.description}
-                        </p>
-                        {showValues ? (
-                            <table className="attr-value-table">
-                                <thead>
-                                    <tr>
-                                        <th>Value</th>
-                                        <th>Description</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {attr.values!.map((v) => {
-                                        const isDefault =
-                                            attr.defaultValue != null &&
-                                            String(attr.defaultValue) ===
-                                                v.value;
-                                        return (
-                                            <tr key={v.value}>
-                                                <td>
-                                                    <code className="attr-value-chip">
-                                                        {v.value}
-                                                    </code>
-                                                    {isDefault ? (
-                                                        <span className="attr-default-marker">
-                                                            {" "}
-                                                            (default)
-                                                        </span>
-                                                    ) : null}
-                                                </td>
-                                                <td>{v.description || ""}</td>
-                                            </tr>
-                                        );
-                                    })}
-                                </tbody>
-                            </table>
-                        ) : null}
-                    </div>
-                );
-            })}
-        </div>
+                        </div>
+                    );
+                })}
+            </div>
+        </WithMathJaxIfNeeded>
     );
 }
 
@@ -290,12 +318,30 @@ function formatType(typeName?: PropAttrType, isArray?: boolean) {
 }
 
 /**
- * Format an attribute's default value for display. Returns `null` when there
- * is no meaningful default (`null`/`undefined`), so callers can omit it.
+ * Render an attribute's default value for display. Returns `null` when
+ * there is no meaningful default (`null`/`undefined`, an empty string, or
+ * an empty array), so callers can omit the "Default value: …" prefix
+ * altogether. Math-expression defaults (the `{ type: "math", latex }`
+ * sentinel produced by `get-schema.ts`) are rendered through MathJax so the
+ * actual expression — not the raw serialized object — appears in the docs.
  */
-function formatDefaultValue(value: unknown): string | null {
+function renderDefaultValue(value: unknown): React.ReactNode {
     if (value == null) {
         return null;
+    }
+    if (isMathDefaultValue(value)) {
+        // `\(…\)` is the MathJax inline-math delimiter. `dynamic` and
+        // `hideUntilTypeset="first"` mirror how `<m>`-style math is
+        // rendered elsewhere in DoenetML — the latex is hidden until the
+        // first typeset pass, which avoids a flash of raw source on first
+        // paint.
+        return (
+            <MathJax
+                inline
+                dynamic
+                hideUntilTypeset="first"
+            >{`\\(${value.latex}\\)`}</MathJax>
+        );
     }
     if (typeof value === "string") {
         // An empty-string default carries no useful information.
@@ -309,4 +355,23 @@ function formatDefaultValue(value: unknown): string | null {
         return String(value);
     }
     return JSON.stringify(value);
+}
+
+/**
+ * Wrap children in a `MathJaxContext` only when at least one default value
+ * needs MathJax to render — most components have no math defaults, and
+ * mounting a context (which loads the MathJax script) on every reference
+ * page would be wasteful. When no math is present we render children plain
+ * to keep the DOM identical to the pre-MathJax behavior.
+ */
+function WithMathJaxIfNeeded({
+    needed,
+    children,
+}: React.PropsWithChildren<{ needed: boolean }>) {
+    if (!needed) {
+        return <>{children}</>;
+    }
+    // `version={4}` matches the MathJax major version used elsewhere in
+    // DoenetML (see `doenetml.tsx`).
+    return <MathJaxContext version={4}>{children}</MathJaxContext>;
 }

--- a/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
@@ -1221,6 +1221,21 @@ export default class BaseComponent {
                 // because attributes for these state variables (e.g.
                 // `padZeros`, `displayDigits`) don't declare their own
                 // `defaultValue` — the default lives here.
+                //
+                // The `hasEssential` guard is a deliberate narrowing:
+                // non-essential state defs may carry a `defaultValue` field
+                // for purposes unrelated to "this is the resting value if
+                // nothing else sets it" (e.g. a fallback used by an internal
+                // definition function). Only essential state vars are
+                // semantically "the value the runtime falls back to," so only
+                // they donate a default here.
+                //
+                // We assign `theStateDef.defaultValue` by reference. The
+                // existing callers downstream — `get-schema.ts` and the docs
+                // pipeline — treat the value as read-only. If a future state
+                // def declares an object or array default, callers must not
+                // mutate it through this surface, or they'll corrupt the
+                // state def's own copy.
                 if (
                     theStateDef.hasEssential &&
                     theStateDef.defaultValue !== undefined

--- a/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
@@ -1214,6 +1214,20 @@ export default class BaseComponent {
                     stateVariableDescriptions[varName].description =
                         theStateDef.description;
                 }
+                // Surface the resting/default value the runtime falls back to
+                // when nothing else (attribute, child, parent) sets the
+                // variable. This is what consumers like the docs schema treat
+                // as the effective default of the corresponding attribute,
+                // because attributes for these state variables (e.g.
+                // `padZeros`, `displayDigits`) don't declare their own
+                // `defaultValue` — the default lives here.
+                if (
+                    theStateDef.hasEssential &&
+                    theStateDef.defaultValue !== undefined
+                ) {
+                    stateVariableDescriptions[varName].defaultValue =
+                        theStateDef.defaultValue;
+                }
                 if (theStateDef.isArray) {
                     stateVariableDescriptions[varName].isArray = true;
                     stateVariableDescriptions[varName].numDimensions =

--- a/packages/doenetml-worker-javascript/src/utils/componentInfoObjects.ts
+++ b/packages/doenetml-worker-javascript/src/utils/componentInfoObjects.ts
@@ -84,6 +84,16 @@ type StateVariableDescription = {
         | { componentType: string; isAttributeNamed: string }
     )[][];
     entryPrefixes: string[];
+    /**
+     * Resting value the runtime falls back to when nothing else (attribute,
+     * child, parent) sets this state variable. Populated by
+     * `BaseComponent.returnStateVariableInfo` from each state def's
+     * `hasEssential` + `defaultValue` pair so the docs schema can surface
+     * it as the effective default of a matching attribute (e.g. `padZeros`,
+     * `displayDigits`, whose default lives on the state variable rather
+     * than the attribute declaration).
+     */
+    defaultValue?: unknown;
 };
 
 /**

--- a/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.tsx
+++ b/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.tsx
@@ -1,25 +1,9 @@
 import React from "react";
 import { MathJax } from "better-react-mathjax";
 import { parseInlineMarkdown } from "@doenet/utils/markdown/parseInlineMarkdown";
+import { isMathDefaultValue } from "@doenet/static-assets/schema";
 import { HelpContent } from "./types";
 import "./context-help-panel.css";
-
-/**
- * Sentinel emitted by `encodeDefaultValueForJson` in
- * `static-assets/scripts/get-schema.ts` for a `math-expressions` default
- * value (e.g. `<math>`'s `assumptions` attribute). Matches the same shape
- * consumed by docs-nextra's `props-display.tsx`; kept in sync by contract.
- */
-type MathDefaultValue = { type: "math"; latex: string };
-
-function isMathDefaultValue(val: unknown): val is MathDefaultValue {
-    return (
-        typeof val === "object" &&
-        val !== null &&
-        (val as { type?: unknown }).type === "math" &&
-        typeof (val as { latex?: unknown }).latex === "string"
-    );
-}
 
 /**
  * Render schema description text, mapping the shared inline-markdown tokens

--- a/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.tsx
+++ b/packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.tsx
@@ -1,7 +1,25 @@
 import React from "react";
+import { MathJax } from "better-react-mathjax";
 import { parseInlineMarkdown } from "@doenet/utils/markdown/parseInlineMarkdown";
 import { HelpContent } from "./types";
 import "./context-help-panel.css";
+
+/**
+ * Sentinel emitted by `encodeDefaultValueForJson` in
+ * `static-assets/scripts/get-schema.ts` for a `math-expressions` default
+ * value (e.g. `<math>`'s `assumptions` attribute). Matches the same shape
+ * consumed by docs-nextra's `props-display.tsx`; kept in sync by contract.
+ */
+type MathDefaultValue = { type: "math"; latex: string };
+
+function isMathDefaultValue(val: unknown): val is MathDefaultValue {
+    return (
+        typeof val === "object" &&
+        val !== null &&
+        (val as { type?: unknown }).type === "math" &&
+        typeof (val as { latex?: unknown }).latex === "string"
+    );
+}
 
 /**
  * Render schema description text, mapping the shared inline-markdown tokens
@@ -252,9 +270,30 @@ export function ContextHelpPanel({
     }
 }
 
-function formatValue(val: unknown): string {
+function formatValue(val: unknown): React.ReactNode {
+    if (isMathDefaultValue(val)) {
+        // `\(…\)` is the MathJax inline-math delimiter. The surrounding
+        // `<MathJaxContext>` is set up at the top of `doenetml.tsx`, so we
+        // can drop a `<MathJax>` directly into the help panel without
+        // managing a context here.
+        return (
+            <MathJax
+                inline
+                dynamic
+                hideUntilTypeset="first"
+            >{`\\(${val.latex}\\)`}</MathJax>
+        );
+    }
     if (Array.isArray(val)) {
-        return val.map((v) => formatValue(v)).join(", ");
+        // Interleave React nodes with comma separators rather than calling
+        // `.join(", ")`, which would coerce any inner `<MathJax>` element to
+        // the string `[object Object]`.
+        return val.map((v, i) => (
+            <React.Fragment key={i}>
+                {i > 0 ? ", " : null}
+                {formatValue(v)}
+            </React.Fragment>
+        ));
     }
     if (typeof val === "string") {
         return resolveCssVariables(val);

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -36,18 +36,49 @@ export function getExistingDocSlugs(): Set<string> {
 }
 
 /**
- * Encode a `defaultValue` for inclusion in the schema JSON. JSON has no
- * representation for `Infinity`, `-Infinity`, or `NaN` — `JSON.stringify`
- * silently rewrites them to `null`, which is indistinguishable from an
- * explicit `null` default. To preserve the distinction, encode each
- * non-finite number as a sentinel string before serialization. Help
- * consumers render strings as-is, so `<booleanList maxNumber>` will
- * surface as `"Infinity"` instead of being silently dropped as `null`.
+ * Encode a `defaultValue` for inclusion in the schema JSON.
+ *
+ * - JSON has no representation for `Infinity`, `-Infinity`, or `NaN` —
+ *   `JSON.stringify` silently rewrites them to `null`, which is
+ *   indistinguishable from an explicit `null` default. To preserve the
+ *   distinction, encode each non-finite number as a sentinel string. Help
+ *   consumers render strings as-is, so `<booleanList maxNumber>` surfaces as
+ *   `"Infinity"` instead of being silently dropped as `null`.
+ *
+ * - `math-expressions` `Expression` objects (e.g. the default of the `<math>`
+ *   `assumptions` attribute) round-trip through `JSON.stringify` as
+ *   `{ objectType: "math-expression", tree: ... }`, which is opaque to a
+ *   reader. Replace them with a `{ type: "math", latex }` sentinel so the
+ *   docs UI can render the LaTeX with MathJax.
  */
 function encodeDefaultValueForJson(val: unknown): unknown {
+    if (isMathExpression(val)) {
+        return { type: "math", latex: val.toLatex() };
+    }
     if (typeof val !== "number" || Number.isFinite(val)) return val;
     if (Number.isNaN(val)) return "NaN";
     return val > 0 ? "Infinity" : "-Infinity";
+}
+
+/**
+ * `math-expressions` exports its `Expression` class as the default export
+ * of `math-expressions`. Instances carry a `tree` (own property), a
+ * prototype `toLatex()`, and a `toJSON()` that writes the
+ * `{ objectType: "math-expression", tree }` shape that shows up in the
+ * default schema serialization — but `objectType` is only present on the
+ * `toJSON` output, not on the instance itself. So we probe for the
+ * instance shape (`toLatex` + `tree`) rather than the serialized one, and
+ * stay free of a direct `math-expressions` dependency in this module.
+ */
+function isMathExpression(
+    val: unknown,
+): val is { toLatex: () => string; tree: unknown } {
+    return (
+        typeof val === "object" &&
+        val !== null &&
+        typeof (val as { toLatex?: unknown }).toLatex === "function" &&
+        "tree" in val
+    );
 }
 
 /**
@@ -238,6 +269,16 @@ type PublicStateVariableDescription = {
     arrayVarNameFromPropIndex?: Function;
     description: string;
     fromAttribute?: boolean;
+    /**
+     * Resting value the runtime uses when nothing else (attribute, child,
+     * parent) sets the state variable. Surfaced here by
+     * `BaseComponent.returnStateVariableInfo` from each state def's
+     * `hasEssential` + `defaultValue` pair. Used by the attribute loop to
+     * fall back when an attribute declaration does not carry its own
+     * `defaultValue` (e.g. number-display attrs like `padZeros`,
+     * `displayDigits`, whose default lives on the state variable).
+     */
+    defaultValue?: unknown;
 };
 
 type SchemaAttribute = {
@@ -522,6 +563,27 @@ export function getSchema(
                 excludedStateVariableNames.add(attrDef.createStateVariable);
             }
         }
+        // Map state variable name → its essential `defaultValue`, when the
+        // state def declares one. Used below to surface a default for
+        // attributes (e.g. `padZeros`, `displayDigits`) whose attribute
+        // declaration omits `defaultValue` because the actual resting value
+        // is defined on the state variable, not the attribute. We read from
+        // the *full* (non-public-only) state variable info so non-public
+        // state defs can still donate a default to a public attribute.
+        const stateVarDefaults: Record<string, unknown> = {};
+        const stateVarInfo =
+            componentInfoObjects.stateVariableInfo[type]
+                ?.stateVariableDescriptions;
+        if (stateVarInfo) {
+            for (const varName in stateVarInfo) {
+                const svDesc = stateVarInfo[varName] as {
+                    defaultValue?: unknown;
+                };
+                if (svDesc.defaultValue !== undefined) {
+                    stateVarDefaults[varName] = svDesc.defaultValue;
+                }
+            }
+        }
         for (const attrName in attrObj) {
             const attrDef = attrObj[attrName];
             if (attrDef.excludeFromSchema) continue;
@@ -541,10 +603,26 @@ export function getSchema(
                 name: attrName,
                 description: attrDef.description,
             };
-            if (attrDef.defaultValue !== undefined) {
-                attrSpec.defaultValue = encodeDefaultValueForJson(
-                    attrDef.defaultValue,
-                );
+            // Prefer the default declared on the attribute itself. When it
+            // doesn't declare one, fall back to the matching state
+            // variable's default — this covers number-display attributes
+            // like `padZeros`, `displayDigits`, `displayDecimals`, etc.
+            // whose actual resting value is defined on the state variable
+            // (so the runtime can also inherit it from a child/parent)
+            // rather than on the attribute. The matching state variable is
+            // the one named by `createStateVariable`, or — when the
+            // attribute doesn't even declare a `createStateVariable` — a
+            // state variable with the same name as the attribute.
+            const fallbackStateVarName =
+                attrDef.createStateVariable ?? attrName;
+            const fallbackDefault = stateVarDefaults[fallbackStateVarName];
+            const resolvedDefault =
+                attrDef.defaultValue !== undefined
+                    ? attrDef.defaultValue
+                    : fallbackDefault;
+            if (resolvedDefault !== undefined) {
+                attrSpec.defaultValue =
+                    encodeDefaultValueForJson(resolvedDefault);
             }
 
             const booleanAliasValues: string[] = [];

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -6,7 +6,7 @@ import {
     createComponentInfoObjects,
     SchemaSubarrayDescription,
 } from "../../doenetml-worker-javascript/src/utils/componentInfoObjects";
-import type { ValidValueEntry } from "../src/schema";
+import type { MathDefaultValue, ValidValueEntry } from "../src/schema";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REFERENCE_DOCS_DIR = path.resolve(
@@ -53,7 +53,11 @@ export function getExistingDocSlugs(): Set<string> {
  */
 function encodeDefaultValueForJson(val: unknown): unknown {
     if (isMathExpression(val)) {
-        return { type: "math", latex: val.toLatex() };
+        const sentinel: MathDefaultValue = {
+            type: "math",
+            latex: val.toLatex(),
+        };
+        return sentinel;
     }
     if (typeof val !== "number" || Number.isFinite(val)) return val;
     if (Number.isNaN(val)) return "NaN";
@@ -613,6 +617,18 @@ export function getSchema(
             // the one named by `createStateVariable`, or — when the
             // attribute doesn't even declare a `createStateVariable` — a
             // state variable with the same name as the attribute.
+            //
+            // The attribute-name fallback relies on a codebase convention:
+            // when a `returnXxxAttributes()` helper omits both
+            // `defaultValue` and `createStateVariable` from an attribute
+            // declaration, the attribute and its backing state variable
+            // share a name (e.g. `padZeros` → `padZeros`). If that
+            // convention is ever broken — an attribute happens to share a
+            // name with an unrelated state variable — this would silently
+            // pull in the wrong default. We accept that risk because the
+            // alternative (a heavier explicit mapping) would force every
+            // attribute declaration to wire up a state variable name even
+            // when the existing convention already pairs them.
             const fallbackStateVarName =
                 attrDef.createStateVariable ?? attrName;
             const fallbackDefault = stateVarDefaults[fallbackStateVarName];

--- a/packages/static-assets/src/schema.ts
+++ b/packages/static-assets/src/schema.ts
@@ -7,6 +7,29 @@ import doenetSchema from "./generated/doenet-schema.json";
  */
 export type ValidValueEntry = { value: string; description: string };
 
+/**
+ * Sentinel shape produced by `get-schema.ts`'s `encodeDefaultValueForJson`
+ * for a `math-expressions` default value (e.g. `<math>`'s `assumptions`
+ * attribute, which defaults to `me.fromAst("＿")`). Without this rewrite,
+ * the default would round-trip through `JSON.stringify` as the opaque
+ * `{ objectType: "math-expression", tree: ... }` shape — readable only to
+ * someone who knows the `math-expressions` library. Renderers (docs-nextra
+ * `props-display.tsx`, doenetml `ContextHelpPanel.tsx`) detect this
+ * sentinel with `isMathDefaultValue` and typeset the `latex` through
+ * MathJax. This type and its guard are the contract shared between the
+ * producer in this package and the two renderers.
+ */
+export type MathDefaultValue = { type: "math"; latex: string };
+
+export function isMathDefaultValue(val: unknown): val is MathDefaultValue {
+    return (
+        typeof val === "object" &&
+        val !== null &&
+        (val as { type?: unknown }).type === "math" &&
+        typeof (val as { latex?: unknown }).latex === "string"
+    );
+}
+
 export type SchemaProperty = {
     name: string;
     /**

--- a/packages/static-assets/test/schema-help.test.ts
+++ b/packages/static-assets/test/schema-help.test.ts
@@ -17,6 +17,8 @@ describe("generated schema help fields", () => {
     const collect = elementsByName.collect;
     const math = elementsByName.math;
     const num = elementsByName.number;
+    const mathInput = elementsByName.mathInput;
+    const round = elementsByName.round;
 
     it("has the piloted components present in the generated schema", () => {
         // Asserted up front so later tests don't fail with confusing
@@ -164,6 +166,24 @@ describe("generated schema help fields", () => {
         expect(padZeros?.defaultValue).toBe(false);
         expect(displayDigits?.defaultValue).toBe(3);
         expect(displayDecimals?.defaultValue).toBe(2);
+    });
+
+    it("honors a component's `displayDigitsDefault` override on the state-variable fallback", () => {
+        // Most components default `displayDigits` to 3 via the state
+        // variable. `<mathInput>` (and `<matrixInput>`) override the state
+        // def's `defaultValue` to 10, and `<round>` overrides it to 14, so
+        // those overrides must flow through the state-variable fallback in
+        // `get-schema.ts`. If the fallback were ever flattened back to the
+        // attribute declaration, every component would silently revert to
+        // 3 — pin all three so that regression is caught.
+        const mathInputDD = mathInput.attributes.find(
+            (a) => a.name === "displayDigits",
+        );
+        const roundDD = round.attributes.find(
+            (a) => a.name === "displayDigits",
+        );
+        expect(mathInputDD?.defaultValue).toBe(10);
+        expect(roundDD?.defaultValue).toBe(14);
     });
 
     it('encodes a math-expression default as { type: "math", latex } so the docs can render MathJax', () => {

--- a/packages/static-assets/test/schema-help.test.ts
+++ b/packages/static-assets/test/schema-help.test.ts
@@ -15,6 +15,8 @@ describe("generated schema help fields", () => {
     const fn = elementsByName.function;
     const ref = elementsByName.ref;
     const collect = elementsByName.collect;
+    const math = elementsByName.math;
+    const num = elementsByName.number;
 
     it("has the piloted components present in the generated schema", () => {
         // Asserted up front so later tests don't fail with confusing
@@ -143,6 +145,40 @@ describe("generated schema help fields", () => {
         );
         expect(xsProp?.description).toBe("The point's coordinates as a list.");
         expect(xProp?.description).not.toBe(xsProp?.description);
+    });
+
+    it("falls back to a state variable's defaultValue when an attribute declares none", () => {
+        // `padZeros`, `displayDigits`, and `displayDecimals` on `<number>`
+        // are declared by `returnNumberDisplayAttributes()` without their
+        // own `defaultValue` — the resting value lives on the state
+        // variable so it can also be inherited from children/parents. The
+        // schema generator should still surface that resting value as the
+        // attribute's effective default.
+        const padZeros = num.attributes.find((a) => a.name === "padZeros");
+        const displayDigits = num.attributes.find(
+            (a) => a.name === "displayDigits",
+        );
+        const displayDecimals = num.attributes.find(
+            (a) => a.name === "displayDecimals",
+        );
+        expect(padZeros?.defaultValue).toBe(false);
+        expect(displayDigits?.defaultValue).toBe(3);
+        expect(displayDecimals?.defaultValue).toBe(2);
+    });
+
+    it('encodes a math-expression default as { type: "math", latex } so the docs can render MathJax', () => {
+        // `<math>`'s `assumptions` attribute defaults to
+        // `me.fromAst("＿")`. Left alone it serializes opaquely as
+        // `{ objectType: "math-expression", tree: "＿" }`; the schema
+        // generator should replace it with a small `{ type: "math",
+        // latex }` sentinel so docs-nextra can route it through MathJax.
+        const assumptions = math.attributes.find(
+            (a) => a.name === "assumptions",
+        );
+        expect(assumptions?.defaultValue).toEqual({
+            type: "math",
+            latex: "＿",
+        });
     });
 
     it("uses a schema subarray's own description when set", () => {


### PR DESCRIPTION
## Why

Two gaps in the generated schema were surfacing in both the reference docs and the editor's context-sensitive help panel:

1. **Missing defaults on number-display attributes.** `padZeros`, `displayDigits`, `displayDecimals`, `displaySmallAsZero`, and `avoidScientificNotation` are declared by `returnNumberDisplayAttributes()` *without* a `defaultValue` — the resting value lives on the state variable so it can also be inherited from a child/parent. The schema generator only looked at the attribute declaration, so docs and help showed no default for them.
2. **Math-expression default rendered as a serialized object.** `<math>`'s `assumptions` defaults to `me.fromAst("＿")`. `math-expressions`' `toJSON()` writes `{ objectType: "math-expression", tree: "＿" }`, which is what landed in the schema and in the rendered output — opaque to anyone who doesn't import the library.

## What

**Schema generation** (`packages/static-assets/scripts/get-schema.ts` + `packages/doenetml-worker-javascript/src/...`)

- `BaseComponent.returnStateVariableInfo` now surfaces each state def's `hasEssential` + `defaultValue` pair on the state variable description, and `StateVariableDescription` gains a typed `defaultValue?: unknown`.
- `get-schema.ts` falls back to the matching state variable's default when an attribute does not declare its own (resolved via `createStateVariable`, or by attribute name when not declared).
- `encodeDefaultValueForJson` detects `math-expressions` `Expression` instances (probing the instance shape `toLatex` + `tree`; `objectType` only appears on the `toJSON` output, not the instance) and replaces them with a `{ type: "math", latex }` sentinel.

**Rendering** — both UIs were updated in lockstep so the sentinel is never user-visible:

- `packages/docs-nextra/components/props-display.tsx`: `formatDefaultValue` → `renderDefaultValue` (returns `React.ReactNode`). Math sentinels render through `<MathJax inline dynamic hideUntilTypeset="first">`. `AttrDisplay` conditionally wraps itself in `MathJaxContext` only when at least one attribute has a math default, so reference pages without math defaults don't pay to load MathJax.
- `packages/doenetml/src/EditorViewer/contextHelp/ContextHelpPanel.tsx`: `formatValue` widens from `string` to `React.ReactNode` and emits the same `<MathJax>` node. The editor already mounts `MathJaxContext` at the top of `doenetml.tsx`, so no context wiring is needed here. The array branch now interleaves React nodes with comma separators rather than `.join(", ")`, which would coerce inner elements to `[object Object]`.

## Verification

Regenerated `doenet-schema.json` now shows:
- `padZeros` → `"defaultValue": false`
- `displayDigits` → `"defaultValue": 3` (and `10` on `<mathInput>` / `<matrixInput>` per their `displayDigitsDefault: 10` overrides)
- `displayDecimals` → `"defaultValue": 2`
- `displaySmallAsZero` → `"defaultValue": 1e-14`
- `avoidScientificNotation` → `"defaultValue": false`
- `assumptions` → `"defaultValue": { "type": "math", "latex": "＿" }`

Tests:
- Added two focused tests in `packages/static-assets/test/schema-help.test.ts` pinning the new behavior (state-variable fallback for number-display attrs; math sentinel for `assumptions`).
- All 26 `@doenet/static-assets` tests pass.
- All 75 `@doenet/doenetml` tests under `src/EditorViewer/contextHelp/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)