### PR TITLE
chore(changesets): drop lsp-tools/static-assets from pending changesets + add changesets skill

### DIFF
--- a/.changeset/context-help-array-index-aliases.md
+++ b/.changeset/context-help-array-index-aliases.md
@@ -1,7 +1,5 @@
 ---
 "@doenet/doenetml": patch
-"@doenet/lsp-tools": patch
-"@doenet/static-assets": patch
 "@doenet/standalone": patch
 "@doenet/doenetml-iframe": patch
 "@doenet/vscode-extension": patch

--- a/.changeset/select-implicit-single-index-shorthand.md
+++ b/.changeset/select-implicit-single-index-shorthand.md
@@ -1,6 +1,5 @@
 ---
 "@doenet/doenetml": patch
-"@doenet/lsp-tools": patch
 "@doenet/standalone": patch
 "@doenet/doenetml-iframe": patch
 "@doenet/vscode-extension": patch

--- a/.changeset/style-number-breakdown-help.md
+++ b/.changeset/style-number-breakdown-help.md
@@ -1,6 +1,5 @@
 ---
 "@doenet/doenetml": patch
-"@doenet/lsp-tools": patch
 "@doenet/standalone": patch
 "@doenet/doenetml-iframe": patch
 "@doenet/vscode-extension": patch

