### PR TITLE
Group reference-page attributes and properties into collapsible, linked sections

### DIFF
--- a/.changeset/docs-grouped-collapsible-attrs-props.md
+++ b/.changeset/docs-grouped-collapsible-attrs-props.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Docs: group attributes and properties on component reference pages into collapsible sections — a curated "Highlighted" group (open by default), functional groups (e.g. number display, labels), an "Other" group, and a "Common to all components" group that surfaces the previously hidden `BaseComponent` attributes. Adds a filter box, a Reveal/Collapse-all toggle, and links from each listed attribute/property to its worked example (including examples on other pages of a multi-page reference).
+
+Drives the grouping with optional, docs-only `groupName`/`highlighted` metadata on attribute definitions and public state variables, threaded into the generated schema.

--- a/.changeset/docs-grouped-collapsible-attrs-props.md
+++ b/.changeset/docs-grouped-collapsible-attrs-props.md
@@ -6,6 +6,6 @@
 "doenet-vscode-extension": patch
 ---
 
-Docs: group attributes and properties on component reference pages into collapsible sections — a curated "Highlighted" group (open by default), functional groups (e.g. number display, labels), an "Other" group, and a "Common to all components" group that surfaces the previously hidden `BaseComponent` attributes. Adds a filter box, a Reveal/Collapse-all toggle, and links from each listed attribute/property to its worked example (including examples on other pages of a multi-page reference).
+Docs: group attributes and properties on component reference pages into collapsible sections — a curated "Highlighted" group (open by default), functional groups (e.g. number display, labels), an "Other" group, and a "Common to all components" group that surfaces the previously hidden `BaseComponent` attributes. Adds a filter box, an Expand/Collapse-all toggle, and links from each listed attribute/property to its worked example (including examples on other pages of a multi-page reference).
 
 Drives the grouping with optional, docs-only `groupName`/`highlighted` metadata on attribute definitions and public state variables, threaded into the generated schema.

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
                 "esprima": "^4.0.1",
                 "file-saver": "^2.0.5",
                 "framer-motion": "^12.23.26",
+                "github-slugger": "^2.0.0",
                 "glob": "^11.1.0",
                 "handsontable": "^12.4.0",
                 "hi-base32": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
         "esprima": "^4.0.1",
         "file-saver": "^2.0.5",
         "framer-motion": "^12.23.26",
+        "github-slugger": "^2.0.0",
         "glob": "^11.1.0",
         "handsontable": "^12.4.0",
         "hi-base32": "^0.5.1",

