### PR TITLE
ci: pin node to 24.15.0 to work around extract-zip hang in 24.16.0

### DIFF
--- a/.github/workflows/changesets-version-pr.yml
+++ b/.github/workflows/changesets-version-pr.yml
@@ -25,7 +25,8 @@ jobs:
             - name: Use Node.js 24
               uses: actions/setup-node@v6
               with:
-                  node-version: 24.x
+                  # See ci.yml for the rationale behind pinning to 24.15.0.
+                  node-version: 24.15.0
                   cache: "npm"
 
             - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,11 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [24.x]
+                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
+                # (https://github.com/nodejs/node/issues/63487) that hangs
+                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
+                # Revisit once a fixed 24.x release is available in setup-node.
+                node-version: [24.15.0]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
         steps:
@@ -75,7 +79,11 @@ jobs:
         needs: build
         strategy:
             matrix:
-                node-version: [24.x]
+                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
+                # (https://github.com/nodejs/node/issues/63487) that hangs
+                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
+                # Revisit once a fixed 24.x release is available in setup-node.
+                node-version: [24.15.0]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         steps:
             - uses: actions/checkout@v6
@@ -112,7 +120,11 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node-version: [24.x]
+                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
+                # (https://github.com/nodejs/node/issues/63487) that hangs
+                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
+                # Revisit once a fixed 24.x release is available in setup-node.
+                node-version: [24.15.0]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
                 test-group: [group1, group2, group3, group4]
         steps:
@@ -150,7 +162,11 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node-version: [24.x]
+                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
+                # (https://github.com/nodejs/node/issues/63487) that hangs
+                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
+                # Revisit once a fixed 24.x release is available in setup-node.
+                node-version: [24.15.0]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
                 test-group:
                     [
@@ -245,7 +261,11 @@ jobs:
         if: needs.changes.outputs.prefigure == 'true'
         strategy:
             matrix:
-                node-version: [24.x]
+                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
+                # (https://github.com/nodejs/node/issues/63487) that hangs
+                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
+                # Revisit once a fixed 24.x release is available in setup-node.
+                node-version: [24.15.0]
         steps:
             - uses: actions/checkout@v6
             - name: Use Node.js ${{ matrix.node-version }}
@@ -338,7 +358,11 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [24.x]
+                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
+                # (https://github.com/nodejs/node/issues/63487) that hangs
+                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
+                # Revisit once a fixed 24.x release is available in setup-node.
+                node-version: [24.15.0]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
         steps:
@@ -383,7 +407,11 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [24.x]
+                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
+                # (https://github.com/nodejs/node/issues/63487) that hangs
+                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
+                # Revisit once a fixed 24.x release is available in setup-node.
+                node-version: [24.15.0]
 
         steps:
             - name: Checkout sources
@@ -405,7 +433,11 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [24.x]
+                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
+                # (https://github.com/nodejs/node/issues/63487) that hangs
+                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
+                # Revisit once a fixed 24.x release is available in setup-node.
+                node-version: [24.15.0]
 
         steps:
             - uses: actions/checkout@v6
@@ -461,7 +493,11 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [24.x]
+                # Pinned to 24.15.0: Node 24.16.0 has an extract-zip regression
+                # (https://github.com/nodejs/node/issues/63487) that hangs
+                # cypress/playwright install scripts, freezing `npm ci` indefinitely.
+                # Revisit once a fixed 24.x release is available in setup-node.
+                node-version: [24.15.0]
 
         steps:
             - uses: actions/checkout@v6

--- a/.github/workflows/gh-pages-docs.yml
+++ b/.github/workflows/gh-pages-docs.yml
@@ -27,7 +27,8 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [24.x]
+                # See ci.yml for the rationale behind pinning to 24.15.0.
+                node-version: [24.15.0]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
         steps:

--- a/.github/workflows/publish-prefigure.yml
+++ b/.github/workflows/publish-prefigure.yml
@@ -48,7 +48,8 @@ jobs:
             - name: Use Node.js 24
               uses: actions/setup-node@v6
               with:
-                  node-version: 24.x
+                  # See ci.yml for the rationale behind pinning to 24.15.0.
+                  node-version: 24.15.0
                   registry-url: https://registry.npmjs.org
                   cache: "npm"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,8 @@ jobs:
             - name: Use Node.js 24
               uses: actions/setup-node@v6
               with:
-                  node-version: 24.x
+                  # See ci.yml for the rationale behind pinning to 24.15.0.
+                  node-version: 24.15.0
                   registry-url: https://registry.npmjs.org
                   cache: "npm"
 
@@ -124,7 +125,8 @@ jobs:
             - name: Use Node.js 24
               uses: actions/setup-node@v6
               with:
-                  node-version: 24.x
+                  # See ci.yml for the rationale behind pinning to 24.15.0.
+                  node-version: 24.15.0
                   registry-url: https://registry.npmjs.org
                   cache: "npm"
 


### PR DESCRIPTION
## Summary

CI jobs hang at `npm ci` ~50% of the time, eventually getting killed at the 6h timeout. The intermittency tracks the rolling deployment of the new `ubuntu-24.04` runner image `20260525.161` (released 2026-05-25), which bumps Node from 24.15.0 to 24.16.0 in the toolcache. Node 24.16.0 has an `extract-zip` regression (nodejs/node#63487, opened 2026-05-22) that hangs cypress and playwright install scripts indefinitely.

Pin `node-version` to 24.15.0 in every workflow so `actions/setup-node` ignores the broken cached version regardless of which image hosts the job. Revisit once a fixed 24.x release lands.

### Evidence
- Every cancelled `npm ci` in recent runs was on image `20260525.161` running Node 24.16.0; every successful job in the same matrix was on `20260518.149` running Node 24.15.0.
- Hung process tree at termination: `npm ci` → `sh` → two threads — consistent with a stuck cypress/playwright install script.
- The DoenetML-to-PreTeXt devcontainer job is unaffected because it installs Node inside its devcontainer image.

## Test plan

- [ ] CI passes on this PR.
- [ ] Re-run all jobs; CI passes a second time. The fix is considered verified after two consecutive green runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)