### PR TITLE
docs: add worked examples for undocumented component features

### DIFF
--- a/packages/docs-nextra/pages/reference/booleanList.mdx
+++ b/packages/docs-nextra/pages/reference/booleanList.mdx
@@ -144,3 +144,19 @@ rendered by the `<booleanList>{:dn}`.
 
 The `numComponents` property renders the number of boolean values stored in the list.
 
+
+
+---
+
+### Property Example: numValues
+
+
+```doenet-example
+  <booleanList name="bList">0 1 0 1 1 1 0 0 1</booleanList>
+  <p><c>numValues</c> = $bList.numValues</p>
+```
+
+
+
+The `numValues` property is an alias for `numComponents`: it also renders the number of boolean values stored in the list (respecting the `maxNumber` cap, if set).
+

--- a/packages/docs-nextra/pages/reference/point.mdx
+++ b/packages/docs-nextra/pages/reference/point.mdx
@@ -416,14 +416,14 @@ In this example, only one indicator appears initially, since point A has the `hi
 ```doenet-example
 <graph size="small" displayXAxis="false" displayYAxis="false">
   <shortDescription>A graph of points drawn with different marker shapes</shortDescription>
-  <point coords="(-6,4)" markerStyle="circle"><label>circle</label></point>
-  <point coords="(-2,4)" markerStyle="square"><label>square</label></point>
-  <point coords="(2,4)" markerStyle="triangle"><label>triangle</label></point>
-  <point coords="(6,4)" markerStyle="diamond"><label>diamond</label></point>
-  <point coords="(-6,-4)" markerStyle="triangleDown"><label>triangleDown</label></point>
-  <point coords="(-2,-4)" markerStyle="triangleLeft"><label>triangleLeft</label></point>
-  <point coords="(2,-4)" markerStyle="cross"><label>cross</label></point>
-  <point coords="(6,-4)" markerStyle="plus"><label>plus</label></point>
+  <point coords="(-6,1)" markerStyle="circle"><label>circle</label></point>
+  <point coords="(-2,3)" markerStyle="square"><label>square</label></point>
+  <point coords="(2,5)" markerStyle="triangle"><label>triangle</label></point>
+  <point coords="(6,7)" markerStyle="diamond"><label>diamond</label></point>
+  <point coords="(-6,-7)" markerStyle="triangleDown"><label>triangleDown</label></point>
+  <point coords="(-2,-5)" markerStyle="triangleLeft"><label>triangleLeft</label></point>
+  <point coords="(2,-3)" markerStyle="cross"><label>cross</label></point>
+  <point coords="(6,-1)" markerStyle="plus"><label>plus</label></point>
 </graph>
 ```
 

--- a/packages/docs-nextra/pages/reference/point.mdx
+++ b/packages/docs-nextra/pages/reference/point.mdx
@@ -410,6 +410,71 @@ In this example, only one indicator appears initially, since point A has the `hi
 
 ---
 
+### Attribute Example: markerStyle
+
+
+```doenet-example
+<graph size="small" displayXAxis="false" displayYAxis="false">
+  <shortDescription>A graph of points drawn with different marker shapes</shortDescription>
+  <point coords="(-6,4)" markerStyle="circle"><label>circle</label></point>
+  <point coords="(-2,4)" markerStyle="square"><label>square</label></point>
+  <point coords="(2,4)" markerStyle="triangle"><label>triangle</label></point>
+  <point coords="(6,4)" markerStyle="diamond"><label>diamond</label></point>
+  <point coords="(-6,-4)" markerStyle="triangleDown"><label>triangleDown</label></point>
+  <point coords="(-2,-4)" markerStyle="triangleLeft"><label>triangleLeft</label></point>
+  <point coords="(2,-4)" markerStyle="cross"><label>cross</label></point>
+  <point coords="(6,-4)" markerStyle="plus"><label>plus</label></point>
+</graph>
+```
+
+
+
+The `markerStyle` attribute sets the shape of the marker drawn at the point. Valid values are `circle`, `square`, `triangle` (an alias for `triangleUp`), `triangleUp`, `triangleDown`, `triangleLeft`, `triangleRight`, `diamond`, `cross`, and `plus`. The default value is `circle`.
+
+
+
+---
+
+### Attribute Example: markerSize
+
+
+```doenet-example
+<graph size="small" displayXAxis="false" displayYAxis="false">
+  <shortDescription>A graph of points drawn at increasing marker sizes</shortDescription>
+  <point coords="(-6,0)" markerSize="3"><label>3</label></point>
+  <point coords="(-2,0)" markerSize="6"><label>6</label></point>
+  <point coords="(2,0)" markerSize="10"><label>10</label></point>
+  <point coords="(6,0)" markerSize="16"><label>16</label></point>
+</graph>
+```
+
+
+
+The `markerSize` attribute sets the size of the marker in pixels. The default value is `5`.
+
+
+
+---
+
+### Attribute Example: markerFilled
+
+
+```doenet-example
+<graph size="small" displayXAxis="false" displayYAxis="false">
+  <shortDescription>A graph of a filled marker and an open marker</shortDescription>
+  <point coords="(-3,0)" markerStyle="square"><label>filled</label></point>
+  <point coords="(3,0)" markerStyle="square" markerFilled="false"><label>open</label></point>
+</graph>
+```
+
+
+
+The `markerFilled` attribute determines whether the marker is drawn solid (`true`) or as an open outline (`false`). The default value is `true`. It has no effect when `markerStyle` is `cross` or `plus`, which have no interior.
+
+
+
+---
+
 ### Attribute Example: Standard graphical attributes
 
 