--- a/packages/docs-nextra/components/props-display.tsx
+++ b/packages/docs-nextra/components/props-display.tsx
@@ -363,7 +363,7 @@ function renderPropItem(
 }
 
 /** One collapsible group: a `<details>` controlled by React state so the
- * page-level Reveal/Collapse-all toggle stays authoritative. */
+ * page-level Expand/Collapse-all toggle stays authoritative. */
 function CollapsibleGroup({
     title,
     count,
@@ -382,7 +382,7 @@ function CollapsibleGroup({
                 className="attr-group-summary"
                 onClick={(e) => {
                     // Own the open state in React rather than letting the
-                    // browser toggle natively, so Reveal/Collapse-all wins.
+                    // browser toggle natively, so Expand/Collapse-all wins.
                     e.preventDefault();
                     onToggle();
                 }}
@@ -397,7 +397,7 @@ function CollapsibleGroup({
 
 /**
  * The interactive body shared by `AttrDisplay`, `PropDisplay`, and
- * `AttrPropDisplay`: one filter box + Reveal/Collapse-all toggle controlling
+ * `AttrPropDisplay`: one filter box + Expand/Collapse-all toggle controlling
  * the collapsible attribute and/or property sections.
  */
 function CollapsibleAttrPropSection({

--- a/packages/docs-nextra/components/props-display.tsx
+++ b/packages/docs-nextra/components/props-display.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import { Link } from "nextra-theme-docs";
-import React from "react";
+import React, { useMemo, useState } from "react";
 import { MathJax, MathJaxContext } from "better-react-mathjax";
 import { isMathDefaultValue } from "@doenet/static-assets/schema";
 
@@ -48,6 +50,10 @@ export type AttrInfo = {
     values?: AttrValueInfo[];
     /** Whether the attribute accepts an array of values */
     isArray?: boolean;
+    /** Functional group this attribute belongs to (e.g. `"number-display"`). */
+    groupName?: string;
+    /** Whether this attribute is hand-picked into the "Highlighted" section. */
+    highlighted?: boolean;
 };
 
 export type PropInfo = {
@@ -61,7 +67,530 @@ export type PropInfo = {
     description: string;
     /** Whether the prop accepts an array of values */
     isArray?: boolean;
+    /** Functional group this prop belongs to (e.g. `"number-display"`). */
+    groupName?: string;
+    /** Whether this prop is hand-picked into the "Highlighted" section. */
+    highlighted?: boolean;
 };
+
+/**
+ * Display order for the known functional groups. Groups not listed here are
+ * sorted alphabetically after the known ones, so adding a new `groupName` in
+ * the worker never requires a change here to render (it just lands at the end).
+ */
+const GROUP_ORDER = [
+    "number-display",
+    "labels",
+    "positioning",
+    "styling",
+    "answer-grading",
+    "scoring",
+    "triggering",
+];
+
+/** Human-readable section titles for the known functional groups. */
+const GROUP_LABELS: Record<string, string> = {
+    "number-display": "Number display",
+    labels: "Labels",
+    positioning: "Positioning",
+    styling: "Styling",
+    "answer-grading": "Answer grading",
+    scoring: "Scoring",
+    triggering: "Triggering",
+};
+
+function compareGroupNames(a: string, b: string): number {
+    const ia = GROUP_ORDER.indexOf(a);
+    const ib = GROUP_ORDER.indexOf(b);
+    if (ia !== -1 && ib !== -1) {
+        return ia - ib;
+    }
+    if (ia !== -1) {
+        return -1;
+    }
+    if (ib !== -1) {
+        return 1;
+    }
+    return a.localeCompare(b);
+}
+
+type GroupItem = {
+    name: string;
+    common: boolean;
+    groupName?: string;
+    highlighted?: boolean;
+    description: string;
+};
+
+type GroupSection<T> = {
+    id: string;
+    label: string;
+    items: T[];
+    defaultOpen: boolean;
+};
+
+/**
+ * Partition an already-name-sorted list of attributes/properties into the
+ * ordered, collapsible sections rendered in the docs:
+ *   1. Highlighted (hand-picked, open by default)
+ *   2. Functional groups (by `groupName`, in `GROUP_ORDER`, closed)
+ *   3. Other (ungrouped, closed)
+ *   4. Common to all components (closed, last)
+ *
+ * A highlighted item with a `groupName` intentionally appears in BOTH the
+ * Highlighted section and its functional group. A highlighted item without a
+ * group appears only in Highlighted (not also dumped into "Other"). `common`
+ * items always sink to the last section regardless of any group tag.
+ */
+function partitionIntoSections<T extends GroupItem>(
+    items: T[],
+): GroupSection<T>[] {
+    const highlighted: T[] = [];
+    const common: T[] = [];
+    const grouped = new Map<string, T[]>();
+    const other: T[] = [];
+
+    for (const item of items) {
+        if (item.common) {
+            common.push(item);
+            continue;
+        }
+        if (item.highlighted) {
+            highlighted.push(item);
+        }
+        if (item.groupName) {
+            const arr = grouped.get(item.groupName) ?? [];
+            arr.push(item);
+            grouped.set(item.groupName, arr);
+        } else if (!item.highlighted) {
+            other.push(item);
+        }
+    }
+
+    const sections: GroupSection<T>[] = [];
+    if (highlighted.length > 0) {
+        sections.push({
+            id: "highlighted",
+            label: "Highlighted",
+            items: highlighted,
+            defaultOpen: true,
+        });
+    }
+    for (const groupName of [...grouped.keys()].sort(compareGroupNames)) {
+        sections.push({
+            id: `group:${groupName}`,
+            label: GROUP_LABELS[groupName] ?? groupName,
+            items: grouped.get(groupName)!,
+            defaultOpen: false,
+        });
+    }
+    if (other.length > 0) {
+        sections.push({
+            id: "other",
+            label: "Other",
+            items: other,
+            defaultOpen: false,
+        });
+    }
+    if (common.length > 0) {
+        sections.push({
+            id: "common",
+            label: "Common to all components",
+            items: common,
+            defaultOpen: false,
+        });
+    }
+    return sections;
+}
+
+/**
+ * Render the inline backtick `code` spans in a description string; everything
+ * else is plain text. Schema descriptions use only this one bit of markdown
+ * (e.g. "Like `numbers`, but does not reorder commutative operands."), so a
+ * full markdown renderer would be overkill.
+ */
+function renderInlineCode(text: string): React.ReactNode {
+    if (!text.includes("`")) {
+        return text;
+    }
+    // Splitting on backticks puts plain text at even indices and the contents
+    // of each `code` span at odd indices.
+    return text.split("`").map((part, i) =>
+        i % 2 === 1 ? (
+            <code className="attr-inline-code" key={i}>
+                {part}
+            </code>
+        ) : (
+            <React.Fragment key={i}>{part}</React.Fragment>
+        ),
+    );
+}
+
+/** Render a single attribute item. `idPrefix` keeps DOM ids unique across the
+ * Highlighted duplicate (`attr-hl-…`) and the canonical copy (`attr-…`). */
+function renderAttrItem(
+    attr: AttrInfo,
+    links: Record<string, string>,
+    idPrefix: string,
+) {
+    const linkTarget = links[attr.name];
+    const nameElm = linkTarget ? (
+        <Link href={linkTarget}>{attr.name}</Link>
+    ) : (
+        attr.name
+    );
+    const typeLabel = formatType(attr.type, attr.isArray);
+    const isKeyword = attr.type === "keyword";
+    const defaultNode = renderDefaultValue(attr.defaultValue);
+    // `boolean` attributes only ever take true/false, so the value table would
+    // be noise — skip it for them.
+    const showValues =
+        attr.type !== "boolean" &&
+        attr.values != null &&
+        attr.values.length > 0;
+    return (
+        <div
+            className="attr-item"
+            id={`${idPrefix}-${attr.name}`}
+            key={attr.name}
+        >
+            <div>
+                <code className="attr-name attr-name-box">{nameElm}</code>
+            </div>
+            <p className="attr-detail">
+                {typeLabel ? (
+                    <>
+                        <em className="attr-type">{typeLabel}</em>.{" "}
+                    </>
+                ) : null}
+                {/* The default value follows the type, except for keyword
+                attributes, where it is marked in the value list below. Math
+                defaults are typeset by MathJax, so we render them in a plain
+                `<span>` instead of `<code>` — wrapping typeset math inside a
+                monospace `<code>` block produces awkward mixed-typography
+                output. */}
+                {!isKeyword && defaultNode !== null ? (
+                    <>
+                        Default value:{" "}
+                        {isMathDefaultValue(attr.defaultValue) ? (
+                            <span className="attr-default attr-default-math">
+                                {defaultNode}
+                            </span>
+                        ) : (
+                            <code className="attr-default">{defaultNode}</code>
+                        )}
+                        .{" "}
+                    </>
+                ) : null}
+                {renderInlineCode(attr.description)}
+            </p>
+            {showValues ? (
+                <table className="attr-value-table">
+                    <thead>
+                        <tr>
+                            <th>Value</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {attr.values!.map((v) => {
+                            const isDefault =
+                                attr.defaultValue != null &&
+                                String(attr.defaultValue) === v.value;
+                            return (
+                                <tr key={v.value}>
+                                    <td>
+                                        <code className="attr-value-chip">
+                                            {v.value}
+                                        </code>
+                                        {isDefault ? (
+                                            <span className="attr-default-marker">
+                                                {" "}
+                                                (default)
+                                            </span>
+                                        ) : null}
+                                    </td>
+                                    <td>
+                                        {v.description
+                                            ? renderInlineCode(v.description)
+                                            : ""}
+                                    </td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            ) : null}
+        </div>
+    );
+}
+
+/** Render a single property item. */
+function renderPropItem(
+    prop: PropInfo,
+    refName: string,
+    links: Record<string, string>,
+    idPrefix: string,
+) {
+    const linkTarget = links[prop.name];
+    const nameElm = linkTarget ? (
+        <Link href={linkTarget}>{prop.name}</Link>
+    ) : (
+        prop.name
+    );
+    const typeLabel = formatType(prop.type, prop.isArray);
+    return (
+        <div
+            className="prop-item"
+            id={`${idPrefix}-${prop.name}`}
+            key={prop.name}
+        >
+            <div>
+                <code className="prop-name-box">
+                    ${refName}.<span className="prop-name">{nameElm}</span>
+                </code>
+            </div>
+            <p className="prop-detail">
+                {typeLabel ? (
+                    <>
+                        <em className="prop-type">{typeLabel}</em>.{" "}
+                    </>
+                ) : null}
+                {renderInlineCode(prop.description)}
+            </p>
+        </div>
+    );
+}
+
+/** One collapsible group: a `<details>` controlled by React state so the
+ * page-level Reveal/Collapse-all toggle stays authoritative. */
+function CollapsibleGroup({
+    title,
+    count,
+    open,
+    onToggle,
+    children,
+}: React.PropsWithChildren<{
+    title: string;
+    count: number;
+    open: boolean;
+    onToggle: () => void;
+}>) {
+    return (
+        <details className="attr-group" open={open}>
+            <summary
+                className="attr-group-summary"
+                onClick={(e) => {
+                    // Own the open state in React rather than letting the
+                    // browser toggle natively, so Reveal/Collapse-all wins.
+                    e.preventDefault();
+                    onToggle();
+                }}
+            >
+                {title}
+                <span className="attr-group-count"> ({count})</span>
+            </summary>
+            <div className="attr-group-body">{children}</div>
+        </details>
+    );
+}
+
+/**
+ * The interactive body shared by `AttrDisplay`, `PropDisplay`, and
+ * `AttrPropDisplay`: one filter box + Reveal/Collapse-all toggle controlling
+ * the collapsible attribute and/or property sections.
+ */
+function CollapsibleAttrPropSection({
+    name,
+    attrs,
+    props,
+    attrLinks = {},
+    propLinks = {},
+    attrCaptionName,
+    propCaptionName,
+    missingAttrsNote = null,
+    missingPropsNote = null,
+}: {
+    name: string;
+    attrs?: AttrInfo[];
+    props?: PropInfo[];
+    /** Map of attribute name → anchor of its worked example. */
+    attrLinks?: Record<string, string>;
+    /** Map of property name → anchor of its worked example. */
+    propLinks?: Record<string, string>;
+    attrCaptionName?: React.ReactNode;
+    propCaptionName?: React.ReactNode;
+    missingAttrsNote?: React.ReactNode;
+    missingPropsNote?: React.ReactNode;
+}) {
+    const refName = name.charAt(0).toLowerCase();
+
+    const attrSections = useMemo(
+        () => (attrs ? partitionIntoSections(attrs) : []),
+        [attrs],
+    );
+    const propSections = useMemo(
+        () => (props ? partitionIntoSections(props) : []),
+        [props],
+    );
+
+    const [query, setQuery] = useState("");
+    const [openMap, setOpenMap] = useState<Record<string, boolean>>(() => {
+        const map: Record<string, boolean> = {};
+        for (const s of attrSections) {
+            map[`attr:${s.id}`] = s.defaultOpen;
+        }
+        for (const s of propSections) {
+            map[`prop:${s.id}`] = s.defaultOpen;
+        }
+        return map;
+    });
+
+    const q = query.trim().toLowerCase();
+    const filtering = q !== "";
+    const matches = (item: GroupItem) =>
+        !filtering ||
+        item.name.toLowerCase().includes(q) ||
+        item.description.toLowerCase().includes(q);
+
+    const allKeys = [
+        ...attrSections.map((s) => `attr:${s.id}`),
+        ...propSections.map((s) => `prop:${s.id}`),
+    ];
+    const allOpen = allKeys.length > 0 && allKeys.every((k) => openMap[k]);
+    const toggle = (key: string) =>
+        setOpenMap((m) => ({ ...m, [key]: !m[key] }));
+    const setAll = (value: boolean) =>
+        setOpenMap(Object.fromEntries(allKeys.map((k) => [k, value])));
+
+    const attrsNeedMath = (attrs ?? []).some((a) =>
+        isMathDefaultValue(a.defaultValue),
+    );
+
+    const renderSections = (
+        sections: GroupSection<AttrInfo | PropInfo>[],
+        kind: "attr" | "prop",
+    ) =>
+        sections.map((section) => {
+            const key = `${kind}:${section.id}`;
+            const visibleItems = section.items.filter(matches);
+            if (filtering && visibleItems.length === 0) {
+                return null;
+            }
+            const open = filtering ? true : Boolean(openMap[key]);
+            const highlightedSection = section.id === "highlighted";
+            const idPrefix =
+                kind === "attr"
+                    ? highlightedSection
+                        ? "attr-hl"
+                        : "attr"
+                    : highlightedSection
+                      ? "prop-hl"
+                      : "prop";
+            return (
+                <CollapsibleGroup
+                    key={key}
+                    title={section.label}
+                    count={visibleItems.length}
+                    open={open}
+                    onToggle={() => toggle(key)}
+                >
+                    {kind === "attr"
+                        ? (visibleItems as AttrInfo[]).map((item) =>
+                              renderAttrItem(item, attrLinks, idPrefix),
+                          )
+                        : (visibleItems as PropInfo[]).map((item) =>
+                              renderPropItem(
+                                  item,
+                                  refName,
+                                  propLinks,
+                                  idPrefix,
+                              ),
+                          )}
+                </CollapsibleGroup>
+            );
+        });
+
+    const renderedAttrSections = renderSections(attrSections, "attr");
+    const renderedPropSections = renderSections(propSections, "prop");
+    const attrAllHidden =
+        renderedAttrSections.length > 0 &&
+        renderedAttrSections.every((s) => s === null);
+    const propAllHidden =
+        renderedPropSections.length > 0 &&
+        renderedPropSections.every((s) => s === null);
+
+    return (
+        <>
+            <div className="attr-prop-controls">
+                <input
+                    type="search"
+                    className="attr-filter-input"
+                    placeholder="Filter attributes and properties…"
+                    aria-label="Filter attributes and properties"
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                />
+                {!filtering && allKeys.length > 0 ? (
+                    <button
+                        type="button"
+                        className="reveal-all-toggle"
+                        onClick={() => setAll(!allOpen)}
+                    >
+                        {allOpen ? "Collapse all" : "Expand all"}
+                    </button>
+                ) : null}
+            </div>
+
+            {attrs ? (
+                <WithMathJaxIfNeeded needed={attrsNeedMath}>
+                    <div className="attr-list" id="attr-list">
+                        <h3 className="attr-list-caption">
+                            Attributes for{" "}
+                            {attrCaptionName || (
+                                <code>
+                                    {"<"}
+                                    {name}
+                                    {">"}
+                                </code>
+                            )}
+                        </h3>
+                        {renderedAttrSections}
+                        {attrAllHidden ? (
+                            <p className="attr-filter-empty">
+                                No matching attributes.
+                            </p>
+                        ) : null}
+                    </div>
+                </WithMathJaxIfNeeded>
+            ) : (
+                missingAttrsNote
+            )}
+
+            {props ? (
+                <div className="prop-list" id="prop-list">
+                    <h3 className="prop-list-caption">
+                        Properties for{" "}
+                        {propCaptionName || (
+                            <code>
+                                {"<"}
+                                {name} name="{refName}"{">"}
+                            </code>
+                        )}
+                    </h3>
+                    {renderedPropSections}
+                    {propAllHidden ? (
+                        <p className="attr-filter-empty">
+                            No matching properties.
+                        </p>
+                    ) : null}
+                </div>
+            ) : (
+                missingPropsNote
+            )}
+        </>
+    );
+}
 
 export function AttrDisplay({
     name,
@@ -73,125 +602,13 @@ export function AttrDisplay({
     attrs: AttrInfo[];
     links?: Record<string, string>;
 }>) {
-    // `attrs` arrives already sorted by name from computeOptimizedSchema.
-    const componentAttrs = attrs.filter((attr) => !attr.common);
-
     return (
-        <WithMathJaxIfNeeded
-            needed={componentAttrs.some((a) =>
-                isMathDefaultValue(a.defaultValue),
-            )}
-        >
-            <div className="attr-list" id="attr-list">
-                <h3 className="attr-list-caption">
-                    Attributes for{" "}
-                    {children || (
-                        <code>
-                            {"<"}
-                            {name}
-                            {">"}
-                        </code>
-                    )}
-                </h3>
-                {componentAttrs.map((attr) => {
-                    const linkTarget = links[attr.name];
-                    const nameElm = linkTarget ? (
-                        <Link href={linkTarget}>{attr.name}</Link>
-                    ) : (
-                        attr.name
-                    );
-                    const typeLabel = formatType(attr.type, attr.isArray);
-                    const isKeyword = attr.type === "keyword";
-                    const defaultNode = renderDefaultValue(attr.defaultValue);
-                    // `boolean` attributes only ever take true/false, so the
-                    // value table would be noise — skip it for them.
-                    const showValues =
-                        attr.type !== "boolean" &&
-                        attr.values != null &&
-                        attr.values.length > 0;
-                    return (
-                        <div className="attr-item" key={attr.name}>
-                            <div>
-                                <code className="attr-name attr-name-box">
-                                    {nameElm}
-                                </code>
-                            </div>
-                            <p className="attr-detail">
-                                {typeLabel ? (
-                                    <>
-                                        <em className="attr-type">
-                                            {typeLabel}
-                                        </em>
-                                        .{" "}
-                                    </>
-                                ) : null}
-                                {/* The default value follows the type, except for
-                                keyword attributes, where it is marked in the
-                                value list below. Math defaults are typeset by
-                                MathJax, so we render them in a plain `<span>`
-                                instead of `<code>` — wrapping typeset math
-                                inside a monospace `<code>` block produces
-                                awkward mixed-typography output. */}
-                                {!isKeyword && defaultNode !== null ? (
-                                    <>
-                                        Default value:{" "}
-                                        {isMathDefaultValue(
-                                            attr.defaultValue,
-                                        ) ? (
-                                            <span className="attr-default attr-default-math">
-                                                {defaultNode}
-                                            </span>
-                                        ) : (
-                                            <code className="attr-default">
-                                                {defaultNode}
-                                            </code>
-                                        )}
-                                        .{" "}
-                                    </>
-                                ) : null}
-                                {attr.description}
-                            </p>
-                            {showValues ? (
-                                <table className="attr-value-table">
-                                    <thead>
-                                        <tr>
-                                            <th>Value</th>
-                                            <th>Description</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {attr.values!.map((v) => {
-                                            const isDefault =
-                                                attr.defaultValue != null &&
-                                                String(attr.defaultValue) ===
-                                                    v.value;
-                                            return (
-                                                <tr key={v.value}>
-                                                    <td>
-                                                        <code className="attr-value-chip">
-                                                            {v.value}
-                                                        </code>
-                                                        {isDefault ? (
-                                                            <span className="attr-default-marker">
-                                                                {" "}
-                                                                (default)
-                                                            </span>
-                                                        ) : null}
-                                                    </td>
-                                                    <td>
-                                                        {v.description || ""}
-                                                    </td>
-                                                </tr>
-                                            );
-                                        })}
-                                    </tbody>
-                                </table>
-                            ) : null}
-                        </div>
-                    );
-                })}
-            </div>
-        </WithMathJaxIfNeeded>
+        <CollapsibleAttrPropSection
+            name={name}
+            attrs={attrs}
+            attrLinks={links}
+            attrCaptionName={children}
+        />
     );
 }
 
@@ -205,72 +622,37 @@ export function PropDisplay({
     props: PropInfo[];
     links?: Record<string, string>;
 }>) {
-    // `props` arrives already sorted by name from computeOptimizedSchema.
-    const componentProps = props.filter((prop) => !prop.common);
-    const refName = name.charAt(0).toLowerCase();
-
     return (
-        <div className="prop-list" id="prop-list">
-            <h3 className="prop-list-caption">
-                Props for{" "}
-                {children || (
-                    <code>
-                        {"<"}
-                        {name} name="{refName}"{">"}
-                    </code>
-                )}
-            </h3>
-            {componentProps.map((prop) => {
-                const linkTarget = links[prop.name];
-                const nameElm = linkTarget ? (
-                    <Link href={linkTarget}>{prop.name}</Link>
-                ) : (
-                    prop.name
-                );
-                const typeLabel = formatType(prop.type, prop.isArray);
-                return (
-                    <div className="prop-item" key={prop.name}>
-                        <div>
-                            <code className="prop-name-box">
-                                ${refName}.
-                                <span className="prop-name">{nameElm}</span>
-                            </code>
-                        </div>
-                        <p className="prop-detail">
-                            {typeLabel ? (
-                                <>
-                                    <em className="prop-type">{typeLabel}</em>
-                                    .{" "}
-                                </>
-                            ) : null}
-                            {prop.description}
-                        </p>
-                    </div>
-                );
-            })}
-        </div>
+        <CollapsibleAttrPropSection
+            name={name}
+            props={props}
+            propLinks={links}
+            propCaptionName={children}
+        />
     );
 }
 
 /**
- * Renders the body of an "Attributes and Properties" section: the attribute
- * list and the property list, substituting a short message for either one
- * when the component has none. The section heading itself is emitted as a
- * real Markdown heading by the `autoInsertAttrPropDescriptions` remark plugin.
+ * Renders the body of an "Attributes and Properties" section: the collapsible
+ * attribute and property lists, substituting a short message for either one
+ * when the component has none. The section heading itself is emitted as a real
+ * Markdown heading by the `autoInsertAttrPropDescriptions` remark plugin.
  */
 export function AttrPropDisplay({
     name,
     attrs = [],
     props = [],
-    links = {},
+    attrLinks = {},
+    propLinks = {},
 }: {
     name: string;
     attrs?: AttrInfo[];
     props?: PropInfo[];
-    links?: Record<string, string>;
+    attrLinks?: Record<string, string>;
+    propLinks?: Record<string, string>;
 }) {
-    const hasAttrs = attrs.some((attr) => !attr.common);
-    const hasProps = props.some((prop) => !prop.common);
+    const hasAttrs = attrs.length > 0;
+    const hasProps = props.length > 0;
     const nameCode = (
         <code>
             {"<"}
@@ -283,18 +665,19 @@ export function AttrPropDisplay({
         return <p>The {nameCode} component has no attributes or properties.</p>;
     }
     return (
-        <>
-            {hasAttrs ? (
-                <AttrDisplay name={name} attrs={attrs} links={links} />
-            ) : (
+        <CollapsibleAttrPropSection
+            name={name}
+            attrs={hasAttrs ? attrs : undefined}
+            props={hasProps ? props : undefined}
+            attrLinks={attrLinks}
+            propLinks={propLinks}
+            missingAttrsNote={
                 <p>The {nameCode} component has no attributes.</p>
-            )}
-            {hasProps ? (
-                <PropDisplay name={name} props={props} links={links} />
-            ) : (
+            }
+            missingPropsNote={
                 <p>The {nameCode} component has no properties.</p>
-            )}
-        </>
+            }
+        />
     );
 }
 
@@ -328,7 +711,7 @@ function renderDefaultValue(value: unknown): React.ReactNode {
     if (isMathDefaultValue(value)) {
         // `\(…\)` is the MathJax inline-math delimiter. `dynamic` and
         // `hideUntilTypeset="first"` mirror how `<m>`-style math is
-        // rendered elsewhere in DoenetML — the latex is hidden until the
+        // rendered elsewhere in DoenetML — the latter is hidden until the
         // first typeset pass, which avoids a flash of raw source on first
         // paint.
         return (

--- a/packages/docs-nextra/components/props-display.tsx
+++ b/packages/docs-nextra/components/props-display.tsx
@@ -226,6 +226,16 @@ function renderInlineCode(text: string): React.ReactNode {
     );
 }
 
+/** Render an attribute/property name, linking it to its worked example when
+ * `links` has an entry for it. */
+function renderName(
+    name: string,
+    links: Record<string, string>,
+): React.ReactNode {
+    const linkTarget = links[name];
+    return linkTarget ? <Link href={linkTarget}>{name}</Link> : name;
+}
+
 /** Render a single attribute item. `idPrefix` keeps DOM ids unique across the
  * Highlighted duplicate (`attr-hl-…`) and the canonical copy (`attr-…`). */
 function renderAttrItem(
@@ -233,12 +243,7 @@ function renderAttrItem(
     links: Record<string, string>,
     idPrefix: string,
 ) {
-    const linkTarget = links[attr.name];
-    const nameElm = linkTarget ? (
-        <Link href={linkTarget}>{attr.name}</Link>
-    ) : (
-        attr.name
-    );
+    const nameElm = renderName(attr.name, links);
     const typeLabel = formatType(attr.type, attr.isArray);
     const isKeyword = attr.type === "keyword";
     const defaultNode = renderDefaultValue(attr.defaultValue);
@@ -332,12 +337,7 @@ function renderPropItem(
     links: Record<string, string>,
     idPrefix: string,
 ) {
-    const linkTarget = links[prop.name];
-    const nameElm = linkTarget ? (
-        <Link href={linkTarget}>{prop.name}</Link>
-    ) : (
-        prop.name
-    );
+    const nameElm = renderName(prop.name, links);
     const typeLabel = formatType(prop.type, prop.isArray);
     return (
         <div
@@ -478,15 +478,10 @@ function CollapsibleAttrPropSection({
                 return null;
             }
             const open = filtering ? true : Boolean(openMap[key]);
-            const highlightedSection = section.id === "highlighted";
-            const idPrefix =
-                kind === "attr"
-                    ? highlightedSection
-                        ? "attr-hl"
-                        : "attr"
-                    : highlightedSection
-                      ? "prop-hl"
-                      : "prop";
+            // The Highlighted section duplicates items that also appear in a
+            // functional group, so it gets an `-hl` id prefix to keep DOM ids
+            // unique (e.g. `attr-hl-displayDigits` vs. `attr-displayDigits`).
+            const idPrefix = kind + (section.id === "highlighted" ? "-hl" : "");
             return (
                 <CollapsibleGroup
                     key={key}

--- a/packages/docs-nextra/package.json
+++ b/packages/docs-nextra/package.json
@@ -40,7 +40,8 @@
             "files": [
                 "scripts/**/*.ts",
                 "scripts/**/*.tsx",
-                "tsconfig.json"
+                "tsconfig.json",
+                "vite.config.ts"
             ],
             "output": [
                 "dist/**/*.js",

--- a/packages/docs-nextra/pages/style.css
+++ b/packages/docs-nextra/pages/style.css
@@ -43,6 +43,8 @@
 .attr-item,
 .prop-item {
     margin: 1.25em 0;
+    /* Keep deep-link targets clear of the sticky page header. */
+    scroll-margin-top: 5rem;
 }
 
 /* Gray pill around the attribute/property name, mirroring the editor
@@ -72,6 +74,16 @@
     padding: 0.05rem 0.35rem;
 }
 :is(html[class~="dark"] .nextra-content) .attr-default {
+    background-color: rgb(55, 65, 81);
+}
+
+/* Inline `code` spans inside attribute/property descriptions. */
+.attr-inline-code {
+    background-color: rgb(243, 244, 246);
+    border-radius: 0.25rem;
+    padding: 0.05rem 0.35rem;
+}
+:is(html[class~="dark"] .nextra-content) .attr-inline-code {
     background-color: rgb(55, 65, 81);
 }
 
@@ -113,4 +125,89 @@
     margin-top: 0.5em;
     margin-bottom: 1em;
     font-style: italic;
+}
+
+/* Filter box + Reveal/Collapse-all toggle above the attribute/property lists. */
+.attr-prop-controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 1em 0 0.5em;
+}
+.attr-filter-input {
+    flex: 1 1 16rem;
+    min-width: 10rem;
+    border: 1px solid rgb(209, 213, 219);
+    border-radius: 0.375rem;
+    padding: 0.35rem 0.6rem;
+    background-color: transparent;
+}
+.attr-filter-input:focus {
+    outline: 2px solid rgb(29, 85, 197);
+    outline-offset: -1px;
+}
+:is(html[class~="dark"] .nextra-content) .attr-filter-input {
+    border-color: rgb(75, 85, 99);
+}
+.reveal-all-toggle {
+    border: 1px solid rgb(209, 213, 219);
+    border-radius: 0.375rem;
+    padding: 0.35rem 0.7rem;
+    font-size: 0.875rem;
+    white-space: nowrap;
+    cursor: pointer;
+    background-color: rgb(243, 244, 246);
+}
+.reveal-all-toggle:hover {
+    background-color: rgb(229, 231, 235);
+}
+:is(html[class~="dark"] .nextra-content) .reveal-all-toggle {
+    border-color: rgb(75, 85, 99);
+    background-color: rgb(55, 65, 81);
+}
+:is(html[class~="dark"] .nextra-content) .reveal-all-toggle:hover {
+    background-color: rgb(75, 85, 99);
+}
+
+/* Collapsible group within an attribute/property list. */
+.attr-group {
+    border: 1px solid rgb(229, 231, 235);
+    border-radius: 0.5rem;
+    margin: 0.5em 0;
+}
+:is(html[class~="dark"] .nextra-content) .attr-group {
+    border-color: rgb(55, 65, 81);
+}
+.attr-group-summary {
+    cursor: pointer;
+    padding: 0.5rem 0.75rem;
+    font-weight: 600;
+    list-style-position: inside;
+    border-radius: 0.5rem;
+}
+.attr-group-summary:hover {
+    background-color: rgb(243, 244, 246);
+}
+:is(html[class~="dark"] .nextra-content) .attr-group-summary:hover {
+    background-color: rgb(55, 65, 81);
+}
+.attr-group-count {
+    font-weight: 400;
+    color: rgb(107, 114, 128);
+}
+.attr-group-body {
+    padding: 0 0.75rem 0.25rem;
+}
+/* The first item's top margin would double the summary's padding. */
+.attr-group-body > .attr-item:first-child,
+.attr-group-body > .prop-item:first-child {
+    margin-top: 0.5em;
+}
+
+/* Shown when a filter query matches nothing. */
+.attr-filter-empty {
+    margin: 0.5em 0 0.5em 0.25em;
+    font-style: italic;
+    color: rgb(107, 114, 128);
 }

--- a/packages/docs-nextra/pages/style.css
+++ b/packages/docs-nextra/pages/style.css
@@ -127,7 +127,7 @@
     font-style: italic;
 }
 
-/* Filter box + Reveal/Collapse-all toggle above the attribute/property lists. */
+/* Filter box + Expand/Collapse-all toggle above the attribute/property lists. */
 .attr-prop-controls {
     display: flex;
     flex-wrap: wrap;

--- a/packages/docs-nextra/scripts/auto-insert-attr-prop-descriptions.ts
+++ b/packages/docs-nextra/scripts/auto-insert-attr-prop-descriptions.ts
@@ -35,7 +35,47 @@ type ExampleRef = {
 // Mirror of Nextra's own heading-slug logic so the anchors we link to match
 // the ids it assigns. Nextra skips headings whose parent is a tab.
 const SKIP_FOR_PARENT_NAMES = new Set(["Tab", "Tabs.Tab"]);
-const EXAMPLE_HEADING_RE = /^(Attribute|Property) Example:\s*(.+)$/i;
+
+type ExampleKind = "attribute" | "property";
+
+// Worked examples appear under one of two heading conventions:
+//   1. A typed item heading that names its own kind, e.g.
+//      "### Attribute Example: functionSymbols" (used on the math pages).
+//   2. A bare "### Example: <name>" item beneath a "## Attribute Examples" or
+//      "## Property Examples" section heading (used on the answer pages),
+//      where the section supplies the kind.
+const SECTION_HEADING_RE = /^(attribute|property) examples?$/i;
+const TYPED_EXAMPLE_RE = /^(attribute|property) example:\s*(.+)$/i;
+const BARE_EXAMPLE_RE = /^examples?:\s*(.+)$/i;
+
+/** The example-section kind a heading establishes (e.g. "Attribute Examples"),
+ * or null when the heading is not an example-section heading. */
+function exampleSectionKind(text: string): ExampleKind | null {
+    const match = SECTION_HEADING_RE.exec(text.trim());
+    return match ? (match[1].toLowerCase() as ExampleKind) : null;
+}
+
+/** Classify a heading as a worked-example item, using `sectionKind` (the
+ * enclosing example section) for the bare "Example: <name>" form. Returns null
+ * for headings that are not example items. */
+function classifyExampleHeading(
+    text: string,
+    sectionKind: ExampleKind | null,
+): { kind: ExampleKind; names: string[] } | null {
+    const trimmed = text.trim();
+    const typed = TYPED_EXAMPLE_RE.exec(trimmed);
+    if (typed) {
+        return {
+            kind: typed[1].toLowerCase() as ExampleKind,
+            names: splitExampleNames(typed[2]),
+        };
+    }
+    const bare = BARE_EXAMPLE_RE.exec(trimmed);
+    if (bare && sectionKind) {
+        return { kind: sectionKind, names: splitExampleNames(bare[1]) };
+    }
+    return null;
+}
 
 /** Split the names listed after an example heading's colon. A heading may
  * cover several attributes/properties separated by `,` or `/` (e.g.
@@ -71,6 +111,7 @@ function getFlattenedValue(node: any): string {
 function collectExampleHeadings(tree: MdastRoot): ExampleHeading[] {
     const slugger = new GithubSlugger();
     const found: ExampleHeading[] = [];
+    let sectionKind: ExampleKind | null = null;
     visit(tree, "heading", (node: any, _index, parent: any) => {
         if (node.depth === 1) {
             return;
@@ -82,16 +123,15 @@ function collectExampleHeadings(tree: MdastRoot): ExampleHeading[] {
         // Advance the slugger for every heading so dedup counters stay in sync,
         // even for headings that are not examples.
         const slug = slugger.slug(value);
-        const match = EXAMPLE_HEADING_RE.exec(value.trim());
-        if (!match) {
-            return;
+        // A top-level heading opens (or, when not an example section, closes)
+        // the example-section context that bare "Example: x" items inherit.
+        if (node.depth === 2) {
+            sectionKind = exampleSectionKind(value);
         }
-        const names = splitExampleNames(match[2]);
-        found.push({
-            slug,
-            kind: match[1].toLowerCase() as "attribute" | "property",
-            names,
-        });
+        const example = classifyExampleHeading(value, sectionKind);
+        if (example) {
+            found.push({ slug, kind: example.kind, names: example.names });
+        }
     });
     return found;
 }
@@ -139,6 +179,7 @@ function scanRawReferencePage(content: string): {
     let component: string | null = null;
     const examples: ExampleHeading[] = [];
     let fenceMarker: string | null = null;
+    let sectionKind: ExampleKind | null = null;
 
     for (const line of content.split(/\r?\n/)) {
         const fence = line.match(/^(`{3,}|~{3,})/);
@@ -169,15 +210,17 @@ function scanRawReferencePage(content: string): {
             continue;
         }
         const slug = slugger.slug(text);
-        const match = EXAMPLE_HEADING_RE.exec(text.trim());
-        if (!match) {
-            continue;
+        if (depth === 2) {
+            sectionKind = exampleSectionKind(text);
         }
-        examples.push({
-            slug,
-            kind: match[1].toLowerCase() as "attribute" | "property",
-            names: splitExampleNames(match[2]),
-        });
+        const example = classifyExampleHeading(text, sectionKind);
+        if (example) {
+            examples.push({
+                slug,
+                kind: example.kind,
+                names: example.names,
+            });
+        }
     }
     return { component, examples };
 }

--- a/packages/docs-nextra/scripts/auto-insert-attr-prop-descriptions.ts
+++ b/packages/docs-nextra/scripts/auto-insert-attr-prop-descriptions.ts
@@ -1,7 +1,7 @@
 import { visit } from "unist-util-visit";
 import { Plugin } from "unified";
 import { computeOptimizedSchema } from "./compute-optimized-schema";
-import { parseModule, Program as EstreeProgram } from "esprima";
+import { objectToEstree } from "./object-to-estree";
 import { Heading, Root as MdastRoot } from "mdast";
 import GithubSlugger from "github-slugger";
 import * as fs from "node:fs";
@@ -525,35 +525,4 @@ function injectSummary(
 
     // Add the summary to the search data.
     file.data.extraSearchData["component-summary#Description"] = info.summary;
-}
-
-/**
- * Turn a plain JS object into an ESTree object suitable for including in a `mdxJsxAttributeValueExpression`.
- */
-function objectToEstree(obj: any): EstreeProgram {
-    const estreeRaw = parseModule(`const IGNORE = ${JSON.stringify(obj)}`);
-
-    const decl = estreeRaw.body[0];
-    if (decl.type !== "VariableDeclaration") {
-        throw new Error("PARSE ERROR: Expected a VariableDeclaration");
-    }
-    const decl2 = decl.declarations[0];
-    if (decl2.type !== "VariableDeclarator") {
-        throw new Error("PARSE ERROR: Expected a VariableDeclarator");
-    }
-    const expr = decl2.init;
-    if (!expr) {
-        throw new Error("PARSE ERROR: Expected an Expression");
-    }
-
-    return {
-        type: "Program",
-        body: [
-            {
-                type: "ExpressionStatement",
-                expression: expr,
-            },
-        ],
-        sourceType: "module",
-    };
 }

--- a/packages/docs-nextra/scripts/auto-insert-attr-prop-descriptions.ts
+++ b/packages/docs-nextra/scripts/auto-insert-attr-prop-descriptions.ts
@@ -3,11 +3,227 @@ import { Plugin } from "unified";
 import { computeOptimizedSchema } from "./compute-optimized-schema";
 import { parseModule, Program as EstreeProgram } from "esprima";
 import { Heading, Root as MdastRoot } from "mdast";
+import GithubSlugger from "github-slugger";
+import * as fs from "node:fs";
+import * as path from "node:path";
 // Importing this automatically imports all the types from `mdast-util-mdx-jsx`.
 import "mdast-util-mdx-jsx";
 import type { MdxJsxFlowElement } from "mdast-util-mdx-jsx";
 
 type OptimizedInfo = ReturnType<typeof computeOptimizedSchema>[string];
+
+/**
+ * A worked-example heading parsed from the page, e.g. `### Attribute Example:
+ * boxed` or `### Property Example: width, height`. `slug` is the anchor id
+ * Nextra will assign (see `collectExampleHeadings`); `names` are the raw,
+ * comma-split tokens after the colon.
+ */
+type ExampleHeading = {
+    slug: string;
+    kind: "attribute" | "property";
+    names: string[];
+};
+
+/** An example heading resolved to a concrete link target (same-page `#slug`
+ * or cross-page `/reference/<page>#slug`). */
+type ExampleRef = {
+    href: string;
+    kind: "attribute" | "property";
+    names: string[];
+};
+
+// Mirror of Nextra's own heading-slug logic so the anchors we link to match
+// the ids it assigns. Nextra skips headings whose parent is a tab.
+const SKIP_FOR_PARENT_NAMES = new Set(["Tab", "Tabs.Tab"]);
+const EXAMPLE_HEADING_RE = /^(Attribute|Property) Example:\s*(.+)$/i;
+
+/** Split the names listed after an example heading's colon. A heading may
+ * cover several attributes/properties separated by `,` or `/` (e.g.
+ * `displayDigits/displayDecimals`, `numRows/ numColumns`); names are
+ * identifiers, so `/` is always a separator, never part of a name. */
+function splitExampleNames(text: string): string[] {
+    return text
+        .split(/[,/]/)
+        .map((name) => name.trim())
+        .filter(Boolean);
+}
+
+/** Flatten a heading node's text content (matches Nextra's `getFlattenedValue`). */
+function getFlattenedValue(node: any): string {
+    return (node.children ?? [])
+        .map((child: any) =>
+            "children" in child
+                ? getFlattenedValue(child)
+                : "value" in child
+                  ? child.value
+                  : "",
+        )
+        .join("");
+}
+
+/**
+ * Walk the page's headings in document order, advancing one stateful
+ * `github-slugger` exactly as Nextra's `remark-headings` does, so the slugs we
+ * compute for example headings match the anchor ids Nextra emits (including
+ * its `-1`/`-2` dedup suffixes). Only headings of depth ≥ 2 are slugged
+ * (Nextra returns early for the page `# h1`).
+ */
+function collectExampleHeadings(tree: MdastRoot): ExampleHeading[] {
+    const slugger = new GithubSlugger();
+    const found: ExampleHeading[] = [];
+    visit(tree, "heading", (node: any, _index, parent: any) => {
+        if (node.depth === 1) {
+            return;
+        }
+        if (parent && SKIP_FOR_PARENT_NAMES.has(parent.name)) {
+            return;
+        }
+        const value = getFlattenedValue(node);
+        // Advance the slugger for every heading so dedup counters stay in sync,
+        // even for headings that are not examples.
+        const slug = slugger.slug(value);
+        const match = EXAMPLE_HEADING_RE.exec(value.trim());
+        if (!match) {
+            return;
+        }
+        const names = splitExampleNames(match[2]);
+        found.push({
+            slug,
+            kind: match[1].toLowerCase() as "attribute" | "property",
+            names,
+        });
+    });
+    return found;
+}
+
+/**
+ * Multi-page references (e.g. `math` + `math2`, `answer1`…`answer4`) spread a
+ * component's worked examples across several pages, while the attribute/property
+ * listing may live on only one of them. To link a listing to every example of
+ * its component, we index examples across ALL reference pages, keyed by the
+ * component each page documents.
+ *
+ * The component is read from each page's `# <tag>` H1 — every reference page
+ * (including continuation pages with no display tag) declares it there — so no
+ * extra per-page wiring is needed to associate the pages of one reference.
+ *
+ * Cached for the process: like the schema, the index is built once. Editing an
+ * example heading on another page requires restarting the dev server to update
+ * cross-page links (same constraint as schema changes).
+ */
+let crossPageExampleIndexCache: Map<string, ExampleRef[]> | null = null;
+
+/** Resolve the `pages/reference` directory from the file currently being
+ * processed, or `null` when the file is not a reference page. */
+function getReferenceDir(file: { path?: string; history?: string[] }) {
+    const filePath = file.path ?? file.history?.[0];
+    if (!filePath) {
+        return null;
+    }
+    const dir = path.dirname(filePath);
+    return path.basename(dir) === "reference" ? dir : null;
+}
+
+/**
+ * Scan a reference page's raw markdown for the component it documents (from the
+ * `# <tag>` H1) and its example headings, advancing one `github-slugger` over
+ * every depth-≥2 heading in document order to match Nextra's anchor ids.
+ * Fenced code blocks are skipped so DoenetML examples containing `#` are not
+ * mistaken for headings.
+ */
+function scanRawReferencePage(content: string): {
+    component: string | null;
+    examples: ExampleHeading[];
+} {
+    const slugger = new GithubSlugger();
+    let component: string | null = null;
+    const examples: ExampleHeading[] = [];
+    let fenceMarker: string | null = null;
+
+    for (const line of content.split(/\r?\n/)) {
+        const fence = line.match(/^(`{3,}|~{3,})/);
+        if (fence) {
+            const marker = fence[1][0];
+            if (fenceMarker === null) {
+                fenceMarker = marker;
+            } else if (marker === fenceMarker) {
+                fenceMarker = null;
+            }
+            continue;
+        }
+        if (fenceMarker !== null) {
+            continue;
+        }
+        const heading = line.match(/^(#{1,6})\s+(.*?)\s*#*\s*$/);
+        if (!heading) {
+            continue;
+        }
+        const depth = heading[1].length;
+        const text = heading[2];
+        if (depth === 1) {
+            // Nextra returns before slugging the H1; read the component tag.
+            const tag = text.match(/<\s*([A-Za-z0-9_]+)/);
+            if (tag && !component) {
+                component = tag[1];
+            }
+            continue;
+        }
+        const slug = slugger.slug(text);
+        const match = EXAMPLE_HEADING_RE.exec(text.trim());
+        if (!match) {
+            continue;
+        }
+        examples.push({
+            slug,
+            kind: match[1].toLowerCase() as "attribute" | "property",
+            names: splitExampleNames(match[2]),
+        });
+    }
+    return { component, examples };
+}
+
+/** Build (and cache) the component → cross-page example links index by
+ * scanning every reference page on disk. Hrefs are absolute
+ * (`/reference/<page>#<slug>`) so they resolve from any other page. */
+function getCrossPageExampleIndex(refDir: string): Map<string, ExampleRef[]> {
+    if (crossPageExampleIndexCache) {
+        return crossPageExampleIndexCache;
+    }
+    const index = new Map<string, ExampleRef[]>();
+    let fileNames: string[];
+    try {
+        fileNames = fs.readdirSync(refDir);
+    } catch {
+        return index;
+    }
+    for (const fileName of fileNames) {
+        if (!fileName.endsWith(".mdx") || fileName.startsWith("_")) {
+            continue;
+        }
+        let content: string;
+        try {
+            content = fs.readFileSync(path.join(refDir, fileName), "utf8");
+        } catch {
+            continue;
+        }
+        const { component, examples } = scanRawReferencePage(content);
+        if (!component || examples.length === 0) {
+            continue;
+        }
+        const route = `/reference/${fileName.slice(0, -".mdx".length)}`;
+        const list = index.get(component) ?? [];
+        for (const example of examples) {
+            list.push({
+                href: `${route}#${example.slug}`,
+                kind: example.kind,
+                names: example.names,
+            });
+        }
+        index.set(component, list);
+    }
+    crossPageExampleIndexCache = index;
+    return index;
+}
 
 export const autoInsertAttrPropDescriptions: Plugin<
     void[],
@@ -17,6 +233,24 @@ export const autoInsertAttrPropDescriptions: Plugin<
     const optimizedSchema = computeOptimizedSchema();
     return (tree, file) => {
         file.data.extraSearchData = {};
+
+        // Collected up front, before we splice in the "Attributes and
+        // Properties" heading below: that heading's slug never collides with
+        // an example heading's, so its absence here does not perturb the
+        // example slugs. The current page's examples come from this precise
+        // mdast scan (exact anchors); other pages' come from the disk index.
+        const currentRoute = `/reference/${file.stem ?? ""}`;
+        const samePageExamples: ExampleRef[] = collectExampleHeadings(tree).map(
+            (example) => ({
+                href: `#${example.slug}`,
+                kind: example.kind,
+                names: example.names,
+            }),
+        );
+        const refDir = getReferenceDir(file);
+        const crossPageIndex = refDir
+            ? getCrossPageExampleIndex(refDir)
+            : new Map<string, ExampleRef[]>();
 
         visit(tree, (node, index, parent) => {
             if (node?.type !== "mdxJsxFlowElement") {
@@ -40,11 +274,27 @@ export const autoInsertAttrPropDescriptions: Plugin<
                 return;
             }
 
+            // Merge this page's own examples with examples for the same
+            // component on other pages of a multi-page reference (excluding
+            // this page, already covered by the precise same-page scan).
+            const crossPageExamples = (crossPageIndex.get(name) ?? []).filter(
+                (ref) => !ref.href.startsWith(`${currentRoute}#`),
+            );
+            const { attrLinks, propLinks } = buildExampleLinks(info, [
+                ...samePageExamples,
+                ...crossPageExamples,
+            ]);
+
             if (node.name === "AttrDisplay") {
                 injectAttrs(node, info, file);
+                // Standalone <AttrDisplay> renders only attributes, so its
+                // `links` prop carries the attribute-example anchors.
+                injectLinksAttribute(node, "links", attrLinks);
             }
             if (node.name === "PropDisplay") {
                 injectProps(node, info, file);
+                // Standalone <PropDisplay> renders only properties.
+                injectLinksAttribute(node, "links", propLinks);
             }
             if (node.name === "ComponentDisplay") {
                 injectSummary(node, info, file);
@@ -56,6 +306,12 @@ export const autoInsertAttrPropDescriptions: Plugin<
                 // node's position, so it always runs.
                 injectAttrs(node, info, file);
                 injectProps(node, info, file);
+                // Attribute and property examples are kept in separate maps so
+                // a name that is both an attribute and a property (e.g.
+                // `format`) links to the right kind of example — or to none,
+                // when only one kind of example exists.
+                injectLinksAttribute(node, "attrLinks", attrLinks);
+                injectLinksAttribute(node, "propLinks", propLinks);
 
                 // Emit the section heading as a real Markdown heading so it
                 // picks up the theme's heading styling, anchor, and TOC entry.
@@ -148,6 +404,65 @@ function injectProps(
         .filter((prop) => !prop.common)
         .map((prop) => `${prop.name}: ${prop.description}`)
         .join("\n");
+}
+
+/**
+ * Build two maps — one for attributes, one for properties — pairing each
+ * listed name with the anchor of its worked example. "Attribute Example: …"
+ * headings only feed the attribute map and "Property Example: …" headings only
+ * the property map, so a name that is both an attribute and a property (e.g.
+ * `format`) links to the correct kind of example (or to none, when only one
+ * kind exists). Keys are the real attribute/property names so the renderer's
+ * `links[name]` lookup hits; heading tokens are matched case-insensitively.
+ */
+function buildExampleLinks(
+    info: OptimizedInfo,
+    examples: ExampleRef[],
+): { attrLinks: Record<string, string>; propLinks: Record<string, string> } {
+    const attrNames = new Map(
+        info.attrs.map((attr) => [attr.name.toLowerCase(), attr.name]),
+    );
+    const propNames = new Map(
+        info.props.map((prop) => [prop.name.toLowerCase(), prop.name]),
+    );
+    const attrLinks: Record<string, string> = {};
+    const propLinks: Record<string, string> = {};
+    for (const example of examples) {
+        const isAttr = example.kind === "attribute";
+        const lookup = isAttr ? attrNames : propNames;
+        const target = isAttr ? attrLinks : propLinks;
+        for (const token of example.names) {
+            const realName = lookup.get(token.toLowerCase());
+            // Keep the first match (the same-page example is listed first), so
+            // an on-page example wins over a cross-page one of the same name.
+            if (realName && target[realName] === undefined) {
+                target[realName] = example.href;
+            }
+        }
+    }
+    return { attrLinks, propLinks };
+}
+
+/** Inject a links map onto a node under `attrName`, skipping empty maps. */
+function injectLinksAttribute(
+    node: MdxJsxFlowElement,
+    attrName: string,
+    links: Record<string, string>,
+): void {
+    if (hasAttribute(node, attrName) || Object.keys(links).length === 0) {
+        return;
+    }
+    node.attributes.push({
+        type: "mdxJsxAttribute",
+        name: attrName,
+        value: {
+            type: "mdxJsxAttributeValueExpression",
+            value: JSON.stringify(links),
+            data: {
+                estree: objectToEstree(links),
+            },
+        },
+    });
 }
 
 /** Inject the schema `summary` onto a `<ComponentDisplay>`. */

--- a/packages/docs-nextra/scripts/compute-optimized-schema.ts
+++ b/packages/docs-nextra/scripts/compute-optimized-schema.ts
@@ -13,12 +13,16 @@ const SCHEMA: {
             defaultValue?: unknown;
             values?: string[];
             autocompleteValues?: { value: string; description: string }[];
+            groupName?: string;
+            highlighted?: boolean;
         }[];
         properties: {
             name: string;
             type?: string;
             isArray: boolean;
             description: string;
+            groupName?: string;
+            highlighted?: boolean;
         }[];
         acceptsStringChildren: boolean;
         top: boolean;
@@ -62,6 +66,10 @@ export function computeOptimizedSchema() {
 
     // Now that all attributes are computed, we can count each attribute. If the attribute appears on > 90% of elements,
     // we mark it as common.
+    //
+    // `common` takes precedence over `groupName`/`highlighted` in the renderer:
+    // a common attribute always renders in the bottom "Common to all
+    // components" section regardless of any group tag it may carry.
     const attrCounts: Record<string, number> = {};
     for (const element of doenetSchema.elements) {
         for (const attr of element.attributes) {
@@ -129,6 +137,12 @@ function getAttrInfo(element: (typeof SCHEMA)["elements"][number]) {
         if (correspondingProp?.isArray) {
             info.isArray = true;
         }
+        if (attr.groupName !== undefined) {
+            info.groupName = attr.groupName;
+        }
+        if (attr.highlighted) {
+            info.highlighted = true;
+        }
 
         attrInfo.push(info);
     }
@@ -141,6 +155,13 @@ function getAttrInfo(element: (typeof SCHEMA)["elements"][number]) {
  * Find information about all props of an element.
  */
 function getPropInfo(element: (typeof SCHEMA)["elements"][number]) {
+    // Derive grouping for properties that share a name with an attribute, so
+    // an attribute and its property always land in the same docs group. A
+    // property's own group (set on a pure-output state def) wins; otherwise we
+    // fall back to the same-named attribute's group.
+    const attrLookup = Object.fromEntries(
+        element.attributes.map((attr) => [attr.name, attr]),
+    );
     const propInfo: PropInfo[] = [];
     for (const prop of element.properties) {
         const info: PropInfo = {
@@ -153,6 +174,14 @@ function getPropInfo(element: (typeof SCHEMA)["elements"][number]) {
         }
         if (prop.isArray) {
             info.isArray = true;
+        }
+        const correspondingAttr = attrLookup[prop.name];
+        const groupName = prop.groupName ?? correspondingAttr?.groupName;
+        if (groupName !== undefined) {
+            info.groupName = groupName;
+        }
+        if (prop.highlighted ?? correspondingAttr?.highlighted) {
+            info.highlighted = true;
         }
 
         propInfo.push(info);

--- a/packages/docs-nextra/vite.config.ts
+++ b/packages/docs-nextra/vite.config.ts
@@ -13,5 +13,11 @@ export default defineConfig({
             },
             formats: ["es"],
         },
+        rollupOptions: {
+            // These scripts run in Node (as Next.js remark plugins), so keep
+            // Node built-ins external rather than letting the lib build stub
+            // them out (which leaves e.g. `fs.readdirSync` undefined).
+            external: [/^node:/],
+        },
     },
 });

--- a/packages/doenetml-worker-javascript/src/components/Answer.js
+++ b/packages/doenetml-worker-javascript/src/components/Answer.js
@@ -57,6 +57,7 @@ export default class Answer extends InlineComponent {
             forRenderer: true,
             defaultValue: false,
             public: true,
+            highlighted: true,
             description:
                 "Whether to render the answer's input inline rather than as a block.",
         };
@@ -65,6 +66,7 @@ export default class Answer extends InlineComponent {
             createStateVariable: "symbolicEquality",
             defaultValue: false,
             public: true,
+            highlighted: true,
             description:
                 "Whether comparison uses symbolic equality (rather than numeric evaluation).",
         };

--- a/packages/doenetml-worker-javascript/src/components/Math.js
+++ b/packages/doenetml-worker-javascript/src/components/Math.js
@@ -71,6 +71,7 @@ export default class MathComponent extends InlineComponent {
             createStateVariable: "format",
             defaultValue: "text",
             public: true,
+            highlighted: true,
             toLowerCase: true,
             validValues: [
                 {
@@ -90,6 +91,7 @@ export default class MathComponent extends InlineComponent {
             createStateVariable: "simplify",
             defaultValue: "none",
             public: true,
+            highlighted: true,
             toLowerCase: true,
             valueForTrue: "full",
             valueForFalse: "none",
@@ -128,6 +130,10 @@ export default class MathComponent extends InlineComponent {
         };
 
         Object.assign(attributes, returnNumberDisplayAttributes());
+        // Highlight the most commonly tuned number-display attribute. Because
+        // it keeps its `groupName`, it appears both in the Highlighted section
+        // and in the "Number display" group.
+        attributes.displayDigits.highlighted = true;
 
         attributes.renderMode = {
             description: 'How the math is rendered (e.g. "inline", "display").',

--- a/packages/doenetml-worker-javascript/src/components/Slider.js
+++ b/packages/doenetml-worker-javascript/src/components/Slider.js
@@ -47,6 +47,7 @@ export default class Slider extends BaseComponent {
             ],
             description: "Type of value the slider produces.",
             forRenderer: true,
+            highlighted: true,
         };
         attributes.width = {
             description: "Display width of the slider.",
@@ -112,6 +113,7 @@ export default class Slider extends BaseComponent {
             defaultValue: 0,
             public: true,
             forRenderer: true,
+            highlighted: true,
         };
         attributes.to = {
             description: "Maximum value of the slider's range.",
@@ -120,6 +122,7 @@ export default class Slider extends BaseComponent {
             defaultValue: 10,
             public: true,
             forRenderer: true,
+            highlighted: true,
         };
         attributes.step = {
             description: "Increment between successive slider positions.",
@@ -128,6 +131,7 @@ export default class Slider extends BaseComponent {
             defaultValue: 1,
             public: true,
             forRenderer: true,
+            highlighted: true,
         };
 
         Object.assign(attributes, returnLabelAttributes());

--- a/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
@@ -1175,6 +1175,22 @@ export default class BaseComponent {
                         stateVariableDescriptions[varName].description =
                             attrObj.description;
                     }
+                    // Propagate the docs-only grouping flags onto the
+                    // attribute-derived state variable so a property whose
+                    // backing attribute has a different name (i.e.
+                    // `createStateVariable !== attrName`) still lands in the
+                    // same docs group as its attribute. For the common case
+                    // where attribute and state variable share a name, the
+                    // docs pipeline also derives the group from the attribute
+                    // (see `getPropInfo` in `compute-optimized-schema.ts`).
+                    if (attrObj.groupName !== undefined) {
+                        stateVariableDescriptions[varName].groupName =
+                            attrObj.groupName;
+                    }
+                    if (attrObj.highlighted !== undefined) {
+                        stateVariableDescriptions[varName].highlighted =
+                            attrObj.highlighted;
+                    }
                     // Note: `stateVarExcludeFromSchema` (the
                     // "keep-attribute / hide-companion-state-var" lever
                     // for #1089) is handled in `get-schema.ts` by scanning
@@ -1247,6 +1263,18 @@ export default class BaseComponent {
                 // state var, #1090).
                 if (theStateDef.excludeFromSchema) {
                     stateVariableDescriptions[varName].excludeFromSchema = true;
+                }
+                // Propagate the docs-only grouping flags for pure-output
+                // properties (public state vars with no backing attribute,
+                // e.g. `creditAchieved`), so they can be placed in a docs
+                // group or highlighted directly on the state definition.
+                if (theStateDef.groupName !== undefined) {
+                    stateVariableDescriptions[varName].groupName =
+                        theStateDef.groupName;
+                }
+                if (theStateDef.highlighted !== undefined) {
+                    stateVariableDescriptions[varName].highlighted =
+                        theStateDef.highlighted;
                 }
                 // Surface the resting/default value the runtime falls back to
                 // when nothing else (attribute, child, parent) sets the

--- a/packages/doenetml-worker-javascript/src/utils/answer.js
+++ b/packages/doenetml-worker-javascript/src/utils/answer.js
@@ -10,6 +10,7 @@ export function returnStandardAnswerAttributes() {
             createStateVariable: "weight",
             defaultValue: 1,
             public: true,
+            groupName: "answer-grading",
             description:
                 "Relative weight of this answer when aggregating credit across multiple answers.",
         },
@@ -18,6 +19,7 @@ export function returnStandardAnswerAttributes() {
             createStateVariable: "handGraded",
             defaultValue: false,
             public: true,
+            groupName: "answer-grading",
             description:
                 "Whether this answer is graded by hand rather than automatically.",
         },
@@ -26,6 +28,7 @@ export function returnStandardAnswerAttributes() {
             createStateVariable: "matchPartial",
             defaultValue: false,
             public: true,
+            groupName: "answer-grading",
             description:
                 "Whether to award partial credit when the response is partially correct.",
         },
@@ -34,6 +37,7 @@ export function returnStandardAnswerAttributes() {
             createStateVariable: "maxNumAttempts",
             defaultValue: Infinity,
             public: true,
+            groupName: "answer-grading",
             description:
                 "Maximum number of times the response can be submitted.",
         },
@@ -41,6 +45,7 @@ export function returnStandardAnswerAttributes() {
             createComponentOfType: "boolean",
             createStateVariable: "showCorrectnessPreliminary",
             defaultValue: true,
+            groupName: "answer-grading",
             description:
                 "Whether to display whether the submitted response is correct.",
         },
@@ -49,6 +54,7 @@ export function returnStandardAnswerAttributes() {
             createStateVariable: "colorCorrectnessPreliminary",
             defaultValue: true,
             public: true,
+            groupName: "answer-grading",
             // The runtime stores the raw attribute value under
             // `colorCorrectnessPreliminary` so a derived `colorCorrectness`
             // state def can combine it with the ancestor's setting. Authors
@@ -65,6 +71,7 @@ export function returnStandardAnswerAttributes() {
             createStateVariable: "disableAfterCorrect",
             defaultValue: false,
             public: true,
+            groupName: "answer-grading",
             description:
                 "Whether to disable the answer after a fully correct response has been submitted.",
         },
@@ -75,6 +82,7 @@ export function returnStandardAnswerAttributes() {
             defaultValue: "Check Work",
             public: true,
             forRenderer: true,
+            groupName: "answer-grading",
             description:
                 "Label for the submit button when correctness is shown.",
         },
@@ -85,6 +93,7 @@ export function returnStandardAnswerAttributes() {
             defaultValue: "Submit Response",
             public: true,
             forRenderer: true,
+            groupName: "answer-grading",
             description:
                 "Label for the submit button when correctness is not shown.",
         },
@@ -94,6 +103,7 @@ export function returnStandardAnswerAttributes() {
             createStateVariable: "displayDigitsForResponses",
             defaultValue: 10,
             public: true,
+            groupName: "answer-grading",
             description:
                 "Number of significant digits to display when rendering numeric responses.",
         },
@@ -103,6 +113,7 @@ export function returnStandardAnswerAttributes() {
             createStateVariable: "displayDigitsForCreditAchieved",
             defaultValue: 3,
             public: true,
+            groupName: "answer-grading",
             description:
                 "Number of significant digits to display for the credit achieved value.",
         },

--- a/packages/doenetml-worker-javascript/src/utils/componentInfoObjects.ts
+++ b/packages/doenetml-worker-javascript/src/utils/componentInfoObjects.ts
@@ -113,6 +113,19 @@ type StateVariableDescription = {
      * attribute-derived, addressing the second scope item of #1089.
      */
     excludeFromSchema?: boolean;
+    /**
+     * Docs-only: the functional group this property belongs to in the
+     * reference docs. Propagated by `BaseComponent.returnStateVariableInfo`
+     * either from the backing attribute or, for pure-output properties, from
+     * the state def itself. See `AttributeDefinition.groupName`.
+     */
+    groupName?: string;
+    /**
+     * Docs-only: when `true`, this property is hand-picked as one of the most
+     * useful and is surfaced in the "Highlighted" section of the reference
+     * docs. See `AttributeDefinition.highlighted`.
+     */
+    highlighted?: boolean;
 };
 
 /**

--- a/packages/doenetml-worker-javascript/src/utils/dast/types.ts
+++ b/packages/doenetml-worker-javascript/src/utils/dast/types.ts
@@ -308,6 +308,22 @@ export type AttributeDefinition<T> = {
     triggerActionOnChange?: string;
     /** One-sentence description of the attribute, surfaced in editor help and docs. */
     description: string;
+    /**
+     * Docs-only: the functional group this attribute belongs to in the
+     * reference docs (e.g. `"number-display"`, `"labels"`). Attributes sharing
+     * a `groupName` render together in a collapsible section. When omitted, the
+     * attribute falls into the generic "Other" group. The group vocabulary and
+     * display labels live in the docs renderer, so adding a new group does not
+     * require a worker change.
+     */
+    groupName?: string;
+    /**
+     * Docs-only: when `true`, this attribute is hand-picked as one of the most
+     * useful for the component and is surfaced in the "Highlighted" section
+     * (open by default) at the top of the reference docs, in addition to its
+     * `groupName` section.
+     */
+    highlighted?: boolean;
     /** If `true`, attribute values are converted to lower case */
     toLowerCase?: boolean;
     /** If `true`, leave the attribute serialized when the component is created */

--- a/packages/doenetml-worker-javascript/src/utils/graphical.js
+++ b/packages/doenetml-worker-javascript/src/utils/graphical.js
@@ -4,6 +4,7 @@ export function returnAnchorAttributes() {
     return {
         anchor: {
             createComponentOfType: "point",
+            groupName: "positioning",
             description:
                 "Coordinates of the anchor point used to position this component on a graph.",
         },
@@ -15,6 +16,7 @@ export function returnAnchorAttributes() {
             forRenderer: true,
             toLowerCase: true,
             isLocation: true,
+            groupName: "positioning",
             validValues: [
                 {
                     value: "upperRight",
@@ -100,6 +102,7 @@ export function returnAnchorStateVariableDefinition() {
             forRenderer: true,
             hasEssential: true,
             isLocation: true,
+            groupName: "positioning",
             shadowingInstructions: {
                 createComponentOfType: "point",
             },

--- a/packages/doenetml-worker-javascript/src/utils/label.ts
+++ b/packages/doenetml-worker-javascript/src/utils/label.ts
@@ -8,6 +8,7 @@ export function returnLabelAttributes() {
             createStateVariable: "labelIsName",
             defaultValue: false,
             public: true,
+            groupName: "labels",
             description:
                 "Whether to use this component's name as its rendered label.",
         },
@@ -272,6 +273,7 @@ export function returnLabelStateVariableDefinitions({
         description: "The label rendered with this component.",
         forRenderer: true,
         public: true,
+        groupName: "labels",
         shadowingInstructions: {
             createComponentOfType: "label",
             addStateVariablesShadowingStateVariables: {

--- a/packages/doenetml-worker-javascript/src/utils/numberDisplay.js
+++ b/packages/doenetml-worker-javascript/src/utils/numberDisplay.js
@@ -340,27 +340,32 @@ export function returnNumberDisplayAttributes() {
     return {
         displayDigits: {
             createComponentOfType: "integer",
+            groupName: "number-display",
             description:
                 "Number of significant digits to display when rendering this number.",
         },
         displayDecimals: {
             createComponentOfType: "integer",
+            groupName: "number-display",
             description:
                 "Number of decimal places to display when rendering this number.",
         },
         displaySmallAsZero: {
             createComponentOfType: "number",
+            groupName: "number-display",
             valueForTrue: 1e-14,
             valueForFalse: 0,
             description: "Threshold below which numbers are displayed as zero.",
         },
         padZeros: {
             createComponentOfType: "boolean",
+            groupName: "number-display",
             description:
                 "Whether to pad displayed numbers with trailing zeros to fill the requested digits/decimals.",
         },
         avoidScientificNotation: {
             createComponentOfType: "boolean",
+            groupName: "number-display",
             description:
                 "Whether to render numbers in full decimal form rather than scientific notation.",
         },

--- a/packages/doenetml-worker-javascript/src/utils/scoredSection.js
+++ b/packages/doenetml-worker-javascript/src/utils/scoredSection.js
@@ -4,6 +4,7 @@ export function returnScoredSectionAttributes() {
             createComponentOfType: "boolean",
             createStateVariable: "aggregateScoresPreliminary",
             defaultValue: false,
+            groupName: "scoring",
             description:
                 "Whether to aggregate scores of scored descendants into a section credit-achieved value.",
         },
@@ -12,6 +13,7 @@ export function returnScoredSectionAttributes() {
             createStateVariable: "weight",
             defaultValue: 1,
             public: true,
+            groupName: "scoring",
             description:
                 "Relative weight of this section when aggregated by an enclosing scored section.",
         },
@@ -21,6 +23,7 @@ export function returnScoredSectionAttributes() {
             createStateVariable: "sectionWideCheckWork",
             defaultValue: false,
             public: true,
+            groupName: "scoring",
             description:
                 "Whether to show a single section-wide check-work button instead of per-answer buttons.",
         },
@@ -28,6 +31,7 @@ export function returnScoredSectionAttributes() {
             createComponentOfType: "boolean",
             createStateVariable: "showCorrectnessPreliminary",
             defaultValue: false,
+            groupName: "scoring",
             description:
                 "Whether to display correctness indicators for answers in this section.",
         },
@@ -35,6 +39,7 @@ export function returnScoredSectionAttributes() {
             createComponentOfType: "boolean",
             createStateVariable: "colorCorrectnessPreliminary",
             defaultValue: false,
+            groupName: "scoring",
             description:
                 "Whether to color-code answers in this section based on correctness.",
         },
@@ -42,6 +47,7 @@ export function returnScoredSectionAttributes() {
             createComponentOfType: "boolean",
             createStateVariable: "forceIndividualAnswerColoring",
             defaultValue: false,
+            groupName: "scoring",
             description:
                 "Whether to force per-answer color-correctness even when section-wide check work is enabled.",
         },
@@ -51,6 +57,7 @@ export function returnScoredSectionAttributes() {
             defaultValue: "Check Work",
             public: true,
             forRenderer: true,
+            groupName: "scoring",
             description:
                 "Label for the section-wide submit button when correctness is shown.",
         },
@@ -60,6 +67,7 @@ export function returnScoredSectionAttributes() {
             defaultValue: "Submit Response",
             public: true,
             forRenderer: true,
+            groupName: "scoring",
             description:
                 "Label for the section-wide submit button when correctness is not shown.",
         },
@@ -69,6 +77,7 @@ export function returnScoredSectionAttributes() {
             createStateVariable: "displayDigitsForCreditAchieved",
             defaultValue: 3,
             public: true,
+            groupName: "scoring",
             description:
                 "Number of significant digits to display for the section's credit achieved value.",
         },

--- a/packages/doenetml-worker-javascript/src/utils/triggering.js
+++ b/packages/doenetml-worker-javascript/src/utils/triggering.js
@@ -5,21 +5,25 @@ export function returnStandardTriggeringAttributes(triggerActionOnChange) {
             createStateVariable: "triggerWhen",
             defaultValue: false,
             triggerActionOnChange,
+            groupName: "triggering",
             description:
                 "Boolean expression that fires the action whenever it transitions to true.",
         },
         triggerWith: {
             createReferences: true,
+            groupName: "triggering",
             description:
                 "References to components whose value changes should fire this action.",
         },
         triggerWhenObjectsClicked: {
             createReferences: true,
+            groupName: "triggering",
             description:
                 "References to components whose click events should fire this action.",
         },
         triggerWhenObjectsFocused: {
             createReferences: true,
+            groupName: "triggering",
             description:
                 "References to components whose focus events should fire this action.",
         },

--- a/packages/static-assets/scripts/generate-relaxng-schema.ts
+++ b/packages/static-assets/scripts/generate-relaxng-schema.ts
@@ -55,7 +55,20 @@ function schemaToRelaxNgSchema(schema: GeneratedSchema): RelaxNgSchema {
                 ),
                 children: item.children.map((child) => ({ ref: child })),
                 textChildrenAllowed: item.acceptsStringChildren,
-                properties: item.properties,
+                // Strip docs-only metadata (`groupName`/`highlighted`) that the
+                // schema carries for the reference docs but that has no role in
+                // XML validation or editor autocomplete.
+                properties: item.properties.map((property) => {
+                    const {
+                        groupName: _groupName,
+                        highlighted: _highlighted,
+                        ...rest
+                    } = property as SchemaProperty & {
+                        groupName?: string;
+                        highlighted?: boolean;
+                    };
+                    return rest;
+                }),
             } satisfies RelaxNgAttribute,
         ]),
     );

--- a/packages/static-assets/scripts/get-schema.ts
+++ b/packages/static-assets/scripts/get-schema.ts
@@ -262,6 +262,12 @@ type PropertyDescription = {
     indexAliases?: string[][];
     description: string;
     fromAttribute?: boolean;
+    /** Docs-only: functional group for the reference docs. See
+     * `AttributeDefinition.groupName`. */
+    groupName?: string;
+    /** Docs-only: surface this property in the docs "Highlighted" section.
+     * See `AttributeDefinition.highlighted`. */
+    highlighted?: boolean;
 };
 
 type ArrayElementDescription = {
@@ -304,6 +310,12 @@ type StateVariableDescription = {
      * its companion state var, #1090). See #1089.
      */
     excludeFromSchema?: boolean;
+    /** Docs-only: functional group for the reference docs. See
+     * `AttributeDefinition.groupName`. */
+    groupName?: string;
+    /** Docs-only: surface in the docs "Highlighted" section. See
+     * `AttributeDefinition.highlighted`. */
+    highlighted?: boolean;
 };
 
 type PublicStateVariableDescription = {
@@ -342,6 +354,12 @@ type PublicStateVariableDescription = {
     defaultValue?: unknown;
     /** See `StateVariableDescription.excludeFromSchema`. */
     excludeFromSchema?: boolean;
+    /** Docs-only: functional group for the reference docs. See
+     * `AttributeDefinition.groupName`. */
+    groupName?: string;
+    /** Docs-only: surface in the docs "Highlighted" section. See
+     * `AttributeDefinition.highlighted`. */
+    highlighted?: boolean;
 };
 
 type SchemaAttribute = {
@@ -365,6 +383,12 @@ type SchemaAttribute = {
     description: string;
     /** Default value for the attribute (if defined). */
     defaultValue?: unknown;
+    /** Docs-only: functional group this attribute belongs to in the reference
+     * docs (e.g. `"number-display"`). See `AttributeDefinition.groupName`. */
+    groupName?: string;
+    /** Docs-only: when `true`, surface this attribute in the docs "Highlighted"
+     * section. See `AttributeDefinition.highlighted`. */
+    highlighted?: boolean;
 };
 
 type SchemaElement = {
@@ -725,6 +749,13 @@ export function getSchema(
                 name: attrName,
                 description: attrDef.description,
             };
+            // Docs-only grouping metadata, surfaced into the reference docs.
+            if (attrDef.groupName !== undefined) {
+                attrSpec.groupName = attrDef.groupName;
+            }
+            if (attrDef.highlighted !== undefined) {
+                attrSpec.highlighted = attrDef.highlighted;
+            }
             // Prefer the default declared on the attribute itself. When it
             // doesn't declare one, fall back to the matching state
             // variable's default — this covers number-display attributes
@@ -1242,6 +1273,16 @@ function singlePropFromDescription({
 
     if (description.fromAttribute) {
         prop.fromAttribute = true;
+    }
+
+    // Docs-only grouping metadata. For attribute-derived properties this is
+    // also derivable from the same-named attribute in the docs pipeline; for
+    // pure-output properties it is the only source.
+    if (description.groupName !== undefined) {
+        prop.groupName = description.groupName;
+    }
+    if (description.highlighted !== undefined) {
+        prop.highlighted = description.highlighted;
     }
 
     if (description.isArray) {


### PR DESCRIPTION
## Summary

The component reference pages listed every attribute and property in one long flat list, giving equal visual weight to rarely- and commonly-used options and forcing readers to scroll past everything. This reworks that listing into a navigable structure:

- **Collapsible sections**, in order: a curated **Highlighted** group (open by default) → functional groups (e.g. *Number display*, *Labels*, *Positioning*, *Answer grading*, *Scoring*, *Triggering*) → **Other** → **Common to all components** (closed). The last group restores the `BaseComponent` attributes (`hide`, `disabled`, `fixed`, `styleNumber`, …) that were previously hidden entirely.
- **Filter box** that narrows the list by name/description and auto-expands matching groups.
- **Expand all / Collapse all** toggle (so Ctrl+F can reach collapsed content).
- **Example links**: each listed attribute/property links to its worked example, including examples on **other pages of a multi-page reference** (e.g. `math` → `math2`). A name that is both an attribute and a property links to the correct kind of example.

Grouping is driven by optional, **docs-only** `groupName`/`highlighted` metadata on attribute definitions and public state variables, threaded through the generated schema. Highlighting is a separate flag from `groupName`, so a highlighted attribute appears in both the Highlighted group and its functional group.

### Scope

This PR ships the full mechanism plus a representative sample of tagging:

- Tagged the shared attribute utilities (`numberDisplay`, `label`, `graphical` anchor, `answer`, `triggering`, `scoredSection`).
- Hand-curated highlights on a few components (`Math`, `Slider`, `Answer`).

Mass-curation of highlights across the remaining components is intended as a follow-up.

### Implementation notes

- Multi-page references are associated by the component named in each page's `# <tag>` H1, so continuation pages need no extra wiring.
- The remark plugin needed Node built-ins (`fs`/`path`) to index examples across pages; the docs scripts' Vite lib build was stubbing those out, so `node:*` is now externalized in `vite.config.ts`.
- Docs-only metadata is stripped from the RelaxNG schema (it has no role in validation/autocomplete).

## Test plan

- [ ] `npm run build:schema -w packages/static-assets` regenerates `doenet-schema.json` with only `groupName`/`highlighted` added; RelaxNG schema unchanged.
- [ ] Reference pages render the grouped/collapsible sections, filter box, and Expand/Collapse-all toggle (verified on `/reference/math`, `/reference/slider`, `/reference/answer`, `/reference/definition`).
- [ ] Highlighted-and-grouped attribute (`math` `displayDigits`) appears in both the Highlighted and Number display groups with distinct anchors.
- [ ] Attribute/property names link to the correct same-page and cross-page worked examples; an attribute-only example does not link a same-named property.
- [ ] `tsc` passes for `docs-nextra` and `static-assets`; no new type errors in the worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)