### PR TITLE
chore: enforce Claude Code footer and clean PR titles via gh hooks

### DIFF
--- a/.claude/hooks/gh-footer-check.sh
+++ b/.claude/hooks/gh-footer-check.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Enforce the Claude Code footer on agent-authored GitHub text.
+# See AGENTS.md → "Agent-Authored GitHub Activity": gh issue/pr create &
+# comment bodies, and gh api posts to /comments or /replies, must end with
+# the footer so reviewers can see the text was generated.
+#
+# Reads the PreToolUse hook JSON on stdin, inspects the Bash command, and
+# exits 2 (blocking the tool call) when a matching gh command lacks the footer.
+set -uo pipefail
+
+FOOTER_URL="https://claude.com/claude-code"
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null)
+[ -n "$cmd" ] || exit 0
+
+# Is this one of the gh commands that posts agent-authored text?
+is_posting=0
+case "$cmd" in
+    *"gh issue create"* | *"gh issue comment"* | *"gh pr create"* | *"gh pr comment"*)
+        is_posting=1
+        ;;
+esac
+# gh api write (not a read) to a comment/reply endpoint. A write supplies a
+# body via a field flag (-f/-F/--field/--raw-field/--input) or an explicit
+# POST method; a plain GET to /comments (listing comments) must NOT be gated.
+if printf '%s' "$cmd" | grep -q 'gh api' &&
+    printf '%s' "$cmd" | grep -qE '/(comments|replies)([/?[:space:]"'\'']|$)' &&
+    printf '%s' "$cmd" | grep -qE '([[:space:]](-f|-F|--field|--raw-field|--input)[ =]|(-X[ ]*|--method[ =])POST)'; then
+    is_posting=1
+fi
+
+[ "$is_posting" -eq 1 ] || exit 0
+
+# 1) Footer present inline (covers --body, -f body=, and heredocs).
+case "$cmd" in
+*"$FOOTER_URL"*) exit 0 ;;
+esac
+
+# 2) Body supplied from a file via --body-file/-F (issue & pr only; gh api
+#    uses --input and is not checked here). Inspect the referenced file.
+if ! printf '%s' "$cmd" | grep -q 'gh api'; then
+    paths=$(printf '%s' "$cmd" |
+        grep -oE -- '(--body-file[ =]|-F[ =])[^[:space:]]+' |
+        sed -E 's/^(--body-file|-F)[ =]//')
+    for p in $paths; do
+        p=${p%\"}
+        p=${p#\"}
+        p=${p%\'}
+        p=${p#\'}
+        if [ -f "$p" ] && grep -qF "$FOOTER_URL" "$p" 2>/dev/null; then
+            exit 0
+        fi
+    done
+fi
+
+cat >&2 <<EOF
+Blocked: Claude Code footer missing from this gh command.
+
+AGENTS.md ("Agent-Authored GitHub Activity") requires that gh issue/pr
+create & comment bodies, and gh api posts to /comments or /replies, end with:
+
+🤖 Generated with [Claude Code]($FOOTER_URL)
+
+Add that line to the --body / -f body= / --body-file content and re-run.
+EOF
+exit 2

--- a/.claude/hooks/gh-pr-title-check.sh
+++ b/.claude/hooks/gh-pr-title-check.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Block an issue/PR number in a pull-request title.
+# See AGENTS.md: don't put the issue number in the PR title. Squash-merge
+# appends " (#<PR-number>)" automatically, so "fix: ... (#1179)" becomes
+# "fix: ... (#1179) (#1182)" after merge. Reference issues from the PR body.
+#
+# Reads the PreToolUse hook JSON on stdin and inspects the Bash command. Only
+# the --title value is examined (never the body, which legitimately references
+# issues, e.g. "Closes #1179"). Exits 2 (blocking the tool call) on a match.
+set -uo pipefail
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null)
+[ -n "$cmd" ] || exit 0
+
+# Only pr create / pr edit set a title.
+case "$cmd" in
+*"gh pr create"* | *"gh pr edit"*) ;;
+*) exit 0 ;;
+esac
+
+# Extract the --title / -t / --title= value. A title is always inline on the
+# command line (there is no --title-file), so it can be read from the command.
+title=$(printf '%s' "$cmd" |
+    grep -oE -- '(--title[ =]|-t[ =])("[^"]*"|'\''[^'\'']*'\''|[^[:space:]]+)' |
+    head -n1 |
+    sed -E 's/^(--title|-t)[ =]//')
+title=${title%\"}
+title=${title#\"}
+title=${title%\'}
+title=${title#\'}
+[ -n "$title" ] || exit 0
+
+if printf '%s' "$title" | grep -qE '#[0-9]+'; then
+    cat >&2 <<EOF
+Blocked: PR title contains an issue/PR number.
+
+AGENTS.md: don't put the issue number in the PR title. Squash-merge appends
+" (#<PR-number>)" automatically, so "... (#1179)" becomes "... (#1179) (#1182)"
+after merge. Drop the "#<number>" from --title and reference the issue from the
+PR body instead (e.g. "Closes #1179.").
+EOF
+    exit 2
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,11 @@
                         "type": "command",
                         "command": "h=\"$([ -n \"${CLAUDE_PROJECT_DIR:-}\" ] && echo \"$CLAUDE_PROJECT_DIR\" || git rev-parse --show-toplevel 2>/dev/null || echo \"$PWD\")/.claude/hooks/pre-commit-prettier.sh\"; [ -x \"$h\" ] || exit 0; bash \"$h\"",
                         "timeout": 30
+                    },
+                    {
+                        "type": "command",
+                        "command": "h=\"$([ -n \"${CLAUDE_PROJECT_DIR:-}\" ] && echo \"$CLAUDE_PROJECT_DIR\" || git rev-parse --show-toplevel 2>/dev/null || echo \"$PWD\")/.claude/hooks/gh-footer-check.sh\"; [ -x \"$h\" ] || exit 0; bash \"$h\"",
+                        "timeout": 10
                     }
                 ]
             }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,11 @@
                         "type": "command",
                         "command": "h=\"$([ -n \"${CLAUDE_PROJECT_DIR:-}\" ] && echo \"$CLAUDE_PROJECT_DIR\" || git rev-parse --show-toplevel 2>/dev/null || echo \"$PWD\")/.claude/hooks/gh-footer-check.sh\"; [ -x \"$h\" ] || exit 0; bash \"$h\"",
                         "timeout": 10
+                    },
+                    {
+                        "type": "command",
+                        "command": "h=\"$([ -n \"${CLAUDE_PROJECT_DIR:-}\" ] && echo \"$CLAUDE_PROJECT_DIR\" || git rev-parse --show-toplevel 2>/dev/null || echo \"$PWD\")/.claude/hooks/gh-pr-title-check.sh\"; [ -x \"$h\" ] || exit 0; bash \"$h\"",
+                        "timeout": 10
                     }
                 ]
             }


