### PR TITLE
fix(hooks): gate review writes and inspect --input files in footer check

### DIFF
--- a/.claude/hooks/gh-footer-check.sh
+++ b/.claude/hooks/gh-footer-check.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Enforce the Claude Code footer on agent-authored GitHub text.
 # See AGENTS.md → "Agent-Authored GitHub Activity": gh issue/pr create &
-# comment bodies, and gh api posts to /comments or /replies, must end with
-# the footer so reviewers can see the text was generated.
+# comment bodies, and gh api posts to /comments, /replies, or /reviews, must
+# end with the footer so reviewers can see the text was generated.
 #
 # Reads the PreToolUse hook JSON on stdin, inspects the Bash command, and
 # exits 2 (blocking the tool call) when a matching gh command lacks the footer.
@@ -21,12 +21,14 @@ case "$cmd" in
         is_posting=1
         ;;
 esac
-# gh api write (not a read) to a comment/reply endpoint. A write supplies a
-# body via a field flag (-f/-F/--field/--raw-field/--input) or an explicit
-# POST method; a plain GET to /comments (listing comments) must NOT be gated.
+# gh api write (not a read) to a comment/reply/review endpoint. A write
+# supplies a body via a field flag (-f/-F/--field/--raw-field/--input) or an
+# explicit POST/PUT/PATCH method; a plain GET (e.g. listing comments) must NOT
+# be gated. /reviews is included because a review POST carries inline comments
+# plus a body, and review-body updates use PUT.
 if printf '%s' "$cmd" | grep -q 'gh api' &&
-    printf '%s' "$cmd" | grep -qE '/(comments|replies)([/?[:space:]"'\'']|$)' &&
-    printf '%s' "$cmd" | grep -qE '([[:space:]](-f|-F|--field|--raw-field|--input)[ =]|(-X[ ]*|--method[ =])POST)'; then
+    printf '%s' "$cmd" | grep -qE '/(comments|replies|reviews)([/?[:space:]"'\'']|$)' &&
+    printf '%s' "$cmd" | grep -qE '([[:space:]](-f|-F|--field|--raw-field|--input)[ =]|(-X[ ]*|--method[ =])(POST|PUT|PATCH))'; then
     is_posting=1
 fi
 
@@ -37,28 +39,34 @@ case "$cmd" in
 *"$FOOTER_URL"*) exit 0 ;;
 esac
 
-# 2) Body supplied from a file via --body-file/-F (issue & pr only; gh api
-#    uses --input and is not checked here). Inspect the referenced file.
-if ! printf '%s' "$cmd" | grep -q 'gh api'; then
+# 2) Body supplied from a file. For gh issue/pr that's --body-file/-F; for
+#    gh api (which sends a JSON payload) it's --input. Inspect the referenced
+#    file(s) for the footer. A "-" path (stdin) is not a file, so it is skipped.
+if printf '%s' "$cmd" | grep -q 'gh api'; then
+    paths=$(printf '%s' "$cmd" |
+        grep -oE -- '--input[ =][^[:space:]]+' |
+        sed -E 's/^--input[ =]//')
+else
     paths=$(printf '%s' "$cmd" |
         grep -oE -- '(--body-file[ =]|-F[ =])[^[:space:]]+' |
         sed -E 's/^(--body-file|-F)[ =]//')
-    for p in $paths; do
-        p=${p%\"}
-        p=${p#\"}
-        p=${p%\'}
-        p=${p#\'}
-        if [ -f "$p" ] && grep -qF "$FOOTER_URL" "$p" 2>/dev/null; then
-            exit 0
-        fi
-    done
 fi
+for p in $paths; do
+    p=${p%\"}
+    p=${p#\"}
+    p=${p%\'}
+    p=${p#\'}
+    if [ -f "$p" ] && grep -qF "$FOOTER_URL" "$p" 2>/dev/null; then
+        exit 0
+    fi
+done
 
 cat >&2 <<EOF
 Blocked: Claude Code footer missing from this gh command.
 
 AGENTS.md ("Agent-Authored GitHub Activity") requires that gh issue/pr
-create & comment bodies, and gh api posts to /comments or /replies, end with:
+create & comment bodies, and gh api posts to /comments, /replies, or
+/reviews, end with:
 
 🤖 Generated with [Claude Code]($FOOTER_URL)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ When an agent posts a PR comment, opens an issue, or comments on an issue, end t
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ```
 
-This includes review-comment replies posted via `gh api ... /replies`, top-level PR comments, and any `gh issue create` / `gh issue comment` invocations. PR and issue *descriptions* created via `gh pr create` / `gh issue create` already get the footer through their templated body — this rule is the catch for the smaller surfaces where it's easy to forget.
+This includes review-comment replies posted via `gh api ... /replies`, full reviews (their summary body and any inline comments) posted via `gh api ... /reviews`, top-level PR comments, and any `gh issue create` / `gh issue comment` invocations. PR and issue *descriptions* created via `gh pr create` / `gh issue create` already get the footer through their templated body — this rule is the catch for the smaller surfaces where it's easy to forget.
 
 ## Changesets
 


### PR DESCRIPTION
## Summary

Fixes two gaps in the `.claude/hooks/gh-footer-check.sh` PreToolUse hook that enforces the Claude Code footer on agent-authored GitHub text.

While reviewing #1235 I posted a review whose inline comments slipped through without the footer. The hook didn't catch it for two reasons:

1. **Review endpoint not gated.** The hook's endpoint allowlist only matched `/comments` and `/replies`. A review created with `gh api .../pulls/{n}/reviews` carries both a summary body and inline comments, and review-body updates use `PUT` — neither was checked. The method matcher also only recognized `POST`.

2. **`--input` files not inspected.** For the `gh api` JSON-payload path, the footer was only detected if its URL appeared literally in the command text. The file-inspection branch (used for `--body-file`) was skipped entirely for `gh api`, so a footer living in an `--input` JSON file was never validated.

## Changes

- Add the review endpoint to the gated set alongside comments/replies.
- Count `PUT`/`PATCH` (not just `POST`) as writes.
- Inspect `--input` JSON files for the footer, the same way `--body-file` is inspected for `gh issue`/`gh pr`.
- Document the review case in `AGENTS.md`.

## Testing

Ran the hook against 12 scenarios (review POST/PUT with and without footer, listing GETs that must not be gated, `--input` files with/without footer, inline and `--body-file` comments). All behave as expected — writes lacking the footer are blocked, reads and footer-bearing writes pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
