### PR TITLE
chore: ignore .claude/ per-machine files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,8 @@ packages/doenetml-to-pretext-python/doenetml_to_pretext/js-assets/*
 __pycache__
 .pytest_cache
 *.egg-info
+
+# Claude Code per-machine files (settings.json and hooks/ are tracked;
+# these are user/runtime overrides that must not be committed).
+.claude/settings.local.json
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## What

Adds two `.claude/` files to the repo `.gitignore`:

- `.claude/settings.local.json` — Claude Code's canonical per-user settings override
- `.claude/scheduled_tasks.lock` — runtime lock file Claude creates while a session is active

## Why

Both files are per-machine artifacts that should never be committed. `settings.local.json` can leak personal paths, env vars, or permission grants; `scheduled_tasks.lock` is just noise in `git status`. Until now they were only ignored on machines that had their own global `~/.config/git/ignore` rule — anyone running Claude Code on this repo without that personal setup would see them as untracked-or-stageable.

Tracked `.claude/` files (`settings.json`, `hooks/`) are deliberately *not* changed — those are shared project hooks/config.

## Scope

`.gitignore` only. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)