### PR TITLE
fix(worker): handle <latex> children without a latex state variable

### DIFF
--- a/.changeset/latex-child-with-non-latex-state-variable.md
+++ b/.changeset/latex-child-with-non-latex-state-variable.md
@@ -1,0 +1,10 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/v06-to-v07": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Fix `<latex>` crashing when one of its children lacks a `latex` state variable. Constructs like `<latex><text>foo</text></latex>`, `<latex>$mathInput.latex</latex>` (where `<mathInput>` does not expose a `.latex` prop), or any reference whose resolved component lacks `latex` previously raised "Unknown state variable latex of `<idx>`" from the worker, which leaked the internal state-variable name to the rendered viewer. The `<latex>` value-dependency now marks `text`/`latex` as optional on its children, matching `<m>`/`<me>`/`<md>`, so children without `latex` fall back to their `text` value.

--- a/packages/doenetml-worker-javascript/src/components/Latex.js
+++ b/packages/doenetml-worker-javascript/src/components/Latex.js
@@ -32,6 +32,7 @@ export default class Latex extends TextComponent {
                 dependencyType: "child",
                 childGroups: ["textLike"],
                 variableNames: ["text", "latex"],
+                variablesOptional: true,
             },
         });
 

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/latex.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/latex.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestCore } from "../utils/test-core";
+
+const Mock = vi.fn();
+vi.stubGlobal("postMessage", Mock);
+vi.mock("hyperformula");
+
+describe("Latex tag tests @group2", async () => {
+    // Regression test for the worker crash described at
+    // packages/docs-nextra/pages/reference/latex.mdx — using a property
+    // reference such as `$math.latex` as the child of a `<latex>` element
+    // previously triggered "Unknown state variable latex of <idx>" because
+    // the `<latex>` value-dependency required `latex` on every textLike
+    // child without marking the lookup optional. Children whose component
+    // type does not expose a `latex` state variable (e.g. plain `<text>`,
+    // a placeholder for a non-existent prop, or a `<mathInput>`) crashed
+    // dependency setup. With `variablesOptional: true`, the dependency
+    // gracefully falls back to the child's `text` state variable.
+
+    it("text child without a latex state variable does not crash", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `<latex name="lat"><text>foo</text></latex>`,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("lat")].stateValues.value,
+        ).eq("foo");
+    });
+
+    it("$math.latex as a latex child renders the math as latex", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<math name="expected">x^2 + 2x + 1</math>
+<latex name="exp">$expected.latex</latex>
+            `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("exp")].stateValues.value,
+        ).eq("x^{2} + 2 x + 1");
+    });
+
+    it("$mathInput.latex as a latex child resolves without crashing", async () => {
+        // `<mathInput>` does not expose a `latex` state variable, so the
+        // reference resolves to a blank placeholder. The important thing
+        // is that the worker does not throw an internal-state-variable
+        // error that leaks to the rendered viewer.
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<mathInput name="user" prefill="x^2" />
+<latex name="exp">$user.latex</latex>
+            `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            typeof stateVariables[await resolvePathToNodeIdx("exp")].stateValues
+                .value,
+        ).eq("string");
+    });
+
+    it("full docs example renders without a worker error", async () => {
+        // Reproduces the example at
+        // packages/docs-nextra/pages/reference/latex.mdx
+        // "Compare a <mathInput> value against an expected expression".
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<setup>
+  <math name="expected">x^2 + 2x + 1</math>
+</setup>
+
+<p>
+  <mathInput name="user"><label>Expand <m>(x + 1)^2</m></label></mathInput>
+</p>
+
+<p>You entered (as LaTeX):
+  <c><latex name="latex1">$user.latex</latex></c>
+</p>
+<p>Expected (as LaTeX):
+  <c><latex name="latex2">$expected.latex</latex></c>
+</p>
+            `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("latex1")].stateValues
+                .value,
+        ).toBeDefined();
+        expect(
+            stateVariables[await resolvePathToNodeIdx("latex2")].stateValues
+                .value,
+        ).eq("x^{2} + 2 x + 1");
+    });
+});


### PR DESCRIPTION
## Problem

The `<latex>` component crashed during dependency setup when one of its
children lacked a `latex` state variable. The crash surfaced as
`Unknown state variable latex of <idx>` (the trailing number varies per
run — it's an internal component idx) and leaked the internal
state-variable name to the rendered viewer.

Reproducible via the `<mathInput>` example in
`packages/docs-nextra/pages/reference/latex.mdx`:

```doenet
<setup>
  <math name="expected">x^2 + 2x + 1</math>
</setup>
<p>
  <mathInput name="user" />
</p>
<p>You entered (as LaTeX):
  <c><latex>$user.latex</latex></c>
</p>
```

`<mathInput>` does not expose a `latex` state variable, so `$user.latex`
resolves to a placeholder whose component type has no `latex`. The
broader pattern — any `<text>` (or other textLike child) inside a
`<latex>` — crashed for the same reason, e.g.
`<latex><text>foo</text></latex>`.

## Root cause

`Latex.js`'s `value` definition declared a child dependency that
requested both `text` and `latex` from every textLike child without
marking the lookup optional. When a child had no `latex` state variable
(and was not an array-entry prefix), `Core.createFromArrayEntry` threw
the "Unknown state variable" error from `StalenessPropagator.ts`.

## Fix

Mark `mathTextLikeChildren` as `variablesOptional: true`, matching the
analogous dependency in `MMeMen.js` (for `<m>`, `<me>`, `<md>`). The
existing definition already inspects `comp.stateValues.latex !==
undefined` and falls back to `comp.stateValues.text`, so the path is
already prepared for missing-latex children. With `variablesOptional`,
the framework filters out children that don't have `latex`, the
definition takes the `text` branch for those children, and no crash is
raised.

## Tests

Added `packages/doenetml-worker-javascript/src/test/tagSpecific/latex.test.ts`
covering:

- `<latex><text>foo</text></latex>` (plain text child without `latex`).
- `<latex>$math.latex</latex>` (a math reference; the previously working path stays working).
- `<latex>$mathInput.latex</latex>` (the broken docs example — does not crash).
- The full `<mathInput>` + `$expected.latex` docs example.

All four pass with the fix; without the fix three of them throw the
"Unknown state variable latex of `<idx>`" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