--- a/packages/docs-nextra/pages/reference/polygon.mdx
+++ b/packages/docs-nextra/pages/reference/polygon.mdx
@@ -238,16 +238,16 @@ The `preserveSimilarity` attribute preserves the shape of the `<polygon>{:dn}` u
 
 
 ```doenet-example
-<p>Dragging the highlighted vertex no longer rotates this rigid polygon.</p>
+<p>With rotation disabled, dragging the highlighted vertex resizes (dilates) this polygon instead of rotating it.</p>
 <graph size="small">
-  <shortDescription>A graph of a rigid polygon that cannot be rotated</shortDescription>
-  <polygon name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" rigid allowRotation="false"/>
+  <shortDescription>A graph of a similarity-preserving polygon that cannot be rotated</shortDescription>
+  <polygon name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" preserveSimilarity allowRotation="false"/>
 </graph>
 ```
 
 
 
-When the `<polygon>{:dn}` is `rigid` or preserves similarity, the `allowRotation` attribute controls whether dragging the highlighted vertex may rotate it. Set to `false` to forbid rotation. The default value is `true`.
+When the `<polygon>{:dn}` is `rigid` or preserves similarity, the `allowRotation` attribute controls whether dragging the highlighted vertex may rotate it. Set to `false` to forbid rotation. The default value is `true`. Because this polygon uses `preserveSimilarity` (which allows dilation), disabling rotation leaves the highlighted vertex able to uniformly scale the polygon.
 
 
 

--- a/packages/docs-nextra/pages/reference/polygon.mdx
+++ b/packages/docs-nextra/pages/reference/polygon.mdx
@@ -200,7 +200,7 @@ can still be repositioned on the `<graph>{:dn}`.
 
 
 ```doenet-example
-<p>Drag the interior to move the polygon, or drag a vertex to rotate it.</p>
+<p>Drag the highlighted vertex to rotate the polygon, or drag an edge to move it.</p>
 <graph size="small">
   <shortDescription>A graph of a rigid polygon</shortDescription>
   <polygon name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" rigid/>
@@ -209,7 +209,7 @@ can still be repositioned on the `<graph>{:dn}`.
 
 
 
-The `rigid` attribute locks the shape and size of the `<polygon>{:dn}`, treating it as a rigid body. Dragging the interior translates the polygon, and dragging a vertex rotates it about its centroid. The default value is `false`, in which case each vertex may be dragged independently.
+The `rigid` attribute locks the shape and size of the `<polygon>{:dn}`, treating it as a rigid body. Drag an edge to translate the polygon, and drag the highlighted vertex to rotate it about its centroid. Only that highlighted vertex (the rotation handle) is draggable; the other vertices are locked. A `filled` polygon can additionally be translated by dragging its interior. The default value is `false`, in which case each vertex may be dragged independently.
 
 
 
@@ -219,7 +219,7 @@ The `rigid` attribute locks the shape and size of the `<polygon>{:dn}`, treating
 
 
 ```doenet-example
-<p>Drag a vertex to rotate and resize the polygon, or drag the interior to move it.</p>
+<p>Drag the highlighted vertex to rotate and resize the polygon, or drag an edge to move it.</p>
 <graph size="small">
   <shortDescription>A graph of a polygon that preserves similarity</shortDescription>
   <polygon name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" preserveSimilarity/>
@@ -228,7 +228,7 @@ The `rigid` attribute locks the shape and size of the `<polygon>{:dn}`, treating
 
 
 
-The `preserveSimilarity` attribute preserves the shape of the `<polygon>{:dn}` up to similarity: dragging a vertex rotates and uniformly scales (dilates) the polygon, while dragging the interior translates it. Unlike `rigid`, the overall size may change. The default value is `false`.
+The `preserveSimilarity` attribute preserves the shape of the `<polygon>{:dn}` up to similarity: dragging the highlighted vertex rotates and uniformly scales (dilates) the polygon, while dragging an edge translates it. Unlike `rigid`, the overall size may change. The default value is `false`.
 
 
 