### PR DESCRIPTION
## Summary

Two `PreToolUse` Bash hooks that enforce this repo's "Agent-Authored GitHub Activity" conventions from AGENTS.md, which previously relied on the agent remembering. Both are registered in `.claude/settings.json` alongside the existing prettier hook in the same `PreToolUse`/`Bash` matcher (same bootstrap pattern, `timeout: 10`), and exit 2 with a reminder when violated.

### 1. Footer enforcement — `.claude/hooks/gh-footer-check.sh`
Requires the Claude Code footer on agent-authored GitHub text.
- Gates: `gh issue create`, `gh issue comment`, `gh pr create`, `gh pr comment`, and `gh api` **writes** to `/comments` or `/replies`.
- A plain `gh api .../comments` **GET** (reading comments) is intentionally **not** blocked — only fires when a body/field flag or explicit POST is present.
- Footer detection covers inline body flags, `-f body=`, heredocs, and `--body-file`/`-F <file>` (the referenced file is read).

### 2. PR-title cleanliness — `.claude/hooks/gh-pr-title-check.sh`
Blocks an issue/PR number in a pull-request title (squash-merge appends ` (#<PR-number>)` automatically, so a manual `(#1179)` becomes `... (#1179) (#1182)`).
- Inspects **only** the `--title`/`-t`/`--title=` value of PR create/edit commands; the body is never scanned, so referencing an issue in the body stays allowed.
- Titles are always inline (no `--title-file`), so extraction is reliable.

## Test plan
- [x] Footer hook: 8 pipe-tests pass (allow vs. block across the gated commands, GET vs. write, inline footer, `--body-file` with/without footer).
- [x] Title hook: 10 tests pass — blocks parenthesized `(#N)`, bare `#N`, `-t`/`--title=` forms, and PR-edit titles; allows clean titles, an issue number that appears only in the body, `pr view`, and `git commit`.
- [x] `jq -e` confirms valid JSON and all three Bash hooks registered.
- [x] Footer hook verified live in-session (a command with `gh issue create` and no footer was blocked by the harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)