### PR TITLE
feat(math): support plus-minus operator via math-expressions alpha93

### DIFF
--- a/.changeset/upgrade-math-expressions-alpha93.md
+++ b/.changeset/upgrade-math-expressions-alpha93.md
@@ -1,0 +1,9 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Upgrade `math-expressions` to `2.0.0-alpha93`.
+
+This adds support for the plus-minus operator: `\pm` in the LaTeX parser and the `±` symbol in the text parser. For example, `<math format="latex">\pm \sqrt{x}</math>` now parses instead of rendering blank.

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
                 "jszip": "^3.10.1",
                 "katex": "^0.16.27",
                 "lorem-ipsum": "^2.0.8",
-                "math-expressions": "^2.0.0-alpha92",
+                "math-expressions": "^2.0.0-alpha93",
                 "micromark": "^4.0.2",
                 "nanoid": "^5.1.6",
                 "nextra": "^3.3.1",
@@ -16627,9 +16627,9 @@
             }
         },
         "node_modules/math-expressions": {
-            "version": "2.0.0-alpha92",
-            "resolved": "https://registry.npmjs.org/math-expressions/-/math-expressions-2.0.0-alpha92.tgz",
-            "integrity": "sha512-PjeIpjBd3gi4Gl/sLqw8y/2irPHJg+6RQJIv9thnQWixgKkJdTR0AG8dHsx7Ner/IWUd7Z68rQsvbHbSLEmDVQ==",
+            "version": "2.0.0-alpha93",
+            "resolved": "https://registry.npmjs.org/math-expressions/-/math-expressions-2.0.0-alpha93.tgz",
+            "integrity": "sha512-d3gmUN0JeDEyidPztME0rMoVKy2J2b2TBhjtseFd01eQpu2bkYj8K46uAiH7TxpZiYkbQXkGKSr/H51IIe+kEA==",
             "license": "(GPL-3.0 OR Apache-2.0)",
             "dependencies": {
                 "@babel/cli": "^7.28.6",
@@ -27496,7 +27496,7 @@
             "dependencies": {
                 "color-name": "^1.1.4",
                 "get-contrast": "^3.0.0",
-                "math-expressions": "^2.0.0-alpha92",
+                "math-expressions": "^2.0.0-alpha93",
                 "micromark": "^4.0.2",
                 "nearest-color": "^0.4.4",
                 "rgb": "^0.1.0"

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
         "jszip": "^3.10.1",
         "katex": "^0.16.27",
         "lorem-ipsum": "^2.0.8",
-        "math-expressions": "^2.0.0-alpha92",
+        "math-expressions": "^2.0.0-alpha93",
         "micromark": "^4.0.2",
         "nanoid": "^5.1.6",
         "nextra": "^3.3.1",

--- a/packages/doenetml-worker-javascript/src/test/math/mathExpressionsEquality.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/math/mathExpressionsEquality.test.ts
@@ -1019,6 +1019,30 @@ describe("Math expressions equality tests @group2", async () => {
             symbolicSimplifyEqual: true,
             symbolicSimplifyExpandEqual: true,
         },
+        {
+            expr1: '<math format="latex">\\pm \\sqrt{x}</math>',
+            expr2: "±sqrt(x)",
+            equal: true,
+            symbolicEqual: true,
+            symbolicSimplifyEqual: true,
+            symbolicSimplifyExpandEqual: true,
+        },
+        {
+            expr1: "x ± y",
+            expr2: "± y + x",
+            equal: true,
+            symbolicEqual: false,
+            symbolicSimplifyEqual: true,
+            symbolicSimplifyExpandEqual: true,
+        },
+        {
+            expr1: "a ± b",
+            expr2: "a + b",
+            equal: false,
+            symbolicEqual: false,
+            symbolicSimplifyEqual: false,
+            symbolicSimplifyExpandEqual: false,
+        },
     ];
 
     for (let [ind, info] of equivalences.entries()) {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/math.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/math.test.ts
@@ -134,6 +134,36 @@ describe("Math tag tests @group3", async () => {
         ).eqls(["/", "x", "z"]);
     });
 
+    it("parse plus-minus", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <math format="latex" name="latexUnary">\\pm \\sqrt{x}</math>
+    <math format="latex" name="latexBinary">a \\pm b</math>
+    <math name="textUnary">±sqrt(x)</math>
+    <math name="textBinary">a ± b</math>
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        expect(
+            stateVariables[await resolvePathToNodeIdx("latexUnary")].stateValues
+                .value.tree,
+        ).eqls(["pm", ["apply", "sqrt", "x"]]);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("latexBinary")]
+                .stateValues.value.tree,
+        ).eqls(["+", "a", ["pm", "b"]]);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("textUnary")].stateValues
+                .value.tree,
+        ).eqls(["pm", ["apply", "sqrt", "x"]]);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("textBinary")].stateValues
+                .value.tree,
+        ).eqls(["+", "a", ["pm", "b"]]);
+    });
+
     it("copy latex property", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -53,7 +53,7 @@
     "dependencies": {
         "color-name": "^1.1.4",
         "get-contrast": "^3.0.0",
-        "math-expressions": "^2.0.0-alpha92",
+        "math-expressions": "^2.0.0-alpha93",
         "micromark": "^4.0.2",
         "nearest-color": "^0.4.4",
         "rgb": "^0.1.0"


### PR DESCRIPTION
## Summary
- Upgrade `math-expressions` to `2.0.0-alpha93`, which adds parsing of the plus-minus operator: `\pm` in the LaTeX parser and the `±` symbol in the text parser.
- Previously `<math format="latex">\pm \sqrt{x}</math>` rendered blank; it now parses to a `pm` operator.
- Add a parsing test (`math.test.ts`) covering unary/binary `\pm` and `±` across both parsers, and three equality cases (`mathExpressionsEquality.test.ts`) covering LaTeX≡unicode, commutativity, and distinctness from plain `+`.

Closes #1206.

## Test plan
- [x] `npx vitest run src/test/tagSpecific/math.test.ts -t "parse plus-minus"`
- [x] `npx vitest run src/test/math/mathExpressionsEquality.test.ts -t "±"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)