@@ -238,7 +238,7 @@ The `preserveSimilarity` attribute preserves the shape of the `<polygon>{:dn}` u
 
 
 ```doenet-example
-<p>Dragging a vertex no longer rotates this rigid polygon.</p>
+<p>Dragging the highlighted vertex no longer rotates this rigid polygon.</p>
 <graph size="small">
   <shortDescription>A graph of a rigid polygon that cannot be rotated</shortDescription>
   <polygon name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" rigid allowRotation="false"/>
@@ -247,7 +247,7 @@ The `preserveSimilarity` attribute preserves the shape of the `<polygon>{:dn}` u
 
 
 
-When the `<polygon>{:dn}` is `rigid` or preserves similarity, the `allowRotation` attribute controls whether dragging a vertex may rotate it. Set to `false` to forbid rotation. The default value is `true`.
+When the `<polygon>{:dn}` is `rigid` or preserves similarity, the `allowRotation` attribute controls whether dragging the highlighted vertex may rotate it. Set to `false` to forbid rotation. The default value is `true`.
 
 
 
@@ -257,7 +257,7 @@ When the `<polygon>{:dn}` is `rigid` or preserves similarity, the `allowRotation
 
 
 ```doenet-example
-<p>Dragging the interior no longer moves this rigid polygon, but a vertex still rotates it.</p>
+<p>Dragging an edge no longer moves this rigid polygon, but the highlighted vertex still rotates it.</p>
 <graph size="small">
   <shortDescription>A graph of a rigid polygon that cannot be translated</shortDescription>
   <polygon name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" rigid allowTranslation="false"/>
@@ -266,7 +266,7 @@ When the `<polygon>{:dn}` is `rigid` or preserves similarity, the `allowRotation
 
 
 
-When the `<polygon>{:dn}` is `rigid` or preserves similarity, the `allowTranslation` attribute controls whether dragging the interior may move it. Set to `false` to forbid translation. The default value is `true`.
+When the `<polygon>{:dn}` is `rigid` or preserves similarity, the `allowTranslation` attribute controls whether dragging an edge (or the interior of a `filled` polygon) may move it. Set to `false` to forbid translation. The default value is `true`.
 
 
 
@@ -285,7 +285,7 @@ When the `<polygon>{:dn}` is `rigid` or preserves similarity, the `allowTranslat
 
 
 
-When the `<polygon>{:dn}` preserves similarity, the `allowDilation` attribute controls whether dragging a vertex may uniformly scale it. The default value is `true`; combining `preserveSimilarity` with `allowDilation="false"` is equivalent to `rigid`. (Setting `rigid` always forces dilation off.)
+When the `<polygon>{:dn}` preserves similarity, the `allowDilation` attribute controls whether dragging the highlighted vertex may uniformly scale it. The default value is `true`; combining `preserveSimilarity` with `allowDilation="false"` is equivalent to `rigid`. (Setting `rigid` always forces dilation off.)
 
 
 
@@ -319,7 +319,7 @@ Reflection is not currently triggered by a built-in drag or click gesture; it is
 
 
 ```doenet-example
-<p>Drag a vertex to rotate the polygon about its second vertex.</p>
+<p>Drag the highlighted vertex to rotate the polygon about its second vertex.</p>
 <graph size="small">
   <shortDescription>A graph of a rigid polygon rotating about a chosen vertex</shortDescription>
   <polygon name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" rigid rotateAround="vertex" rotationVertex="2"/>

--- a/packages/docs-nextra/pages/reference/polygon.mdx
+++ b/packages/docs-nextra/pages/reference/polygon.mdx
@@ -196,6 +196,139 @@ can still be repositioned on the `<graph>{:dn}`.
 
 ---
 
