### PR TITLE
fix(context-help): handle composite-wrapper descendants and reject invalid index access

### DIFF
--- a/.changeset/context-help-composite-wrapper-descendants.md
+++ b/.changeset/context-help-composite-wrapper-descendants.md
@@ -10,6 +10,6 @@ Fix the editor's context-sensitive help for `$container.member` access through c
 
 Example: a `<select name="s">` with two `<option>` branches each containing `<text name="t">`. The autocomplete dropdown correctly offered `t` at `$s[1].`, but the help panel went blank — `getNamedDescendant` requires a uniquely-addressable name and saw two matches.
 
-The resolver already includes such names in `visibleDescendantNames` for indexed access through a composite (walking `<case>` / `<else>` / `<option>` wrappers transparently via `collectNamesFromCompositeChildren`). The help-side descendant lookup in `resolveRefMemberDescendantHelp` now mirrors that wrapper walk and returns the first match: sibling-replicated descendants of those wrappers share schemas, so any one match yields the right help payload.
+The resolver already includes such names in `visibleDescendantNames` for indexed access through a composite (walking `<case>` / `<else>` / `<option>` wrappers transparently via `collectNamesFromCompositeChildren`). The help-side descendant lookup in `resolveRefMemberDescendantHelp` now mirrors that wrapper walk and returns the first match — but only when every branch resolves the name to the same component type. When branches diverge (e.g. one `<option><math name="t">` and another `<option><text name="t">`), the help layer can't statically tell which branch the runtime will pick, so the panel stays blank rather than guessing.
 
 Closes #1179.

--- a/.changeset/context-help-composite-wrapper-descendants.md
+++ b/.changeset/context-help-composite-wrapper-descendants.md
@@ -1,0 +1,15 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Fix the editor's context-sensitive help for `$container.member` access through composite wrappers, when multiple wrapper branches each declare a descendant with the same name.
+
+Example: a `<select name="s">` with two `<option>` branches each containing `<text name="t">`. The autocomplete dropdown correctly offered `t` at `$s[1].`, but the help panel went blank — `getNamedDescendant` requires a uniquely-addressable name and saw two matches.
+
+The resolver already includes such names in `visibleDescendantNames` for indexed access through a composite (walking `<case>` / `<else>` / `<option>` wrappers transparently via `collectNamesFromCompositeChildren`). The help-side descendant lookup in `resolveRefMemberDescendantHelp` now mirrors that wrapper walk and returns the first match: sibling-replicated descendants of those wrappers share schemas, so any one match yields the right help payload.
+
+Closes #1179.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,8 @@ This checkout may use a personal fork as `origin` and the canonical `Doenet/Doen
 - Before pushing, run `npm run prettier:format` on modified files.
 - Before creating the PR, confirm only intended files are staged — this repository often has unrelated local work in the tree.
 - After creating the PR, verify the branch has been pushed to `origin` and the PR links to the correct target branch (`Doenet/DoenetML:main`).
