### PR TITLE
docs: accessibility concept + guides, and a link to them from the editor report

### DIFF
--- a/.changeset/accessibility-report-docs-link.md
+++ b/.changeset/accessibility-report-docs-link.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Editor: the accessibility report now links to the accessibility documentation.
+
+A "Learn how Doenet approaches accessibility" link at the top of the report points to `<docsURL>/concepts/accessibility`, where new Concept and Guide pages explain what the WCAG checks do and don't guarantee and how to write accessible activities.

--- a/packages/docs-nextra/pages/concepts/_meta.ts
+++ b/packages/docs-nextra/pages/concepts/_meta.ts
@@ -2,6 +2,7 @@ export default {
     essentialConcepts: "Essential Concepts",
     references: "References",
     styling: "Styling & Meaning",
+    accessibility: "Accessibility",
     documentStructure: {
         name: "Document Structure",
         display: "hidden",

--- a/packages/docs-nextra/pages/concepts/accessibility.mdx
+++ b/packages/docs-nextra/pages/concepts/accessibility.mdx
@@ -1,0 +1,64 @@
+import { Callout } from "nextra/components"
+
+
+# Accessibility in Doenet
+
+An accessible activity is one that *every* student can read and learn from — including students who use a screen reader, navigate by keyboard instead of a mouse, or rely on high contrast or enlarged text. Doenet helps you get there in two quite different ways, and it is worth keeping them separate in your mind:
+
+1. it **checks** your document against the [WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/) accessibility guidelines and warns you about violations, and
+2. more ambitiously, it tries to convey the *meaning* of what you build through more than one channel, so the same idea reaches a reader who can't use the visual one.
+
+This page is about the difference between those two — why passing the first is not the same as achieving the second, and how Doenet pursues each.
+
+<Callout type="info">
+Looking for the steps? See **[Checking Accessibility](../guides/check-accessibility)** (how to read the WCAG report), **[Writing Accessible Activities](../guides/accessible-activities)** (descriptions, labels, links, headings, tables), and **[Accessible Interactive Graphs](../guides/accessible-interactive-graphs)**. This page explains the *why* behind those recipes.
+</Callout>
+
+## Passing the checker is a floor, not a ceiling
+
+As you edit, Doenet checks your document against WCAG AA and flags violations — the status indicator above the viewer turns purple, and the accessibility report lists each problem. That check is real, and keeping it at zero is worth doing. But clearing it does **not** make your activity accessible. It makes it *not obviously broken.* You can satisfy every automated rule and still leave a screen-reader user stranded.
+
+A short description of `"a graph"{:dn}` technically satisfies the rule that a graph must have a description — and tells a blind student nothing about the graph. Labelling an input `"input"{:dn}` clears the unlabeled-input violation and conveys nothing about what to type. The checker can confirm *that* you wrote a description; it cannot judge whether the description lets someone who can't see the figure actually do the problem. That judgment is yours.
+
+So treat the checker as a **floor**. It catches the omissions that guarantee inaccessibility — an unlabeled input, an undescribed image — and it keeps accessibility *visible* while you author instead of leaving it to an audit at the end. Genuine accessibility is the *ceiling*: a separate, human task that begins where the checker stops.
+
+## What true accessibility asks of you
+
+The heart of accessibility is conveying the same meaning in more than one form. A sighted student takes in a graph at a glance; a screen-reader user needs that same information in words, in an order that makes sense, at the right level of detail. Getting that right depends on what the content is *for* — and only you know that.
+
+The same picture needs a different description in a "find the discontinuity" problem than in a "read off the intercepts" problem: one description should mention the open circle at the vertex, the other the axis scales and intercepts. Doenet can *require* a description; it cannot write a good one, because a good one depends on your pedagogical intent. This is the part that can't be automated, and it is the part that matters most.
+
+## How Doenet helps you convey meaning
+
+Several pieces of Doenet's design exist to make that re-expression possible. None of them removes the author's judgment, but together they give your meaning somewhere to live other than the pixels on the screen.
+
+### Baseline checks keep accessibility in view
+
+As long as you supply the information only you can — a label on an input, a short description for a graph — Doenet follows standard practice and produces WCAG-conformant output for you. When you leave that information out, it warns you on the spot. The point of the warning is less the rule than the *visibility*: accessibility stays in front of you as you write, rather than becoming a cleanup pass you never get to. (See [Checking Accessibility](../guides/check-accessibility).)
+
+### Semantic markup carries meaning, not just appearance
+
+When you say what something *is* rather than how it looks — an excluded `<endpoint>{:dn}`, an `<answer>{:dn}`, a `<section>{:dn}` introduced by a `<title>{:dn}` — Doenet has something it can re-express in another modality. Meaning that lives only in visual styling, like a hollow marker or a larger font, cannot be handed to a screen reader. Meaning that lives in a component can. This is why semantic markup is the foundation of both today's accessibility and what is coming: the more of your intent is recorded as structure, the more channels Doenet can eventually route it through. (See [Essential Concepts](essentialConcepts) and [semantic components](styling#some-distinctions-have-a-name-semantic-components).)
+
+### Styles adapt to the reader
+
+Doenet's styling is built on the same idea. Because a visual distinction — "these two curves are different" — is recorded as a *style number* rather than a raw color painted onto each curve, Doenet has one well-defined place to re-express that distinction for a reader who needs different colors or higher contrast. The distinction you encoded survives, shown in a form that works for that reader. [Styling, meaning, and accessibility](styling#why-distinctions-live-in-style-numbers-accessibility) develops this argument in full; it is the clearest worked example of the principle on this page.
+
+### Graphs you can explore by listening
+
+A static description hands a screen-reader user one frozen paragraph about a figure. The [PreFigure renderer](../guides/accessible-interactive-graphs#navigate-the-pieces-with-the-prefigure-renderer) lets you do better: you attach **annotations** to the individual pieces of a graph, and a screen-reader user can then move through the construction piece by piece — hearing each annotation while the graph highlights and zooms to the piece in focus. That turns a figure from something *read to* the student into something they can *explore*.
+
+### Interactive graphs: the hard part, still in progress
+
+Doenet is built around interactive, exploratory graphics — students drag points, vectors, and curves and watch the consequences. Dragging is a mouse gesture. It is not available to someone working by keyboard or screen reader, and giving them an equally good way to manipulate a graph is genuinely unsolved. Doenet has first steps — [on-screen controls](../guides/accessible-interactive-graphs#let-keyboard-users-operate-the-graph-with-addcontrols) that move an object from the keyboard, descriptions that update as the figure changes — but this is an active frontier with a long way still to go. We would rather tell you that plainly than imply the problem is finished.
+
+## Accessibility is shared work
+
+The division of labor is the theme running through all of the above. Doenet handles what can be made to work for everyone automatically — conformant markup, adaptable styles, the navigation machinery for graphs. The parts that depend on intent and context — *what* a description should say, *which* distinctions a reader must perceive, *whether* a keyboard path through a problem is as good as the mouse one — are yours. Keep the checker at zero, and then keep going past it. And where Doenet's accessibility tools themselves fall short of a document you are trying to make accessible, raise it at [community.doenet.org](https://community.doenet.org) — the gaps authors identify are what shape what we build next.
+
+## Where to go next
+
+- **[Checking Accessibility](../guides/check-accessibility)** — read the WCAG report and understand what each check does (and doesn't) verify.
+- **[Writing Accessible Activities](../guides/accessible-activities)** — descriptions, labels, links, headings, tables, and contrast.
+- **[Accessible Interactive Graphs](../guides/accessible-interactive-graphs)** — descriptions that update, keyboard controls, and graph annotations.
+- **[Styling, meaning, and accessibility](styling)** — the styling design and the accessibility argument behind it.

--- a/packages/docs-nextra/pages/concepts/styling.mdx
+++ b/packages/docs-nextra/pages/concepts/styling.mdx
@@ -52,5 +52,6 @@ Concretely: if two objects are *importantly* different, give them different **st
 ## Where to go next
 
 - **[Styling Components guide](../guides/styling-components)** — how to set style numbers, override settings, and write style definitions.
+- **[Accessibility in Doenet](accessibility)** — the broader accessibility picture that the adaptation argument above is part of.
 - **[`<styleDefinition>{:dn}` reference](../reference/styleDefinition)** — the settings a style definition accepts.
 - **[Essential Concepts](essentialConcepts)** — the broader model of components, attributes, and properties.

--- a/packages/docs-nextra/pages/guides/_meta.ts
+++ b/packages/docs-nextra/pages/guides/_meta.ts
@@ -1,5 +1,8 @@
 export default {
     "styling-components": "Styling Components",
+    "accessible-activities": "Writing Accessible Activities",
+    "check-accessibility": "Checking Accessibility",
+    "accessible-interactive-graphs": "Accessible Interactive Graphs",
     answerValidation: {
         name: "Answer Validation",
         display: "hidden",

--- a/packages/docs-nextra/pages/guides/accessible-activities.mdx
+++ b/packages/docs-nextra/pages/guides/accessible-activities.mdx
@@ -1,0 +1,233 @@
+import { Callout } from "nextra/components"
+import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
+
+
+# Writing Accessible Activities
+
+This guide is a set of practical recipes for the everyday accessibility of a Doenet activity: describing images and graphs, labelling inputs, writing good links, structuring with headings, and building accessible tables. Each recipe clears a check from the [accessibility report](../guides/check-accessibility) and, more importantly, makes your activity usable by someone who can't see it.
+
+<Callout type="info">
+These recipes supply the information the [accessibility checker](../guides/check-accessibility) looks for. But clearing a check is the floor, not the goal — a description has to actually be *useful*. For why that distinction matters, see **[Accessibility in Doenet](../concepts/accessibility)**.
+</Callout>
+
+Most of these recipes use two children you can add to many components:
+
+- **`<shortDescription>{:dn}`** — a brief description read by **screen readers only**. It is not shown on screen, so it is where you put information a sighted reader already gets from the visuals.
+- **`<description>{:dn}`** — longer information shown to **everyone**, in a disclosure or popup. Use it for detail that helps all readers.
+
+---
+
+## Describe graphs, images, and videos
+
+A screen reader can't see an image, a graph, or a video, so each one needs a `<shortDescription>{:dn}` that conveys what it shows. Without one, the [checker](../guides/check-accessibility) reports a violation.
+
+Put the `<shortDescription>{:dn}` as a child of the visual component. Write it for someone who can't see the image and needs to know what it depicts:
+
+```doenet-editor-horiz
+<figure>
+  <image
+    source="https://upload.wikimedia.org/wikipedia/commons/5/5a/Sciurus_carolinensis_-British_Columbia%2C_Canada-8.jpg"
+    size="small"
+  >
+    <shortDescription>A gray squirrel hangs upside-down from a tree trunk, stretching toward a hanging bird feeder.</shortDescription>
+  </image>
+  <caption>A determined squirrel raids the bird feeder.</caption>
+</figure>
+```
+
+A `<caption>{:dn}` (shown to everyone) is not a substitute for a `<shortDescription>{:dn}` (read to screen readers): the caption above says *that* the squirrel is determined, while the short description says *what is in the picture*. Pair them.
+
+### Add longer detail with `<description>`
+
+When there is more to say than belongs in a short description — background, a source credit, a fuller account of a complex figure — add a `<description>{:dn}`. It is shown to every reader in a disclosure, so both sighted and screen-reader users get it:
+
+```doenet-editor-horiz
+<image
+  source="https://upload.wikimedia.org/wikipedia/commons/0/02/Donut.jpg"
+  size="small"
+>
+  <shortDescription>A single chocolate-frosted ring donut on a white background.</shortDescription>
+  <description>
+    <p>Photograph from
+    <ref to="https://commons.wikimedia.org/wiki/File:Donut.jpg">Wikimedia Commons</ref>,
+    used under a Creative Commons license.</p>
+  </description>
+</image>
+```
+
+### Mark a purely decorative image
+
+If an image carries no information — a border flourish, a background texture — it should be *skipped* by screen readers rather than described. Mark it `decorative{:dn}` and the checker won't ask for a description:
+
+```doenet
+<image source="decorative-divider.png" decorative />
+```
+
+Only mark something decorative if a reader truly loses nothing by not knowing it is there. The same attribute works on a `<graph>{:dn}` used purely for decoration.
+
+<Callout type="warning">
+A screen reader reads a `<shortDescription>{:dn}` as plain text, so don't put math components like `<m>{:dn}` inside one — they are read out as raw notation. Spell the math out in words ("x squared", not `<m>x^2</m>{:dn}`). The checker flags embedded math as an advisory.
+</Callout>
+
+Graphs follow the same rule and have an entire guide of their own — see [Accessible Interactive Graphs](../guides/accessible-interactive-graphs). A `<video>{:dn}` also needs a `<shortDescription>{:dn}` (a video can't be marked decorative).
+
+---
+
+## Label every input
+
+Every input — `<mathInput>{:dn}`, `<textInput>{:dn}`, `<choiceInput>{:dn}`, `<booleanInput>{:dn}`, `<matrixInput>{:dn}` — needs a label a screen reader can announce. **Ordinary text next to an input is not a label:** it looks like one to a sighted reader, but nothing connects the two, so a screen reader announces the input as unlabeled. There are three ways to make the connection, depending on your layout.
+
+### A visible label, with `<label>`
+
+The usual case: put a `<label>{:dn}` inside the input. It renders next to the input and is programmatically tied to it.
+
+```doenet-editor-horiz
+<p>
+  <mathInput name="x0">
+    <label>Initial value <m>x_0</m></label>
+  </mathInput>
+</p>
+```
+
+### A label placed elsewhere, with `<label for="...">`
+
+When your layout needs the label to sit somewhere other than right on the input, write a `<label>{:dn}` with a `for{:dn}` attribute pointing at the input's name. The two are associated even though they're written separately.
+
+```doenet-editor-horiz
+<p><label for="$age">Your age in years</label>: <textInput name="age" /></p>
+```
+
+### A screen-reader-only label, with `<shortDescription>`
+
+When a visible label would just duplicate the surrounding sentence, use a `<shortDescription>{:dn}` instead. It gives the screen reader a label without adding anything to the screen — useful for inputs embedded in prose:
+
+```doenet-editor-horiz
+<p>List two even numbers:
+  <mathInput name="n1"><shortDescription>First even number</shortDescription></mathInput>,
+  <mathInput name="n2"><shortDescription>Second even number</shortDescription></mathInput>.
+</p>
+```
+
+### Labelling answers
+
+An `<answer>{:dn}` needs a label too, but *where* it goes depends on how the answer is written:
+
+- **The answer creates its own input** (there is no explicit `<*Input>{:dn}` inside it). Put the `<label>{:dn}` inside the answer:
+
+  ```doenet-editor-horiz
+  <p>
+    <answer>
+      <label>What is <m>2 + 2</m>?</label>
+      4
+    </answer>
+  </p>
+  ```
+
+- **The answer contains an explicit input.** Put the `<label>{:dn}` on the *input*, not on the answer:
+
+  ```doenet-editor-horiz
+  <p>
+    <answer>
+      <mathInput name="deriv">
+        <label>Derivative of <m>x^2</m></label>
+      </mathInput>
+      <award>2x</award>
+    </answer>
+  </p>
+  ```
+
+An answer that checks a condition with `<award><when>{:dn}` (rather than creating an input) has nothing to label — keep its prompt as ordinary text beside it. That pattern comes up with interactive graphs; see [the check-work pattern](../guides/accessible-interactive-graphs#pair-the-graph-with-a-check-work-answer).
+
+---
+
+## Write descriptive links
+
+A link's text should make sense on its own. Screen-reader users often pull up a list of a page's links to navigate by; a list of identical "here"s or "this link"s tells them nothing. Write the `<ref>{:dn}` so its text describes the destination:
+
+```doenet-editor-horiz
+<p>For a refresher, see
+<ref to="https://mathinsight.org/derivatives_polynomials_refresher">taking derivatives of polynomials</ref>.</p>
+```
+
+Avoid `see <ref to="...">here</ref>{:dn}` — "here" describes nothing. Make the meaningful phrase the link.
+
+---
+
+## Build structure with headings
+
+Screen-reader users navigate long documents by jumping from heading to heading, so a correct heading structure is essential. In Doenet you don't choose heading *levels* — you nest sectioning components, and each `<title>{:dn}` becomes a heading at the right level automatically. A `<section>{:dn}` inside another section is a sub-heading of it.
+
+```doenet-editor-horiz
+<section>
+  <title>Limits</title>
+  <p>A limit describes the value a function approaches.</p>
+  <section>
+    <title>One-sided limits</title>
+    <p>A one-sided limit approaches from a single direction.</p>
+  </section>
+</section>
+```
+
+Here "Limits" is a top-level heading and "One-sided limits" is nested one level below it. Because the levels are computed from the nesting, they stay correct no matter how you rearrange the document — which you could never guarantee by, say, bolding a line to *look* like a heading. Don't fake a heading with styled text; use a sectioning component so it is a real, navigable heading.
+
+---
+
+## Make tables accessible
+
+Use a `<tabular>{:dn}` for data that is genuinely tabular, and mark the header row with `header{:dn}` on its `<row>{:dn}`. A screen reader then announces each data cell together with its column header, so a listener can tell which column a value is in.
+
+```doenet-editor-horiz
+<tabular>
+  <row header>
+    <cell>Function</cell>
+    <cell>Derivative</cell>
+  </row>
+  <row>
+    <cell><m>x^2</m></cell>
+    <cell><m>2x</m></cell>
+  </row>
+  <row>
+    <cell><m>\sin x</m></cell>
+    <cell><m>\cos x</m></cell>
+  </row>
+</tabular>
+```
+
+Two cautions, both standard table-accessibility advice cast in DoenetML:
+
+- **Don't use a table for visual layout.** A table tells a screen reader "this is a grid of related data." To place things side by side without that meaning, use a `<sideBySide>{:dn}` instead.
+- Wrap the `<tabular>{:dn}` in a `<table>{:dn}` when you want a numbered, titled table you can cross-reference; the `<tabular>{:dn}` alone is just the grid.
+
+---
+
+## Choose colors with enough contrast
+
+Color carries meaning only for readers who can see it and tell the colors apart, so two rules apply. First, never let color be the *only* signal of a distinction — Doenet's [style numbers](../concepts/styling) already pair each color with a different marker shape or dash pattern for exactly this reason. Second, keep enough contrast: when you redefine a color with a [`<styleDefinition>{:dn}`](../reference/styleDefinition), Doenet checks its contrast against the canvas and reports a violation if it is too low. You don't have to compute ratios yourself — just watch the [accessibility report](../guides/check-accessibility). The reasoning behind all of this is in [Styling, meaning, and accessibility](../concepts/styling#why-distinctions-live-in-style-numbers-accessibility).
+
+---
+
+## Put extra guidance where everyone can reach it
+
+It is tempting to tuck a formatting hint into a visual aside — "(type `sqrt` for a square root)". A sighted reader sees it; a screen-reader user working through the input may never reach it. Put guidance an input needs into a `<description>{:dn}` on that input, which is shown to everyone *and* announced with the input:
+
+```doenet-editor-horiz
+<p>
+  <answer>
+    <mathInput name="root">
+      <label>Enter the square root of <m>x</m></label>
+      <description>Type <c>sqrt(x)</c> to enter a square root.</description>
+    </mathInput>
+    <award>sqrt(x)</award>
+  </answer>
+</p>
+```
+
+For longer supporting material, the same principle points to components every reader can open: a `<hint>{:dn}` for an on-demand nudge, a `<footnote>{:dn}` for an aside, or an `<aside>{:dn}` for a note set off from the main flow. Each is reachable by keyboard and announced to screen readers — unlike text whose only cue is that it looks different.
+
+---
+
+## Where to go next
+
+- **[Checking Accessibility](../guides/check-accessibility)** — confirm these recipes cleared the report.
+- **[Accessible Interactive Graphs](../guides/accessible-interactive-graphs)** — descriptions that update, keyboard controls, and graph annotations.
+- **[Accessibility in Doenet](../concepts/accessibility)** — the reasoning behind the recipes.

--- a/packages/docs-nextra/pages/guides/accessible-interactive-graphs.mdx
+++ b/packages/docs-nextra/pages/guides/accessible-interactive-graphs.mdx
@@ -1,0 +1,147 @@
+import { Callout } from "nextra/components"
+import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
+
+
+# Accessible Interactive Graphs
+
+Interactive, draggable graphs are at the heart of Doenet — students move points, vectors, and curves and watch what happens. But dragging is a *mouse* gesture. A student working by keyboard or screen reader can't drag, and may not be able to see the result either. Making an interactive graph accessible means giving those students two things: a way to **perceive** the graph's current state, and a way to **change** it without a mouse.
+
+<Callout type="warning">
+This is an area Doenet is still building out. The techniques below are real and usable today, but fully accessible interactive graphics is an unsolved problem — see [the frontier discussion](../concepts/accessibility#interactive-graphs-the-hard-part-still-in-progress). Expect this guide to grow.
+</Callout>
+
+Every graph still needs the basics from the other guides first: a `<shortDescription>{:dn}` so it isn't flagged as a [violation](../guides/check-accessibility), and labelled controls. This guide is about what to add *beyond* that for graphs students manipulate.
+
+---
+
+## Describe a graph whose state changes
+
+A `<shortDescription>{:dn}` is static, but an interactive graph changes as the student works. Pair the short description (what the graph *is*) with a `<description>{:dn}` that reports the graph's *current state* — and let that description update by building it from the graph's live values. Here, the description names the point's coordinates and which quadrant it is in, and both update as the point moves:
+
+```doenet-editor
+<setup>
+  <span name="locationText">
+    <conditionalContent>
+      <case condition="$P.x > 0 and $P.y > 0">the first quadrant</case>
+      <case condition="$P.x < 0 and $P.y > 0">the second quadrant</case>
+      <case condition="$P.x < 0 and $P.y < 0">the third quadrant</case>
+      <case condition="$P.x > 0 and $P.y < 0">the fourth quadrant</case>
+      <else>an axis</else>
+    </conditionalContent>
+  </span>
+</setup>
+<graph size="small">
+  <shortDescription>A draggable point you move from quadrant to quadrant</shortDescription>
+  <description>P is at x = $P.x, y = $P.y, in $locationText.</description>
+  <point name="P">(3, 2)</point>
+</graph>
+```
+
+Drag the point: the description re-reads its coordinates and quadrant. A screen-reader user who revisits the description hears the up-to-date state instead of a frozen sentence. This is the single most useful technique on the page — a description built from live values turns an opaque figure into something a non-visual reader can follow.
+
+---
+
+## Let keyboard users operate the graph with `addControls`
+
+A description lets a student *perceive* the graph; `addControls{:dn}` lets them *change* it. Add it to a `<graph>{:dn}` and Doenet renders a panel of on-screen controls for the movable objects in the graph. Each control can be reached and operated from the keyboard — so a point can be moved by typing coordinates or operating sliders, with no dragging required.
+
+```doenet-editor-horiz
+<p>Move point P onto the point <m>(2, 3)</m>.</p>
+<graph size="small" addControls="all">
+  <shortDescription>A point P you can move with on-screen coordinate controls</shortDescription>
+  <point name="P">(-1, 0)</point>
+</graph>
+```
+
+`addControls="all"{:dn}` gives both **input boxes** (type a value) and **sliders** (nudge with arrow keys). Use `addControls="inputsOnly"{:dn}` or `addControls="slidersOnly"{:dn}` to offer just one, and `controlsPosition{:dn}` (`left{:dn}`, the default, or `bottom{:dn}`) to place the panel. The controls work for the movable objects Doenet knows how to manipulate — points, line segments, vectors, circles, polygons, and more — and a point can even restrict which axes it exposes.
+
+The payoff: a task that previously *required* dragging now has a keyboard path. A sighted student can still drag the point directly; a keyboard user changes the same coordinates through the controls.
+
+---
+
+## Navigate the pieces with the PreFigure renderer
+
+A description conveys a graph as one block of text. For a graph with several parts, the **PreFigure renderer** lets a reader *explore* it from the keyboard instead — moving through the pieces one at a time, with a screen reader announcing each one and the graph highlighting and zooming to the piece in focus.
+
+<Callout type="warning">
+Switching a graph to the PreFigure renderer currently **disables mouse dragging** of its graphical objects — for now, that interactivity is given up in exchange for the navigation below. Reach for PreFigure on a graph the reader needs to *read*, not one they need to *move*.
+</Callout>
+
+Switch a graph to it with `renderer="prefigure"{:dn}`, then attach **annotations** to the objects you want navigable. An `<annotations>{:dn}` block holds the annotation tree; each `<annotation>{:dn}` carries a `text{:dn}` phrase to announce and, usually, a `ref{:dn}` pointing at the object it describes.
+
+### The annotation tree needs a single root
+
+This is the part people get wrong. PreFigure reads only the **first** `<annotation>{:dn}` directly inside `<annotations>{:dn}` — so if you list your objects as siblings there, only one of them is reachable. The first annotation has to be a single **root** that stands for the whole graph: give it a `text{:dn}` describing the graph and **no `ref{:dn}`**, then nest every per-object annotation inside it.
+
+```doenet-editor-horiz
+<graph renderer="prefigure" size="small">
+  <shortDescription>Two points and the line through them, explorable piece by piece</shortDescription>
+  <point name="A">(-2, 1)</point>
+  <point name="B">(3, 4)</point>
+  <line name="AB" through="$A $B" />
+  <annotations>
+    <annotation text="A line through two points, A and B">
+      <annotation ref="$A" text="point A at negative 2, 1" />
+      <annotation ref="$B" text="point B at 3, 4" />
+      <annotation ref="$AB" text="the line through A and B"
+        speech="A line with positive slope, rising from lower left to upper right through A and B." />
+    </annotation>
+  </annotations>
+</graph>
+```
+
+<Callout type="warning">
+**Symptom of the most common mistake:** if navigating the graph reaches only the *first* object and no others, your annotations are siblings directly inside `<annotations>{:dn}`. Wrap them all in one outer `<annotation>{:dn}` that has a `text{:dn}` for the whole graph and no `ref{:dn}`, as above.
+</Callout>
+
+### Try it without a screen reader
+
+You don't need assistive technology to check that the navigation works. Click the graph (or **Tab** to it and press **Enter**), then:
+
+- **↓ (down arrow)** moves *down* the tree — from the root into its children.
+- **← and → (left and right arrows)** move between objects at the *same* level.
+
+Walk the tree this way and confirm you can reach every object you annotated — not just the first.
+
+A few more details:
+
+- **`text{:dn}`** is the brief label announced for a piece; **`speech{:dn}`** (optional) is a longer description for when a reader asks for more detail.
+- **Nest annotations further** to group related pieces — the two points could sit *inside* the line's annotation, so a reader moves "into" the line to reach them.
+- If an annotation's `ref{:dn}` doesn't resolve to an object in the graph, that annotation is dropped and the accessibility report notes it — so check the report after wiring annotations up.
+
+---
+
+## Pair the graph with a check-work answer
+
+Many Doenet problems ask the student to *arrange* a graph to satisfy some condition, then press a button to check it. The check itself is an `<answer>{:dn}` whose `<award>{:dn}` tests the configuration with a `<when>{:dn}` condition. Because this answer creates no input of its own, it needs no label — keep the prompt as ordinary text beside it, and the **Check Work** button it renders is reachable by keyboard like any button.
+
+Putting the pieces together gives a fully keyboard- and screen-reader-operable version of the classic "drag until it's right, then check" problem — perceive the state through the description, change it with `addControls{:dn}`, and check it with the button:
+
+```doenet-editor
+<p>Move point P into the first quadrant, then check your work.</p>
+<graph size="small" addControls="all">
+  <shortDescription>A movable point P; move it into the first quadrant</shortDescription>
+  <description>P is at x = $P.x, y = $P.y.</description>
+  <point name="P">(-3, -2)</point>
+</graph>
+<p>
+  <answer>
+    <award><when>$P.x > 0 and $P.y > 0</when></award>
+  </answer>
+</p>
+```
+
+The same activity now works three ways at once: drag the point with a mouse, move it with the keyboard controls, or read its position from the description — and any of them can finish by pressing Check Work.
+
+---
+
+## A work in progress
+
+These techniques cover a lot, but not everything. Some interactions still have no good non-visual equivalent, and matching the fluidity of dragging for every kind of object is exactly the open problem Doenet is working on. When you build an interactive graph, the test to apply is simple: **can a student who cannot use a mouse, and a student who cannot see the screen, each complete the task?** If not, a description that updates, `addControls{:dn}`, and PreFigure annotations are the tools to reach for — and where they fall short, that gap is one we are actively trying to close. **If you hit a wall these tools can't get you past, tell us about it at [community.doenet.org](https://community.doenet.org)** — the obstacles authors run into are what steer where Doenet's accessibility tools go next. For the bigger picture, see [Accessibility in Doenet](../concepts/accessibility#interactive-graphs-the-hard-part-still-in-progress).
+
+## Where to go next
+
+- **[Writing Accessible Activities](../guides/accessible-activities)** — the baseline recipes every graph also needs.
+- **[Checking Accessibility](../guides/check-accessibility)** — confirm the graph and its inputs clear the report.
+- **[Accessibility in Doenet](../concepts/accessibility)** — why interactive graphs are the hard part.
+- **[Styling, meaning, and accessibility](../concepts/styling)** — how style numbers keep graph distinctions perceivable.

--- a/packages/docs-nextra/pages/guides/check-accessibility.mdx
+++ b/packages/docs-nextra/pages/guides/check-accessibility.mdx
@@ -1,0 +1,107 @@
+import { Callout } from "nextra/components"
+import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
+
+
+# Checking Your Activity's Accessibility
+
+As you edit, Doenet checks your document against the **WCAG AA** accessibility guidelines and reports what it finds in three connected places: a status indicator above the viewer, an accessibility report you can open, and inline marks in the code editor. This guide shows how to read all three and what the checks do — and do not — cover.
+
+<Callout type="info">
+The checker tells you when your document *violates* a guideline. It cannot tell you whether your document is *genuinely* usable by someone who can't see it — that part is up to you. For why that distinction matters, see **[Accessibility in Doenet](../concepts/accessibility)**. For the recipes that fix the issues below, see **[Writing Accessible Activities](../guides/accessible-activities)**.
+</Callout>
+
+## Read the status indicator above the viewer
+
+Every Doenet editor shows an accessibility status indicator just above the rendered document. It has two states:
+
+- **Green** — no WCAG AA violations were found.
+- **Purple, labelled "WCAG"** — at least one WCAG AA violation was found.
+
+The color tracks **violations only**. The example below is deliberately incomplete — a graph with no description and an input whose prompt is only ordinary text — so its indicator is purple. Run it and look above the viewer:
+
+```doenet-editor-horiz
+<graph size="small">
+  <point name="P" fixed>(3,4)</point>
+</graph>
+<p>What is the x-coordinate of P? <mathInput name="x" /></p>
+```
+
+The sentence "What is the x-coordinate of P?" looks like a label, but it is just text sitting next to the input — nothing connects the two, so a screen reader announces the input as unlabeled. That, plus the undescribed graph, is two violations.
+
+## Open the accessibility report
+
+Click the status indicator — or the **Accessibility** tab (marked with an accessibility icon <svg viewBox="0 0 512 512" width="1em" height="1em" fill="#5b21b6" style={{ display: "inline-block", verticalAlign: "-0.125em" }} role="img" aria-label="accessibility"><path d="M256 112a56 56 0 1 1 56-56 56.06 56.06 0 0 1-56 56z"/><path d="m432 112.8-.45.12-.42.13c-1 .28-2 .58-3 .89-18.61 5.46-108.93 30.92-172.56 30.92-59.13 0-141.28-22-167.56-29.47a73.79 73.79 0 0 0-8-2.58c-19-5-32 14.3-32 31.94 0 17.47 15.7 25.79 31.55 31.76v.28l95.22 29.74c9.73 3.73 12.33 7.54 13.6 10.84 4.13 10.59.83 31.56-.34 38.88l-5.8 45-32.19 176.19q-.15.72-.27 1.47l-.23 1.27c-2.32 16.15 9.54 31.82 32 31.82 19.6 0 28.25-13.53 32-31.94s28-157.57 42-157.57 42.84 157.57 42.84 157.57c3.75 18.41 12.4 31.94 32 31.94 22.52 0 34.38-15.74 32-31.94a57.17 57.17 0 0 0-.76-4.06L329 301.27l-5.79-45c-4.19-26.21-.82-34.87.32-36.9a1.09 1.09 0 0 0 .08-.15c1.08-2 6-6.48 17.48-10.79l89.28-31.21a16.9 16.9 0 0 0 1.62-.52c16-6 32-14.3 32-31.93S451 107.81 432 112.8z"/></svg> and a count) in the editor's footer — to open the **accessibility report**. The report has two lists:
+
+- **Accessibility violations (WCAG AA)** — the problems that turn the indicator purple. Each entry names the line it is on and describes the fix. The heading links out to the official WCAG guidelines.
+- **Other accessibility issues** — advisory recommendations that are *not* WCAG violations (more on these below).
+
+For the example above, the first list reports two violations — one telling you the `<graph>{:dn}` must have a short description (or be marked decorative), and one telling you the `<mathInput>{:dn}` must have a short description or a label. When a list has nothing in it, it reads **None found**.
+
+## Fix the violations
+
+Both violations are fixed by supplying the information only you can provide: a [short description](../guides/accessible-activities#describe-graphs-images-and-videos) for the graph, and a [label](../guides/accessible-activities#label-every-input) on the input. With those in place, the indicator turns green:
+
+```doenet-editor-horiz
+<graph size="small">
+  <shortDescription>A single point, labeled P, at coordinates (3, 4)</shortDescription>
+  <point name="P" fixed>(3,4)</point>
+</graph>
+<p>
+  <mathInput name="x">
+    <label>What is the x-coordinate of P?</label>
+  </mathInput>
+</p>
+```
+
+The `<label>{:dn}` is now part of the input: it renders in the same place the sentence did, so the page looks the same, but it is programmatically tied to the input and a screen reader announces them together.
+
+## Green isn't the whole story: advisories
+
+The second list — **Other accessibility issues** — holds recommendations that don't rise to a WCAG violation, so they leave the indicator green. A green indicator means "no violations," not "nothing to improve." It is worth opening the report even when the indicator is green.
+
+A common advisory is a short description that contains mathematics. A screen reader reads a short description as plain text, so a `<m>{:dn}` inside it is read out as raw notation. The graph below has a perfectly valid description as far as the violation check is concerned — the indicator stays green — but the report's second list flags the embedded math:
+
+```doenet-editor-horiz
+<graph size="small">
+  <shortDescription>The graph of <m>y = x^2</m></shortDescription>
+  <function>x^2</function>
+</graph>
+```
+
+Spelling the math out in words clears the advisory:
+
+```doenet-editor-horiz
+<graph size="small">
+  <shortDescription>The parabola y equals x squared, opening upward</shortDescription>
+  <function>x^2</function>
+</graph>
+```
+
+## See the problems inline in the editor
+
+The report lists issues by line, but you can also have Doenet mark them directly in the code. At the top of the accessibility report is a checkbox, **Show accessibility diagnostics in editor**. When it is on (the default), each flagged component gets a colored underline in the code editor; hover over the underline to read the same message the report shows. Turn the checkbox off to hide the marks while you work on something else.
+
+## What the checks cover
+
+These are the accessibility checks Doenet runs today. The list is expected to grow over time.
+
+| What you wrote | Result |
+| --- | --- |
+| A `<graph>{:dn}` or `<image>{:dn}` with no short description and not marked `decorative{:dn}` | **Violation** |
+| A `<video>{:dn}` with no short description | **Violation** |
+| An input (`<mathInput>{:dn}`, `<textInput>{:dn}`, `<choiceInput>{:dn}`, `<booleanInput>{:dn}`, `<matrixInput>{:dn}`, …) with no `<label>{:dn}` and no short description | **Violation** |
+| An `<answer>{:dn}` that creates its own input but has no `<label>{:dn}` or short description | **Violation** |
+| A `<styleDefinition>{:dn}` whose colors don't have enough contrast against the canvas | **Violation** |
+| A short description that contains math components | Advisory |
+
+The violation checks are about whether the *required information is present*; the [recipes guide](../guides/accessible-activities) shows how to supply it well. Color contrast is checked automatically for every style definition — see [Styling, meaning, and accessibility](../concepts/styling#why-distinctions-live-in-style-numbers-accessibility).
+
+## What passing does and doesn't mean
+
+A green indicator means your document has none of the omissions above. It does **not** mean a screen-reader or keyboard user can actually complete your activity — a description can be present but useless, a label can be accurate but uninformative. Reaching zero violations is the right first step; the real work of writing descriptions someone can learn from begins there. See [Accessibility in Doenet](../concepts/accessibility#passing-the-checker-is-a-floor-not-a-ceiling).
+
+## Where to go next
+
+- **[Writing Accessible Activities](../guides/accessible-activities)** — the recipes that clear these checks: descriptions, labels, links, headings, and tables.
+- **[Accessible Interactive Graphs](../guides/accessible-interactive-graphs)** — making draggable graphs usable by keyboard and screen reader.
+- **[Accessibility in Doenet](../concepts/accessibility)** — why the checker is a floor, not a ceiling.

--- a/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
+++ b/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
@@ -271,6 +271,10 @@ export function DiagnosticsResponseTabContents({
         (diagnostic) => diagnostic.level === 2,
     );
 
+    // Tolerate a trailing slash on the consumer-supplied `docsURL` so that
+    // e.g. "https://docs.doenet.org/" doesn't produce a "//concepts/..." URL.
+    const docsBase = docsURL.replace(/\/+$/, "");
+
     return (
         <div
             className={classNames("diagnostics-response-tabs-container", {
@@ -346,7 +350,7 @@ export function DiagnosticsResponseTabContents({
                                 />
                                 <p className="accessibility-report-intro">
                                     <a
-                                        href={`${docsURL}/concepts/accessibility`}
+                                        href={`${docsBase}/concepts/accessibility`}
                                         target="_blank"
                                         rel="noreferrer"
                                     >

--- a/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
+++ b/packages/doenetml/src/EditorViewer/DiagnosticsResponseTabs.tsx
@@ -344,6 +344,16 @@ export function DiagnosticsResponseTabContents({
                                     label="Show accessibility diagnostics in editor"
                                     onChange={setShowAccessibilityAnnotations}
                                 />
+                                <p className="accessibility-report-intro">
+                                    <a
+                                        href={`${docsURL}/concepts/accessibility`}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                    >
+                                        Learn how Doenet approaches
+                                        accessibility
+                                    </a>
+                                </p>
                                 <section className="accessibility-report-section">
                                     <div className="accessibility-report-heading critical">
                                         <h3>

--- a/packages/doenetml/src/EditorViewer/editor-viewer.css
+++ b/packages/doenetml/src/EditorViewer/editor-viewer.css
@@ -267,6 +267,11 @@
     gap: 1rem;
 }
 
+.editor-panel .accessibility-report-intro {
+    margin: 0;
+    font-size: 0.9rem;
+}
+
 .editor-panel .accessibility-report-section {
     border: 1px solid #d0d5dd;
     border-radius: 0.5rem;


### PR DESCRIPTION
## Summary

Adds an accessibility section to the DoenetML docs — one Concept page and three Guides, following the concept↔guide split established by the styling docs — and links the in-editor accessibility report to the new Concept page.

### Docs (Diátaxis: Concepts + Guides)

- **Concepts → Accessibility in Doenet** (`concepts/accessibility`) — the entry point. Compliance vs. true accessibility (the WCAG checker as a *floor, not a ceiling*), and how Doenet works toward genuine accessibility: baseline WCAG warnings, semantic markup, adaptable styles, the PreFigure renderer, and the honest interactive-graph frontier.
- **Guides → Checking Accessibility** (`guides/check-accessibility`) — the green/purple status indicator, the WCAG report (violations vs. advisories), the footer tab, inline annotations, and a table of every current check.
- **Guides → Writing Accessible Activities** (`guides/accessible-activities`) — short descriptions on graphs/images/videos (and `decorative`), labelling inputs and answers, descriptive links, headings via nested sections, accessible tables with header rows, and contrast.
- **Guides → Accessible Interactive Graphs** (`guides/accessible-interactive-graphs`) — descriptions that update from live values, `addControls` for keyboard operation, and the PreFigure renderer with `<annotations>` (including the single-root-annotation requirement and how to test navigation without a screen reader).

All pages are registered in `_meta.ts` and cross-linked in both directions; the styling concept page gains a reciprocal link, and both the concept and the interactive-graphs guide invite readers to community.doenet.org to report accessibility gaps.

### Editor

- The accessibility report now opens with a **"Learn how Doenet approaches accessibility"** link to `<docsURL>/concepts/accessibility`, so authors can reach the explanation of what the checks do and don't guarantee.

## Testing

- `npm run build -w packages/docs-nextra` → clean (318/318 static pages, all four new pages rendered).
- `npm run build -w packages/doenetml` → clean (typechecks the editor change).

## Notes

- The report link resolves once the docs redeploy to `docs.doenet.org`.
- Examples were verified against `doenet-schema.json`; deliberately-incomplete examples in *Checking Accessibility* are clearly marked as such (they exist to show the checker flagging a violation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