+### Attribute Example: rigid
+
+
+```doenet-example
+<p>Drag the interior to move the polygon, or drag a vertex to rotate it.</p>
+<graph size="small">
+  <shortDescription>A graph of a rigid polygon</shortDescription>
+  <polygon name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" rigid/>
+</graph>
+```
+
+
+
+The `rigid` attribute locks the shape and size of the `<polygon>{:dn}`, treating it as a rigid body. Dragging the interior translates the polygon, and dragging a vertex rotates it about its centroid. The default value is `false`, in which case each vertex may be dragged independently.
+
+
+
+---
+
+### Attribute Example: preserveSimilarity
+
+
+```doenet-example
+<p>Drag a vertex to rotate and resize the polygon, or drag the interior to move it.</p>
+<graph size="small">
+  <shortDescription>A graph of a polygon that preserves similarity</shortDescription>
+  <polygon name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" preserveSimilarity/>
+</graph>
+```
+
+
+
+The `preserveSimilarity` attribute preserves the shape of the `<polygon>{:dn}` up to similarity: dragging a vertex rotates and uniformly scales (dilates) the polygon, while dragging the interior translates it. Unlike `rigid`, the overall size may change. The default value is `false`.
+
+
+
+---
+
+### Attribute Example: allowRotation
+
+
+```doenet-example
+<p>Dragging a vertex no longer rotates this rigid polygon.</p>
+<graph size="small">
+  <shortDescription>A graph of a rigid polygon that cannot be rotated</shortDescription>
+  <polygon name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" rigid allowRotation="false"/>
+</graph>
+```
+
+
+
+When the `<polygon>{:dn}` is `rigid` or preserves similarity, the `allowRotation` attribute controls whether dragging a vertex may rotate it. Set to `false` to forbid rotation. The default value is `true`.
+
+
+
+---
+
+### Attribute Example: allowTranslation
+
+
+```doenet-example
+<p>Dragging the interior no longer moves this rigid polygon, but a vertex still rotates it.</p>
+<graph size="small">
+  <shortDescription>A graph of a rigid polygon that cannot be translated</shortDescription>
+  <polygon name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" rigid allowTranslation="false"/>
+</graph>
+```
+
+
+
+When the `<polygon>{:dn}` is `rigid` or preserves similarity, the `allowTranslation` attribute controls whether dragging the interior may move it. Set to `false` to forbid translation. The default value is `true`.
+
+
+
+---
+
+### Attribute Example: allowDilation
+
+
+```doenet-example
+<p>This polygon preserves similarity but may not be resized, so it behaves rigidly.</p>
+<graph size="small">
+  <shortDescription>A graph of a similarity-preserving polygon that cannot be dilated</shortDescription>
+  <polygon name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" preserveSimilarity allowDilation="false"/>
+</graph>
+```
+
+
+
+When the `<polygon>{:dn}` preserves similarity, the `allowDilation` attribute controls whether dragging a vertex may uniformly scale it. The default value is `true`; combining `preserveSimilarity` with `allowDilation="false"` is equivalent to `rigid`. (Setting `rigid` always forces dilation off.)
+
+
+
+---
+
+### Attribute Example: allowReflection
+
+
+```doenet-example
+<p>Try to flip the polygon by dragging a vertex across the others.</p>
+<graph size="small">
+  <shortDescription>A graph of a polygon that cannot be reflected</shortDescription>
+  <polygon name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" allowReflection="false"/>
+</graph>
+```
+
+
+
+The `allowReflection` attribute controls whether the `<polygon>{:dn}` may be flipped (reflected) while dragging. Set to `false` to prevent reflection. The default value is `true`.
+
+
+
+---
+
+### Attribute Example: rotateAround
+
+
+```doenet-example
+<p>Drag a vertex to rotate the polygon about its second vertex.</p>
+<graph size="small">
+  <shortDescription>A graph of a rigid polygon rotating about a chosen vertex</shortDescription>
+  <polygon name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" rigid rotateAround="vertex" rotationVertex="2"/>
+</graph>
+```
+
+
+
+When the `<polygon>{:dn}` is `rigid` or preserves similarity, the `rotateAround` attribute sets the center of rotation. Valid values are `centroid` (the default), `vertex` (the vertex given by `rotationVertex`), and `point` (the explicit point given by `rotationCenter`).
+
+
+
+---
+
 ### Attribute Example: Standard graphical attributes
 
 

--- a/packages/docs-nextra/pages/reference/polygon.mdx
+++ b/packages/docs-nextra/pages/reference/polygon.mdx
@@ -295,16 +295,21 @@ When the `<polygon>{:dn}` preserves similarity, the `allowDilation` attribute co
 
 
 ```doenet-example
-<p>Try to flip the polygon by dragging a vertex across the others.</p>
+<p>Note: click either polygon to reflect it.</p>
+<callAction target="$poly1" actionName="reflectPolygon" triggerWhenObjectsClicked="$poly1"/>
+<callAction target="$poly2" actionName="reflectPolygon" triggerWhenObjectsClicked="$poly2"/>
 <graph size="small">
-  <shortDescription>A graph of a polygon that cannot be reflected</shortDescription>
-  <polygon name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" allowReflection="false"/>
+  <shortDescription>A graph of two polygons, one of which can be reflected by clicking</shortDescription>
+  <polygon name="poly1" vertices="(-8,2) (-6,-3) (-1,4)"/>
+  <polygon name="poly2" vertices="(2,2) (4,-3) (9,4)" styleNumber="2" allowReflection="false"/>
 </graph>
 ```
 
 
 
-The `allowReflection` attribute controls whether the `<polygon>{:dn}` may be flipped (reflected) while dragging. Set to `false` to prevent reflection. The default value is `true`.
+The `allowReflection` attribute controls whether the `<polygon>{:dn}` may be flipped (reflected) across a vertical line through its centroid. The default value is `true`.
+
+Reflection is not currently triggered by a built-in drag or click gesture; it is performed by the `reflectPolygon` action. In this example that action is invoked with [`<callAction>{:dn}`](callAction.mdx) whenever a polygon is clicked. The first polygon reflects on each click, while the second has `allowReflection="false"`, so clicking it has no effect.
 
 
 

