### PR TITLE
Propagate styleNumber from composites to their members

### DIFF
--- a/.changeset/style-number-composite-propagation.md
+++ b/.changeset/style-number-composite-propagation.md
@@ -1,0 +1,9 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+---
+
+Propagate `styleNumber` from a composite (e.g. `<group>`) to the components it creates.
+
+Setting `styleNumber` on a `<group>` previously had no effect on the members inside it — they rendered with the default style — because `styleNumber` only inherited from the rendered parent, and a group's members are reparented out of the group into its container. Members now fall back to the `styleNumber` of the composite that created them, so `<group styleNumber="4">…</group>` styles its contents the same way `<graph styleNumber="4">` already did. An explicit `styleNumber` on a member still wins, and a containing element's `styleNumber` (e.g. the `<graph>` the group sits in) takes precedence over the group's.

--- a/.changeset/style-number-composite-propagation.md
+++ b/.changeset/style-number-composite-propagation.md
@@ -4,6 +4,10 @@
 "@doenet/doenetml-iframe": patch
 ---
 
-Propagate `styleNumber` from a composite (e.g. `<group>`) to the components it creates.
+Propagate `styleNumber` from a composite (e.g. `<group>`) to the components it creates, and make the nearest setting win.
 
-Setting `styleNumber` on a `<group>` previously had no effect on the members inside it — they rendered with the default style — because `styleNumber` only inherited from the rendered parent, and a group's members are reparented out of the group into its container. Members now fall back to the `styleNumber` of the composite that created them, so `<group styleNumber="4">…</group>` styles its contents the same way `<graph styleNumber="4">` already did. An explicit `styleNumber` on a member still wins, and a containing element's `styleNumber` (e.g. the `<graph>` the group sits in) takes precedence over the group's.
+Setting `styleNumber` on a `<group>` previously had no effect on the members inside it — they rendered with the default style — because `styleNumber` only inherited from the rendered parent, and a group's members are reparented out of the group into its container. Members now also fall back to the `styleNumber` of the composite that created them.
+
+Relatedly, when an attribute can inherit from both a parent and a source composite, the **source composite (the innermost authored wrapper) now wins over the parent**. This makes a `<group styleNumber="4">` behave like the nearest container: in `<graph styleNumber="5"><group styleNumber="4">…</group></graph>` the grouped points are style 4, and a loose point alongside them is style 5 — the same result you get from a `<graph styleNumber="4">` nested in a `<section styleNumber="5">`, so authors don't have to know which components are composites. Extending such a graph (`<graph extend="$g" styleNumber="2" />`) re-resolves each member in its new context: a loose point picks up the new `2`, while grouped points keep the group's `4`.
+
+An explicit `styleNumber` on a member still wins over everything. The new precedence also applies to the other attributes that already used both fall-backs (`<math>`/`<mathList>` `functionSymbols`, `splitSymbols`, `referencesAreFunctionSymbols`), where a wrapping list composite now likewise takes precedence over a more distant containing element.

--- a/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
@@ -383,6 +383,7 @@ export default class BaseComponent {
                 defaultValue: 1,
                 public: true,
                 fallBackToParentStateVariable: "styleNumber",
+                fallBackToSourceCompositeStateVariable: "styleNumber",
                 description:
                     "The style number used to select this component's visual styling from the available style definitions.",
             },

--- a/packages/doenetml-worker-javascript/src/core/StateVariableDefinitionFactory.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableDefinitionFactory.ts
@@ -1251,14 +1251,17 @@ function _copyPassthroughAttributes(
  *
  * The `definition` resolves the attribute value from one of the four
  * dependency shapes (`attributeComponent` / `attributePrimitive` /
- * `attributeRefResolutions` / fall-back via parent or
- * source-composite), then validates it via `validateAttributeValue`.
+ * `attributeRefResolutions` / fall-back), then validates it via
+ * `validateAttributeValue`. The fall-back consults the source composite
+ * before the parent, so a more-local setting (e.g. a `<group>` the
+ * component sits in) wins over a more-distant one (e.g. the surrounding
+ * `<graph>`).
  *
  * The `inverseDefinition` (used unless `noInverse` is set) routes a
