### PR TITLE
feat(editor): make accessibility diagnostics less intrusive

### DIFF
--- a/.changeset/softer-accessibility-diagnostics.md
+++ b/.changeset/softer-accessibility-diagnostics.md
@@ -1,0 +1,9 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Make accessibility diagnostics less intrusive in the editor. The squiggle now covers only the opening tag (`<graph`, `<image`, …) instead of the entire multi-line element, so the hover popup no longer follows the cursor across an element's body. The squiggle and tooltip are restyled to a dotted purple to read as advisory rather than as a hard error, and a new "Show accessibility diagnostics in editor" toggle on the accessibility report tab lets authors silence the editor squiggles while still seeing the issues in the report and status button.

--- a/packages/codemirror/src/extensions/lsp/tooltip.css
+++ b/packages/codemirror/src/extensions/lsp/tooltip.css
@@ -10,39 +10,40 @@
     color: #900;
 }
 .cm-lint-tooltip .heading.accessibility-level-1 {
-    color: #b42318;
+    color: #5b21b6;
 }
 .cm-lint-tooltip .heading.accessibility-level-2 {
-    color: #6e3cbc;
+    color: #9061d1;
 }
 .cm-lintRange.cm-doenet-accessibility-diagnostic {
     background-image: none !important;
     text-decoration-line: underline;
-    text-decoration-style: wavy;
-    text-decoration-thickness: 0.8px;
-    text-underline-offset: 0.08em;
+    text-decoration-style: dotted;
+    text-decoration-thickness: 0.6px;
+    text-underline-offset: 0.18em;
+    text-decoration-skip-ink: none;
 }
 
 .cm-lintRange.cm-doenet-accessibility-diagnostic-level-1 {
-    text-decoration-color: #b42318;
+    text-decoration-color: #5b21b6;
 }
 
 .cm-lintRange.cm-doenet-accessibility-diagnostic-level-2 {
-    text-decoration-color: #6e3cbc;
+    text-decoration-color: #b9a4e6;
 }
 
 .cm-tooltip-lint
     .cm-diagnostic.cm-diagnostic-warning:has(
         .cm-lint-tooltip .heading.accessibility-level-1
     ) {
-    border-left-color: #b42318;
+    border-left-color: #5b21b6;
 }
 
 .cm-tooltip-lint
     .cm-diagnostic.cm-diagnostic-warning:has(
         .cm-lint-tooltip .heading.accessibility-level-2
     ) {
-    border-left-color: #6e3cbc;
+    border-left-color: #9061d1;
 }
 
 .cm-diagnostic {

--- a/packages/codemirror/src/extensions/lsp/tooltip.css
+++ b/packages/codemirror/src/extensions/lsp/tooltip.css
@@ -29,7 +29,7 @@
 }
 
 .cm-lintRange.cm-doenet-accessibility-diagnostic-level-2 {
-    text-decoration-color: #b9a4e6;
+    text-decoration-color: #9061d1;
 }
 
 .cm-tooltip-lint