--- a/packages/docs-nextra/pages/reference/polyline.mdx
+++ b/packages/docs-nextra/pages/reference/polyline.mdx
@@ -150,7 +150,7 @@ polyline as a whole can still be repositioned on the `<graph>{:dn}`.
 
 
 ```doenet-example
-<p>Drag the polyline to move it, or drag a vertex to rotate it.</p>
+<p>Drag the highlighted vertex to rotate the polyline, or drag an edge to move it.</p>
 <graph size="small">
   <shortDescription>A graph of a rigid polyline</shortDescription>
   <polyline name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" rigid/>
@@ -159,7 +159,7 @@ polyline as a whole can still be repositioned on the `<graph>{:dn}`.
 
 
 
-The `rigid` attribute locks the shape and size of the `<polyline>{:dn}`, treating it as a rigid body. Dragging the polyline translates it, and dragging a vertex rotates it about its centroid. The default value is `false`, in which case each vertex may be dragged independently.
+The `rigid` attribute locks the shape and size of the `<polyline>{:dn}`, treating it as a rigid body. Drag an edge to translate the polyline, and drag the highlighted vertex to rotate it about its centroid. Only that highlighted vertex (the rotation handle) is draggable; the other vertices are locked. The default value is `false`, in which case each vertex may be dragged independently.
 
 
 
@@ -169,7 +169,7 @@ The `rigid` attribute locks the shape and size of the `<polyline>{:dn}`, treatin
 
 
 ```doenet-example
-<p>Drag a vertex to rotate and resize the polyline, or drag it to move it.</p>
+<p>Drag the highlighted vertex to rotate and resize the polyline, or drag an edge to move it.</p>
 <graph size="small">
   <shortDescription>A graph of a polyline that preserves similarity</shortDescription>
   <polyline name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" preserveSimilarity/>
@@ -178,7 +178,7 @@ The `rigid` attribute locks the shape and size of the `<polyline>{:dn}`, treatin
 
 
 
-The `preserveSimilarity` attribute preserves the shape of the `<polyline>{:dn}` up to similarity: dragging a vertex rotates and uniformly scales (dilates) the polyline, while dragging it translates it. Unlike `rigid`, the overall size may change. The default value is `false`.
+The `preserveSimilarity` attribute preserves the shape of the `<polyline>{:dn}` up to similarity: dragging the highlighted vertex rotates and uniformly scales (dilates) the polyline, while dragging an edge translates it. Unlike `rigid`, the overall size may change. The default value is `false`.
 
 
 
@@ -188,7 +188,7 @@ The `preserveSimilarity` attribute preserves the shape of the `<polyline>{:dn}` 
 
 
 ```doenet-example
-<p>Dragging a vertex no longer rotates this rigid polyline.</p>
+<p>Dragging the highlighted vertex no longer rotates this rigid polyline.</p>
 <graph size="small">
   <shortDescription>A graph of a rigid polyline that cannot be rotated</shortDescription>
   <polyline name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" rigid allowRotation="false"/>
@@ -197,7 +197,7 @@ The `preserveSimilarity` attribute preserves the shape of the `<polyline>{:dn}` 
 
 
 
-When the `<polyline>{:dn}` is `rigid` or preserves similarity, the `allowRotation` attribute controls whether dragging a vertex may rotate it. Set to `false` to forbid rotation. The default value is `true`.
+When the `<polyline>{:dn}` is `rigid` or preserves similarity, the `allowRotation` attribute controls whether dragging the highlighted vertex may rotate it. Set to `false` to forbid rotation. The default value is `true`.
 
 
 
@@ -207,7 +207,7 @@ When the `<polyline>{:dn}` is `rigid` or preserves similarity, the `allowRotatio
 
 
 ```doenet-example
-<p>Dragging this rigid polyline no longer moves it, but a vertex still rotates it.</p>
+<p>Dragging an edge no longer moves this rigid polyline, but the highlighted vertex still rotates it.</p>
 <graph size="small">
   <shortDescription>A graph of a rigid polyline that cannot be translated</shortDescription>
   <polyline name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" rigid allowTranslation="false"/>
@@ -216,7 +216,7 @@ When the `<polyline>{:dn}` is `rigid` or preserves similarity, the `allowRotatio
 
 
 
-When the `<polyline>{:dn}` is `rigid` or preserves similarity, the `allowTranslation` attribute controls whether dragging it may move it. Set to `false` to forbid translation. The default value is `true`.
+When the `<polyline>{:dn}` is `rigid` or preserves similarity, the `allowTranslation` attribute controls whether dragging an edge may move it. Set to `false` to forbid translation. The default value is `true`.
 
 
 
@@ -235,7 +235,7 @@ When the `<polyline>{:dn}` is `rigid` or preserves similarity, the `allowTransla
 
 
 
-When the `<polyline>{:dn}` preserves similarity, the `allowDilation` attribute controls whether dragging a vertex may uniformly scale it. The default value is `true`; combining `preserveSimilarity` with `allowDilation="false"` is equivalent to `rigid`. (Setting `rigid` always forces dilation off.)
+When the `<polyline>{:dn}` preserves similarity, the `allowDilation` attribute controls whether dragging the highlighted vertex may uniformly scale it. The default value is `true`; combining `preserveSimilarity` with `allowDilation="false"` is equivalent to `rigid`. (Setting `rigid` always forces dilation off.)
 
 
 
@@ -269,7 +269,7 @@ Reflection is not currently triggered by a built-in drag or click gesture; it is
 
 
 ```doenet-example