- * desired value back to the same source — propagating to the parent
- * state variable, source-composite state variable, or essential value
- * when no underlying component is present, or back to the attribute
- * component when one is.
+ * desired value back to the same source — propagating to the
+ * source-composite state variable, parent state variable, or essential
+ * value when no underlying component is present, or back to the
+ * attribute component when one is. Its precedence mirrors `definition`.
  */
 function _buildAttributeDerivedDefinitions({
     varName,
@@ -1298,36 +1301,38 @@ function _buildAttributeDerivedDefinitions({
         ) {
             attributeValue = dependencyValues.attributeRefResolutions;
         } else {
-            // parentValue would be undefined if fallBackToParentStateVariable wasn't specified
-            // parentValue would be null if the parentValue state variables
-            // did not exist or its value was null
-            let haveParentValue = dependencyValues.parentValue != null;
+            // sourceCompositeValue would be undefined if fallBackToSourceCompositeStateVariable wasn't specified
+            // sourceCompositeValue would be null if the sourceCompositeValue state variables
+            // did not exist or its value was null.
+            // The source composite (the innermost authored wrapper, e.g. a
+            // <group> the component sits in) is consulted before the parent so
+            // that a more-local setting wins over a more-distant one.
+            let haveSourceCompositeValue =
+                dependencyValues.sourceCompositeValue != null;
             if (
-                haveParentValue &&
-                !usedDefault.parentValue &&
+                haveSourceCompositeValue &&
+                !usedDefault.sourceCompositeValue &&
                 essentialValues[varName] === undefined
             ) {
                 return {
                     setValue: {
-                        [varName]: dependencyValues.parentValue,
+                        [varName]: dependencyValues.sourceCompositeValue,
                     },
                     checkForActualChange: { [varName]: true },
                 };
             } else {
-                // sourceCompositeValue would be undefined if fallBackToSourceCompositeStateVariable wasn't specified
-                // sourceCompositeValue would be null if the sourceCompositeValue state variables
+                // parentValue would be undefined if fallBackToParentStateVariable wasn't specified
+                // parentValue would be null if the parentValue state variables
                 // did not exist or its value was null
-
-                let haveSourceCompositeValue =
-                    dependencyValues.sourceCompositeValue != null;
+                let haveParentValue = dependencyValues.parentValue != null;
                 if (
-                    haveSourceCompositeValue &&
-                    !usedDefault.sourceCompositeValue &&
+                    haveParentValue &&
+                    !usedDefault.parentValue &&
                     essentialValues[varName] === undefined
                 ) {
                     return {
                         setValue: {
-                            [varName]: dependencyValues.sourceCompositeValue,
+                            [varName]: dependencyValues.parentValue,
                         },
                         checkForActualChange: { [varName]: true },
                     };
@@ -1371,36 +1376,39 @@ function _buildAttributeDerivedDefinitions({
                 return { success: false };
             }
 
-            let haveParentValue = dependencyValues.parentValue != null;
+            // Mirror the forward `definition`'s precedence: the source
+            // composite is consulted before the parent, so a desired value
+            // must be routed back to whichever source was actually read.
+            let haveSourceCompositeValue =
+                dependencyValues.sourceCompositeValue != null;
             if (
-                haveParentValue &&
-                !usedDefault.parentValue &&
+                haveSourceCompositeValue &&
+                !usedDefault.sourceCompositeValue &&
                 essentialValues[varName] === undefined
             ) {
-                // value from parent was used, so propagate back to parent
+                // value from source composite was used, so propagate back to source composite
                 return {
                     success: true,
                     instructions: [
                         {
-                            setDependency: "parentValue",
+                            setDependency: "sourceCompositeValue",
                             desiredValue: desiredStateVariableValues[varName],
                         },
                     ],
                 };
             } else {
-                let haveSourceCompositeValue =
-                    dependencyValues.sourceCompositeValue != null;
+                let haveParentValue = dependencyValues.parentValue != null;
                 if (
-                    haveSourceCompositeValue &&
-                    !usedDefault.sourceCompositeValue &&
+                    haveParentValue &&
+                    !usedDefault.parentValue &&
                     essentialValues[varName] === undefined
                 ) {
-                    // value from source composite was used, so propagate back to source composite
+                    // value from parent was used, so propagate back to parent
                     return {
                         success: true,
                         instructions: [
                             {
-                                setDependency: "sourceCompositeValue",
+                                setDependency: "parentValue",
                                 desiredValue:
                                     desiredStateVariableValues[varName],
                             },

--- a/packages/doenetml-worker-javascript/src/core/StateVariableDefinitionFactory.ts
+++ b/packages/doenetml-worker-javascript/src/core/StateVariableDefinitionFactory.ts
@@ -1075,9 +1075,11 @@ function _buildAttributeValueDependency(
  * Build the optional fall-back dependency entries (`parentValue`,
  * `sourceCompositeValue`) for an attribute-derived state variable.
  * Returns an empty object when the spec declares no fall-backs. Both
- * call sites spread the result into their own dependency map; the
- * order in which the spread is placed determines the iteration order
- * of the resulting object.
+ * call sites spread the result into their own dependency map. The
+ * order of these entries does not affect fall-back precedence: the
+ * definitions read each dependency by name and apply a fixed
+ * source-composite-before-parent precedence (see
+ * `_buildAttributeDerivedDefinitions`).
  */
 function _buildAttributeFallbackDependencies(
     attributeSpecification: any,

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/styleOverride.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/styleOverride.test.ts
@@ -487,15 +487,12 @@ describe("styleNumber propagation through composites @group4", async () => {
 `,
         });
 
-        const stateVariables = await core.returnAllStateVariables(false, true);
-        expect(
-            stateVariables[await resolvePathToNodeIdx("P1")].stateValues
-                .styleNumber,
-        ).eq(4);
-        expect(
-            stateVariables[await resolvePathToNodeIdx("P2")].stateValues
-                .styleNumber,
-        ).eq(4);
+        const sv = await core.returnAllStateVariables(false, true);
+        const styleOf = async (name: string) =>
+            sv[await resolvePathToNodeIdx(name)].stateValues.styleNumber;
+
+        expect(await styleOf("P1")).eq(4);
+        expect(await styleOf("P2")).eq(4);
     });
 
     it("an explicit styleNumber on a member overrides the group's", async () => {
@@ -510,17 +507,14 @@ describe("styleNumber propagation through composites @group4", async () => {
 `,
         });
 
-        const stateVariables = await core.returnAllStateVariables(false, true);
+        const sv = await core.returnAllStateVariables(false, true);
+        const styleOf = async (name: string) =>
+            sv[await resolvePathToNodeIdx(name)].stateValues.styleNumber;
+
         // Explicit value on the member wins.
-        expect(
-            stateVariables[await resolvePathToNodeIdx("P1")].stateValues
-                .styleNumber,
-        ).eq(2);
+        expect(await styleOf("P1")).eq(2);
         // Sibling without an explicit value still inherits the group's.
-        expect(
-            stateVariables[await resolvePathToNodeIdx("P2")].stateValues
-                .styleNumber,
-        ).eq(4);
+        expect(await styleOf("P2")).eq(4);
     });
 
     it("a group's styleNumber wins over a containing graph's (innermost wins)", async () => {
@@ -581,15 +575,12 @@ describe("styleNumber propagation through composites @group4", async () => {
 `,
         });
 
-        const stateVariables = await core.returnAllStateVariables(false, true);
-        expect(
-            stateVariables[await resolvePathToNodeIdx("r[1].rp")].stateValues
-                .styleNumber,
-        ).eq(4);
-        expect(
-            stateVariables[await resolvePathToNodeIdx("r[2].rp")].stateValues
-                .styleNumber,
-        ).eq(4);
+        const sv = await core.returnAllStateVariables(false, true);
+        const styleOf = async (name: string) =>
+            sv[await resolvePathToNodeIdx(name)].stateValues.styleNumber;
+
+        expect(await styleOf("r[1].rp")).eq(4);
+        expect(await styleOf("r[2].rp")).eq(4);
     });
 
     it("extending a graph re-resolves styleNumber against the new context", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/styleOverride.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/styleOverride.test.ts
@@ -523,11 +523,13 @@ describe("styleNumber propagation through composites @group4", async () => {
         ).eq(4);
     });
 
-    it("a containing graph's styleNumber wins over the source composite's", async () => {
+    it("a group's styleNumber wins over a containing graph's (innermost wins)", async () => {
         // Members are reparented into the <graph>, so the graph is their
-        // rendered parent. The parent fallback is consulted before the
-        // source-composite fallback, so the graph's value (2) wins over the
-        // group's (4).
+        // rendered parent and the group is their source composite. The
+        // source-composite fallback is consulted before the parent fallback,
+        // so the more-local group's value (4) wins over the graph's (2) —
+        // matching how a <group> behaves like the regular container nearest
+        // the component.
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
 <graph styleNumber="2">
@@ -542,7 +544,7 @@ describe("styleNumber propagation through composites @group4", async () => {
         expect(
             stateVariables[await resolvePathToNodeIdx("P")].stateValues
                 .styleNumber,
-        ).eq(2);
+        ).eq(4);
     });
 
     it("styleNumber chains through nested groups", async () => {
@@ -588,5 +590,76 @@ describe("styleNumber propagation through composites @group4", async () => {
             stateVariables[await resolvePathToNodeIdx("r[2].rp")].stateValues
                 .styleNumber,
         ).eq(4);
+    });
+
+    it("extending a graph re-resolves styleNumber against the new context", async () => {
+        // In the original graph, the loose point takes the graph's 5 and the
+        // grouped points take the group's 4 (innermost wins). When the graph
+        // is extended with styleNumber="2", the loose point — which has no
+        // more-local style source — picks up the new graph's 2, while the
+        // grouped points keep the group's 4 (the <group> is still their
+        // innermost source; the implicit copy composite deletes its own
+        // styleNumber so it doesn't interfere).
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<graph styleNumber="5" name="g">
+  <point name="P0" coords="(3,5)" />
+  <group styleNumber="4">
+    <point name="P1" coords="(-1,1)" />
+    <point name="P2" coords="(2,-2)" />
+  </group>
+</graph>
+
+<graph extend="$g" styleNumber="2" name="g2" />
+`,
+        });
+
+        const sv = await core.returnAllStateVariables(false, true);
+        const styleOf = async (name: string) =>
+            sv[await resolvePathToNodeIdx(name)].stateValues.styleNumber;
+
+        expect(await styleOf("P0")).eq(5);
+        expect(await styleOf("P1")).eq(4);
+        expect(await styleOf("P2")).eq(4);
+
+        expect(await styleOf("g2.P0")).eq(2);
+        expect(await styleOf("g2.P1")).eq(4);
+        expect(await styleOf("g2.P2")).eq(4);
+    });
+
+    it("a group nested in a graph and a graph nested in a section style their points identically", async () => {
+        // Whether the inner styleNumber sits on a composite (<group>) or a
+        // regular component (<graph> inside a <section>) must not change the
+        // result: in both, the loose point follows the outer container and
+        // the inner-wrapped points follow the inner container — including
+        // after extension. Authors shouldn't have to know which components
+        // are composites.
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<section name="s" styleNumber="5">
+  <graph>
+    <point name="Pa" coords="(3,5)" />
+  </graph>
+  <graph styleNumber="4">
+    <point name="Pb1" coords="(-1,1)" />
+    <point name="Pb2" coords="(2,-2)" />
+  </graph>
+</section>
+
+<section extend="$s" styleNumber="2" name="s2" />
+`,
+        });
+
+        const sv = await core.returnAllStateVariables(false, true);
+        const styleOf = async (name: string) =>
+            sv[await resolvePathToNodeIdx(name)].stateValues.styleNumber;
+
+        expect(await styleOf("Pa")).eq(5);
+        expect(await styleOf("Pb1")).eq(4);
+        expect(await styleOf("Pb2")).eq(4);
+
+        expect(await styleOf("s2.Pa")).eq(2);
+        expect(await styleOf("s2.Pb1")).eq(4);
+        expect(await styleOf("s2.Pb2")).eq(4);
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/styleOverride.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/styleOverride.test.ts
@@ -469,3 +469,124 @@ describe("Per-component style override tests @group4", async () => {
         ).toBe(true);
     });
 });
+
+describe("styleNumber propagation through composites @group4", async () => {
+    it("members of a <group styleNumber=N> inherit N", async () => {
+        // A <group> is a composite: its members are reparented out of the
+        // group into its container, so the parent fallback can't see the
+        // group's styleNumber. The source-composite fallback carries it
+        // through instead.
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<graph>
+  <group styleNumber="4">
+    <point name="P1" coords="(-1,1)" />
+    <point name="P2" coords="(2,-2)" />
+  </group>
+</graph>
+`,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("P1")].stateValues
+                .styleNumber,
+        ).eq(4);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("P2")].stateValues
+                .styleNumber,
+        ).eq(4);
+    });
+
+    it("an explicit styleNumber on a member overrides the group's", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<graph>
+  <group styleNumber="4">
+    <point name="P1" coords="(-1,1)" styleNumber="2" />
+    <point name="P2" coords="(2,-2)" />
+  </group>
+</graph>
+`,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        // Explicit value on the member wins.
+        expect(
+            stateVariables[await resolvePathToNodeIdx("P1")].stateValues
+                .styleNumber,
+        ).eq(2);
+        // Sibling without an explicit value still inherits the group's.
+        expect(
+            stateVariables[await resolvePathToNodeIdx("P2")].stateValues
+                .styleNumber,
+        ).eq(4);
+    });
+
+    it("a containing graph's styleNumber wins over the source composite's", async () => {
+        // Members are reparented into the <graph>, so the graph is their
+        // rendered parent. The parent fallback is consulted before the
+        // source-composite fallback, so the graph's value (2) wins over the
+        // group's (4).
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<graph styleNumber="2">
+  <group styleNumber="4">
+    <point name="P" coords="(-1,1)" />
+  </group>
+</graph>
+`,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("P")].stateValues
+                .styleNumber,
+        ).eq(2);
+    });
+
+    it("styleNumber chains through nested groups", async () => {
+        // The inner group has no explicit styleNumber, so it inherits 4 from
+        // the outer group via the source-composite fallback; the point then
+        // inherits 4 from the inner group the same way.
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<graph>
+  <group styleNumber="4">
+    <group>
+      <point name="P" coords="(-1,1)" />
+    </group>
+  </group>
+</graph>
+`,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("P")].stateValues
+                .styleNumber,
+        ).eq(4);
+    });
+
+    it("styleNumber propagates through a <repeat> to its members", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+<graph>
+  <repeat name="r" for="1 2" valueName="v" styleNumber="4">
+    <point name="rp">($v, 0)</point>
+  </repeat>
+</graph>
+`,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("r[1].rp")].stateValues
+                .styleNumber,
+        ).eq(4);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("r[2].rp")].stateValues
+                .styleNumber,
+        ).eq(4);
+    });
+});

