### PR TITLE
docs: fix obsolete DoenetML construct and broken reference links in non-reference docs

### DIFF
--- a/packages/docs-nextra/pages/document_structure/essentialConcepts.mdx
+++ b/packages/docs-nextra/pages/document_structure/essentialConcepts.mdx
@@ -31,7 +31,7 @@ DoenetML is a **markup language** much like HTML. When creating content in Doene
 <graph><shortDescription>A graph of two points</shortDescription>$p1 $p2</graph>
 ```
 
-The available attributes and properties vary by component. See the [Component Examples](./doenetML_components/componentIndex.mdx) section for a full listing for each.
+The available attributes and properties vary by component. See the [Component Examples](../reference/componentIndex) section for a full listing for each.
 
 <a id="componentTypes"></a>
 ## Component Types
@@ -44,17 +44,17 @@ The different types are:
 | Type of Component    | Description                                                                              |
 | -------------------- | ---------------------------------------------------------------------------------------- |
 | [**Paragraph Markup**](../reference/componentTypes.mdx) | used within a paragraph, or `<p>` tag to change the way text is rendered                 |
-| [**Sectional**](../reference/componentTypes#sectionalComponents.mdx)        | used to structure content on the page; may have auto-numbering                           |
-| [**Input**](../reference/componentTypes#inputComponents.mdx)            | used to gather user-input, such as text-boxes, multiple-choice selections, or checkboxes |
-| [**Graphical**](../reference/componentTypes#graphicalComponents.mdx)        | used to render interactive elements on a graph                                           |
-| [**Display Math**](../reference/componentTypes#displayMathComponents.mdx)     | used to render LaTeX; does not invoke the CAS                                            |
-| [**Math**](../reference/componentTypes#mathComponents.mdx)             | used to define mathematical content; can be symbolic or numerical                        |
-| [**Math Operator**](../reference/componentTypes#mathOperatorComponents.mdx)    | used to perform mathematical operations                                                  |
-| [**General Operator**](../reference/componentTypes#generalOperatorComponents.mdx) | used to perform operations on math and non-math components                               |
-| [**Logic**](../reference/componentTypes#logicComponents.mdx)           | used to define boolean conditions                                                        |
-| [**Evaluation**](../reference/componentTypes#evaluationComponents.mdx)       | used with answer validation and awarding of credit                                       |
-| [**Text**](../reference/componentTypes#textComponents.mdx)             | any component that uses text strings outside the context of a paragraph                  |
-| [**Subject-specific**](../reference/componentTypes#subjectSpecificComponents.mdx) | components that are unique to a specific STEM field, such as chemistry or physics      |
+| [**Sectional**](../reference/componentTypes#sectionalComponents)        | used to structure content on the page; may have auto-numbering                           |
+| [**Input**](../reference/componentTypes#inputComponents)            | used to gather user-input, such as text-boxes, multiple-choice selections, or checkboxes |
+| [**Graphical**](../reference/componentTypes#graphicalComponents)        | used to render interactive elements on a graph                                           |
+| [**Display Math**](../reference/componentTypes#displayMathComponents)     | used to render LaTeX; does not invoke the CAS                                            |
+| [**Math**](../reference/componentTypes#mathComponents)             | used to define mathematical content; can be symbolic or numerical                        |
+| [**Math Operator**](../reference/componentTypes#mathOperatorComponents)    | used to perform mathematical operations                                                  |
+| [**General Operator**](../reference/componentTypes#generalOperatorComponents) | used to perform operations on math and non-math components                               |
+| [**Logic**](../reference/componentTypes#logicComponents)           | used to define boolean conditions                                                        |
+| [**Evaluation**](../reference/componentTypes#evaluationComponents)       | used with answer validation and awarding of credit                                       |
+| [**Text**](../reference/componentTypes#textComponents)             | any component that uses text strings outside the context of a paragraph                  |
+| [**Subject-specific**](../reference/componentTypes#subjectSpecificComponents) | components that are unique to a specific STEM field, such as chemistry or physics      |
 
 Some components may belong to more than one functional type, such as a `<sequence>`, which can generate either a numerical or a text sequence, or a `<mathInput>` which collects student's mathematical responses and also stores the value as a Math Component for use in computations by the CAS.
 

--- a/packages/docs-nextra/pages/sandbox/puzzles.mdx
+++ b/packages/docs-nextra/pages/sandbox/puzzles.mdx
@@ -7,7 +7,7 @@ import { AttrDisplay, PropDisplay } from "../../components"
 
 <a id="geo1_puzzle"></a>
 ### Puzzle 1: Line through a point
-Edit the starter code below to create a graph that shows a [line](line.mdx) passing through a [point](point.mdx). 
+Edit the starter code below to create a graph that shows a [line](../reference/line) passing through a [point](../reference/point). 
 When the point is dragged, the line moves with it, rotating around the point's original location.
 When the line is clicked and dragged, the line translates with its original slope. 
 
@@ -22,7 +22,7 @@ When the line is clicked and dragged, the line translates with its original slop
 ---
 <a id="geo2_puzzle"></a>
 ### Puzzle 2: Circle with inscribed polygon
-Edit the starter code below to create a [circle](circle.mdx) with radius $5$ on a graph. Inscribe a [regular polygon](regularPolygon.mdx) 
+Edit the starter code below to create a [circle](../reference/circle) with radius $5$ on a graph. Inscribe a [regular polygon](../reference/regularPolygon) 
 with any number of sides in this circle.
 
 Bonus Challenge: Have the user specify the number of sides.

--- a/packages/docs-nextra/pages/tutorials/intermediateTutorial/iT2-4-properties.mdx
+++ b/packages/docs-nextra/pages/tutorials/intermediateTutorial/iT2-4-properties.mdx
@@ -31,7 +31,7 @@ Doenet will still calculate the slope of $\overset{\longleftrightarrow}{PQ}$ and
 
 ### How to Find Properties
 
-The documentation page for each DoenetML component, as found in either the [Alphabetical Index](../../reference/doenetML_components/componentIndex.mdx) or the [Index by Component Type](../../reference/doenetML_components/componentTypes.mdx)  shows which attributes can be accessed as properties, as well as any additional properties that are available. It's always worth checking the documentation before you write code to do a basic computation; it's possible that Doenet is already doing that calculation for you!
+The documentation page for each DoenetML component, as found in either the [Alphabetical Index](../../reference/componentIndex) or the [Index by Component Type](../../reference/componentTypes)  shows which attributes can be accessed as properties, as well as any additional properties that are available. It's always worth checking the documentation before you write code to do a basic computation; it's possible that Doenet is already doing that calculation for you!
 
 As a basic example, the following code uses the $x$ and $y$-coordinates of points $P$ and $Q$ to compute the length of $\overline{PQ}$, via the distance formula. However, it turns out DoenetML already computes that distance; we can access it using the `length` property of the line segment.
 
@@ -62,7 +62,7 @@ Drag the endpoints around and double check that the distances are updated correc
 
 For those who have written in object-oriented languages such as Java, however, it could be helpful to mention: attributes and properties of DoenetML objects are analogous to setter and getter methods for objects. As mentioned above, the values of many attributes are directly accessible as properties.
 
-Throughout the rest of this tutorial, you'll sometimes see attribute names used as properties. We'll also occasionally point out particularly useful properties which are *not* also attributes. However, it's always worth reading the [reference section of this documentation](../../reference/doenetML_components/componentTypes.mdx) for a DoenetML tag to see what properties are available.
+Throughout the rest of this tutorial, you'll sometimes see attribute names used as properties. We'll also occasionally point out particularly useful properties which are *not* also attributes. However, it's always worth reading the [reference section of this documentation](../../reference/componentTypes) for a DoenetML tag to see what properties are available.
 
 ### Array Notation
 The `<mathList>` tag was briefly introduced in an earlier section. You might recall this is a space-separated list of `<math>` objects:

--- a/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-3-variables-numbers.mdx
+++ b/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-3-variables-numbers.mdx
@@ -21,7 +21,7 @@ In DoenetML, `<math>` denotes a mathematical expression that can be rendered on 
 
 Notice that the contents of a `<math>` tag are rendered in standard mathematical notation, just like `<m>` or `<me>` tags. The difference is that `<math>` can include arithmetic and algebraic operations. Unlike the `<m>` tag, common mathematical functions like "sqrt" and "sin" are recognized and rendered correctly.
 
-By default, DoenetML does not perform any simplifications on the contents of a `<math>` tag, but we can change that behavior using an attribute. Similar to HTML, attributes are used in DoenetML to provide additional information or configuration for an object. Attributes and their values are included in the opening tag when you define an object. (Most tags in DoenetML have many attributes you can use; they're all described in the [Component Examples](../../reference/doenetML_components/componentIndex.mdx) section of this documentation.)
+By default, DoenetML does not perform any simplifications on the contents of a `<math>` tag, but we can change that behavior using an attribute. Similar to HTML, attributes are used in DoenetML to provide additional information or configuration for an object. Attributes and their values are included in the opening tag when you define an object. (Most tags in DoenetML have many attributes you can use; they're all described in the [Component Examples](../../reference/componentIndex) section of this documentation.)
 
 In the following examples, we've added `simplify="true"` to each opening `<math>` tag. Notice how Doenet now simplifies each expression, by computing $1 - 2 = -1$ and $\sqrt{3^2 + 4^2} = 5$.
 

--- a/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-6-user-input.mdx
+++ b/packages/docs-nextra/pages/tutorials/introdTutorial/iT1-6-user-input.mdx
@@ -9,7 +9,7 @@ on the screen, e.g. by changing the coefficients of a polynomial. In other cases
 
 ### Introduction to `<mathInput>`
 
-The simplest way to have the user enter a number or mathematical expression is using a [`<mathInput>`](../../reference/doenetML_components/mathInput.mdx) tag. You can use the name attribute to give the `<mathInput>` a name and refer to it later; the contents of a `<mathInput>` object are essentially treated like a `<math>` object in later references.
+The simplest way to have the user enter a number or mathematical expression is using a [`<mathInput>`](../../reference/mathInput) tag. You can use the name attribute to give the `<mathInput>` a name and refer to it later; the contents of a `<mathInput>` object are essentially treated like a `<math>` object in later references.
 
 In the example below, enter a number in the input box, and press return.
 

--- a/packages/docs-nextra/pages/tutorials/quickStart/quickStart-1.mdx
+++ b/packages/docs-nextra/pages/tutorials/quickStart/quickStart-1.mdx
@@ -22,7 +22,7 @@ This tutorial covers a sample project in 5 parts; each part is about 5-10 minute
 </figure>
 
 <section><title>Creating a Doenet Account</title>  
-<p>Creating an account is fast and easy!  To begin, go to <ref uri="https://doenet.org">doenet.org</ref> and click the "Sign In" button in the corner.</p>
+<p>Creating an account is fast and easy!  To begin, go to <ref to="https://doenet.org">doenet.org</ref> and click the "Sign In" button in the corner.</p>
 
   <image source='doenet:cid=bafkreid56ohl5iy2laol2445zk2tmjs3kn6dia6atqt32es46uqgbxfp54' description='screenshot of Doenet homepage showing Sign in button' asfilename='OnPaste.20240602-122019.png' size="large" mimeType='image/png' />
   
@@ -40,7 +40,7 @@ This tutorial covers a sample project in 5 parts; each part is about 5-10 minute
 
 <section><title>Creating a Doenet Document</title>
 
-<p>Once you're logged in, go to the <ref uri="https://doenet.org">Doenet homepage</ref> and click Portfolio.</p>
+<p>Once you're logged in, go to the <ref to="https://doenet.org">Doenet homepage</ref> and click Portfolio.</p>
 
   <image source='doenet:cid=bafkreigwxqtfyzcxmj7zwgtdnde5c6xuwrb4hxe66ohb3chxapqqc55c6q' description='Doenet Portfolio Button' asfilename='Screenshot 2023-06-09 at 5.53.30 PM.png' width='600' aspectRatio="600/160" mimeType='image/png' />
 
@@ -57,7 +57,7 @@ This tutorial covers a sample project in 5 parts; each part is about 5-10 minute
     <li><p>Click "View" to see your document without the editor; click "Edit" to return to the side-by-side view.</p></li>
     <li><p>Click "Untitled Activity" to change the name of your document.</p></li>
     <li><p>Click "Documentation" to see documentation about individual Doenet tags.  (For now it makes more sense to keep working through this tutorial, and then using the documentation as a reference in the future.)</p></li>
-    <li><p>Click "Controls" to access the Activity Controls.  in particular, when you're ready to share your document with others, go to these controls and click "Public" next to "Visibility."  (See below.)  Once an activity is visible, other users can find it by searching on the "Community" tab on the <ref uri="https://doenet.org">Doenet homepage</ref>.  You can also search for your own activity from the Community tab, open the page, and then copy the URL of your public document from your web browser to share with others.</p></li> 
+    <li><p>Click "Controls" to access the Activity Controls.  in particular, when you're ready to share your document with others, go to these controls and click "Public" next to "Visibility."  (See below.)  Once an activity is visible, other users can find it by searching on the "Community" tab on the <ref to="https://doenet.org">Doenet homepage</ref>.  You can also search for your own activity from the Community tab, open the page, and then copy the URL of your public document from your web browser to share with others.</p></li> 
   </ul>
 <image source='doenet:cid=bafkreiew7b333mt3no7cbkzsnle7nqumwscg54pwkvgk76fzhbs5mjpaim' description='doenet make activity public' asfilename='Screenshot 2023-06-10 at 1.03.13 AM.png' width='400' aspectRatio="400/383"  mimeType='image/png' />  
 </section>


### PR DESCRIPTION
## Summary

Follow-up to #1219 (reference-page cleanup): swept the **non-reference** docs (`tutorials/`, `document_structure/`, `sandbox/`, `index.mdx`, `testExDoenetML.mdx`) for constructions made obsolete by the reference reorganization and by component API renames.

Every tag, attribute, enumerated attribute-value, and `$x.prop` reference in all 121 DoenetML example fences was validated against `packages/static-assets/src/generated/doenet-schema.json`; the DoenetML-dense teaching pages were also read manually for reformulated-but-still-valid usage. The docs were already in good shape — the changes below are the only issues found.

### Obsolete DoenetML construction
- `<ref uri="...">` → `<ref to="...">` in `quickStart-1.mdx` (3×). The `<ref>` target attribute was renamed `uri` → `to` (confirmed against `reference/ref.mdx`).

### Broken links to relocated/renamed reference pages
- Removed the obsolete `reference/doenetML_components/` path segment (pages now live directly under `reference/`) — `iT1-3-variables-numbers.mdx`, `iT1-6-user-input.mdx`, `iT2-4-properties.mdx`, `essentialConcepts.mdx`.
- Fixed malformed anchor links `componentTypes#xxxComponents.mdx` → `componentTypes#xxxComponents` (the `.mdx` after `#` broke the in-page anchor) — `essentialConcepts.mdx` (11 links).
- `sandbox/puzzles.mdx`: bare `line.mdx` / `point.mdx` / `circle.mdx` / `regularPolygon.mdx` → `../reference/<slug>` (they were resolving to nonexistent `sandbox/*` pages).

After the changes, all internal page links resolve and the schema scan is clean.

### Flagged, not fixed
- `index.mdx`: `[**Demos**](demos/)` points to a `pages/demos/` directory that does not exist. The surrounding text describes "demos of in-development DoenetML features," so this is likely a planned/removed section rather than a rename — left for a maintainer to decide.

No changeset: `@doenet/docs-nextra` is not a published package (consistent with #1219, which added none).

## Test plan
- [x] `npm run build -w packages/docs-nextra` succeeds
- [x] Spot-check the edited links resolve in the rendered site (tutorial → reference pages; component-type anchors scroll to the right section; sandbox puzzle links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)