+- **Do not put the issue number in the PR title.** PRs are squash-merged, and GitHub auto-appends ` (#<PR-number>)` to the squashed commit subject. A title like `fix: ... (#1179)` would produce a confusing `fix: ... (#1179) (#1182)` after merge. Reference issues from the PR body instead (e.g. `Closes #1179.`).
+- The same applies to the **commit subject** of any commit in the branch — squash-merge often seeds the merge subject from the PR title, but a branch with a clean per-commit subject avoids confusion if the PR is ever rebase-merged or cherry-picked.
 
 ## Changesets
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,8 +132,7 @@ This checkout may use a personal fork as `origin` and the canonical `Doenet/Doen
 - Before pushing, run `npm run prettier:format` on modified files.
 - Before creating the PR, confirm only intended files are staged — this repository often has unrelated local work in the tree.
 - After creating the PR, verify the branch has been pushed to `origin` and the PR links to the correct target branch (`Doenet/DoenetML:main`).
-- **Do not put the issue number in the PR title.** PRs are squash-merged, and GitHub auto-appends ` (#<PR-number>)` to the squashed commit subject. A title like `fix: ... (#1179)` would produce a confusing `fix: ... (#1179) (#1182)` after merge. Reference issues from the PR body instead (e.g. `Closes #1179.`).
-- The same applies to the **commit subject** of any commit in the branch — squash-merge often seeds the merge subject from the PR title, but a branch with a clean per-commit subject avoids confusion if the PR is ever rebase-merged or cherry-picked.
+- Do not put the issue number in the PR title or in commit subjects on the branch. Squash-merge appends ` (#<PR-number>)` automatically; a title like `fix: ... (#1179)` becomes `fix: ... (#1179) (#1182)` after merge. Reference issues from the PR body instead (e.g. `Closes #1179.`).
 
 ## Changesets
 

--- a/packages/lsp-tools/src/auto-completer/index.ts
+++ b/packages/lsp-tools/src/auto-completer/index.ts
@@ -141,6 +141,66 @@ export type AutoCompleterOptions = {
 };
 
 /**
+ * Wrapper elements whose children should be treated as direct children of
+ * the composite for ref-resolution purposes. Kept in sync with
+ * `COMPOSITE_WRAPPER_NAMES` in `rust-resolver-adapter.ts`; the resolver
+ * walks names through wrappers transparently when it computes
+ * `visibleDescendantNames`, and the help-side descendant lookup must too.
+ */
+const COMPOSITE_WRAPPER_NAMES_FOR_HELP = new Set(["case", "else", "option"]);
+
+/**
+ * Walk the subtree rooted at `node` and return the first descendant element
+ * whose `name` attribute equals `target`, or `null` if none exists.
+ */
+function findNamedDescendant(
+    node: DastElement,
+    target: string,
+): DastElement | null {
+    for (const child of node.children) {
+        if (child.type !== "element") continue;
+        const nameAttr = child.attributes?.name;
+        const nameVal =
+            nameAttr &&
+            nameAttr.children?.length === 1 &&
+            nameAttr.children[0].type === "text"
+                ? nameAttr.children[0].value
+                : undefined;
+        if (nameVal === target) return child;
+        const inner = findNamedDescendant(child, target);
+        if (inner) return inner;
+    }
+    return null;
+}
+
+/**
+ * For composite wrappers (`<select>`, `<conditionalContent>`, …) whose
+ * children are `<case>` / `<else>` / `<option>` branches, return the first
+ * named descendant found by walking the wrapper subtrees. Returns `null`
+ * when `container` has no wrapper children.
+ *
+ * Used as a fallback when `getNamedDescendant` returns `null` because two
+ * sibling branches each declared the same name — the runtime picks one
+ * branch by index, and sibling-replicated descendants carry identical
+ * schemas, so any match produces the right help payload. Parallels
+ * `collectNamesFromCompositeChildren` in `rust-resolver-adapter.ts`,
+ * which is what put `target` into `visibleDescendantNames` in the first
+ * place.
+ */
+function findDescendantViaCompositeWrappers(
+    container: DastElement,
+    target: string,
+): DastElement | null {
+    for (const child of container.children) {
+        if (child.type !== "element") continue;
+        if (!COMPOSITE_WRAPPER_NAMES_FOR_HELP.has(child.name)) continue;
+        const match = findNamedDescendant(child, target);
+        if (match) return match;
+    }
+    return null;
+}
+
+/**
  * Shift snippet cursor offsets after trimming leading whitespace.
  */
 function adjustCursorForTrimStart(
@@ -552,8 +612,23 @@ export class AutoCompleter {
             container,
             memberName,
         );
-        if (!descendant) return null;
-        return this._buildRefHelpInfo(descendant);
+        if (descendant) return this._buildRefHelpInfo(descendant);
+
+        // Composite-wrapper fallback: for `<select>` / `<conditionalContent>`
+        // where multiple `<option>` / `<case>` / `<else>` branches each declare
+        // a descendant with the same `name`, `getNamedDescendant` returns
+        // `null` because the name is not uniquely addressable. But the runtime
+        // picks one branch by index (`$s[1].t`) and the resolver already
+        // included the name in `visibleDescendantNames` (gating this call)
+        // via `collectNamesFromCompositeChildren` — sibling-replicated
+        // descendants carry identical schemas, so any one match produces the
+        // right help payload.
+        const compositeMatch = findDescendantViaCompositeWrappers(
+            container,
+            memberName,
+        );
+        if (compositeMatch) return this._buildRefHelpInfo(compositeMatch);
+        return null;
     }
 
     /**

--- a/packages/lsp-tools/src/auto-completer/index.ts
+++ b/packages/lsp-tools/src/auto-completer/index.ts
@@ -11,7 +11,11 @@ import {
     getCompletionContext,
     type CompletionContext,
 } from "./methods/get-completion-context";
-import type { RustResolverAdapter } from "./rust-resolver-adapter";
+import {
+    COMPOSITE_WRAPPER_NAMES,
+    getElementNameAttributeValue,
+    type RustResolverAdapter,
+} from "./rust-resolver-adapter";
 import { isRepeatLikeElement } from "./repeat-elements";
 
 // Re-exported so consumers (notably `@doenet/lsp`'s context-help feature)
@@ -141,15 +145,6 @@ export type AutoCompleterOptions = {
 };
 
 /**
- * Wrapper elements whose children should be treated as direct children of
- * the composite for ref-resolution purposes. Kept in sync with
- * `COMPOSITE_WRAPPER_NAMES` in `rust-resolver-adapter.ts`; the resolver
- * walks names through wrappers transparently when it computes
- * `visibleDescendantNames`, and the help-side descendant lookup must too.
- */
-const COMPOSITE_WRAPPER_NAMES_FOR_HELP = new Set(["case", "else", "option"]);
-
-/**
  * Walk the subtree rooted at `node` and return the first descendant element
  * whose `name` attribute equals `target`, or `null` if none exists.
  */
@@ -159,14 +154,7 @@ function findNamedDescendant(
 ): DastElement | null {
     for (const child of node.children) {
         if (child.type !== "element") continue;
-        const nameAttr = child.attributes?.name;
-        const nameVal =
-            nameAttr &&
-            nameAttr.children?.length === 1 &&
-            nameAttr.children[0].type === "text"
-                ? nameAttr.children[0].value
-                : undefined;
-        if (nameVal === target) return child;
+        if (getElementNameAttributeValue(child) === target) return child;
         const inner = findNamedDescendant(child, target);
         if (inner) return inner;
     }
@@ -185,7 +173,8 @@ function findNamedDescendant(
  * schemas, so any match produces the right help payload. Parallels
  * `collectNamesFromCompositeChildren` in `rust-resolver-adapter.ts`,
  * which is what put `target` into `visibleDescendantNames` in the first
- * place.
+ * place (so this only runs when the resolver already affirmed the name
+ * is reachable through a wrapper).
  */
 function findDescendantViaCompositeWrappers(
     container: DastElement,
@@ -193,7 +182,7 @@ function findDescendantViaCompositeWrappers(
 ): DastElement | null {
     for (const child of container.children) {
         if (child.type !== "element") continue;
-        if (!COMPOSITE_WRAPPER_NAMES_FOR_HELP.has(child.name)) continue;
+        if (!COMPOSITE_WRAPPER_NAMES.has(child.name)) continue;
         const match = findNamedDescendant(child, target);
         if (match) return match;
     }

--- a/packages/lsp-tools/src/auto-completer/index.ts
+++ b/packages/lsp-tools/src/auto-completer/index.ts
@@ -163,14 +163,21 @@ function findNamedDescendant(
 
 /**
  * For composite wrappers (`<select>`, `<conditionalContent>`, …) whose
- * children are `<case>` / `<else>` / `<option>` branches, return the first
- * named descendant found by walking the wrapper subtrees. Returns `null`
- * when `container` has no wrapper children.
+ * children are `<case>` / `<else>` / `<option>` branches, return the
+ * first named descendant found by walking the wrapper subtrees — **but
+ * only when every wrapper that contains `target` resolves it to the
+ * same component type**. The help layer has no static way to know which
+ * branch the runtime will pick (`<option>` is index-addressable but the
+ * help call site doesn't carry the index; `<case>` is predicate-gated),
+ * so when branches diverge in component type we'd be guessing at the
+ * schema — return `null` and let the panel go blank instead.
  *
- * Used as a fallback when `getNamedDescendant` returns `null` because two
- * sibling branches each declared the same name — the runtime picks one
- * branch by index, and sibling-replicated descendants carry identical
- * schemas, so any match produces the right help payload. Parallels
+ * Returns `null` when `container` has no wrapper children, when no
+ * wrapper contains `target`, or when matches across wrappers disagree
+ * on element name.
+ *
+ * Used as a fallback when `getNamedDescendant` returns `null` because
+ * two sibling branches each declared the same name. Parallels
  * `collectNamesFromCompositeChildren` in `rust-resolver-adapter.ts`,
  * which is what put `target` into `visibleDescendantNames` in the first
  * place (so this only runs when the resolver already affirmed the name
@@ -180,13 +187,19 @@ function findDescendantViaCompositeWrappers(
     container: DastElement,
     target: string,
 ): DastElement | null {
+    const matches: DastElement[] = [];
     for (const child of container.children) {
         if (child.type !== "element") continue;
         if (!COMPOSITE_WRAPPER_NAMES.has(child.name)) continue;
         const match = findNamedDescendant(child, target);
-        if (match) return match;
+        if (match) matches.push(match);
     }
-    return null;
+    if (matches.length === 0) return null;
+    const firstName = matches[0].name;
+    for (let i = 1; i < matches.length; i++) {
+        if (matches[i].name !== firstName) return null;
+    }
+    return matches[0];
 }
 
 /**
@@ -606,12 +619,14 @@ export class AutoCompleter {
         // Composite-wrapper fallback: for `<select>` / `<conditionalContent>`
         // where multiple `<option>` / `<case>` / `<else>` branches each declare
         // a descendant with the same `name`, `getNamedDescendant` returns
-        // `null` because the name is not uniquely addressable. But the runtime
-        // picks one branch by index (`$s[1].t`) and the resolver already
-        // included the name in `visibleDescendantNames` (gating this call)
-        // via `collectNamesFromCompositeChildren` — sibling-replicated
-        // descendants carry identical schemas, so any one match produces the
-        // right help payload.
+        // `null` because the name is not uniquely addressable. The resolver
+        // already included the name in `visibleDescendantNames` (gating this
+        // call) via `collectNamesFromCompositeChildren`. The fallback walks
+        // the wrapper subtrees and returns the first match — but only when
+        // all matching branches resolve the name to the same component type,
+        // since the help layer can't tell which branch the runtime will pick.
+        // Heterogeneous branches yield `null` (panel blank) rather than wrong
+        // help.
         const compositeMatch = findDescendantViaCompositeWrappers(
             container,
             memberName,

--- a/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
+++ b/packages/lsp-tools/src/auto-completer/rust-resolver-adapter.ts
@@ -9,10 +9,32 @@ import type {
 
 /**
  * Wrapper elements whose children should be treated as direct children of
- * the composite for autocomplete purposes.  At runtime, sugar inserts these
- * wrappers and then strips them during replacement expansion.
+ * the composite for ref-resolution purposes.  At runtime, sugar inserts
+ * these wrappers and then strips them during replacement expansion.
+ *
+ * Exported so the help-side descendant walk in `auto-completer/index.ts`
+ * mirrors the resolver's wrapper handling from a single source of truth.
  */
-const COMPOSITE_WRAPPER_NAMES = new Set(["case", "else", "option"]);
+export const COMPOSITE_WRAPPER_NAMES = new Set(["case", "else", "option"]);
+
+/**
+ * Return the literal `name` attribute value for an element, if present.
+ *
+ * Exported so callers in other modules (notably the help-side descendant
+ * walk in `auto-completer/index.ts`) reuse the same single-text-child
+ * extraction this file relies on, instead of re-inlining it.
+ */
+export function getElementNameAttributeValue(el: DastElement): string | null {
+    const nameAttr = el.attributes?.name;
+    if (
+        nameAttr &&
+        nameAttr.children?.length === 1 &&
+        nameAttr.children[0].type === "text"
+    ) {
+        return nameAttr.children[0].value;
+    }
+    return null;
+}
 
 /**
  * Walk all descendants of `root`, returning an array of `{ name, element }`
@@ -24,17 +46,9 @@ function collectAllNamedDescendants(
     const result: Array<{ name: string; element: DastElement }> = [];
     function walk(node: DastNodes) {
         if (node.type === "element") {
-            const nameAttr = node.attributes?.name;
-            if (nameAttr) {
-                // name attribute value is stored in children[0].value
-                const nameVal =
-                    nameAttr.children?.length === 1 &&
-                    nameAttr.children[0].type === "text"
-                        ? nameAttr.children[0].value
-                        : undefined;
-                if (nameVal) {
-                    result.push({ name: nameVal, element: node });
-                }
+            const nameVal = getElementNameAttributeValue(node);
+            if (nameVal) {
+                result.push({ name: nameVal, element: node });
             }
             for (const child of node.children) {
                 walk(child as DastNodes);
@@ -87,13 +101,7 @@ function collectNamesFromCompositeChildren(
         if (child.type !== "element") continue;
         if (COMPOSITE_WRAPPER_NAMES.has(child.name)) continue;
 
-        const nameAttr = child.attributes?.name;
-        const nameVal =
-            nameAttr &&
-            nameAttr.children?.length === 1 &&
-            nameAttr.children[0].type === "text"
-                ? nameAttr.children[0].value
-                : undefined;
+        const nameVal = getElementNameAttributeValue(child);
         if (nameVal) {
             directChildNameCounts.set(
                 nameVal,
@@ -115,13 +123,7 @@ function collectNamesFromCompositeChildren(
             // Direct child of composite (not a wrapper): include its own name
             // only when unique among direct siblings, and always collect
             // unique descendant names from within the child subtree.
-            const nameAttr = child.attributes?.name;
-            const nameVal =
-                nameAttr &&
-                nameAttr.children?.length === 1 &&
-                nameAttr.children[0].type === "text"
-                    ? nameAttr.children[0].value
-                    : undefined;
+            const nameVal = getElementNameAttributeValue(child);
             if (nameVal && directChildNameCounts.get(nameVal) === 1) {
                 result.add(nameVal);
             }
@@ -155,19 +157,6 @@ function getDerivedRepeatNamesFromElement(el: DastElement): string[] {
         }
     }
     return names;
-}
-
-/** Return the literal `name` attribute value for an element, if present. */
-function getElementNameAttributeValue(el: DastElement): string | null {
-    const nameAttr = el.attributes?.name;
-    if (
-        nameAttr &&
-        nameAttr.children?.length === 1 &&
-        nameAttr.children[0].type === "text"
-    ) {
-        return nameAttr.children[0].value;
-    }
-    return null;
 }
 
 /**

--- a/packages/lsp-tools/src/context-help/computeContextHelp.resolver.test.ts
+++ b/packages/lsp-tools/src/context-help/computeContextHelp.resolver.test.ts
@@ -173,4 +173,34 @@ describe("computeContextHelp — resolver-backed takesIndex semantics", () => {
             },
         });
     });
+
+    it("resolves $s[1].t on a <select> whose option branches each declare the same descendant name", async () => {
+        // Two `<option>` branches each declare `<text name="t">`. The
+        // resolver walks wrapper children transparently
+        // (`collectNamesFromCompositeChildren`) so "t" lands in
+        // `visibleDescendantNames` — but `getNamedDescendant` on the
+        // `<select>` returns null because "t" isn't uniquely addressable.
+        // The composite-wrapper fallback in `resolveRefMemberDescendantHelp`
+        // walks `<option>` / `<case>` / `<else>` subtrees and returns the
+        // first match: sibling-replicated descendants of those wrappers
+        // share schemas, so either match yields the right help payload.
+        // Closes #1179.
+        const source = `<select name="s"><option><text name="t">a</text></option><option><text name="t">b</text></option></select>\n$s[1].t`;
+        const completer = await buildCompleterWithAdapter(source, {
+            resolveResult: {
+                nodeIdx: 0, // <select>
+                nodesInResolvedPath: [0],
+                unresolvedPath: null,
+                originalPath: [{ name: "s" }],
+            },
+            takesIndexComponentTypes: new Set(["select"]),
+        });
+        const help = await computeContextHelp(completer, source.length);
+        expect(help).toMatchObject({
+            kind: "refName",
+            refName: "t",
+            displayPath: "s[1].t",
+            targetElementName: "text",
+        });
+    });
 });

--- a/packages/lsp-tools/src/context-help/computeContextHelp.resolver.test.ts
+++ b/packages/lsp-tools/src/context-help/computeContextHelp.resolver.test.ts
@@ -174,6 +174,33 @@ describe("computeContextHelp — resolver-backed takesIndex semantics", () => {
         });
     });
 
+    it("returns NONE when option branches resolve the same descendant name to different component types", async () => {
+        // Heterogeneous wrapper branches: `<option><math name="t">` and
+        // `<option><text name="t">`. The resolver still puts "t" in
+        // `visibleDescendantNames` (it's unique within each `<option>`),
+        // so `resolveRefMemberDescendantHelp` is called and the
+        // composite-wrapper fallback fires. But the matches across
+        // branches disagree on component type — the help layer can't
+        // tell whether the runtime will pick the `<math>` or the
+        // `<text>` branch (`<option>` index isn't propagated to the
+        // help call site; the resolver landed on `<select>` itself).
+        // The fallback returns null and the panel goes blank, rather
+        // than guessing at the schema and surfacing wrong help.
+        // Tightens the fix from #1182 in response to a Copilot review.
+        const source = `<select name="s"><option><math name="t">x</math></option><option><text name="t">b</text></option></select>\n$s[1].t`;
+        const completer = await buildCompleterWithAdapter(source, {
+            resolveResult: {
+                nodeIdx: 0, // <select>
+                nodesInResolvedPath: [0],
+                unresolvedPath: null,
+                originalPath: [{ name: "s" }],
+            },
+            takesIndexComponentTypes: new Set(["select"]),
+        });
+        const help = await computeContextHelp(completer, source.length);
+        expect(help).toEqual({ kind: "none" });
+    });
+
     it("resolves $s[1].t on a <select> whose option branches each declare the same descendant name", async () => {
         // Two `<option>` branches each declare `<text name="t">`. The
         // resolver walks wrapper children transparently


### PR DESCRIPTION
Closes #1179.

## What was wrong

```doenet
<select name="s">
  <option><text name="t">a</text></option>
  <option><text name="t">b</text></option>
</select>
<p>Selected: $s[1].t</p>
```

Cursor on `t` → autocomplete correctly offered `t`, but the help panel went blank. Two `<option>` branches each declared `<text name="t">`, so `getNamedDescendant` returned null (it requires a uniquely-addressable name) and the help layer fell through to nothing.

## What the fix does

`packages/lsp-tools/src/auto-completer/index.ts` — add `findNamedDescendant` and `findDescendantViaCompositeWrappers`, and use them as a fallback in `resolveRefMemberDescendantHelp`. When the unique-name lookup fails, walk the container's `<case>` / `<else>` / `<option>` children and return the first matching descendant.

This mirrors the resolver's existing wrapper walk on the autocomplete side (`collectNamesFromCompositeChildren` in `rust-resolver-adapter.ts`), which is what put `t` into `visibleDescendantNames` and gated the call to `resolveRefMemberDescendantHelp` in the first place. Sibling-replicated descendants of those wrappers share schemas, so the first-match payload is the right one.

## Other cases from the original repro

Two adjacent cases the working tree of an earlier draft had also addressed turned out to already work on `main` after #1178 landed:

- **Completion-driven dispatch for `reference`-kind rows at `$container.`** — `computeContextHelp.ts:575-587` (on `main`) already routes these through `helpForRefMemberByName` when `cursorPos === "refMember"`.
- **`$cc[1].t` on `<conditionalContent>` (`takesIndex: false`)** — `rust-resolver-adapter.ts:565-572` (on `main`) already returns `{ node: null }` for non-`takesIndex` + index, and `helpForRefMemberByName` returns NONE on null.

Both verified post-rebase; this PR no longer needs to touch them.

## Also in this PR: AGENTS.md PR-title note

A separate commit adds two bullets to `AGENTS.md` under "PR Creation" documenting that PR titles (and per-commit subjects) must not include the closed-issue number in trailing `(#n)` form — squash-merge appends ` (#<PR-number>)` automatically, so `… (#1179) (#1182)` would otherwise show up in the merge subject. Reference issues from the body instead.

## Tests

`packages/lsp-tools/src/context-help/computeContextHelp.resolver.test.ts` — one new resolver-backed test exercises the `$s[1].t` case end-to-end against a mock Rust core that scripts the `<select>` resolution. 4/4 tests in that file pass; 75/75 across both context-help suites.

## Tracked separately

A natural shorthand — `$s.t` as sugar for `$s[1].t` when `<select numToSelect="1">` — is filed as #1181 with a strict static-rule scope. Not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)