### PR TITLE
fix(doenetml): defer YouTube IFrame API load until a YouTube video renders

### DIFF
--- a/.changeset/youtube-lazy-load.md
+++ b/.changeset/youtube-lazy-load.md
@@ -1,0 +1,9 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Stop loading the YouTube IFrame API at viewer/editor startup. The `https://www.youtube.com/iframe_api` script is now injected lazily — only when a `<video>` component with a `youtube` attribute actually renders. Documents that contain no YouTube videos make no network request to youtube.com.

--- a/packages/doenetml/src/Viewer/renderers/utils/useYouTubeApi.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useYouTubeApi.ts
@@ -2,15 +2,17 @@ import { useEffect, useState } from "react";
 
 // Globals provided by the YouTube IFrame Player API
 // (https://developers.google.com/youtube/iframe_api_reference). The API
-// script is loaded elsewhere on the page; once it finishes parsing it
-// populates `window.YT` and invokes `window.onYouTubeIframeAPIReady` exactly
-// once.
+// script is loaded lazily by this hook (see `loadScript` below); once it
+// finishes parsing it populates `window.YT` and invokes
+// `window.onYouTubeIframeAPIReady` exactly once.
 declare global {
     interface Window {
         YT?: { Player: new (...args: any[]) => any; PlayerState: any };
         onYouTubeIframeAPIReady?: () => void;
     }
 }
+
+const YT_API_SRC = "https://www.youtube.com/iframe_api";
 
 // `window.onYouTubeIframeAPIReady` is a single-slot global, but multiple
 // components may need to know when YT is ready. These module-level
@@ -36,29 +38,49 @@ function isReady() {
     return Boolean(window.YT?.Player);
 }
 
+// Inject the YouTube IFrame API <script> tag into <head> if it hasn't been
+// added already. Deferred until a YouTube video is actually about to render
+// so that documents without YouTube videos make no network request to
+// youtube.com (see issue #1202).
+function loadScript() {
+    if (document.querySelector(`script[src="${YT_API_SRC}"]`)) {
+        return;
+    }
+    const script = document.createElement("script");
+    script.src = YT_API_SRC;
+    document.head.appendChild(script);
+}
+
 /**
  * React hook that returns `true` once the YouTube IFrame Player API is
  * loaded (`window.YT.Player` is available), and `false` until then.
  *
- * Use this to gate `new window.YT.Player(...)` construction in an effect:
- * the hook re-renders consumers when the API becomes ready, even though it
- * loads asynchronously and may not be present at the first render.
+ * Pass `shouldLoad=true` to trigger lazy injection of the API <script>;
+ * when `false` (the default) the hook is inert and no network request is
+ * made. Use this to gate `new window.YT.Player(...)` construction in an
+ * effect: the hook re-renders consumers when the API becomes ready, even
+ * though it loads asynchronously and may not be present at the first
+ * render.
  */
-export function useYouTubeApi() {
+export function useYouTubeApi(shouldLoad: boolean = false) {
     const [ready, setReady] = useState(isReady);
 
     useEffect(() => {
+        if (!shouldLoad) {
+            return;
+        }
         if (isReady()) {
             setReady(true);
             return;
         }
         install();
+        loadScript();
         const listener = () => setReady(true);
         listeners.add(listener);
         return () => {
             listeners.delete(listener);
         };
-    }, []);
+    }, [shouldLoad]);
 
     return ready;
 }

--- a/packages/doenetml/src/Viewer/renderers/utils/useYouTubeApi.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useYouTubeApi.ts
@@ -76,9 +76,18 @@ export function useYouTubeApi(shouldLoad: boolean = false) {
             return;
         }
         install();
-        loadScript();
         const listener = () => setReady(true);
+        // Subscribe before loadScript() so we cannot miss
+        // `onYouTubeIframeAPIReady` if the script is already in flight from a
+        // prior mount and finishes between these two statements.
         listeners.add(listener);
+        loadScript();
+        // Defense-in-depth: if the API became ready between the top-of-effect
+        // `isReady()` check and now, fall through synchronously instead of
+        // waiting for a callback that has already fired.
+        if (isReady()) {
+            setReady(true);
+        }
         return () => {
             listeners.delete(listener);
         };