--- a/packages/doenetml-worker-javascript/src/utils/dast/types.ts
+++ b/packages/doenetml-worker-javascript/src/utils/dast/types.ts
@@ -267,8 +267,22 @@ export type AttributeDefinition<T> = {
      * If this attribute isn't specified, then the state variable created from this attribute
      * will fall back to copying the value of the state variable
      * `fallBackToParentStateVariable` from the parent.
+     *
+     * When both this and `fallBackToSourceCompositeStateVariable` are set, the
+     * source composite is consulted first (see `fallBackToSourceCompositeStateVariable`).
      */
     fallBackToParentStateVariable?: string;
+    /**
+     * If this attribute isn't specified, then the state variable created from this attribute
+     * will fall back to copying the value of the state variable
+     * `fallBackToSourceCompositeStateVariable` from the source composite
+     * (the innermost authored composite, e.g. a `<group>`, that created the component).
+     *
+     * Takes precedence over `fallBackToParentStateVariable` when both are set, so a
+     * more-local setting on a wrapping composite wins over a more-distant one on the
+     * rendered parent.
+     */
+    fallBackToSourceCompositeStateVariable?: string;
     /** when create the `createComponentOfType`, give it these attributes */
     attributesForCreatedComponent?: Record<string, string>;
     /** when create the `createComponentOfType`, copy these attributes from the parent */

--- a/packages/doenetml-worker-javascript/src/utils/dast/types.ts
+++ b/packages/doenetml-worker-javascript/src/utils/dast/types.ts
@@ -264,23 +264,35 @@ export type AttributeDefinition<T> = {
     propagateToProps?: boolean;
     excludeFromSchema?: boolean;
     /**
-     * If this attribute isn't specified, then the state variable created from this attribute
-     * will fall back to copying the value of the state variable
-     * `fallBackToParentStateVariable` from the parent.
+     * Authoring knob (set here, in the attribute definition): the *name* of a
+     * state variable on the rendered parent.
      *
-     * When both this and `fallBackToSourceCompositeStateVariable` are set, the
-     * source composite is consulted first (see `fallBackToSourceCompositeStateVariable`).
+     * Runtime effect: when a document does not give this attribute a value, the
+     * state variable created from this attribute takes its value by copying that
+     * named state variable from the parent, instead of using `defaultValue`.
+     * Leaving this field undefined means there is no parent fallback — an
+     * unspecified attribute then uses `defaultValue`.
+     *
+     * If `fallBackToSourceCompositeStateVariable` is also set, the source
+     * composite is consulted before the parent (see that field).
      */
     fallBackToParentStateVariable?: string;
     /**
-     * If this attribute isn't specified, then the state variable created from this attribute
-     * will fall back to copying the value of the state variable
-     * `fallBackToSourceCompositeStateVariable` from the source composite
-     * (the innermost authored composite, e.g. a `<group>`, that created the component).
+     * Authoring knob (set here, in the attribute definition): the *name* of a
+     * state variable on the source composite — the innermost composite (e.g. a
+     * `<group>`) that created this component.
      *
-     * Takes precedence over `fallBackToParentStateVariable` when both are set, so a
-     * more-local setting on a wrapping composite wins over a more-distant one on the
-     * rendered parent.
+     * Runtime effect: when a document does not give this attribute a value, the
+     * state variable created from this attribute takes its value by copying that
+     * named state variable from the source composite, instead of using
+     * `defaultValue`. Leaving this field undefined means there is no
+     * source-composite fallback.
+     *
+     * When both this and `fallBackToParentStateVariable` are set, the source
+     * composite is consulted first: its value wins over the parent's whenever the
+     * composite set it to a non-default value (so a more-local setting on a
+     * wrapping composite beats a more-distant one on the rendered parent). If the
+     * composite's value is left at its default, the parent's value is used.
      */
     fallBackToSourceCompositeStateVariable?: string;
     /** when create the `createComponentOfType`, give it these attributes */

--- a/packages/doenetml-worker-javascript/src/utils/dast/types.ts
+++ b/packages/doenetml-worker-javascript/src/utils/dast/types.ts
@@ -264,29 +264,29 @@ export type AttributeDefinition<T> = {
     propagateToProps?: boolean;
     excludeFromSchema?: boolean;
     /**
-     * Authoring knob (set here, in the attribute definition): the *name* of a
-     * state variable on the rendered parent.
+     * Set by the developer in the attribute definition: the *name* of a state
+     * variable on the rendered parent. Leaving this field undefined means there
+     * is no parent fallback.
      *
-     * Runtime effect: when a document does not give this attribute a value, the
-     * state variable created from this attribute takes its value by copying that
-     * named state variable from the parent, instead of using `defaultValue`.
-     * Leaving this field undefined means there is no parent fallback — an
-     * unspecified attribute then uses `defaultValue`.
+     * Resulting behavior for a DoenetML author: when the author does not give
+     * this attribute a value, the state variable created from this attribute
+     * takes its value by copying that named state variable from the parent,
+     * instead of using `defaultValue`.
      *
      * If `fallBackToSourceCompositeStateVariable` is also set, the source
      * composite is consulted before the parent (see that field).
      */
     fallBackToParentStateVariable?: string;
     /**
-     * Authoring knob (set here, in the attribute definition): the *name* of a
-     * state variable on the source composite — the innermost composite (e.g. a
-     * `<group>`) that created this component.
+     * Set by the developer in the attribute definition: the *name* of a state
+     * variable on the source composite — the innermost composite (e.g. a
+     * `<group>`) that created this component. Leaving this field undefined means
+     * there is no source-composite fallback.
      *
-     * Runtime effect: when a document does not give this attribute a value, the
-     * state variable created from this attribute takes its value by copying that
-     * named state variable from the source composite, instead of using
-     * `defaultValue`. Leaving this field undefined means there is no
-     * source-composite fallback.
+     * Resulting behavior for a DoenetML author: when the author does not give
+     * this attribute a value, the state variable created from this attribute
+     * takes its value by copying that named state variable from the source
+     * composite, instead of using `defaultValue`.
      *
      * When both this and `fallBackToParentStateVariable` are set, the source
      * composite is consulted first: its value wins over the parent's whenever the


### PR DESCRIPTION
## Summary

Setting `styleNumber` on a `<group>` previously had no effect on the components inside it — they rendered with the default style — even though the same `styleNumber` set on a `<graph>` or `<section>` styles its contents. `styleNumber` only inherited via the *rendered parent*, and a `<group>` is a composite whose members are reparented out of it into the group's container, so the parent fallback never saw the group's value.

This PR does two things:

1. **Adds `fallBackToSourceCompositeStateVariable: "styleNumber"`** on `BaseComponent`, so a member also falls back to the `styleNumber` of the composite that created it (mirroring the existing `Math`/`MathList` precedent for `functionSymbols`, `splitSymbols`, etc.).

2. **Makes the source composite win over the parent** in the shared attribute-fallback resolution (`StateVariableDefinitionFactory.ts`). The source composite is the *innermost authored wrapper*, so a more-local setting now beats a more-distant one.

## Why the precedence change

With only (1), a `styleNumber` on the *containing graph* would still beat the group, which is the opposite of what authors expect:

```doenet
<graph styleNumber="5">
  <point coords="(3,5)" />        <!-- style 5 (graph) -->
  <group styleNumber="4">
    <point coords="(-1,1)" />     <!-- style 4 (group) -->
    <point coords="(2,-2)" />     <!-- style 4 (group) -->
  </group>
</graph>
```

A `<group styleNumber="4">` should style its contents the way the *nearest* container does — and crucially, it should behave the same as a regular (non-composite) container nesting, since authors shouldn't have to know which components are composites. The section-of-graphs form below now produces the identical `5, 4, 4`:

```doenet
<section styleNumber="5">
  <graph><point coords="(3,5)" /></graph>          <!-- style 5 -->
  <graph styleNumber="4">
    <point coords="(-1,1)" />                       <!-- style 4 -->
    <point coords="(2,-2)" />                       <!-- style 4 -->
  </graph>
</section>
```

Extension re-resolves each member in its new context. `<graph extend="$g" styleNumber="2" />` yields `2, 4, 4`: the loose point (no more-local style source) picks up the new `2`, while the grouped points keep the group's `4`. The implicit copy composite (`_copy`) deletes its own `styleNumber`, so it never interferes. The section form extends identically.

## Precedence summary (highest to lowest)

1. An explicit `styleNumber` on the component.
2. The source composite (innermost authored wrapper, e.g. the `<group>`).
3. The rendered parent (e.g. the surrounding `<graph>`).
4. The default.

## Blast radius

The fallback resolution is shared by every attribute that declares both `fallBackToParentStateVariable` and `fallBackToSourceCompositeStateVariable` — currently `styleNumber` plus `functionSymbols`/`splitSymbols`/`referencesAreFunctionSymbols` on `<math>`/`<mathList>`. For those, a wrapping list composite now likewise wins over a more distant containing element. This only changes behavior in the rare case where *both* a parent and a source composite set the value non-default; all existing Math tests pass unchanged. The `inverseDefinition` was updated to mirror the same precedence.

`document`/`module`/`collect`/copy delete `styleNumber`, and `Intersection` redefines it as a raw `leaveRaw` attribute (no state variable), so the fallback only applies where the state variable exists.

## Tests

Extends `packages/doenetml-worker-javascript/src/test/tagSpecific/styleOverride.test.ts` with a "styleNumber propagation through composites" block: group inheritance, explicit-member override, group-beats-graph precedence, nested groups, `<repeat>`, and the two extend/copy consistency cases above (group-in-graph and graph-in-section producing identical results, original and extended). Regression suites run clean: `mathlist` (functionSymbols/splitSymbols precedence), `group`, `styledefinition`, `unlinked copy`, `intersection`, `stickygroup`, `styleContrastAccessibility`, `textlist`, `matrix`, `answer`.

## Docs follow-up

The issue notes a "Styling Components in Doenet" guide should switch its example from `<graph styleNumber="4">` to `<group styleNumber="4">` once this lands. That guide isn't present in this branch's source (only stale build artifacts under `out/`), so it's left for a separate change.

Closes #1230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)