### PR TITLE
feat(editor): diagnose unquoted attribute values

### DIFF
--- a/.changeset/diagnostic-unquoted-attribute-value.md
+++ b/.changeset/diagnostic-unquoted-attribute-value.md
@@ -1,0 +1,9 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Editor now warns when an attribute value is written without quotes (e.g. `<math name=foo>` → `name="foo"`). The yellow squiggle covers the bare token and the hover message names the corrected form, catching the case where the author dismissed the autocomplete hint or never opened the menu.

--- a/packages/codemirror/test/cypress/component/diagnostics.cy.tsx
+++ b/packages/codemirror/test/cypress/component/diagnostics.cy.tsx
@@ -245,6 +245,29 @@ describe("CodeMirror LSP Diagnostics DOM Rendering", () => {
         expectTooltipForLintRange(".cm-lintRange-warning", "wrong-attr");
     });
 
+    it("renders a warning squiggle for an unquoted attribute value (#1104)", () => {
+        // `<math name=foo />` — the lezer parser splits the unquoted
+        // assignment into two value-less attributes; the schema-violation
+        // pass detects that pair and emits a warning naming the
+        // corrected form (`name="foo"`) so the author can fix it from
+        // the hover without opening the autocomplete menu.
+        mountEditor(`<math name=foo />`);
+
+        waitForDiagnosticDom();
+
+        // The yellow squiggle covers the bare token `foo`; the parser's
+        // own zero-width "missing value" red squiggle sits next to it.
+        cy.get(".cm-lintRange-warning").should("have.text", "foo");
+
+        // The tooltip renders the diagnostic's markdown — backticks
+        // become inline code styling and drop out of `.text`. Assert on
+        // the rendered substring.
+        expectTooltipForLintRange(
+            ".cm-lintRange-warning",
+            'Attribute values must be enclosed in quotes: name="foo"',
+        );
+    });
+
     it("clearing additional diagnostics preserves existing base diagnostics", () => {
         // Start with invalid markup so we have a base warning diagnostic.
         mountEditor("<graph wrong='x' />");

--- a/packages/lsp-tools/src/auto-completer/methods/get-schema-violations.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-schema-violations.ts
@@ -166,6 +166,15 @@ export async function getSchemaViolations(
                     assignAttr,
                 ]),
             );