--- a/packages/doenetml/src/Viewer/renderers/utils/useYouTubeApi.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useYouTubeApi.ts
@@ -57,10 +57,12 @@ function loadScript() {
  * re-renders consumers when the API becomes ready, which is asynchronous
  * and may not happen by the first render.
  *
- * When `shouldLoad` is `true` the hook also injects the API <script> tag on
- * first call; when `false` (the default) the hook is inert and no network
- * request to youtube.com is made. This lets callers defer the script load
- * until a YouTube video is actually about to render.
+ * When `shouldLoad` is `true` the hook injects the API `<script>` tag (if
+ * not already present) so the load can begin. When `false` (the default)
+ * it does not trigger any network request to youtube.com; it still
+ * reports `true` if the API was loaded by a previous consumer. This lets
+ * callers defer the script load until a YouTube video is actually about
+ * to render.
  */
 export function useYouTubeApi(shouldLoad: boolean = false) {
     const [ready, setReady] = useState(isReady);

--- a/packages/doenetml/src/Viewer/renderers/utils/useYouTubeApi.ts
+++ b/packages/doenetml/src/Viewer/renderers/utils/useYouTubeApi.ts
@@ -39,9 +39,8 @@ function isReady() {
 }
 
 // Inject the YouTube IFrame API <script> tag into <head> if it hasn't been
-// added already. Deferred until a YouTube video is actually about to render
-// so that documents without YouTube videos make no network request to
-// youtube.com (see issue #1202).
+// added already. The DOM check makes this safe to call from multiple
+// components (and across HMR reloads in dev).
 function loadScript() {
     if (document.querySelector(`script[src="${YT_API_SRC}"]`)) {
         return;
@@ -53,14 +52,15 @@ function loadScript() {
 
 /**
  * React hook that returns `true` once the YouTube IFrame Player API is
- * loaded (`window.YT.Player` is available), and `false` until then.
+ * loaded (`window.YT.Player` is available), and `false` until then. Use it
+ * to gate `new window.YT.Player(...)` construction in an effect: the hook
+ * re-renders consumers when the API becomes ready, which is asynchronous
+ * and may not happen by the first render.
  *
- * Pass `shouldLoad=true` to trigger lazy injection of the API <script>;
- * when `false` (the default) the hook is inert and no network request is
- * made. Use this to gate `new window.YT.Player(...)` construction in an
- * effect: the hook re-renders consumers when the API becomes ready, even
- * though it loads asynchronously and may not be present at the first
- * render.
+ * When `shouldLoad` is `true` the hook also injects the API <script> tag on
+ * first call; when `false` (the default) the hook is inert and no network
+ * request to youtube.com is made. This lets callers defer the script load
+ * until a YouTube video is actually about to render.
  */
 export function useYouTubeApi(shouldLoad: boolean = false) {
     const [ready, setReady] = useState(isReady);

--- a/packages/doenetml/src/Viewer/renderers/video.tsx
+++ b/packages/doenetml/src/Viewer/renderers/video.tsx
@@ -50,7 +50,11 @@ export default React.memo(function Video(props: UseDoenetRendererProps) {
 
     useRecordVisibilityChanges(ref, callAction, actions);
 
-    const ytReady = useYouTubeApi();
+    // Only request the YouTube IFrame API when this component is actually
+    // rendering a YouTube video. Other video sources (or `<video>` with no
+    // source yet) must not trigger a network request to youtube.com. See
+    // issue #1202.
+    const ytReady = useYouTubeApi(Boolean(SVs.youtube));
 
     useEffect(() => {
         if (!SVs.youtube || !ytReady || !window.YT) {

--- a/packages/doenetml/src/Viewer/renderers/video.tsx
+++ b/packages/doenetml/src/Viewer/renderers/video.tsx
@@ -51,9 +51,8 @@ export default React.memo(function Video(props: UseDoenetRendererProps) {
     useRecordVisibilityChanges(ref, callAction, actions);
 
     // Only request the YouTube IFrame API when this component is actually
-    // rendering a YouTube video. Other video sources (or `<video>` with no
-    // source yet) must not trigger a network request to youtube.com. See
-    // issue #1202.
+    // rendering a YouTube video; non-YouTube sources must not trigger a
+    // network request to youtube.com.
     const ytReady = useYouTubeApi(Boolean(SVs.youtube));
 
     useEffect(() => {

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -146,19 +146,6 @@ export function DoenetViewer({
      */
     onInit?: (elm: HTMLElement) => void;
 }) {
-    useEffect(() => {
-        // Add a YouTube iframe api to the document header if it doesn't exist
-        if (
-            !document.querySelector(
-                'script[src="https://www.youtube.com/iframe_api"]',
-            )
-        ) {
-            const script = document.createElement("script");
-            script.src = "https://www.youtube.com/iframe_api";
-            document.head.appendChild(script);
-        }
-    }, []);
-
     const [variants, setVariants] = useState({
         index: 1,
         numVariants: 1,
@@ -449,19 +436,6 @@ export const DoenetEditor = React.forwardRef<
         ],
         [initialDiagnostics, initialErrors, initialWarnings],
     );
-
-    useEffect(() => {
-        // Add a YouTube iframe api to the document header if it doesn't exist
-        if (
-            !document.querySelector(
-                'script[src="https://www.youtube.com/iframe_api"]',
-            )
-        ) {
-            const script = document.createElement("script");
-            script.src = "https://www.youtube.com/iframe_api";
-            document.head.appendChild(script);
-        }
-    }, []);
 
     const editor = (
         <EditorViewer


### PR DESCRIPTION
## Summary

DoenetML previously injected `https://www.youtube.com/iframe_api` into `<head>` from a `useEffect` at the top of both `DoenetViewer` and `DoenetEditor`, so every page using either component made a network request to `youtube.com` regardless of whether the document contained a YouTube video. This caused security/compliance friction for embedders with strict outbound-network policies (#1202).

Rather than adding an `allowYoutube` opt-out flag (as proposed in the issue), this PR makes the load lazy:

- The `useYouTubeApi` hook now owns the `<script>` injection and accepts a `shouldLoad` boolean. The hook subscribes its listener before injecting the script and re-checks `isReady()` afterwards, so a ready callback that fires while the script is mid-load from a prior mount cannot be missed.
- `<Video>` passes `Boolean(SVs.youtube)`, so the script is injected only when a `<video youtube="...">` is actually about to render.
- The two startup `useEffect`s in `doenetml.tsx` are removed.

Documents with no YouTube videos make no request to `youtube.com`. Documents with a YouTube video behave exactly as before — the script loads on first render, subsequent `<Video>` instances reuse the existing tag, and the existing fan-out of `onYouTubeIframeAPIReady` subscribers is unchanged.

Closes #1202.

## Test plan

- [x] Open a document with no `<video>` element in the viewer; confirm no request to `youtube.com` in the Network tab.
- [x] Open a document with `<video youtube="..." />`; confirm the iframe API request fires once and the video plays/pauses normally.
- [x] Open a document with `<video source="..." />` (no YouTube); confirm no request to `youtube.com`.
- [ ] Switch a `<video youtube="...">` to a different YouTube id; the existing script tag is reused and the new player initializes.
- [x] Existing `packages/test-cypress/cypress/e2e/tagSpecific/video.cy.js` Cypress specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)