-<p>Drag a vertex to rotate the polyline about its second vertex.</p>
+<p>Drag the highlighted vertex to rotate the polyline about its second vertex.</p>
 <graph size="small">
   <shortDescription>A graph of a rigid polyline rotating about a chosen vertex</shortDescription>
   <polyline name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" rigid rotateAround="vertex" rotationVertex="2"/>

--- a/packages/docs-nextra/pages/reference/polyline.mdx
+++ b/packages/docs-nextra/pages/reference/polyline.mdx
@@ -245,16 +245,21 @@ When the `<polyline>{:dn}` preserves similarity, the `allowDilation` attribute c
 
 
 ```doenet-example
-<p>Try to flip the polyline by dragging a vertex across the others.</p>
+<p>Note: click either polyline to reflect it.</p>
+<callAction target="$poly1" actionName="reflectPolyline" triggerWhenObjectsClicked="$poly1"/>
+<callAction target="$poly2" actionName="reflectPolyline" triggerWhenObjectsClicked="$poly2"/>
 <graph size="small">
-  <shortDescription>A graph of a polyline that cannot be reflected</shortDescription>
-  <polyline name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" allowReflection="false"/>
+  <shortDescription>A graph of two polylines, one of which can be reflected by clicking</shortDescription>
+  <polyline name="poly1" vertices="(-8,2) (-6,-3) (-1,4)"/>
+  <polyline name="poly2" vertices="(2,2) (4,-3) (9,4)" styleNumber="2" allowReflection="false"/>
 </graph>
 ```
 
 
 
-The `allowReflection` attribute controls whether the `<polyline>{:dn}` may be flipped (reflected) while dragging. Set to `false` to prevent reflection. The default value is `true`.
+The `allowReflection` attribute controls whether the `<polyline>{:dn}` may be flipped (reflected) across a vertical line through its centroid. The default value is `true`.
+
+Reflection is not currently triggered by a built-in drag or click gesture; it is performed by the `reflectPolyline` action. In this example that action is invoked with [`<callAction>{:dn}`](callAction.mdx) whenever a polyline is clicked. The first polyline reflects on each click, while the second has `allowReflection="false"`, so clicking it has no effect.
 
 
 

--- a/packages/docs-nextra/pages/reference/polyline.mdx
+++ b/packages/docs-nextra/pages/reference/polyline.mdx
@@ -146,6 +146,139 @@ polyline as a whole can still be repositioned on the `<graph>{:dn}`.
 
 ---
 
