### PR TITLE
docs: split PR-description maintenance into its own review-loop step

### DIFF
--- a/docs/REPEATED_REVIEW_OF_PR.md
+++ b/docs/REPEATED_REVIEW_OF_PR.md
@@ -12,9 +12,10 @@ Spawn one subagent and give it the following instructions:
 
 1. Review the PR according to `@./PR_REVIEW_GUIDELINES.md`.
 2. Address all issues identified during the review.
-3. Update the changeset and PR description if the changes warrant it.
-4. Commit and push the results.
-5. Report back a short summary of what was changed (or report "no changes" if nothing needed updating).
+3. Verify the changeset still describes the user-visible behavior in the diff; update if not.
+4. Verify the PR description still describes everything in the diff; update if not. Don't skip this — a stale PR description is the most common review-cycle oversight.
+5. Commit and push the results.
+6. Report back a short summary of what was changed (or report "no changes" if nothing needed updating).
 
 Run cycles sequentially — each new subagent must see the prior subagent's commits, so wait for one to finish before spawning the next.
 


### PR DESCRIPTION
## Summary

- The repeated-review procedure used to bundle changeset and PR-description maintenance into a single soft-hedged step (\"Update the changeset and PR description if the changes warrant it\"). In a recent review loop, the changeset stayed current after follow-up commits but the PR description didn't — exactly the failure mode the soft phrasing invites.
- Split the check into two explicit steps and add a direct note that a stale PR description is the most common review-cycle oversight.

## Test plan

- [x] Re-read `docs/REPEATED_REVIEW_OF_PR.md` and confirm the steps now read as discrete actions (changeset check, PR-description check) rather than one bundled item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)