--- a/packages/doenetml-worker-javascript/src/Core.ts
+++ b/packages/doenetml-worker-javascript/src/Core.ts
@@ -13,7 +13,10 @@ import {
 import { getNumVariants } from "./utils/variants";
 import { removeFunctionsMathExpressionClass } from "./utils/math";
 import { reportTimerError, TimerLabels } from "./utils/timerErrors";
-import { getSourceLocationForComponent } from "./utils/sourceLocation";
+import {
+    getSourceLocationForComponent,
+    narrowPositionToOpeningTag,
+} from "./utils/sourceLocation";
 import type { ComponentInstance } from "./types/componentInstance";
 import { DependencyHandler } from "./core/dependencies";
 import { ActionTriggerScheduler } from "./core/ActionTriggerScheduler";
@@ -645,6 +648,17 @@ export default class Core {
     }
 
     addDiagnostic(diagnostic: any): any {
+        if (diagnostic?.type === "accessibility" && diagnostic.position) {
+            const sourceDoc = diagnostic.sourceDoc ?? 0;
+            const source = this.allDoenetMLs?.[sourceDoc];
+            const narrowed = narrowPositionToOpeningTag(
+                diagnostic.position,
+                source,
+            );
+            if (narrowed !== diagnostic.position) {
+                diagnostic = { ...diagnostic, position: narrowed };
+            }
+        }
         return this.diagnosticsManager.addDiagnostic(diagnostic);
     }
 

--- a/packages/doenetml-worker-javascript/src/Core.ts
+++ b/packages/doenetml-worker-javascript/src/Core.ts
@@ -648,9 +648,14 @@ export default class Core {
     }
 
     addDiagnostic(diagnostic: any): any {
+        // Accessibility records typically point at an entire element span;
+        // shrink that range to just the opening tag so the editor squiggle /
+        // hover only triggers over `<tagname` rather than the whole component.
+        // Non-accessibility records and already-narrow positions (e.g. the
+        // attribute-value ranges from the style-contrast checker) are
+        // returned unchanged by the helper.
         if (diagnostic?.type === "accessibility" && diagnostic.position) {
-            const sourceDoc = diagnostic.sourceDoc ?? 0;
-            const source = this.allDoenetMLs?.[sourceDoc];
+            const source = this.allDoenetMLs[diagnostic.sourceDoc ?? 0];
             const narrowed = narrowPositionToOpeningTag(
                 diagnostic.position,
                 source,

--- a/packages/doenetml-worker-javascript/src/Core.ts
+++ b/packages/doenetml-worker-javascript/src/Core.ts
@@ -651,9 +651,10 @@ export default class Core {
         // Accessibility records typically point at an entire element span;
         // shrink that range to just the opening tag so the editor squiggle /
         // hover only triggers over `<tagname` rather than the whole component.
-        // Non-accessibility records and already-narrow positions (e.g. the
-        // attribute-value ranges from the style-contrast checker) are
-        // returned unchanged by the helper.
+        // Already-narrow positions (e.g. the attribute-value ranges from the
+        // style-contrast checker, whose start char is not `<`) are returned
+        // unchanged by the helper; non-accessibility records skip this block
+        // entirely.
         if (diagnostic?.type === "accessibility" && diagnostic.position) {
             const source = this.allDoenetMLs[diagnostic.sourceDoc ?? 0];
             const narrowed = narrowPositionToOpeningTag(

--- a/packages/doenetml-worker-javascript/src/test/diagnostics/accessibility.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/diagnostics/accessibility.test.ts
@@ -297,6 +297,36 @@ describe("Accessibility diagnostics @group4", async () => {
         expect(diagnosticLines).include(5);
     });
 
+    it("narrows accessibility diagnostic range to the opening tag", async () => {
+        // A `<graph>` missing a short description used to underline the whole
+        // multi-line element, causing the lint hover popup to follow the
+        // cursor around every line.  The range is now shrunk to just
+        // `<graph` so the hover only triggers over the tag name itself.
+        let { core } = await createTestCore({
+            doenetML: `
+    <graph name="g1">
+      <point name="p1">(1, 2)</point>
+      <point name="p2">(3, 4)</point>
+    </graph>
+    `,
+        });
+
+        let diagnosticsByType = getDiagnosticsByType(core);
+        const graphDiagnostic = diagnosticsByType.accessibility.find(
+            (d) =>
+                d.position.start.line === 2 && d.message.includes("`<graph>`"),
+        );
+        expect(graphDiagnostic).toBeDefined();
+        // Start unchanged (points at `<`), end now sits one past the `h`
+        // in `graph` rather than at `</graph>`.
+        expect(graphDiagnostic!.position.start.line).eq(2);
+        expect(graphDiagnostic!.position.end.line).eq(2);
+        const startCol = graphDiagnostic!.position.start.column;
+        expect(graphDiagnostic!.position.end.column).eq(
+            startCol + "<graph".length,
+        );
+    });
+
     it("rejects accessibility diagnostics without a level", async () => {
         const { core } = await createTestCore({
             doenetML: `<text>hello</text>`,

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/answer.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/answer.test.ts
@@ -7612,7 +7612,7 @@ What is the derivative of <function name="f">x^2</function>?
             `an \`<answer>\` creating an input must have a short description or a label`,
         );
         expect(diagnosticsByType.accessibility[3].position.start.line).eq(5);
-        expect(diagnosticsByType.accessibility[3].position.end.line).eq(9);
+        expect(diagnosticsByType.accessibility[3].position.end.line).eq(5);
 
         expect(diagnosticsByType.accessibility[4].message).contain(
             `an \`<answer>\` creating an input must have a short description or a label`,

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/choiceinput.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/choiceinput.test.ts
@@ -3959,14 +3959,16 @@ describe("ChoiceInput tag tests @group4", async () => {
         expect(diagnosticsByType.accessibility[0].message).contain(
             `\`<choiceInput>\` must have a short description or a label`,
         );
+        // Diagnostic range is narrowed to the opening tag, so the end
+        // position now sits on the same line as the start.
         expect(diagnosticsByType.accessibility[0].position.start.line).eq(2);
-        expect(diagnosticsByType.accessibility[0].position.end.line).eq(5);
+        expect(diagnosticsByType.accessibility[0].position.end.line).eq(2);
 
         expect(diagnosticsByType.accessibility[1].message).contain(
             `\`<choiceInput>\` must have a short description or a label`,
         );
         expect(diagnosticsByType.accessibility[1].position.start.line).eq(18);
-        expect(diagnosticsByType.accessibility[1].position.end.line).eq(21);
+        expect(diagnosticsByType.accessibility[1].position.end.line).eq(18);
     });
 
     it("warning if labelPosition is used on non-inline choiceInput, with attribute-level position", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/graph.test.ts
@@ -1761,10 +1761,12 @@ describe("Graph tag tests @group2", async () => {
         expect(diagnosticsByType.accessibility[0].message).contain(
             "`<graph>` must either have a short description or be specified as decorative",
         );
+        // Diagnostic range is narrowed to the opening tag (`<graph`) so the
+        // editor squiggle and hover only cover the tag name itself.
         expect(diagnosticsByType.accessibility[0].position.start.line).eq(2);
         expect(diagnosticsByType.accessibility[0].position.start.column).eq(1);
         expect(diagnosticsByType.accessibility[0].position.end.line).eq(2);
-        expect(diagnosticsByType.accessibility[0].position.end.column).eq(24);
+        expect(diagnosticsByType.accessibility[0].position.end.column).eq(7);
     });
 
     it("with description", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/image.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/image.test.ts
@@ -317,10 +317,12 @@ describe("Image tag tests @group3", async () => {
         expect(diagnosticsByType.accessibility[0].message).contain(
             "`<image>` must either have a short description or be specified as decorative",
         );
+        // Diagnostic range is narrowed to the opening tag (`<image`) so the
+        // editor squiggle and hover only cover the tag name itself.
         expect(diagnosticsByType.accessibility[0].position.start.line).eq(2);
         expect(diagnosticsByType.accessibility[0].position.start.column).eq(1);
         expect(diagnosticsByType.accessibility[0].position.end.line).eq(2);
-        expect(diagnosticsByType.accessibility[0].position.end.column).eq(24);
+        expect(diagnosticsByType.accessibility[0].position.end.column).eq(7);
     });
 
     it("with description", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/video.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/video.test.ts
@@ -178,9 +178,11 @@ describe("Video tag tests @group1", async () => {
         expect(diagnosticsByType.accessibility[0].message).contain(
             "`<video>` must have a short description",
         );
+        // Diagnostic range is narrowed to the opening tag (`<video`) so the
+        // editor squiggle and hover only cover the tag name itself.
         expect(diagnosticsByType.accessibility[0].position.start.line).eq(2);
         expect(diagnosticsByType.accessibility[0].position.start.column).eq(1);
         expect(diagnosticsByType.accessibility[0].position.end.line).eq(2);
-        expect(diagnosticsByType.accessibility[0].position.end.column).eq(24);
+        expect(diagnosticsByType.accessibility[0].position.end.column).eq(7);
     });
 });

--- a/packages/doenetml-worker-javascript/src/utils/sourceLocation.ts
+++ b/packages/doenetml-worker-javascript/src/utils/sourceLocation.ts
@@ -26,3 +26,64 @@ export function getSourceLocationForComponent(
 
     return { position, sourceDoc };
 }
+
+/**
+ * Shrink a position covering an entire element span down to just the opening
+ * tag (`<tagname`). Used so accessibility diagnostics underline / target the
+ * tag name rather than the whole multi-line component — a smaller target
+ * keeps the lint hover from popping up whenever the cursor hovers over the
+ * element's interior.
+ *
+ * Returns the position unchanged when:
+ *   - inputs are missing
+ *   - the character at `start.offset` is not `<` (e.g. attribute-value
+ *     positions emitted by the style-contrast checker)
+ *   - no tag-name characters follow the `<`
+ */
+export function narrowPositionToOpeningTag(
+    position: any,
+    source: string | undefined,
+): any {
+    if (!position || !source) {
+        return position;
+    }
+    const startOffset = position.start?.offset;
+    if (typeof startOffset !== "number" || source[startOffset] !== "<") {
+        return position;
+    }
+
+    const endOffsetLimit =
+        typeof position.end?.offset === "number"
+            ? position.end.offset
+            : source.length;
+
+    let tagEnd = startOffset + 1;
+    while (tagEnd < source.length && tagEnd < endOffsetLimit) {
+        const ch = source[tagEnd];
+        const isNameChar =
+            (ch >= "a" && ch <= "z") ||
+            (ch >= "A" && ch <= "Z") ||
+            (ch >= "0" && ch <= "9") ||
+            ch === "_" ||
+            ch === "-" ||
+            ch === ":";
+        if (!isNameChar) {
+            break;
+        }
+        tagEnd++;
+    }
+
+    if (tagEnd === startOffset + 1) {
+        return position;
+    }
+
+    const tagNameLength = tagEnd - startOffset;
+    return {
+        start: position.start,
+        end: {
+            line: position.start.line,
+            column: position.start.column + tagNameLength,
+            offset: tagEnd,
+        },
+    };
+}

--- a/packages/doenetml-worker-javascript/src/utils/sourceLocation.ts
+++ b/packages/doenetml-worker-javascript/src/utils/sourceLocation.ts
@@ -46,7 +46,7 @@ const TAG_NAME_REGEX = /^[A-Za-z0-9_:-]+/;
  *
  * Returns the position unchanged when:
  *   - inputs are missing
- *   - `start.offset` is missing (we need byte offsets to read the source)
+ *   - `start.offset` is missing (we need a character offset to read the source)
  *   - the character at `start.offset` is not `<` (e.g. attribute-value
  *     positions emitted by the style-contrast checker)
  *   - no tag-name characters follow the `<`

--- a/packages/doenetml-worker-javascript/src/utils/sourceLocation.ts
+++ b/packages/doenetml-worker-javascript/src/utils/sourceLocation.ts
@@ -1,3 +1,5 @@
+import type { Position } from "@doenet/utils";
+
 /**
  * Find the nearest available source position/sourceDoc for a component,
  * walking up `parentIdx` ancestors when the component itself has no
@@ -28,6 +30,14 @@ export function getSourceLocationForComponent(
 }
 
 /**
+ * Matches the run of XML tag-name characters immediately after `<`.
+ * Per XML 1.0 a name may contain a wider set of characters, but DoenetML
+ * tag names only ever use these — keeping the class tight avoids accidentally
+ * consuming non-name characters such as `/` (self-closing slash) or `>`.
+ */
+const TAG_NAME_REGEX = /^[A-Za-z0-9_:-]+/;
+
+/**
  * Shrink a position covering an entire element span down to just the opening
  * tag (`<tagname`). Used so accessibility diagnostics underline / target the
  * tag name rather than the whole multi-line component — a smaller target
@@ -36,54 +46,44 @@ export function getSourceLocationForComponent(
  *
  * Returns the position unchanged when:
  *   - inputs are missing
+ *   - `start.offset` is missing (we need byte offsets to read the source)
  *   - the character at `start.offset` is not `<` (e.g. attribute-value
  *     positions emitted by the style-contrast checker)
  *   - no tag-name characters follow the `<`
  */
 export function narrowPositionToOpeningTag(
-    position: any,
+    position: Position | undefined,
     source: string | undefined,
-): any {
+): Position | undefined {
     if (!position || !source) {
         return position;
     }
-    const startOffset = position.start?.offset;
+    const startOffset = position.start.offset;
     if (typeof startOffset !== "number" || source[startOffset] !== "<") {
         return position;
     }
 
+    // Cap the search at the element's existing end offset so we never widen
+    // the range. Falling back to `source.length` is safe — the regex match
+    // is then the only limit.
     const endOffsetLimit =
-        typeof position.end?.offset === "number"
+        typeof position.end.offset === "number"
             ? position.end.offset
             : source.length;
+    const searchWindow = source.slice(startOffset + 1, endOffsetLimit);
 
-    let tagEnd = startOffset + 1;
-    while (tagEnd < source.length && tagEnd < endOffsetLimit) {
-        const ch = source[tagEnd];
-        const isNameChar =
-            (ch >= "a" && ch <= "z") ||
-            (ch >= "A" && ch <= "Z") ||
-            (ch >= "0" && ch <= "9") ||
-            ch === "_" ||
-            ch === "-" ||
-            ch === ":";
-        if (!isNameChar) {
-            break;
-        }
-        tagEnd++;
-    }
-
-    if (tagEnd === startOffset + 1) {
+    const match = TAG_NAME_REGEX.exec(searchWindow);
+    if (!match) {
         return position;
     }
 
-    const tagNameLength = tagEnd - startOffset;
+    const tagNameLength = 1 + match[0].length;
     return {
         start: position.start,
         end: {
             line: position.start.line,
             column: position.start.column + tagNameLength,
-            offset: tagEnd,
+            offset: startOffset + tagNameLength,
         },
     };
 }

--- a/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
+++ b/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
@@ -187,6 +187,8 @@ export function DiagnosticsResponseTabContents({
     showHelp = true,
     showInfoAnnotations,
     setShowInfoAnnotations,
+    showAccessibilityAnnotations,
+    setShowAccessibilityAnnotations,
     helpContent,
     docsURL,
 }: {
@@ -202,6 +204,8 @@ export function DiagnosticsResponseTabContents({
     showHelp?: boolean;
     showInfoAnnotations: boolean;
     setShowInfoAnnotations: (checked: boolean) => void;
+    showAccessibilityAnnotations: boolean;
+    setShowAccessibilityAnnotations: (checked: boolean) => void;
     helpContent: HelpContent;
     docsURL: string;
 }) {
@@ -335,6 +339,11 @@ export function DiagnosticsResponseTabContents({
                                 tabId="accessibility"
                                 className="diagnostic-panel accessibility-report"
                             >
+                                <AnnotationToggle
+                                    checked={showAccessibilityAnnotations}
+                                    label="Show accessibility diagnostics in editor"
+                                    onChange={setShowAccessibilityAnnotations}
+                                />
                                 <section className="accessibility-report-section">
                                     <div className="accessibility-report-heading critical">
                                         <h3>

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -284,6 +284,8 @@ export const EditorViewer = React.forwardRef<
     const [receivedDiagnosticsFromViewer, setReceivedDiagnosticsFromViewer] =
         useState(false);
     const [showInfoAnnotations, setShowInfoAnnotations] = useState(false);
+    const [showAccessibilityAnnotations, setShowAccessibilityAnnotations] =
+        useState(true);
 
     const [helpContent, setHelpContent] = useState<HelpContent>(HELP_NONE);
     const cursorDebounceTimer = useRef<number | undefined>(undefined);
@@ -434,13 +436,19 @@ export const EditorViewer = React.forwardRef<
         const additionalDiagnostics = toAdditionalDiagnosticsForLsp({
             diagnostics: [...initialDiagnostics, ...diagnostics],
             showInfoAnnotations,
+            showAccessibilityAnnotations,
         });
 
         lspRef.current?.lsp.sendAdditionalDiagnostics(
             lspRef.current.documentUri,
             additionalDiagnostics,
         );
-    }, [initialDiagnostics, diagnostics, showInfoAnnotations]);
+    }, [
+        initialDiagnostics,
+        diagnostics,
+        showInfoAnnotations,
+        showAccessibilityAnnotations,
+    ]);
 
     const {
         warnings: warningsObjs,
@@ -866,6 +874,12 @@ export const EditorViewer = React.forwardRef<
                         showHelp={showHelp}
                         showInfoAnnotations={showInfoAnnotations}
                         setShowInfoAnnotations={setShowInfoAnnotations}
+                        showAccessibilityAnnotations={
+                            showAccessibilityAnnotations
+                        }
+                        setShowAccessibilityAnnotations={
+                            setShowAccessibilityAnnotations
+                        }
                         helpContent={helpContent}
                         docsURL={docsURL}
                     />

--- a/packages/doenetml/src/EditorViewer/diagnostics.test.ts
+++ b/packages/doenetml/src/EditorViewer/diagnostics.test.ts
@@ -38,6 +38,7 @@ describe("toAdditionalDiagnosticsForLsp", () => {
         const [lsp] = toAdditionalDiagnosticsForLsp({
             diagnostics: [dastDiagnostic],
             showInfoAnnotations: false,
+            showAccessibilityAnnotations: true,
         });
         expect(lsp.range).toEqual({
             start: { line: 0, character: 14 },
@@ -67,6 +68,7 @@ describe("toAdditionalDiagnosticsForLsp", () => {
         const out = toAdditionalDiagnosticsForLsp({
             diagnostics: [warning, info, accessibility],
             showInfoAnnotations: true,
+            showAccessibilityAnnotations: true,
         });
         // Each LSP `Range` is shifted by -1 on both `line` and `column`,
         // and `column` is renamed to `character`.
@@ -100,8 +102,33 @@ describe("toAdditionalDiagnosticsForLsp", () => {
         const out = toAdditionalDiagnosticsForLsp({
             diagnostics: [positionless, withPos],
             showInfoAnnotations: false,
+            showAccessibilityAnnotations: true,
         });
         expect(out).toHaveLength(1);
         expect(out[0].message).toBe("has position");
+    });
+
+    it("suppresses accessibility diagnostics when the session toggle is off", () => {
+        // The accessibility report tab still surfaces these records, but the
+        // squiggles in the editor are silenced so the hover popup stops
+        // following the mouse around the offending component.
+        const warning: WarningRecord = {
+            type: "warning",
+            message: "W",
+            position: dastPos(2, 3, 2, 7),
+        };
+        const accessibility: DiagnosticRecord = {
+            type: "accessibility",
+            level: 1,
+            message: "A",
+            position: dastPos(1, 1, 1, 2),
+        };
+        const out = toAdditionalDiagnosticsForLsp({
+            diagnostics: [warning, accessibility],
+            showInfoAnnotations: false,
+            showAccessibilityAnnotations: false,
+        });
+        expect(out).toHaveLength(1);
+        expect(out[0].message).toBe("W");
     });
 });

--- a/packages/doenetml/src/EditorViewer/diagnostics.ts
+++ b/packages/doenetml/src/EditorViewer/diagnostics.ts
@@ -97,9 +97,11 @@ function toLspDiagnostic(diagnostic: DiagnosticRecord): EditorLspDiagnostic {
 export function toAdditionalDiagnosticsForLsp({
     diagnostics,
     showInfoAnnotations,
+    showAccessibilityAnnotations,
 }: {
     diagnostics: DiagnosticRecord[];
     showInfoAnnotations: boolean;
+    showAccessibilityAnnotations: boolean;
 }): EditorLspDiagnostic[] {
     return diagnostics
         .filter((diagnostic) => {
@@ -120,7 +122,7 @@ export function toAdditionalDiagnosticsForLsp({
             }
 
             if (isAccessibilityRecord(diagnostic)) {
-                return true;
+                return showAccessibilityAnnotations;
             }
 
             return false;

--- a/packages/doenetml/src/EditorViewer/editor-viewer.css
+++ b/packages/doenetml/src/EditorViewer/editor-viewer.css
@@ -216,12 +216,12 @@
 
 .editor-panel .diagnostic-tab-icon.is-accessibility-critical,
 .editor-panel .diagnostic-entry-icon.is-accessibility-critical {
-    color: #b42318;
+    color: #5b21b6;
 }
 
 .editor-panel .diagnostic-tab-icon.is-accessibility-advisory,
 .editor-panel .diagnostic-entry-icon.is-accessibility-advisory {
-    color: #6e3cbc;
+    color: #9061d1;
 }
 
 .editor-panel .diagnostic-entry-location {
@@ -290,11 +290,11 @@
 }
 
 .editor-panel .accessibility-report-heading.critical {
-    color: #b42318;
+    color: #5b21b6;
 }
 
 .editor-panel .accessibility-report-heading.advisory {
-    color: #6e3cbc;
+    color: #9061d1;
 }
 
 .viewer-panel {
@@ -329,9 +329,9 @@
 }
 
 .viewer-panel .accessibility-status-button.has-level-1-issues {
-    background: #fef3f2;
-    color: #b42318;
-    box-shadow: inset 0 0 0 1px #f04438;
+    background: #f5f3ff;
+    color: #5b21b6;
+    box-shadow: inset 0 0 0 1px #8b5cf6;
 }
 
 .viewer-panel .accessibility-status-button.no-level-1-issues {

--- a/packages/test-cypress/cypress/e2e/EditorViewer/editorViewerAccessibilityReport.cy.js
+++ b/packages/test-cypress/cypress/e2e/EditorViewer/editorViewerAccessibilityReport.cy.js
@@ -301,11 +301,11 @@ describe(
 
             cy.get(".cm-tooltip-lint .cm-lint-tooltip .heading")
                 .should("contain.text", "WCAG AA Accessibility Violation")
-                .should("have.css", "color", "rgb(180, 35, 24)");
+                .should("have.css", "color", "rgb(91, 33, 182)");
 
             cy.get(
                 ".cm-tooltip-lint .cm-diagnostic:has(.cm-lint-tooltip .heading.accessibility-level-1)",
-            ).should("have.css", "border-left-color", "rgb(180, 35, 24)");
+            ).should("have.css", "border-left-color", "rgb(91, 33, 182)");
         });
 
         it("exposes accessible tab semantics and labels in diagnostics tab strip", () => {


### PR DESCRIPTION
## Summary

Authors were getting frustrated with the accessibility-violation hover — the red squiggle covered the entire (often multi-line) component, so the hover popup kept appearing whenever the cursor moved across the element. The pressure was high enough that some were typing bogus `<shortDescription>` text just to make the squiggle go away.

This PR attacks the intrusiveness from three angles while keeping the diagnostic visible enough that authors don't ignore it:

- **Narrow the editor range to just the opening tag** (`<graph`, `<image`, …). New `narrowPositionToOpeningTag` helper, applied in `Core.addDiagnostic` only for `type === "accessibility"` records. Non-accessibility records and already-narrow positions (style-contrast attribute ranges) are untouched.
- **Re-skin the squiggle and tooltip** into the purple family — level-1 is deep purple `#5b21b6`, level-2 is lighter purple `#9061d1`. Squiggle is now dotted (was wavy) at `0.6px` (was `0.8px`) with more underline offset. Status button and report-tab headings are reskinned to match. Accessibility marks no longer visually read as errors.
- **Session toggle** (`showAccessibilityAnnotations`, default on) — checkbox at the top of the accessibility report tab, mirroring the existing info-diagnostics pattern. When off, the editor squiggles are suppressed but the report tab and status button still show the issues.

Quick-fix code actions (e.g. "Add `description=…`" as a one-click LSP code action) are deferred to a separate PR — there's more subtlety there.

## Test plan

- [x] `vitest run packages/doenetml/src/EditorViewer/diagnostics.test.ts` (incl. new "suppresses accessibility diagnostics when the session toggle is off" case)
- [x] `vitest run src/test/diagnostics/accessibility.test.ts src/test/diagnostics/styleContrastAccessibility.test.ts` in the worker package (22 tests, incl. new "narrows accessibility diagnostic range to the opening tag")
- [x] Accessibility-only subsets of `graph.test.ts`, `image.test.ts`, `video.test.ts`, `choiceinput.test.ts`, `answer.test.ts` — pre-existing assertions on `position.end` updated to reflect the narrowed range
- [x] Prettier clean on all edited files
- [x] Manually verify in the editor: `<graph />` hover only fires over `<graph`, squiggle is dotted purple, accessibility tab has the toggle, toggling it off clears the squiggle without clearing the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)