### PR TITLE
test(codemirror): de-flake delete-then-dot autocomplete accept

### DIFF
--- a/packages/codemirror/test/cypress/component/autocomplete.cy.tsx
+++ b/packages/codemirror/test/cypress/component/autocomplete.cy.tsx
@@ -555,7 +555,16 @@ describe("CodeMirror LSP Autocomplete Plugin", () => {
 
         cy.get(".cm-content").click().type("{ctrl}{end}", { force: true });
         openAutocomplete();
-        cy.get(".cm-content").type("{enter}", { force: true });
+        // Click the `myMath` completion directly rather than relying on
+        // `{enter}` to accept the selected item: openAutocomplete() only
+        // waits for the tooltip element to exist, but the LSP-provided
+        // items can still be populating (and the keyboard selection may
+        // not yet be on the desired item). The .contains() retry also
+        // gives the LSP time to render the label before we click it.
+        cy.get(".cm-tooltip-autocomplete .cm-completionLabel")
+            .contains("myMath")
+            .click();
+        cy.get(".cm-content").invoke("text").should("contain", "$myMath");
 
         // Reproduce a delete-then-dot transition ending at the same final text.
         cy.get(".cm-content").type("x{backspace}.", { force: true });


### PR DESCRIPTION
## Summary

- `codemirror-cypress` was failing ~1/3 of the time in CI, always at the same assertion in `autocomplete.cy.tsx`'s *shows member autocomplete after delete-then-dot on a completed ref* test:
  ```
  AssertionError: expected '<math name=\"myMath\" />\$my.' to include '\$myMath.'
  ```
- Root cause: `openAutocomplete()` returns as soon as `.cm-tooltip-autocomplete` is in the DOM, but the LSP-provided items can still be populating and no item may yet be keyboard-selected. The subsequent `{enter}` was swallowed without accepting `myMath`, so the text stayed at `\$my` and the downstream `.cm-content` assertion timed out.
- Switched the accept step to the `.contains(\"myMath\").click()` pattern already used elsewhere in this spec (lines 129, 271, 292, 332). `.contains()` retries until the LSP label is actually rendered, and `.click()` deterministically applies that specific completion regardless of which item the keyboard has highlighted. Added an intermediate `should(\"contain\", \"\$myMath\")` so a regression fails at the real cause rather than four lines later.

## Test plan

- [x] Locally reproduced the original flake (deterministic on this machine).
- [x] Ran `cypress run --component --spec test/cypress/component/autocomplete.cy.tsx` 8 consecutive times after the fix — all 28 tests pass on every run.
- [ ] CI: confirm `Cypress Tests (24.x, codemirror-cypress)` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)