--- a/.github/skills/changesets/SKILL.md
+++ b/.github/skills/changesets/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: changesets
+description: Rules for creating and editing changeset files in .changeset/ — which @doenet/* packages to list, packages that must never appear, one-directional propagation, the private-flag trap, and changeset file format. Use whenever adding or editing a .changeset/*.md file.
+---
+
+# Changesets Skill
+
+Use this skill when **creating or editing files in `.changeset/`** (typically `.changeset/<some-name>.md`). It covers which `@doenet/*` packages a changeset should list, how version propagation works, and which packages must never appear.
+
+Configuration lives in `.changeset/config.json`. The version-packages PR (`changeset-release/main` branch) is maintained by `.github/workflows/changesets-version-pr.yml`; npm publication is handled separately by `.github/workflows/publish.yml`.
+
+## Fixed Group (synchronized versioning)
+
+Six packages version together:
+
+- `@doenet/doenetml`
+- `@doenet/standalone`
+- `@doenet/doenetml-iframe`
+- `@doenet/v06-to-v07`
+- `@doenet/vscode-extension`
+- `doenet-vscode-extension`
+
+Bump any one of these and Changesets bumps all six. Listing or omitting a fixed-group member only controls which package's CHANGELOG the entry lands in — not whether it gets a version bump.
+
+## Independent Versioning
+
+- `@doenet/prefigure` versions independently.
+
+## Never Versioned
+
+`@doenet/lsp-tools` and `@doenet/static-assets` are never published — their source is bundled into `@doenet/doenetml`, so a change to either rides under `@doenet/doenetml`'s version. **Do not list them in any changeset, ever** — not even when files under `packages/lsp-tools/` or `packages/static-assets/` themselves changed.
+
+Don't infer "never published" from `"private": true` alone. Most packages in this repo (including `@doenet/doenetml`, `@doenet/standalone`, `@doenet/doenetml-iframe`, `@doenet/v06-to-v07`, and `@doenet/prefigure`) carry `"private": true` at the root and are still published, because their Vite build runs `scripts/transform-package-json.ts` to emit a `dist/package.json` with `private: false`. The real signal for "never published" is the absence of that transformer in the package's `vite.config.ts` — `@doenet/lsp-tools` and `@doenet/static-assets` are the two packages where it's missing.
+
+## Which packages to list
+
+Propagation is **one-directional — forward to consumers that re-bundle or re-render the change, never back to dependencies of the changed package.** Include a package iff:
+
+1. Its own source changed in this branch (and the package is published), OR
+2. It bundles, re-exports, or embeds the changed source, and the change is something that package's users will notice. Example: a change in `packages/doenetml/src` is visible to `@doenet/standalone` (bundles `@doenet/doenetml`), `@doenet/doenetml-iframe` (bundles `@doenet/standalone`), and `@doenet/vscode-extension` / `doenet-vscode-extension` (embed the editor) — list those alongside `@doenet/doenetml`. Look at recent changesets in the same area for the conventional set.
+
+Do **not** include a package just because the changed code imports from it. `@doenet/doenetml` depends on `@doenet/lsp-tools` and `@doenet/static-assets`, which makes them tempting to add to an editor changeset — but they're covered by the rule above: never listed.
+
+Fixed-group members all version together regardless of whether they're listed, but listing controls which package's CHANGELOG the entry lands in — list a fixed-group member only when its users would care to read the entry. Editor/viewer changes typically skip `@doenet/v06-to-v07` for this reason, even though v06-to-v07 versions along with the group.
+
+## Bump type
+
+While the repo is < 1.0, default to `patch` for every package in every changeset — even for new API or larger-feeling changes. Revisit this convention once the first 1.0 release is on the horizon.
+
+## File format
+
+Each changeset is a Markdown file in `.changeset/` with YAML frontmatter listing the packages and bump types, followed by the body text that goes into the CHANGELOG:
+
+```markdown
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Editor: <one-line summary of the user-visible change>.
+
+<Optional longer prose: why, what changed, edge cases.>
+
+Closes #1234.
+```
+
+Filename is conventionally a short kebab-case slug of the change (e.g. `context-help-array-index-aliases.md`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,13 +144,21 @@ Six packages version together:
 - `@doenet/v06-to-v07`, `@doenet/vscode-extension`, `doenet-vscode-extension`
 
 ### Independent Versioning
-- `@doenet/prefigure` versions independently
+- `@doenet/prefigure` versions independently.
 
-**Rule**: When creating a changeset for a user-facing change, include **all packages** where the change is visible to end users, not just where the implementation lives.
+### Never Versioned
+- `@doenet/lsp-tools` and `@doenet/static-assets` are private (`"private": true` in their `package.json`) and never published. Their source ships inside `@doenet/doenetml`'s bundle, so a change to either rides under `@doenet/doenetml`'s version. **Do not list them in any changeset, ever** — not even when files under `packages/lsp-tools/` or `packages/static-assets/` themselves changed.
 
-Example: A change to `packages/doenetml/src/Viewer` affects `@doenet/doenetml`, `@doenet/standalone`, `@doenet/doenetml-iframe`, and downstream variants. Include all in the changeset.
+### Which packages to list
 
-User-facing changes in `@doenet/standalone` are also apparent in `@doenet/doenetml-iframe`.
+Propagation is **one-directional — forward to consumers that re-bundle or re-render the change, never back to dependencies of the changed package.** Include a package iff:
+
+1. Its own source changed in this branch (and the package is published), OR
+2. It bundles, re-exports, or embeds the changed source, and the change is something that package's users will notice. Example: a change in `packages/doenetml/src` is visible to `@doenet/standalone` (bundles `@doenet/doenetml`), `@doenet/doenetml-iframe` (bundles `@doenet/standalone`), and `@doenet/vscode-extension` / `doenet-vscode-extension` (embed the editor) — list those alongside `@doenet/doenetml`. Look at recent changesets in the same area for the conventional set.
+
+Do **not** include a package just because the changed code imports from it. `@doenet/doenetml` depends on `@doenet/lsp-tools` and `@doenet/static-assets`, which makes them tempting to add to an editor changeset — but they're covered by the rule above: never listed.
+
+Fixed-group members all version together regardless of whether they're listed, but listing controls which package's CHANGELOG the entry lands in — list a fixed-group member only when its users would care to read the entry. Editor/viewer changes typically skip `@doenet/v06-to-v07` for this reason, even though v06-to-v07 versions along with the group.
 
 ## Key State & Data Flow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,9 +147,9 @@ Six packages version together:
 - `@doenet/prefigure` versions independently.
 
 ### Never Versioned
-- `@doenet/lsp-tools` and `@doenet/static-assets` are never published — their source is bundled into `@doenet/doenetml`, so a change to either rides under `@doenet/doenetml`'s version. **Do not list them in any changeset, ever** — not even when files under `packages/lsp-tools/` or `packages/static-assets/` themselves changed.
+`@doenet/lsp-tools` and `@doenet/static-assets` are never published — their source is bundled into `@doenet/doenetml`, so a change to either rides under `@doenet/doenetml`'s version. **Do not list them in any changeset, ever** — not even when files under `packages/lsp-tools/` or `packages/static-assets/` themselves changed.
 
-    Don't infer this from `"private": true` alone. Most packages in this repo (including `@doenet/doenetml`, `@doenet/standalone`, `@doenet/doenetml-iframe`, `@doenet/v06-to-v07`, and `@doenet/prefigure`) carry `"private": true` at the root and are still published, because their Vite build runs `scripts/transform-package-json.ts` to emit a `dist/package.json` with `private: false`. The real signal for "never published" is the absence of that transformer in the package's `vite.config.ts` — `@doenet/lsp-tools` and `@doenet/static-assets` are the two packages where it's missing.
+Don't infer this from `"private": true` alone. Most packages in this repo (including `@doenet/doenetml`, `@doenet/standalone`, `@doenet/doenetml-iframe`, `@doenet/v06-to-v07`, and `@doenet/prefigure`) carry `"private": true` at the root and are still published, because their Vite build runs `scripts/transform-package-json.ts` to emit a `dist/package.json` with `private: false`. The real signal for "never published" is the absence of that transformer in the package's `vite.config.ts` — `@doenet/lsp-tools` and `@doenet/static-assets` are the two packages where it's missing.
 
 ### Which packages to list
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,9 @@ Six packages version together:
 - `@doenet/prefigure` versions independently.
 
 ### Never Versioned
-- `@doenet/lsp-tools` and `@doenet/static-assets` are private (`"private": true` in their `package.json`) and never published. Their source ships inside `@doenet/doenetml`'s bundle, so a change to either rides under `@doenet/doenetml`'s version. **Do not list them in any changeset, ever** — not even when files under `packages/lsp-tools/` or `packages/static-assets/` themselves changed.
+- `@doenet/lsp-tools` and `@doenet/static-assets` are never published — their source is bundled into `@doenet/doenetml`, so a change to either rides under `@doenet/doenetml`'s version. **Do not list them in any changeset, ever** — not even when files under `packages/lsp-tools/` or `packages/static-assets/` themselves changed.
+
+    Don't infer this from `"private": true` alone. Most packages in this repo (including `@doenet/doenetml`, `@doenet/standalone`, `@doenet/doenetml-iframe`, `@doenet/v06-to-v07`, and `@doenet/prefigure`) carry `"private": true` at the root and are still published, because their Vite build runs `scripts/transform-package-json.ts` to emit a `dist/package.json` with `private: false`. The real signal for "never published" is the absence of that transformer in the package's `vite.config.ts` — `@doenet/lsp-tools` and `@doenet/static-assets` are the two packages where it's missing.
 
 ### Which packages to list
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,31 +136,7 @@ This checkout may use a personal fork as `origin` and the canonical `Doenet/Doen
 
 ## Changesets
 
-The repo uses Changesets for version management. Configuration is in `.changeset/config.json`.
-
-### Fixed Group (synchronized versioning)
-Six packages version together:
-- `@doenet/doenetml`, `@doenet/standalone`, `@doenet/doenetml-iframe`
-- `@doenet/v06-to-v07`, `@doenet/vscode-extension`, `doenet-vscode-extension`
-
-### Independent Versioning
-- `@doenet/prefigure` versions independently.
-
-### Never Versioned
-`@doenet/lsp-tools` and `@doenet/static-assets` are never published — their source is bundled into `@doenet/doenetml`, so a change to either rides under `@doenet/doenetml`'s version. **Do not list them in any changeset, ever** — not even when files under `packages/lsp-tools/` or `packages/static-assets/` themselves changed.
-
-Don't infer this from `"private": true` alone. Most packages in this repo (including `@doenet/doenetml`, `@doenet/standalone`, `@doenet/doenetml-iframe`, `@doenet/v06-to-v07`, and `@doenet/prefigure`) carry `"private": true` at the root and are still published, because their Vite build runs `scripts/transform-package-json.ts` to emit a `dist/package.json` with `private: false`. The real signal for "never published" is the absence of that transformer in the package's `vite.config.ts` — `@doenet/lsp-tools` and `@doenet/static-assets` are the two packages where it's missing.
-
-### Which packages to list
-
-Propagation is **one-directional — forward to consumers that re-bundle or re-render the change, never back to dependencies of the changed package.** Include a package iff:
-
-1. Its own source changed in this branch (and the package is published), OR
-2. It bundles, re-exports, or embeds the changed source, and the change is something that package's users will notice. Example: a change in `packages/doenetml/src` is visible to `@doenet/standalone` (bundles `@doenet/doenetml`), `@doenet/doenetml-iframe` (bundles `@doenet/standalone`), and `@doenet/vscode-extension` / `doenet-vscode-extension` (embed the editor) — list those alongside `@doenet/doenetml`. Look at recent changesets in the same area for the conventional set.
-
-Do **not** include a package just because the changed code imports from it. `@doenet/doenetml` depends on `@doenet/lsp-tools` and `@doenet/static-assets`, which makes them tempting to add to an editor changeset — but they're covered by the rule above: never listed.
-
-Fixed-group members all version together regardless of whether they're listed, but listing controls which package's CHANGELOG the entry lands in — list a fixed-group member only when its users would care to read the entry. Editor/viewer changes typically skip `@doenet/v06-to-v07` for this reason, even though v06-to-v07 versions along with the group.
+The repo uses Changesets for version management. Configuration is in `.changeset/config.json`. **When creating or editing a file under `.changeset/`, invoke the [`changesets`](.github/skills/changesets/SKILL.md) skill** — it documents which `@doenet/*` packages a changeset must list, which must never appear, how version propagation works (one-directional, forward to consumers only), the private-flag trap, and the changeset file format. Don't pattern-match the package list from a sibling `.changeset/*.md` without consulting the skill — recurring mistakes (notably adding `@doenet/lsp-tools` or `@doenet/static-assets`) have crept in that way.
 
 ## Key State & Data Flow
 
@@ -181,7 +157,7 @@ The worker receives serialized updates and returns rendered component states. Re
 2. Implement the **UI renderer** in `packages/doenetml/src/Viewer/renderers` or similar
 3. Register the component in `componentInfoObjects` so the worker knows about it; if the component appears in the DAST/normalized-DAST schema, update the relevant schema definitions too
 4. Add **tests** in both Vitest and Cypress
-5. Add a **changeset** if user-facing
+5. Add a **changeset** if user-facing (see the [`changesets`](.github/skills/changesets/SKILL.md) skill for which packages to list)
 
 ### Debug a rendering issue
 1. Start `npm run dev` and inspect the browser console


### PR DESCRIPTION
## Summary

Three things in one PR, all aimed at stopping the recurring mistake of adding `@doenet/lsp-tools` and `@doenet/static-assets` to changesets:

1. **Fix the immediate damage.** Three pending changesets (`context-help-array-index-aliases`, `select-implicit-single-index-shorthand`, `style-number-breakdown-help`) listed `@doenet/lsp-tools` and `@doenet/static-assets` alongside the packages they actually touched. Both packages are private (never published — their source is bundled into `@doenet/doenetml`), so the version-packages PR (#1114) was bumping them to `1.0.1` for no reason. Removing the two package entries from those three changesets lets the next Changesets workflow run regenerate #1114 without the bogus bumps.

2. **Add a `changesets` skill** at `.github/skills/changesets/SKILL.md` that documents:
   - The fixed group (six packages that version together).
   - `@doenet/prefigure` versions independently.
   - `@doenet/lsp-tools` and `@doenet/static-assets` are **never versioned** — and crucially, that this can't be inferred from `"private": true` alone, since `@doenet/doenetml` and the other fixed-group members also carry `"private": true` at the root and are published anyway via `scripts/transform-package-json.ts`, which emits a `dist/package.json` with `private: false`. The real signal for "never published" is the absence of that transformer from the package's `vite.config.ts`.
   - Propagation is **one-directional** — forward to consumers that re-bundle the change, never back to dependencies of the changed package.
   - Pre-1.0 bump-type convention (default to `patch` for everything) and the file-format example.

3. **Trim AGENTS.md** to a one-paragraph breadcrumb that points to the skill, plus a parenthetical pointer on the "Add a changeset" step in Common Tasks. Detailed rules don't need to sit in AGENTS.md taking context on every task — the skill loads on demand when an agent is actually touching `.changeset/`. The breadcrumb names the recurring mistake by name so an agent skimming AGENTS.md still knows there's a real trap to avoid.

## Test plan

- [ ] After merge, confirm the Changesets workflow re-runs and PR #1114 no longer lists `@doenet/lsp-tools@1.0.1` or `@doenet/static-assets@1.0.1` in its release summary or file diff.
- [ ] Spot-check the `changesets` skill renders correctly on GitHub (frontmatter + headings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)