+### Attribute Example: rigid
+
+
+```doenet-example
+<p>Drag the polyline to move it, or drag a vertex to rotate it.</p>
+<graph size="small">
+  <shortDescription>A graph of a rigid polyline</shortDescription>
+  <polyline name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" rigid/>
+</graph>
+```
+
+
+
+The `rigid` attribute locks the shape and size of the `<polyline>{:dn}`, treating it as a rigid body. Dragging the polyline translates it, and dragging a vertex rotates it about its centroid. The default value is `false`, in which case each vertex may be dragged independently.
+
+
+
+---
+
+### Attribute Example: preserveSimilarity
+
+
+```doenet-example
+<p>Drag a vertex to rotate and resize the polyline, or drag it to move it.</p>
+<graph size="small">
+  <shortDescription>A graph of a polyline that preserves similarity</shortDescription>
+  <polyline name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" preserveSimilarity/>
+</graph>
+```
+
+
+
+The `preserveSimilarity` attribute preserves the shape of the `<polyline>{:dn}` up to similarity: dragging a vertex rotates and uniformly scales (dilates) the polyline, while dragging it translates it. Unlike `rigid`, the overall size may change. The default value is `false`.
+
+
+
+---
+
+### Attribute Example: allowRotation
+
+
+```doenet-example
+<p>Dragging a vertex no longer rotates this rigid polyline.</p>
+<graph size="small">
+  <shortDescription>A graph of a rigid polyline that cannot be rotated</shortDescription>
+  <polyline name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" rigid allowRotation="false"/>
+</graph>
+```
+
+
+
+When the `<polyline>{:dn}` is `rigid` or preserves similarity, the `allowRotation` attribute controls whether dragging a vertex may rotate it. Set to `false` to forbid rotation. The default value is `true`.
+
+
+
+---
+
+### Attribute Example: allowTranslation
+
+
+```doenet-example
+<p>Dragging this rigid polyline no longer moves it, but a vertex still rotates it.</p>
+<graph size="small">
+  <shortDescription>A graph of a rigid polyline that cannot be translated</shortDescription>
+  <polyline name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" rigid allowTranslation="false"/>
+</graph>
+```
+
+
+
+When the `<polyline>{:dn}` is `rigid` or preserves similarity, the `allowTranslation` attribute controls whether dragging it may move it. Set to `false` to forbid translation. The default value is `true`.
+
+
+
+---
+
+### Attribute Example: allowDilation
+
+
+```doenet-example
+<p>This polyline preserves similarity but may not be resized, so it behaves rigidly.</p>
+<graph size="small">
+  <shortDescription>A graph of a similarity-preserving polyline that cannot be dilated</shortDescription>
+  <polyline name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" preserveSimilarity allowDilation="false"/>
+</graph>
+```
+
+
+
+When the `<polyline>{:dn}` preserves similarity, the `allowDilation` attribute controls whether dragging a vertex may uniformly scale it. The default value is `true`; combining `preserveSimilarity` with `allowDilation="false"` is equivalent to `rigid`. (Setting `rigid` always forces dilation off.)
+
+
+
+---
+
+### Attribute Example: allowReflection
+
+
+```doenet-example
+<p>Try to flip the polyline by dragging a vertex across the others.</p>
+<graph size="small">
+  <shortDescription>A graph of a polyline that cannot be reflected</shortDescription>
+  <polyline name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" allowReflection="false"/>
+</graph>
+```
+
+
+
+The `allowReflection` attribute controls whether the `<polyline>{:dn}` may be flipped (reflected) while dragging. Set to `false` to prevent reflection. The default value is `true`.
+
+
+
+---
+
+### Attribute Example: rotateAround
+
+
+```doenet-example
+<p>Drag a vertex to rotate the polyline about its second vertex.</p>
+<graph size="small">
+  <shortDescription>A graph of a rigid polyline rotating about a chosen vertex</shortDescription>
+  <polyline name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" rigid rotateAround="vertex" rotationVertex="2"/>
+</graph>
+```
+
+
+
+When the `<polyline>{:dn}` is `rigid` or preserves similarity, the `rotateAround` attribute sets the center of rotation. Valid values are `centroid` (the default), `vertex` (the vertex given by `rotationVertex`), and `point` (the explicit point given by `rotationCenter`).
+
+
+
+---
+
 ### Attribute Example: Standard graphical attributes
 
 

--- a/packages/docs-nextra/pages/reference/polyline.mdx
+++ b/packages/docs-nextra/pages/reference/polyline.mdx
@@ -188,16 +188,16 @@ The `preserveSimilarity` attribute preserves the shape of the `<polyline>{:dn}` 
 
 
 ```doenet-example
-<p>Dragging the highlighted vertex no longer rotates this rigid polyline.</p>
+<p>With rotation disabled, dragging the highlighted vertex resizes (dilates) this polyline instead of rotating it.</p>
 <graph size="small">
-  <shortDescription>A graph of a rigid polyline that cannot be rotated</shortDescription>
-  <polyline name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" rigid allowRotation="false"/>
+  <shortDescription>A graph of a similarity-preserving polyline that cannot be rotated</shortDescription>
+  <polyline name="poly" vertices="(-6,2) (-3,-2) (3,5) (-1,4)" preserveSimilarity allowRotation="false"/>
 </graph>
 ```
 
 
 
-When the `<polyline>{:dn}` is `rigid` or preserves similarity, the `allowRotation` attribute controls whether dragging the highlighted vertex may rotate it. Set to `false` to forbid rotation. The default value is `true`.
+When the `<polyline>{:dn}` is `rigid` or preserves similarity, the `allowRotation` attribute controls whether dragging the highlighted vertex may rotate it. Set to `false` to forbid rotation. The default value is `true`. Because this polyline uses `preserveSimilarity` (which allows dilation), disabling rotation leaves the highlighted vertex able to uniformly scale the polyline.
 
 
 

--- a/packages/docs-nextra/pages/reference/select.mdx
+++ b/packages/docs-nextra/pages/reference/select.mdx
@@ -258,6 +258,29 @@ Different page variants (which can be accessed from the left-side menu) will hav
 
 ## Attribute Examples
 
+### Attribute Example: numToSelect
+
+
+```doenet-editor-horiz
+<select name="s" type="text" numToSelect="3">
+  red orange yellow green blue indigo violet
+</select>
+
+<p>Selected: $s</p>
+<p>First selected: $s[1]</p>
+```
+
+
+
+The `numToSelect` attribute sets how many values are chosen from the options. The default value is `1`. When more than one is selected, the individual selections are accessed by index (for example, `$s[1]`). Without `withReplacement`, each option can be chosen at most once.
+
+Select a new page variant from the pulldown menu at the top of the 
+editor to see different variants of the document.
+
+
+
+---
+
 ### Attribute Example: withReplacement
 
 

