### PR TITLE
docs: rename "macro" to "reference" across reference and tutorial pages

### DIFF
--- a/packages/docs-nextra/pages/reference/animateFromSequence.mdx
+++ b/packages/docs-nextra/pages/reference/animateFromSequence.mdx
@@ -94,7 +94,7 @@ the radius has been defined as a `<number/>{:dn}` over a sequence of values from
 
 The `<animateFromSequence />{:dn}` component is used to animate the $x$-coordinate of a 
 point which has been defined as a `<number/>{:dn}` over a sequence of values from -9 to 9. 
-The $y$-coordinate of the point is defined with the function evaluation macro `$$f(x)`.
+The $y$-coordinate of the point is defined with the function evaluation reference `$$f(x)`.
 
 
 ---

--- a/packages/docs-nextra/pages/reference/award3.mdx
+++ b/packages/docs-nextra/pages/reference/award3.mdx
@@ -111,7 +111,7 @@ most a single ``<award>{:dn}`` will be awarded -- the matched award with the lar
 
 A common use for `awarded` is to base feedback on particular answers.  It's so 
 common that we allow a shortcut to just use the name of award in a 
-macro (see the use of `$notFully` in this example).
+reference (see the use of `$notFully` in this example).
 
 
 

--- a/packages/docs-nextra/pages/reference/circle.mdx
+++ b/packages/docs-nextra/pages/reference/circle.mdx
@@ -263,7 +263,7 @@ higher numbers are placed in front.
 
 The `throughPoints` property renders the values of the points specified 
 in the `through` attribute stored in an array. These can be rendered on a 
-`<graph>{:dn}` or as a `math`. Enclose the copy macro in an `<asList>{:dn}` 
+`<graph>{:dn}` or as a `math`. Enclose the reference in an `<asList>{:dn}` 
 component for clarity when rendering as a `math`.
 
 

--- a/packages/docs-nextra/pages/reference/evaluate.mdx
+++ b/packages/docs-nextra/pages/reference/evaluate.mdx
@@ -59,7 +59,7 @@ The two required attributes for the `<evaluate/>{:dn}` component are `function` 
 
 
 
-The shortcut macro for the evaluate component is `$$function(input)`.
+The shortcut reference for the evaluate component is `$$function(input)`.
 
 
 

--- a/packages/docs-nextra/pages/reference/function.mdx
+++ b/packages/docs-nextra/pages/reference/function.mdx
@@ -60,7 +60,7 @@ A single variable function can be defined by giving a formula in the variable $x
 The variable can be changed with the `variable` attribute.
 
 
-The function can be evaluated using a macro of the form `$$f(x)` 
+The function can be evaluated using a reference of the form `$$f(x)` 
 or rendered on a `<graph>{:dn}` using the reference `$f`.
 
 
@@ -88,7 +88,7 @@ or rendered on a `<graph>{:dn}` using the reference `$f`.
 A vector-valued function can be created by giving a vector for the formula.  
 The `variables` attribute can specify multiple variables.
 
-The macro notation `$$f(x,y)` can be used with multiple variables.
+The reference notation `$$f(x,y)` can be used with multiple variables.
 
 
 

--- a/packages/docs-nextra/pages/reference/function2.mdx
+++ b/packages/docs-nextra/pages/reference/function2.mdx
@@ -182,7 +182,7 @@ but it can only return a number.
 
 
 If one evaluates using the full syntax of an `<evaluate>{:dn}` component (as opposed to 
-the shortcut evaluation macro `$$f(x,y)`), then one can use the attributes `forceNumeric` or `forceSymbolic`
+the shortcut evaluation reference `$$f(x,y)`), then one can use the attributes `forceNumeric` or `forceSymbolic`
 to force numerical or symbolic evaluation independent of the `symbolic` attribute.
 
 