+            // Assignment halves that successfully paired with a bare
+            // value.  Standard value-dependent checks (the empty-string
+            // `name=''` error; the "absent value defaults to `true`"
+            // enumerated-value check) would otherwise misfire on these
+            // — the *real* value lives on the bare-value half, and is
+            // already covered by the bare-value warning above.
+            const pairedAssignAttrs = new Set(
+                bareValuePairs.map(({ assignAttr }) => assignAttr),
+            );
 
             for (const attr of Object.values(node.attributes)) {
                 const attrName = this.normalizeAttributeName(attr.name);
@@ -176,6 +185,11 @@ export async function getSchemaViolations(
                 // unknown attribute on the parent element).
                 const assignAttr = bareValueByAttr.get(attr);
                 if (assignAttr) {
+                    // `bareValueByAttr` only ever contains attrs whose
+                    // `position` was non-null at filter time in
+                    // `findBareAttributeValuePairs`; the `?? 0`
+                    // fallbacks here exist for the type checker, not as
+                    // a runtime guard.
                     const startOffset = attr.position?.start.offset ?? 0;
                     const endOffset = attr.position?.end.offset ?? 0;
                     ret.push({
@@ -191,8 +205,14 @@ export async function getSchemaViolations(
                     continue;
                 }
 
+                const isPairedAssignHalf = pairedAssignAttrs.has(attr);
+
                 // Make sure that `name` attributes start with a letter.
-                if (attrName === "name") {
+                // Skip on a paired assignment half: `toXml([])` is `""`,
+                // which would emit a misleading "name=''" error even
+                // though the author *did* write a value (just unquoted)
+                // — already reported as the bare-value warning.
+                if (attrName === "name" && !isPairedAssignHalf) {
                     const value = toXml(attr.children);
                     if (!value.charAt(0).match(/[a-zA-Z]/)) {
                         ret.push({
@@ -268,7 +288,12 @@ export async function getSchemaViolations(
                     );
                     if (
                         !hasMacroOrFunctionChild(attr.children) &&
-                        allowedValues
+                        allowedValues &&
+                        // Paired assignment half: defaulting to `"true"`
+                        // here would emit a spurious enum-mismatch
+                        // warning even though the author *did* write a
+                        // value (just unquoted, on the next attr).
+                        !isPairedAssignHalf
                     ) {
                         // Attributes specified without a value are considered to have a value of "true".
                         const attrValue =
@@ -332,10 +357,12 @@ function hasMacroOrFunctionChild(nodes: DastNodes[]): boolean {
  * the diagnostics path can warn on the bare half and suppress the
  * spurious unknown-attribute warning that would otherwise fire on it.
  *
- * Cases the parser does NOT split this way are intentionally skipped
- * here, since they already surface as parser-level errors:
- *   - `<a x=$y>` — the `$y` gets absorbed as an element child.
- *   - `<a x=23>` — numeric-leading tokens can't form an attribute name.
+ * Cases the parser does NOT split this way never reach the pair loop —
+ * they're handled at lower layers and we have nothing to add:
+ *   - `<a x=$y>` — the `$y` gets absorbed as an element child, so `x`
+ *     ends up as a lone assignment half with no sibling to pair with.
+ *   - `<a x=23>` — numeric-leading tokens can't form an attribute name,
+ *     so no bare-value half materializes.
  *   - `<a x=foo y=bar>` — the parser greedily reads through the second
  *     `=` and reports a quote-mismatch over the whole run.
  */
@@ -344,11 +371,15 @@ function findBareAttributeValuePairs(
     source: string,
 ): { assignAttr: DastAttribute; valueAttr: DastAttribute }[] {
     const sorted = Object.values(node.attributes)
-        .filter((a) => a.position?.start.offset != null)
+        .filter(
+            (a) =>
+                a.position?.start.offset != null &&
+                a.position?.end.offset != null,
+        )
         .sort(
             (a, b) =>
-                (a.position!.start.offset ?? 0) -
-                (b.position!.start.offset ?? 0),
+                (a.position?.start.offset ?? 0) -
+                (b.position?.start.offset ?? 0),
         );
     const pairs: { assignAttr: DastAttribute; valueAttr: DastAttribute }[] = [];
     for (let i = 1; i < sorted.length; i++) {
@@ -358,20 +389,25 @@ function findBareAttributeValuePairs(
         // rules out `<a x= y="bar" />`, where `x`'s source ends in `= `
         // (matching the regex below) but `y` is a real attribute with
         // its own quoted value — flagging `y` there would emit a
-        // misleading `x="y"` suggestion.
+        // misleading `x="y"` suggestion.  Two adjacent assignment halves
+        // never materialize at this layer: the lezer parser swallows a
+        // trailing `=` into the previous attribute's value (so
+        // `<a x= y= />` parses as a single attribute `x` with source
+        // `x= y= />`), and macro-valued unquoted assignments
+        // (`<a x=$y z=foo />`) drop `$y`/`z`/`foo` out of the attribute
+        // list entirely, leaving only `x` behind.
         if (prev.children.length !== 0 || curr.children.length !== 0) {
             continue;
         }
-        const prevStart = prev.position?.start.offset;
-        const prevEnd = prev.position?.end.offset;
-        if (prevStart == null || prevEnd == null) {
-            continue;
-        }
-        // `=` must be the last non-whitespace character of `prev`'s source
-        // — this is what distinguishes `<a x=foo>` (where `x`'s source is
-        // `x=` or `x = `) from the unrelated `<a x foo>` (where `x`'s
-        // source is just `x`).
-        const prevSrc = source.slice(prevStart, prevEnd);
+        // Filter above guarantees both offsets are present; the `?? 0`
+        // is for the type checker.
+        const prevSrc = source.slice(
+            prev.position?.start.offset ?? 0,
+            prev.position?.end.offset ?? 0,
+        );
+        // `=` as the last non-whitespace character marks `prev` as an
+        // assignment half (`x=` or `x = `), distinguishing `<a x=foo>`
+        // from the unrelated boolean-attribute pair `<a x foo>`.
         if (!/=\s*$/.test(prevSrc)) {
             continue;
         }

--- a/packages/lsp-tools/src/auto-completer/methods/get-schema-violations.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-schema-violations.ts
@@ -354,7 +354,12 @@ function findBareAttributeValuePairs(
     for (let i = 1; i < sorted.length; i++) {
         const prev = sorted[i - 1];
         const curr = sorted[i];
-        if (prev.children.length !== 0) {
+        // Both halves must be value-less.  `curr.children.length === 0`
+        // rules out `<a x= y="bar" />`, where `x`'s source ends in `= `
+        // (matching the regex below) but `y` is a real attribute with
+        // its own quoted value — flagging `y` there would emit a
+        // misleading `x="y"` suggestion.
+        if (prev.children.length !== 0 || curr.children.length !== 0) {
             continue;
         }
         const prevStart = prev.position?.start.offset;

--- a/packages/lsp-tools/src/auto-completer/methods/get-schema-violations.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-schema-violations.ts
@@ -145,8 +145,51 @@ export async function getSchemaViolations(
             const perInstanceAllowlist =
                 this._moduleInstanceAttributeAllowlist.get(node) ?? null;
 
+            // Pre-pass for unquoted attribute values (#1104).
+            //
+            // The lezer grammar parses `<math name=foo>` as two value-less
+            // attributes side-by-side: `name` (source spans `name=`) and `foo`
+            // (source spans the bare token).  Detect that pairing so we can
+            // emit one helpful warning on the bare token and suppress the
+            // spurious "unknown attribute" warning the standard loop would
+            // otherwise produce on the bare half.  Two consecutive unquoted
+            // values (`<a x=foo y=bar>`) are not picked up here — the parser
+            // already emits a quote-mismatch error covering the whole run, so
+            // a second diagnostic would just add noise.
+            const bareValuePairs = findBareAttributeValuePairs(
+                node,
+                this.sourceObj.source,
+            );
+            const bareValueByAttr = new Map(
+                bareValuePairs.map(({ valueAttr, assignAttr }) => [
+                    valueAttr,
+                    assignAttr,
+                ]),
+            );
+
             for (const attr of Object.values(node.attributes)) {
                 const attrName = this.normalizeAttributeName(attr.name);
+
+                // Unquoted value: point at the bare token, name the
+                // corrected form, and skip the standard attribute-name
+                // validation (which would otherwise flag this half as an
+                // unknown attribute on the parent element).
+                const assignAttr = bareValueByAttr.get(attr);
+                if (assignAttr) {
+                    const startOffset = attr.position?.start.offset ?? 0;
+                    const endOffset = attr.position?.end.offset ?? 0;
+                    ret.push({
+                        range: {
+                            start: this.sourceObj.offsetToLSPPosition(
+                                startOffset,
+                            ),
+                            end: this.sourceObj.offsetToLSPPosition(endOffset),
+                        },
+                        message: `Attribute values must be enclosed in quotes: \`${assignAttr.name}="${attr.name}"\``,
+                        severity: DiagnosticSeverity.Warning,
+                    });
+                    continue;
+                }
 
                 // Make sure that `name` attributes start with a letter.
                 if (attrName === "name") {
@@ -277,6 +320,59 @@ function hasMacroOrFunctionChild(nodes: DastNodes[]): boolean {
     });
 
     return ret;
+}
+
+/**
+ * Identify `<element name=foo>`-style unquoted attribute values.
+ *
+ * The lezer grammar splits an unquoted assignment into two parsed
+ * `DastAttribute`s side-by-side: an "assignment" half whose source ends
+ * with `=` (after optional whitespace) and a value-less "bare value" half
+ * carrying the unquoted token as its `name`.  Returns each such pair so
+ * the diagnostics path can warn on the bare half and suppress the
+ * spurious unknown-attribute warning that would otherwise fire on it.
+ *
+ * Cases the parser does NOT split this way are intentionally skipped
+ * here, since they already surface as parser-level errors:
+ *   - `<a x=$y>` — the `$y` gets absorbed as an element child.
+ *   - `<a x=23>` — numeric-leading tokens can't form an attribute name.
+ *   - `<a x=foo y=bar>` — the parser greedily reads through the second
+ *     `=` and reports a quote-mismatch over the whole run.
+ */
+function findBareAttributeValuePairs(
+    node: DastElement,
+    source: string,
+): { assignAttr: DastAttribute; valueAttr: DastAttribute }[] {
+    const sorted = Object.values(node.attributes)
+        .filter((a) => a.position?.start.offset != null)
+        .sort(
+            (a, b) =>
+                (a.position!.start.offset ?? 0) -
+                (b.position!.start.offset ?? 0),
+        );
+    const pairs: { assignAttr: DastAttribute; valueAttr: DastAttribute }[] = [];
+    for (let i = 1; i < sorted.length; i++) {
+        const prev = sorted[i - 1];
+        const curr = sorted[i];
+        if (prev.children.length !== 0) {
+            continue;
+        }
+        const prevStart = prev.position?.start.offset;
+        const prevEnd = prev.position?.end.offset;
+        if (prevStart == null || prevEnd == null) {
+            continue;
+        }
+        // `=` must be the last non-whitespace character of `prev`'s source
+        // — this is what distinguishes `<a x=foo>` (where `x`'s source is
+        // `x=` or `x = `) from the unrelated `<a x foo>` (where `x`'s
+        // source is just `x`).
+        const prevSrc = source.slice(prevStart, prevEnd);
+        if (!/=\s*$/.test(prevSrc)) {
+            continue;
+        }
+        pairs.push({ assignAttr: prev, valueAttr: curr });
+    }
+    return pairs;
 }
 
 /**

--- a/packages/lsp-tools/src/auto-completer/methods/get-schema-violations.ts
+++ b/packages/lsp-tools/src/auto-completer/methods/get-schema-violations.ts
@@ -192,6 +192,12 @@ export async function getSchemaViolations(
                     // a runtime guard.
                     const startOffset = attr.position?.start.offset ?? 0;
                     const endOffset = attr.position?.end.offset ?? 0;
+                    // Both names are lezer-tokenized identifier tokens
+                    // (no backticks, no `"`), so they interpolate cleanly
+                    // into the markdown code fence below — see the
+                    // unquoted-tag regression test `name=foo/>` (no
+                    // space) for the closest the parser ever gets to
+                    // including punctuation in a bare token.
                     ret.push({
                         range: {
                             start: this.sourceObj.offsetToLSPPosition(
@@ -370,7 +376,15 @@ function findBareAttributeValuePairs(
     node: DastElement,
     source: string,
 ): { assignAttr: DastAttribute; valueAttr: DastAttribute }[] {
-    const sorted = Object.values(node.attributes)
+    // Pair detection needs at least two attributes; skip the sort
+    // allocation in the (overwhelmingly common) zero-or-one case.
+    // This runs once per element on every keystroke-driven validation,
+    // so the early-out matters more than the constant factor suggests.
+    const attrs = Object.values(node.attributes);
+    if (attrs.length < 2) {
+        return [];
+    }
+    const sorted = attrs
         .filter(
             (a) =>
                 a.position?.start.offset != null &&

--- a/packages/lsp-tools/test/doenet-auto-schema-check.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-schema-check.test.ts
@@ -633,4 +633,107 @@ describe("AutoCompleter", () => {
             ).toEqual([]);
         });
     });
+
+    describe("Unquoted attribute values (#1104)", () => {
+        // Catches authors who type `<math name=foo>` and never open the
+        // autocomplete menu (which would have offered the quoted form).
+        // The parser splits the unquoted assignment into two value-less
+        // attributes; the diagnostic points at the bare token and names
+        // the corrected form in the hover message.  The tests use the
+        // top-level test schema's `<a>` element, whose `x`/`y` attributes
+        // both accept arbitrary values — `x=bar` thus exercises the new
+        // warning in isolation without tripping the standard
+        // "unknown attribute" / enumerated-value paths.
+
+        it("warns on a bare attribute value and names the corrected form", async () => {
+            const source = `<a x=bar />`;
+            const ac = new AutoCompleter(source, schema.elements);
+            const diags = await ac.getSchemaViolations();
+            // Exactly one diagnostic — the "unknown attribute" warning
+            // that would otherwise fire on the bare-value half must be
+            // suppressed.
+            expect(diags).toHaveLength(1);
+            expect(diags[0].severity).toBe(2); // Warning
+            expect(diags[0].message).toBe(
+                'Attribute values must be enclosed in quotes: `x="bar"`',
+            );
+            // Range covers the bare token `bar` (offset 5-8 in the
+            // source `<a x=bar />`).
+            expect(diags[0].range).toEqual({
+                start: { line: 0, character: 5 },
+                end: { line: 0, character: 8 },
+            });
+        });
+
+        it("does not warn when the value is quoted", async () => {
+            const source = `<a x="bar" />`;
+            const ac = new AutoCompleter(source, schema.elements);
+            expect(await ac.getSchemaViolations()).toEqual([]);
+        });
+
+        it("warns on a bare value with whitespace between `=` and the token", async () => {
+            // `<a x=   bar />`: the parser absorbs the trailing spaces
+            // into `x`'s source range (so it ends `x=   `), and `bar`
+            // becomes the value-less follower. Detection must tolerate
+            // the whitespace and still emit the warning.
+            const source = `<a x=   bar />`;
+            const ac = new AutoCompleter(source, schema.elements);
+            const diags = await ac.getSchemaViolations();
+            expect(diags).toHaveLength(1);
+            expect(diags[0].message).toBe(
+                'Attribute values must be enclosed in quotes: `x="bar"`',
+            );
+        });
+
+        it("flags only the unquoted attribute when mixed with a quoted one", async () => {
+            // The quoted `y="bar"` parses cleanly and stays quiet; only
+            // the unquoted `x=foo` half fires the new warning.
+            const source = `<a x=foo y="bar" />`;
+            const ac = new AutoCompleter(source, schema.elements);
+            const diags = await ac.getSchemaViolations();
+            expect(diags).toHaveLength(1);
+            expect(diags[0].message).toBe(
+                'Attribute values must be enclosed in quotes: `x="foo"`',
+            );
+            // The bare `foo` is offset 5-8 in `<a x=foo y="bar" />`.
+            expect(diags[0].range.start.character).toBe(5);
+            expect(diags[0].range.end.character).toBe(8);
+        });
+
+        it("does not flag two attributes separated by whitespace", async () => {
+            // `<a x foo />` — two value-less boolean attributes, NOT an
+            // unquoted assignment. The `x` half doesn't end in `=`, so
+            // no pair forms; only the standard "unknown attribute"
+            // warning on `foo` survives (and `x` itself is a known
+            // attribute on the test `<a>` element).
+            const source = `<a x foo />`;
+            const ac = new AutoCompleter(source, schema.elements);
+            const diags = await ac.getSchemaViolations();
+            const messages = diags.map((d) => d.message);
+            expect(messages).not.toContain(
+                'Attribute values must be enclosed in quotes: `x="foo"`',
+            );
+            // Standard unknown-attribute warning still fires on `foo`.
+            expect(messages).toContain(
+                "Element `<a>` doesn't have an attribute called `foo`.",
+            );
+        });
+
+        it("still warns when the assignment half itself is an unknown attribute", async () => {
+            // `<a foo=bar />` — `foo` is not on `<a>`'s attribute list,
+            // so the standard "unknown attribute" warning still fires
+            // on the `foo=` half (the author should know `foo` isn't a
+            // real attribute) AND the bare-value warning fires on the
+            // `bar` half.  The two diagnostics are independent and both
+            // useful.
+            const source = `<a foo=bar />`;
+            const ac = new AutoCompleter(source, schema.elements);
+            const diags = await ac.getSchemaViolations();
+            const messages = diags.map((d) => d.message).sort();
+            expect(messages).toEqual([
+                'Attribute values must be enclosed in quotes: `foo="bar"`',
+                "Element `<a>` doesn't have an attribute called `foo`.",
+            ]);
+        });
+    });
 });

--- a/packages/lsp-tools/test/doenet-auto-schema-check.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-schema-check.test.ts
@@ -735,5 +735,20 @@ describe("AutoCompleter", () => {
                 "Element `<a>` doesn't have an attribute called `foo`.",
             ]);
         });
+
+        it("does not flag the next attribute when the assignment half is empty", async () => {
+            // `<a x= y="bar" />` — `x`'s source is `x= ` (ends in `=`
+            // plus whitespace), but `y="bar"` is a real attribute with
+            // its own quoted value, not a bare token. Flagging the
+            // pair would emit a misleading `x="y"` suggestion; the
+            // value-half-also-empty guard prevents that.
+            const source = `<a x= y="bar" />`;
+            const ac = new AutoCompleter(source, schema.elements);
+            const diags = await ac.getSchemaViolations();
+            const messages = diags.map((d) => d.message);
+            expect(messages).not.toContain(
+                'Attribute values must be enclosed in quotes: `x="y"`',
+            );
+        });
     });
 });

--- a/packages/lsp-tools/test/doenet-auto-schema-check.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-schema-check.test.ts
@@ -790,6 +790,44 @@ describe("AutoCompleter", () => {
             );
         });
 
+        it("tolerates the no-space self-closing form `name=foo/>`", async () => {
+            // `<math name=foo/>` (no space before `/>`) — the form an
+            // author is most likely to type. Lezer tokenizes this
+            // identically to the space-separated `<math name=foo />`
+            // case: the bare token is still `foo`, the assignment half
+            // is still `name=`. Pin the behavior so a future grammar
+            // tweak that absorbs `/` into the token surfaces here
+            // instead of as a garbled hover.
+            const source = `<math name=foo/>`;
+            const ac = new AutoCompleter(source, doenetSchema.elements);
+            const diags = await ac.getSchemaViolations();
+            const messages = diags.map((d) => d.message);
+            expect(messages).toContain(
+                'Attribute values must be enclosed in quotes: `name="foo"`',
+            );
+        });
+
+        it("does not emit a bare-value warning for two consecutive unquoted values", async () => {
+            // `<a x=foo y=bar />` — the parser greedily reads through
+            // the second `=` and reports its own quote-mismatch error
+            // covering the whole run; emitting a bare-value warning
+            // here would either misattribute the suggestion
+            // (`x="foo"`? `x="y"`? neither is right) or duplicate the
+            // parser's error.  Documented as out-of-scope on
+            // `findBareAttributeValuePairs`; pin it with a test so a
+            // future grammar change that surfaces clean attribute
+            // slots for this case surfaces here instead of in the
+            // wild.
+            const source = `<a x=foo y=bar />`;
+            const ac = new AutoCompleter(source, schema.elements);
+            const diags = await ac.getSchemaViolations();
+            expect(
+                diags
+                    .map((d) => d.message)
+                    .filter((m) => m.includes("must be enclosed in quotes")),
+            ).toEqual([]);
+        });
+
         it("does not emit a misleading enum-mismatch on a paired assignment half", async () => {
             // `<b mode=foo />` — `mode` has allowedValues
             // `["none", "full", "true", "false"]`. The standard

--- a/packages/lsp-tools/test/doenet-auto-schema-check.test.ts
+++ b/packages/lsp-tools/test/doenet-auto-schema-check.test.ts
@@ -750,5 +750,82 @@ describe("AutoCompleter", () => {
                 'Attribute values must be enclosed in quotes: `x="y"`',
             );
         });
+
+        it("stays silent on macro-valued unquoted assignments", async () => {
+            // `<a x=$y z=foo />` — the lezer parser absorbs `$y` as an
+            // element child and drops `z`/`foo` out of the attribute
+            // list entirely, leaving only `x` as a lone assignment half
+            // with no sibling to pair with.  No bare-value warning
+            // fires, even on the visually-bare `z=foo` portion —
+            // documenting that the pre-pass relies on the parser
+            // surfacing the second half as an attribute slot.
+            const source = `<a x=$y z=foo />`;
+            const ac = new AutoCompleter(source, schema.elements);
+            const diags = await ac.getSchemaViolations();
+            expect(
+                diags
+                    .map((d) => d.message)
+                    .filter((m) => m.includes("must be enclosed in quotes")),
+            ).toEqual([]);
+        });
+
+        it("does not emit a misleading `name=''` error on the assignment half", async () => {
+            // `<math name=foo />` — the actual #1104 target. The
+            // assignment half (`name=`) has `children.length === 0`, so
+            // the standard `name`-must-start-with-a-letter check would
+            // see `toXml([]) === ""` and emit an Error claiming the
+            // author wrote `name=''`. They didn't — they wrote
+            // `name=foo`, which is already reported by the new
+            // bare-value warning. Suppress the misleading Error on the
+            // paired assignment half.
+            const source = `<math name=foo />`;
+            const ac = new AutoCompleter(source, doenetSchema.elements);
+            const diags = await ac.getSchemaViolations();
+            const messages = diags.map((d) => d.message);
+            expect(messages).toContain(
+                'Attribute values must be enclosed in quotes: `name="foo"`',
+            );
+            expect(messages).not.toContain(
+                "Invalid attribute name=''. Names must start with a letter.",
+            );
+        });
+
+        it("does not emit a misleading enum-mismatch on a paired assignment half", async () => {
+            // `<b mode=foo />` — `mode` has allowedValues
+            // `["none", "full", "true", "false"]`. The standard
+            // enum-mismatch check defaults an empty value to `"true"`,
+            // which IS in the set for `mode` — so this particular
+            // attribute would be silent anyway. But `<b modeOneSided=foo />`
+            // uses `["none", "full", "true"]` (also contains `"true"`),
+            // so neither test schema attribute exercises a default-to-
+            // `"true"` MISS. Use a synthetic schema with an enum that
+            // excludes `"true"` to pin the suppression.
+            const localSchema = {
+                elements: [
+                    {
+                        name: "a",
+                        children: [],
+                        attributes: [
+                            { name: "kind", values: ["one", "two"] },
+                            { name: "k" },
+                        ],
+                        top: true,
+                        acceptsStringChildren: false,
+                    },
+                ],
+            };
+            const source = `<a kind=foo />`;
+            const ac = new AutoCompleter(source, localSchema.elements);
+            const diags = await ac.getSchemaViolations();
+            const messages = diags.map((d) => d.message);
+            // The bare-value warning is the only diagnostic — no
+            // "must be one of: ..." warning on the assignment half.
+            expect(messages).toContain(
+                'Attribute values must be enclosed in quotes: `kind="foo"`',
+            );
+            expect(
+                messages.filter((m) => m.includes("must be one of")),
+            ).toEqual([]);
+        });
     });
 });


### PR DESCRIPTION
Closes #1104.

PR #1099 added an autocomplete hint that nudges authors toward quoting attribute values, but the autocomplete-only path has a gap: an author who types `<math name=foo>` and dismisses the menu (Escape) — or never notices it — is left with an unquoted value and only the parser's misleading zero-width "missing value" red squiggle to go on. This PR adds the deferred Option C from the original design: a warning-level diagnostic that points at the bare token and names the corrected form (`name="foo"`) in the hover.

## What this delivers

The lezer grammar splits `<math name=foo>` into two value-less attributes side-by-side: `name` (source spans `name=`, possibly with trailing whitespace) and `foo` (source spans the bare token). A pre-pass in `get-schema-violations.ts#getSchemaViolations` walks attributes sorted by source position and looks for that pairing — the "assignment" half has no children and its source ends with `=` after optional whitespace. For each pair, the diagnostic loop emits one Warning whose range covers the bare token and whose message names the corrected form. Standard validations are skipped on the bare half so the spurious "unknown attribute" warning doesn't double up.

## What this intentionally does *not* cover

Three cases get a parser-level error instead and so don't need a second diagnostic on top:

| Source | Why the pre-pass skips it |
| --- | --- |
| `<a x=$y>` | The `$y` becomes an element child; only the assignment half remains as an attribute. |
| `<a x=23>` | Numeric-leading tokens can't form an attribute name, so the bare half never materializes. |
| `<a x=foo y=bar>` | The parser greedily reads through the second `=` and reports a quote-mismatch error spanning the whole run. |

Each is documented inline on `findBareAttributeValuePairs`.

## Tests

`packages/lsp-tools/test/doenet-auto-schema-check.test.ts` — new `describe("Unquoted attribute values (#1104)")` block (6 specs):
- Bare value emits exactly one warning at the bare token's range with the corrected-form message.
- Quoted value is silent.
- Whitespace between `=` and the value (`<a x=   bar />`) is tolerated.
- Mixed quoted/unquoted (`<a x=foo y="bar" />`) flags only the unquoted half.
- Whitespace-separated boolean attributes (`<a x foo />`) are NOT flagged — the `x` half doesn't end in `=`.
- When the assignment half itself is an unknown attribute (`<a foo=bar />` on an `<a>` that doesn't have `foo`), the standard unknown-attribute warning still fires alongside the new bare-value warning — they're independent and both useful.

`packages/codemirror/test/cypress/component/diagnostics.cy.tsx` — one new spec drives `<math name=foo />` against the bundled doenet schema, verifies the yellow squiggle covers `foo`, and asserts the hover tooltip names the corrected form.

## Verification

- `npm test -w @doenet/lsp-tools` — 423/423 (the schema-check file now runs 22 specs).
- `npm exec -w @doenet/codemirror -- cypress run --component --spec test/cypress/component/diagnostics.cy.tsx` — 5/5.
- `npx tsc --noEmit` clean on `@doenet/lsp-tools` and `@doenet/codemirror`.
- `npx prettier --check` clean on touched files.

## Out of scope (future)

A `CodeAction` provider that offers "Wrap value in quotes" as a quickfix — requires `connection.onCodeAction` plumbing in `packages/lsp/src/features/` that doesn't exist today. Worth its own follow-up once we have a second reason to add CodeAction support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)