--- a/packages/docs-nextra/pages/reference/ul.mdx
+++ b/packages/docs-nextra/pages/reference/ul.mdx
@@ -59,3 +59,67 @@ components (list items) as children.
 `<ul>{:dn}` components can only take `<li>{:dn}` children. Individual `<li>{:dn}` children may themselves contain graphs, problems, paragraphs, and other content.
 
 
+
+## Attribute Examples
+
+### Attribute Example: marker
+
+
+```doenet-editor-horiz
+<p>Default (disc):</p>
+<ul>
+  <li>coffee</li>
+  <li>cheese</li>
+</ul>
+
+<p><attr>marker</attr> = circle:</p>
+<ul marker="circle">
+  <li>coffee</li>
+  <li>cheese</li>
+</ul>
+
+<p><attr>marker</attr> = square:</p>
+<ul marker="square">
+  <li>coffee</li>
+  <li>cheese</li>
+</ul>
+```
+
+
+
+The `marker` attribute sets the bullet style for the list items. For an unordered list the valid values are `disc`, `circle`, and `square`; any other value is ignored and the level-based default is used instead. If unspecified, the bullet is determined by the list's `level`.
+
+
+
+---
+
+### Attribute Example: level
+
+
+```doenet-editor-horiz
+<p><attr>level</attr> = 1 (disc):</p>
+<ul level="1">
+  <li>coffee</li>
+  <li>cheese</li>
+</ul>
+
+<p><attr>level</attr> = 2 (circle):</p>
+<ul level="2">
+  <li>coffee</li>
+  <li>cheese</li>
+</ul>
+
+<p><attr>level</attr> = 3 (square):</p>
+<ul level="3">
+  <li>coffee</li>
+  <li>cheese</li>
+</ul>
+```
+
+
+
+The `level` attribute sets the (1-based) nesting level of the list, which determines the default bullet: level 1 renders a disc, level 2 a circle, and level 3 a square, cycling for deeper levels. When a `<ul>{:dn}` is nested inside another list, its level is computed automatically, so this attribute is typically only set to override that default.
+
+The `label` and `cols` attributes are also accepted in the schema, but they are not yet used when rendering the list.
+
+

--- a/packages/docs-nextra/pages/reference/ul.mdx
+++ b/packages/docs-nextra/pages/reference/ul.mdx
@@ -120,6 +120,4 @@ The `marker` attribute sets the bullet style for the list items. For an unordere
 
 The `level` attribute sets the (1-based) nesting level of the list, which determines the default bullet: level 1 renders a disc, level 2 a circle, and level 3 a square, cycling for deeper levels. When a `<ul>{:dn}` is nested inside another list, its level is computed automatically, so this attribute is typically only set to override that default.
 
-The `label` and `cols` attributes are also accepted in the schema, but they are not yet used when rendering the list.
-
 


### PR DESCRIPTION
## Summary

Follow-up to #1219. Closes #1220.

Adds worked `### Attribute Example:` / `### Property Example:` subsections for attributes/properties that exist in the schema (and so appear in the auto-generated `<AttrPropDisplay>` tables) but had no example or explanatory prose. Follows the page structure established in #1219.

- **`point`** — `markerStyle` (all valid shapes), `markerSize`, `markerFilled`.
- **`polygon`** / **`polyline`** — rigid-body / transformation attributes: `rigid`, `preserveSimilarity`, `allowRotation`, `allowTranslation`, `allowDilation`, `allowReflection`, `rotateAround`.
- **`ul`** — new `## Attribute Examples` section with `marker` (disc/circle/square) and `level`.
- **`booleanList`** — `numValues` property (alias of `numComponents`).
- **`select`** — `numToSelect` (`withReplacement` already gained an example in #1219).

### Notes / decisions
- Behavior for the rigid-body attributes was taken from `Polyline.js` and its worker tests rather than guessed: `rigid` forces `allowDilation` off and supersedes the `allow*` flags; `preserveSimilarity allowDilation="false"` is equivalent to `rigid`; `rotateAround` values are `centroid` / `vertex` / `point`. These relationships are stated in the prose.
- **`allowReflection`**: reflection is *not* a drag/click gesture — it is only reachable via the `reflectPolygon` / `reflectPolyline` action, which reflects across a vertical line through the centroid. Both `allowReflection` examples trigger that action with `<callAction>` on click (and link to `callAction`), and note there is no built-in flip gesture yet. Filed #1223 to design a discoverable flip UI.
- **`ul` `label` / `cols`**: these are listed in #1220 but the renderer ignores both, so rather than document them they are being hidden from the schema entirely in #1227. This PR therefore documents only the functional `marker` and `level` attributes.

## Test plan
- [x] `npm run build` in `packages/docs-nextra` succeeds (exit 0); MDX errors abort the build, so all reference pages compiled and prerendered.
- [ ] Interactive drag behavior of the `polygon`/`polyline` examples (rotation/dilation about the highlighted vertex, edge-drag translation, click-to-reflect) was verified against source and existing tests, **not** by manual interaction in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)