### PR TITLE
ci: bound devcontainer jobs and surface lifecycle script logs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
     "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
     "features": {
         "ghcr.io/devcontainers/features/node:1": {
-            "version": "lts"
+            "version": "24.15.0"
         },
         "ghcr.io/devcontainers/features/rust:1": {
             "version": "latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,12 +273,6 @@ jobs:
     test-doenetml-to-pretext-devcontainer:
         name: Devcontainer Runs Tests
         runs-on: ubuntu-latest
-        # Disabled: @playwright/browser-chromium's install.js currently hangs
-        # inside this devcontainer after the Chromium download completes
-        # (transitive dep via @vscode/test-web). Re-enable by removing `if: false`
-        # once upstream is fixed. The underlying doenetml-to-pretext tests are
-        # also exercised by Test Main on the plain runner.
-        if: false
         timeout-minutes: 25
         steps:
             - uses: actions/checkout@v6
@@ -296,9 +290,6 @@ jobs:
         name: DoenetML to PreTeXt Tests
         runs-on: ubuntu-latest
         needs: build
-        # See sibling job above: disabled while upstream Playwright install hang
-        # is unresolved. Remove `if: false` to re-enable.
-        if: false
         timeout-minutes: 25
         steps:
             - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,6 +273,7 @@ jobs:
     test-doenetml-to-pretext-devcontainer:
         name: Devcontainer Runs Tests
         runs-on: ubuntu-latest
+        timeout-minutes: 25
         steps:
             - uses: actions/checkout@v6
 
@@ -280,7 +281,7 @@ jobs:
               uses: devcontainers/ci@v0.3
               with:
                   runCmd: |
-                      npm ci
+                      npm ci --foreground-scripts --loglevel=info
                       # This package runs tests in a headless browser. If it can run, the other tests should too.
                       npm run build -w packages/doenetml-to-pretext
                       npm run test -w packages/doenetml-to-pretext
@@ -289,6 +290,7 @@ jobs:
         name: DoenetML to PreTeXt Tests
         runs-on: ubuntu-latest
         needs: build
+        timeout-minutes: 25
         steps:
             - uses: actions/checkout@v6
 
@@ -301,7 +303,7 @@ jobs:
               uses: devcontainers/ci@v0.3
               with:
                   runCmd: |
-                      npm ci
+                      npm ci --foreground-scripts --loglevel=info
                       npm run build -w packages/doenetml-to-pretext
                       npm run test -w packages/doenetml-to-pretext
                       npm run build -w packages/doenetml-to-pretext-python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,12 @@ jobs:
     test-doenetml-to-pretext-devcontainer:
         name: Devcontainer Runs Tests
         runs-on: ubuntu-latest
+        # @playwright/browser-chromium's install.js currently hangs inside this
+        # devcontainer after the Chromium download completes (transitive dep via
+        # @vscode/test-web). Bound the runtime and don't block CI on it; the
+        # underlying doenetml-to-pretext tests are also exercised by Test Main.
         timeout-minutes: 25
+        continue-on-error: true
         steps:
             - uses: actions/checkout@v6
 
@@ -281,10 +286,7 @@ jobs:
               uses: devcontainers/ci@v0.3
               with:
                   runCmd: |
-                      # @vscode/test-web pulls @playwright/browser-chromium whose install.js
-                      # hangs after the Chromium download in this container; skip it since
-                      # the doenetml-to-pretext tests don't use Playwright.
-                      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci
+                      npm ci
                       # This package runs tests in a headless browser. If it can run, the other tests should too.
                       npm run build -w packages/doenetml-to-pretext
                       npm run test -w packages/doenetml-to-pretext
@@ -294,6 +296,7 @@ jobs:
         runs-on: ubuntu-latest
         needs: build
         timeout-minutes: 25
+        continue-on-error: true
         steps:
             - uses: actions/checkout@v6
 
@@ -306,7 +309,7 @@ jobs:
               uses: devcontainers/ci@v0.3
               with:
                   runCmd: |
-                      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci
+                      npm ci
                       npm run build -w packages/doenetml-to-pretext
                       npm run test -w packages/doenetml-to-pretext
                       npm run build -w packages/doenetml-to-pretext-python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,12 +273,13 @@ jobs:
     test-doenetml-to-pretext-devcontainer:
         name: Devcontainer Runs Tests
         runs-on: ubuntu-latest
-        # @playwright/browser-chromium's install.js currently hangs inside this
-        # devcontainer after the Chromium download completes (transitive dep via
-        # @vscode/test-web). Bound the runtime and don't block CI on it; the
-        # underlying doenetml-to-pretext tests are also exercised by Test Main.
+        # Disabled: @playwright/browser-chromium's install.js currently hangs
+        # inside this devcontainer after the Chromium download completes
+        # (transitive dep via @vscode/test-web). Re-enable by removing `if: false`
+        # once upstream is fixed. The underlying doenetml-to-pretext tests are
+        # also exercised by Test Main on the plain runner.
+        if: false
         timeout-minutes: 25
-        continue-on-error: true
         steps:
             - uses: actions/checkout@v6
 
@@ -295,8 +296,10 @@ jobs:
         name: DoenetML to PreTeXt Tests
         runs-on: ubuntu-latest
         needs: build
+        # See sibling job above: disabled while upstream Playwright install hang
+        # is unresolved. Remove `if: false` to re-enable.
+        if: false
         timeout-minutes: 25
-        continue-on-error: true
         steps:
             - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,10 @@ jobs:
               uses: devcontainers/ci@v0.3
               with:
                   runCmd: |
-                      npm ci --foreground-scripts --loglevel=info
+                      # @vscode/test-web pulls @playwright/browser-chromium whose install.js
+                      # hangs after the Chromium download in this container; skip it since
+                      # the doenetml-to-pretext tests don't use Playwright.
+                      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci
                       # This package runs tests in a headless browser. If it can run, the other tests should too.
                       npm run build -w packages/doenetml-to-pretext
                       npm run test -w packages/doenetml-to-pretext
@@ -303,7 +306,7 @@ jobs:
               uses: devcontainers/ci@v0.3
               with:
                   runCmd: |
-                      npm ci --foreground-scripts --loglevel=info
+                      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci
                       npm run build -w packages/doenetml-to-pretext
                       npm run test -w packages/doenetml-to-pretext
                       npm run build -w packages/doenetml-to-pretext-python


### PR DESCRIPTION
## Final summary

Root cause turned out to be the upstream Node.js regression [nodejs/node#63487](https://github.com/nodejs/node/issues/63487) — Node 24.16.0 broke `extract-zip`, which `@playwright/browser-chromium@1.57.0`'s install.js uses to unzip the Chromium archive it downloads during `npm ci`. The devcontainer's `ghcr.io/devcontainers/features/node:1` feature was pinned to `"version": "lts"` (a moving target), so it started installing 24.16.0 sometime between 06:43 and 15:38 UTC on 2026-05-21 — exactly when the devcontainer CI jobs began hanging.

### Fix landing here

- `.devcontainer/devcontainer.json`: pin the node feature to `"version": "24.15.0"` (last known-good Node release before the regression).
- `.github/workflows/ci.yml`: add `timeout-minutes: 25` to both devcontainer jobs as a permanent safety bound against future similar hangs (devcontainer-based jobs previously had no per-job timeout and could consume the full 360-min workflow timeout).

Both devcontainer jobs are green again on this branch with the Node pin. Follow-up to lift the pin once nodejs/node#63487 is fixed is tracked in #1166.

### Commit history

The middle commits walk through the investigation arc (verbose npm logging to pinpoint the install.js as the hang site → `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` attempt that broke the tests → `continue-on-error` that didn't suppress timeout-cancellations → `if: false` workaround → discovery of the Node version correlation → Node pin). They'll be flattened on squash merge.

---

<details>
<summary>Original PR description (for context with the early comments)</summary>

## Summary
- Both devcontainer-based jobs ([Devcontainer Runs Tests](https://github.com/Doenet/DoenetML/blob/main/.github/workflows/ci.yml#L273), [DoenetML to PreTeXt Tests](https://github.com/Doenet/DoenetML/blob/main/.github/workflows/ci.yml#L288)) started hanging inside `npm ci` around ~07:00–15:38 UTC on 2026-05-21 and have not recovered since. They consume the full 360-min workflow timeout and block CI completion.
- The hang is reproducible at the same spot across multiple runs: every log ends right after npm prints the `mathjax-full@3.2.2` deprecation warning, then 6h of silence until cancellation. The devcontainer itself builds and starts fine — it's specifically `npm ci` that hangs, almost certainly on a transitive postinstall script that npm buffers stdio for.
- Other CI jobs run the same `npm ci` (and the same `doenetml-to-pretext` build/test the devcontainer job duplicates) on the plain runner without issue, so this is environment-specific to devcontainer execution.

## Changes
- `timeout-minutes: 25` on both jobs so a hang fails the job in ~25 min instead of burning a full 6 h workflow timeout.
- `npm ci --foreground-scripts --loglevel=info` so the next failure surfaces which lifecycle script is hanging — npm's default output hides postinstall stdio until the script exits, which is why the existing logs go silent.

## Notes
- This is a diagnostic-and-mitigation change. Once the next run identifies which postinstall hangs (likely a binary-download script that's blocking on a CDN reachable only from outside the devcontainer's docker network), we can apply a permanent fix (skip the script, set the matching `*_SKIP_DOWNLOAD=1` env, or similar).
- The two devcontainer jobs only validate that the devcontainer setup works for contributors — they don't add unique test coverage. `doenetml-to-pretext` is already covered by `Test Main`. Even if these jobs fail at the timeout, no actual code-correctness signal is lost.

## Test plan
- [ ] PR's own CI: the two devcontainer jobs either complete in <25 min (transient fixed itself) or fail with verbose logs showing the culprit lifecycle script.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
