### PR TITLE
fix(codemirror): auto-close inner tag when nested in same-name parent

### DIFF
--- a/.changeset/fix-nested-same-name-autoclose-1117.md
+++ b/.changeset/fix-nested-same-name-autoclose-1117.md
@@ -1,0 +1,15 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Fix auto-completion of closing tags when nesting an element with the same
+tag name as its parent. Previously, typing `<p>` inside an existing
+`<p></p>` would not insert the inner `</p>` (the parser's stack-matching
+"stole" the only `</p>` for the inner element), and typing `</` afterward
+would not suggest the closing tag. The completion logic now walks up the
+contiguous chain of same-name ancestor elements and, if any of them is
+missing a close tag, treats the inner element as still needing one. (#1117)

--- a/packages/codemirror/test/cypress/component/auto-close-tag.cy.tsx
+++ b/packages/codemirror/test/cypress/component/auto-close-tag.cy.tsx
@@ -159,6 +159,43 @@ describe("CodeMirror Auto-Close Tag Extension", () => {
             cy.get(".cm-line").should("have.text", "<tag><tag></tag>");
         });
 
+        it("inserts closing tag for nested same-name when parent has pre-existing close (#1117)", () => {
+            // Parser stack-matches the only </p> to the inner <p>; without
+            // the stolen-close-tag heuristic, no auto-close would fire.
+            cy.mount(
+                <div style={{ height: "400px", width: "600px" }}>
+                    <CodeMirror value="<p></p>" />
+                </div>,
+            );
+
+            // Place cursor between `<p>` and `</p>` (after offset 3), then type `<p>`.
+            cy.get(".cm-content")
+                .click()
+                .type("{home}{rightArrow}{rightArrow}{rightArrow}<p>", {
+                    force: true,
+                });
+            cy.get(".cm-line").should("have.text", "<p><p></p></p>");
+        });
+
+        it("inserts closing tag for deeply nested same-name domino (#1117)", () => {
+            // <p><p></p></p> -> nest a third <p> inside the inner one.
+            // Without the heuristic, parser would treat the new innermost as
+            // closed by the first </p>.
+            cy.mount(
+                <div style={{ height: "400px", width: "600px" }}>
+                    <CodeMirror value="<p><p></p></p>" />
+                </div>,
+            );
+
+            // Cursor between the inner <p> (offset 6) and inner </p>; type `<p>`.
+            cy.get(".cm-content")
+                .click()
+                .type("{home}" + "{rightArrow}".repeat(6) + "<p>", {
+                    force: true,
+                });
+            cy.get(".cm-line").should("have.text", "<p><p><p></p></p></p>");
+        });
+
         it("preserves exact case", () => {
             cy.mount(
                 <div style={{ height: "400px", width: "600px" }}>

--- a/packages/codemirror/test/cypress/component/autocomplete.cy.tsx
+++ b/packages/codemirror/test/cypress/component/autocomplete.cy.tsx
@@ -165,6 +165,33 @@ describe("CodeMirror LSP Autocomplete Plugin", () => {
         cy.get(".cm-line").should("have.text", `<matrix></matrix>`);
     });
 
+    it("completes closing tag for inner same-name element when parent stole close (#1117)", () => {
+        // Parser stack-matches the only </matrix> to the inner <matrix>.
+        // Without the stolen-close-tag heuristic, no `/matrix>` suggestion
+        // would appear because the inner element looks already-closed.
+        cy.mount(
+            <div style={{ height: "400px", width: "600px" }}>
+                <CodeMirror
+                    value={`<matrix><matrix></matrix>`}
+                    doenetWorkerUrl={doenetWorkerUrl}
+                />
+            </div>,
+        );
+
+        // Position cursor in the body of the inner <matrix>, between its
+        // opening `<matrix>` (ending at offset 16) and the `</matrix>`.
+        cy.get(".cm-content")
+            .click()
+            .type("{home}" + "{rightArrow}".repeat(16) + "<", {
+                force: true,
+            });
+        cy.get(".cm-tooltip-autocomplete .cm-completionLabel").first().click();
+        cy.get(".cm-line").should(
+            "have.text",
+            `<matrix><matrix></matrix></matrix>`,
+        );
+    });
+
     it("inserts element snippets", () => {
         cy.mount(
             <div style={{ height: "400px", width: "600px" }}>

--- a/packages/lsp-tools/src/doenet-source-object/index.ts
+++ b/packages/lsp-tools/src/doenet-source-object/index.ts
@@ -321,6 +321,15 @@ export class DoenetSourceObject extends LazyDataObject {
                 }
                 if (!lezerNodeParent?.getChild("CloseTag")) {
                     closed = false;
+                } else if (
+                    this._isCloseTagStolenFromAncestor(lezerNodeParent)
+                ) {
+                    // The parser found a CloseTag for us, but its stack-based
+                    // matching has likely "stolen" what the user intended as
+                    // an ancestor's close tag for this inner element
+                    // (issue #1117). Treat as unclosed so callers (auto-close
+                    // and `</` completion) insert / suggest a fresh close tag.
+                    closed = false;
                 }
                 break;
             }
@@ -339,6 +348,61 @@ export class DoenetSourceObject extends LazyDataObject {
         }
 
         return { tagComplete, closed };
+    }
+
+    /**
+     * Walk up the contiguous chain of same-name ancestor `Element` nodes
+     * starting from `elementNode`'s parent. Returns true if any of those
+     * same-name ancestors is missing its `CloseTag` — meaning the parser's
+     * stack-based matching has shifted close tags down a level and the
+     * close tag the parser attributed to `elementNode` was, from the user's
+     * perspective, "stolen" from an ancestor (issue #1117).
+     *
+     * Stops at the first ancestor with a different tag name (or at the
+     * root): the stealing pattern only happens through a same-name chain,
+     * because that's the only configuration where the parser stack can
+     * shuffle close tags. For example, `<p><div><p></p></div>` does NOT
+     * trigger — `<div>` breaks the chain and the inner `</p>` is
+     * genuinely the inner `<p>`'s own.
+     *
+     * Comparison is case-sensitive to match XML/DoenetML semantics.
+     */
+    _isCloseTagStolenFromAncestor(
+        elementNode: NonNullable<ReturnType<typeof this._lezerCursor>["node"]>,
+    ): boolean {
+        const openTag = elementNode.getChild("OpenTag");
+        const tagNameNode = openTag?.getChild("TagName");
+        if (!tagNameNode) {
+            return false;
+        }
+        const tagName = this.source.slice(tagNameNode.from, tagNameNode.to);
+        if (!tagName) {
+            return false;
+        }
+
+        let ancestor = elementNode.parent;
+        while (ancestor) {
+            if (ancestor.type.name !== "Element") {
+                return false;
+            }
+            const ancestorOpenTag = ancestor.getChild("OpenTag");
+            const ancestorTagNameNode = ancestorOpenTag?.getChild("TagName");
+            if (!ancestorTagNameNode) {
+                return false;
+            }
+            const ancestorName = this.source.slice(
+                ancestorTagNameNode.from,
+                ancestorTagNameNode.to,
+            );
+            if (ancestorName !== tagName) {
+                return false;
+            }
+            if (!ancestor.getChild("CloseTag")) {
+                return true;
+            }
+            ancestor = ancestor.parent;
+        }
+        return false;
     }
 
     /**

--- a/packages/lsp-tools/src/doenet-source-object/index.ts
+++ b/packages/lsp-tools/src/doenet-source-object/index.ts
@@ -28,6 +28,7 @@ import type {
     Position as LSPPosition,
     Range as LSPRange,
 } from "vscode-languageserver";
+import type { SyntaxNode } from "@lezer/common";
 import { elementAtOffset, nodeAtOffset } from "./methods/at-offset";
 import {
     findAttributeContainingOffset,
@@ -367,9 +368,7 @@ export class DoenetSourceObject extends LazyDataObject {
      *
      * Comparison is case-sensitive to match XML/DoenetML semantics.
      */
-    _isCloseTagStolenFromAncestor(
-        elementNode: NonNullable<ReturnType<typeof this._lezerCursor>["node"]>,
-    ): boolean {
+    _isCloseTagStolenFromAncestor(elementNode: SyntaxNode): boolean {
         const openTag = elementNode.getChild("OpenTag");
         const tagNameNode = openTag?.getChild("TagName");
         if (!tagNameNode) {

--- a/packages/lsp-tools/test/doenet-source-object.test.ts
+++ b/packages/lsp-tools/test/doenet-source-object.test.ts
@@ -345,4 +345,122 @@ describe("DoenetSourceObject", () => {
             `);
         }
     });
+
+    describe("isCompleteElement (issue #1117 stolen-close-tag heuristic)", () => {
+        // Helper: get the element whose open-tag starts at `tagOpenIdx`
+        // (the offset of the `<`).
+        function elementAt(source: string, tagOpenIdx: number) {
+            const sourceObj = new DoenetSourceObject(source);
+            const { node } = sourceObj.elementAtOffsetWithContext(
+                tagOpenIdx + 1,
+            );
+            return { sourceObj, node: node as DastElement };
+        }
+
+        it("reports closed=false for inner same-name child of unclosed parent", () => {
+            // Parser stack-matches the only </p> to the inner <p>; user intent
+            // is for the inner to still need its own close tag.
+            const source = "<p><p></p>";
+            const { sourceObj, node } = elementAt(
+                source,
+                source.indexOf("<p>", 1),
+            );
+            expect(node.name).toEqual("p");
+            expect(sourceObj.isCompleteElement(node)).toEqual({
+                tagComplete: true,
+                closed: false,
+            });
+        });
+
+        it("reports closed=true when same-name nesting is fully balanced", () => {
+            const source = "<p><p></p></p>";
+            const { sourceObj, node } = elementAt(
+                source,
+                source.indexOf("<p>", 1),
+            );
+            expect(node.name).toEqual("p");
+            expect(sourceObj.isCompleteElement(node)).toEqual({
+                tagComplete: true,
+                closed: true,
+            });
+        });
+
+        it("reports closed=false for innermost in a deeply nested domino case", () => {
+            // <p><p><p></p></p>  — only two </p> for three <p>.
+            // Innermost lezer-closed, middle lezer-closed, outermost unclosed.
+            // Walk past closed same-name middle to find unclosed same-name outermost.
+            const source = "<p><p><p></p></p>";
+            const { sourceObj, node } = elementAt(
+                source,
+                source.lastIndexOf("<p>"),
+            );
+            expect(node.name).toEqual("p");
+            expect(sourceObj.isCompleteElement(node)).toEqual({
+                tagComplete: true,
+                closed: false,
+            });
+        });
+
+        it("does NOT flip when a different-name ancestor breaks the chain", () => {
+            // The inner <p>'s </p> is genuinely its own; the outer <p>'s
+            // unclosed state is unrelated because <div> sits between them.
+            const source = "<p><div><p></p></div>";
+            const { sourceObj, node } = elementAt(
+                source,
+                source.indexOf("<p>", 1),
+            );
+            expect(node.name).toEqual("p");
+            expect(sourceObj.isCompleteElement(node)).toEqual({
+                tagComplete: true,
+                closed: true,
+            });
+        });
+
+        it("reports closed=true when parent has a different tag name", () => {
+            const source = "<a><p></p>";
+            const { sourceObj, node } = elementAt(
+                source,
+                source.indexOf("<p>"),
+            );
+            expect(node.name).toEqual("p");
+            expect(sourceObj.isCompleteElement(node)).toEqual({
+                tagComplete: true,
+                closed: true,
+            });
+        });
+
+        it("is case-sensitive (<P> and <p> are different tags)", () => {
+            const source = "<P><p></p>";
+            const { sourceObj, node } = elementAt(
+                source,
+                source.indexOf("<p>"),
+            );
+            expect(node.name).toEqual("p");
+            // <P> ≠ <p>, so the walk stops at the different-name ancestor.
+            expect(sourceObj.isCompleteElement(node)).toEqual({
+                tagComplete: true,
+                closed: true,
+            });
+        });
+
+        it("reports tagComplete=false for an unfinished open tag (regression)", () => {
+            const source = "<p";
+            const { sourceObj, node } = elementAt(source, 0);
+            expect(node.name).toEqual("p");
+            expect(sourceObj.isCompleteElement(node)).toEqual({
+                tagComplete: false,
+                closed: false,
+            });
+        });
+
+        it("self-closing tag reports tagComplete=true, closed=true (regression)", () => {
+            const source = "<p/>";
+            const { sourceObj, node } = elementAt(source, 0);
+            expect(node.name).toEqual("p");
+            expect(sourceObj.isCompleteElement(node)).toEqual({
+                tagComplete: true,
+                closed: true,
+            });
+        });
+    });
 });


### PR DESCRIPTION
Fixes #1117.

## Problem

When a user types `<p>` inside an existing `<p></p>`, the Lezer parser's stack-based tag matching attributes the only `</p>` to the *inner* `<p>`. From the parser's point of view the inner element is closed and the outer is now unclosed, so the editor's auto-close handler decides no `</p>` insert is needed — the user is left with `<p><p></p>`. Typing `</` inside the inner element afterward also fails to suggest the closing tag for the same reason.

## Fix

`DoenetSourceObject.isCompleteElement` previously reported `closed: true` whenever the Lezer parent `Element` had any `CloseTag` child. It now additionally walks up the *contiguous chain of same-name ancestor `Element` nodes*; if any of those same-name ancestors is missing its own `CloseTag`, the parser has shifted close tags down a level and the element is reported as `closed: false` so the auto-close handler (and the `</` completion branch) does the right thing.

The walk stops at the first different-name ancestor, since the stealing pattern only happens through a same-name chain. For example, `<p><div><p></p></div>` correctly does NOT trigger — `<div>` breaks the chain and the inner `</p>` is genuinely the inner `<p>`'s own.

Comparison is case-sensitive to match XML/DoenetML semantics.

## Cases verified

| Source | Inner element `closed` before | after |
| --- | --- | --- |
| `<p><p></p>` | true (bug) | **false** ✓ |
| `<p><p></p></p>` (balanced) | true | true |
| `<p><p><p></p></p>` (domino) | true (bug) | **false** ✓ |
| `<p><div><p></p></div>` | true | true (chain broken by `<div>`) |
| `<a><p></p>` | true | true (different name) |
| `<P><p></p>` | true | true (case-sensitive) |

## Tests

- `packages/lsp-tools/test/doenet-source-object.test.ts` — 8 new Vitest cases (all 200 tests in the package pass).
- `packages/codemirror/test/cypress/component/auto-close-tag.cy.tsx` — 2 new component tests (all 17 in the spec pass).
- `packages/codemirror/test/cypress/component/autocomplete.cy.tsx` — 1 new component test (all 29 in the spec pass).

## Changeset

Patch bump for the user-facing fixed-group packages (`@doenet/doenetml`, `@doenet/standalone`, `@doenet/doenetml-iframe`, `@doenet/vscode-extension`, `doenet-vscode-extension`), matching the precedent of `autocomplete-bare-value-nested-and-whitespace.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)