--- a/packages/docs-nextra/pages/reference/lineSegment.mdx
+++ b/packages/docs-nextra/pages/reference/lineSegment.mdx
@@ -46,7 +46,7 @@ Without any attributes, the default `<lineSegment>{:dn}` has endpoints $(0,0)$ a
 
 
 The `endpoints` property of a named `<lineSegment>{:dn}` can be 
-rendered on a `<graph>{:dn}` with the macro `$name.property`.
+rendered on a `<graph>{:dn}` with the reference `$name.property`.
 
 
 

--- a/packages/docs-nextra/pages/reference/module.mdx
+++ b/packages/docs-nextra/pages/reference/module.mdx
@@ -7,7 +7,7 @@ import { AttrPropDisplay } from "../../components"
 
 `<module>{:dn}` is a [General Operator](../document_structure/essentialConcepts#component-types)
 component that provides a way to organize a sequence of repeatable content. It is similar to creating
-a macro that can be reused multiple times within a DoenetML document.
+a reference that can be reused multiple times within a DoenetML document.
 
 <AttrPropDisplay name='module'/>
 

--- a/packages/docs-nextra/pages/reference/odeSystem.mdx
+++ b/packages/docs-nextra/pages/reference/odeSystem.mdx
@@ -36,7 +36,7 @@ import { AttrPropDisplay } from "../../components"
 
 
 
-The required attributes as well as the `<rightHandSide>{:dn}` child of the `<odeSystem>{:dn}` component for a single differential equation are retrieved from user input. A `<function>{:dn}` is then defined by accessing the `numericalSolution` property of the named `<odeSystem>{:dn}` component. The solution can be graphed and evaluated in this manner using typical function evaluation techniques (i.e. by using either the `$$functionName(input)` evaluation macro or the `<evaluate>{:dn}` component.) 
+The required attributes as well as the `<rightHandSide>{:dn}` child of the `<odeSystem>{:dn}` component for a single differential equation are retrieved from user input. A `<function>{:dn}` is then defined by accessing the `numericalSolution` property of the named `<odeSystem>{:dn}` component. The solution can be graphed and evaluated in this manner using typical function evaluation techniques (i.e. by using either the `$$functionName(input)` evaluation reference or the `<evaluate>{:dn}` component.) 
 
 
 

--- a/packages/docs-nextra/pages/reference/piecewiseFunction.mdx
+++ b/packages/docs-nextra/pages/reference/piecewiseFunction.mdx
@@ -54,7 +54,7 @@ endpoints must also be graphed as independent components (see [`<endpoint>{:dn}`
 The `<piecewiseFunction>{:dn}` component is defined by assigning `<function>{:dn}` children 
 for each distinct region of the function's domain. The named `<piecewiseFunction>{:dn}` can 
 then be evaluated in the same manner as the `<function>{:dn}` component using 
-the `$$functionName(input)` evaluation macro.
+the `$$functionName(input)` evaluation reference.
 
 
 *Note*: When using a `<piecewiseFunction>{:dn}` for evaluation, it is necessary to include 

--- a/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-0-cover.mdx
+++ b/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-0-cover.mdx
@@ -44,7 +44,7 @@ Covers the basics of getting input from the user and incorporating it into your 
     Attributes covered: `prefill`, `unorderedCompare`
 
 1. [**Functions and Function Evaluation**](iT1-7-functions.mdx)
-Explains how to define a function in DoenetML and evaluate it with numeric or symbolic input. Introduces the `$$` macro, and covers the differences between `$` and `$$`. Also discusses how to create a user-defined function, and the differences between symbolic and numeric evaluations.
+Explains how to define a function in DoenetML and evaluate it with numeric or symbolic input. Introduces the `$$` reference, and covers the differences between `$` and `$$`. Also discusses how to create a user-defined function, and the differences between symbolic and numeric evaluations.
 
     Tags covered: `<function>`, `<evaluate>` (and `$$`)
 

--- a/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-7-functions.mdx
+++ b/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-7-functions.mdx
@@ -34,8 +34,8 @@ In the above example, the function $f$ was defined in the `<setup>` block. If yo
 <p><m>g(x) = <function name="g">sin( pi x)</function></m></p>
 ```
 
-### The `$$` Macro
-In mathematics we spend a lot of time evaluating functions. It would be time consuming and awkward to write `<evaluate function="$functionName" input="inputValue" />` every time you want to plug a value into a function. Fortunately, DoenetML provides a time-saving macro:
+### The `$$` Reference
+In mathematics we spend a lot of time evaluating functions. It would be time consuming and awkward to write `<evaluate function="$functionName" input="inputValue" />` every time you want to plug a value into a function. Fortunately, DoenetML provides a time-saving reference:
 
 ```doenet
      $$f(inputValue)

--- a/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-8-domains.mdx
+++ b/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-8-domains.mdx
@@ -33,7 +33,7 @@ In DoenetML, we can compute the derivative of an elementary function using the `
 <derivative name="fPrime">$f</derivative>
 ```
 
-creates a new DoenetML function named `fPrime` which is the derivative of $f$. The new function `fPrime` can be used in all the same ways as the original function, including evaluation using the `$$` macro. Here's an example.
+creates a new DoenetML function named `fPrime` which is the derivative of $f$. The new function `fPrime` can be used in all the same ways as the original function, including evaluation using the `$$` reference. Here's an example.
 
 ```doenet-editor-horiz
 <setup>


### PR DESCRIPTION
## Summary

Closes #1161.

The DoenetML `$foo` substitution mechanism has been renamed from **"macro"** to **"reference"**. This PR sweeps the remaining mentions in `packages/docs-nextra/pages/` so the prose matches current terminology — codified in [`.github/skills/doenetml-docs-authoring/SKILL.md`](https://github.com/Doenet/DoenetML/blob/main/.github/skills/doenetml-docs-authoring/SKILL.md) under "Other small things."

## Changes

13 files, 15 line edits — pure prose, no schema or code changes.

**Reference pages (10):** `animateFromSequence.mdx`, `award3.mdx`, `circle.mdx`, `evaluate.mdx`, `function.mdx` (two mentions), `function2.mdx`, `lineSegment.mdx`, `module.mdx`, `odeSystem.mdx`, `piecewiseFunction.mdx`.

**Tutorial pages (3):** `iT1-0-cover.mdx`, `iT1-7-functions.mdx` (including the `### The \`$$\` Macro` section heading → `### The \`$$\` Reference`), `iT1-8-domains.mdx`.

Representative rewrites:

| Before | After |
| --- | --- |
| "the `$$` macro" | "the `$$` reference" |
| "the function evaluation macro `$$f(x)`" | "the function evaluation reference `$$f(x)`" |
| "the shortcut macro for the evaluate component" | "the shortcut reference for the evaluate component" |
| "the macro `$name.property`" | "the reference `$name.property`" |
| "Enclose the copy macro" | "Enclose the reference" |
| "a macro that can be reused" | "a reference that can be reused" |

## Out of scope (intentionally left alone)

- The MathJax-docs URL in `iT1-1-writing-mathematics.mdx` (`docs.mathjax.org/.../macros/...`) — LaTeX/MathJax macros are a different concept.
- PreTeXt `<macros>` / `<pg-macros>` / `WWMacros` element names under `.github/skills/pretext-authoring/`.
- Worker-side `<callAction>` / `<triggerSet>` "action macro" wiring under `packages/doenetml-worker-javascript/`.

After this PR, `grep -rIn "macro" packages/docs-nextra/pages/` returns only the MathJax URL above.

## Verification

- `grep -rIn "macro" packages/docs-nextra/pages/` — only the MathJax URL remains.
- `npx prettier --check` on all 13 touched files — clean.
- No changeset: `docs-nextra` is not in `.changeset/config.json`'s tracked package set, so docs-site-only prose doesn't ship one.
- Skipped `next build` since these are MDX-only edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)