### PR TITLE
fix(viewer): recover from stalled core-worker startup without aborting slow documents

### DIFF
--- a/.changeset/viewer-core-boot-resilience.md
+++ b/.changeset/viewer-core-boot-resilience.md
@@ -1,0 +1,12 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Make the document viewer resilient to a stalled core-worker startup, and stop slow documents from being aborted before they finish loading.
+
+- If the core worker stalled while starting up (under CPU/timing pressure), the viewer could be left permanently blank — no document and no error. It now watchdogs the worker's brief startup handshake and restarts a worker that fails to come up or hangs; after repeated failures it shows a "could not be started — reload the page" message instead of staying blank.
+- The document-evaluation phase — which can legitimately take seconds to minutes on complex documents — is no longer time-limited, so large documents finish loading instead of being aborted.

--- a/packages/doenetml-worker/src/CoreWorker.ts
+++ b/packages/doenetml-worker/src/CoreWorker.ts
@@ -180,7 +180,8 @@ export class CoreWorker {
             this.flags_set = true;
         } finally {
             // Always release the queue, even if WASM init or set_flags throws,
-            // so a transient failure doesn't deadlock all later calls (#2957).
+            // so a transient failure doesn't deadlock all later calls
+            // (Doenet/DoenetApps#2957).
             resolve();
         }
     }

--- a/packages/doenetml-worker/src/CoreWorker.ts
+++ b/packages/doenetml-worker/src/CoreWorker.ts
@@ -143,9 +143,14 @@ export class CoreWorker {
         } catch (err) {
             console.error("Error when setting source", err);
             throw err;
+        } finally {
+            // Always release the queue, even on a throw (e.g. a transient WASM
+            // init failure). Skipping this leaves `isProcessingPromise`
+            // unresolved, which permanently deadlocks every later call — and
+            // hangs the viewer with no way to recover. See
+            // Doenet/DoenetApps#2957.
+            resolve();
         }
-
-        resolve();
     }
 
     async setFlags(args: { flags: Flags }) {
@@ -155,25 +160,29 @@ export class CoreWorker {
 
         await isProcessingPromise;
 
-        if (!this.wasm_initialized) {
-            await init({ module_or_path: wasmBlobUrl });
-            this.wasm_initialized = true;
-        }
-
-        if (!this.doenetCore) {
-            this.doenetCore = PublicDoenetMLCore.new();
-        }
-        if (this.core_type === "javascript") {
-            if (!this.javascriptCore) {
-                this.javascriptCore = new PublicDoenetMLCoreJavascript();
+        try {
+            if (!this.wasm_initialized) {
+                await init({ module_or_path: wasmBlobUrl });
+                this.wasm_initialized = true;
             }
-            this.javascriptCore.setFlags(args.flags);
+
+            if (!this.doenetCore) {
+                this.doenetCore = PublicDoenetMLCore.new();
+            }
+            if (this.core_type === "javascript") {
+                if (!this.javascriptCore) {
+                    this.javascriptCore = new PublicDoenetMLCoreJavascript();
+                }
+                this.javascriptCore.setFlags(args.flags);
+            }
+
+            this.doenetCore.set_flags(JSON.stringify(args.flags));
+            this.flags_set = true;
+        } finally {
+            // Always release the queue, even if WASM init or set_flags throws,
+            // so a transient failure doesn't deadlock all later calls (#2957).
+            resolve();
         }
-
-        this.doenetCore.set_flags(JSON.stringify(args.flags));
-        this.flags_set = true;
-
-        resolve();
     }
 
     async initializeJavascriptCore({

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -215,8 +215,9 @@ export function DocViewer({
     const coreWorker = useRef<Remote<CoreWorker> | null>(null);
     // Native handle for the same worker `coreWorker` wraps, kept so a wedged
     // worker can be force-terminated even when its Comlink `terminate()` would
-    // itself hang on the stuck queue (#2957). Set and cleared in lockstep with
-    // `coreWorker` (always via `attachNewCoreWorker`/`teardownCurrentCoreWorker`).
+    // itself hang on the stuck queue (Doenet/DoenetApps#2957). Set and
+    // cleared in lockstep with `coreWorker` (always via
+    // `attachNewCoreWorker`/`teardownCurrentCoreWorker`).
     const nativeCoreWorker = useRef<Worker | null>(null);
 
     // Spin up a fresh core worker and store its Comlink remote and native
@@ -252,10 +253,11 @@ export function DocViewer({
         return () => {
             // Best-effort graceful terminate, but always guarantee a native
             // kill so a wedged worker (whose Comlink terminate would hang) is
-            // still released on unmount (#2957). `disposeCoreWorker` already
-            // swallows its own errors; the `.catch` is here so this
-            // fire-and-forget call can't surface an unhandled rejection if that
-            // ever changes (AGENTS.md: no fire-and-forget promises).
+            // still released on unmount (Doenet/DoenetApps#2957).
+            // `disposeCoreWorker` already swallows its own errors; the
+            // `.catch` is here so this fire-and-forget call can't surface an
+            // unhandled rejection if that ever changes (AGENTS.md: no
+            // fire-and-forget promises).
             teardownCurrentCoreWorker({ graceful: true }).catch((e) => {
                 console.warn("DocViewer: core worker teardown failed", e);
             });
@@ -463,7 +465,8 @@ export function DocViewer({
         if (coreWorker.current !== null) {
             preventMoreAnimations.current = true;
             // Bounded graceful terminate + guaranteed native kill, so swapping
-            // in a fresh worker can't hang on a wedged predecessor (#2957).
+            // in a fresh worker can't hang on a wedged predecessor
+            // (Doenet/DoenetApps#2957).
             await teardownCurrentCoreWorker({ graceful: true });
             actionsBeforeCoreCreated.current = [];
             for (let id in animationInfo.current) {
@@ -1086,8 +1089,8 @@ export function DocViewer({
     }
 
     // Put the viewer into a visible "core failed to start" error state rather
-    // than leaving it blank at stage "wait" forever (#2957). Shared by every
-    // core-start failure path.
+    // than leaving it blank at stage "wait" forever (Doenet/DoenetApps#2957).
+    // Shared by every core-start failure path.
     function failCoreStart() {
         coreCreationInProgress.current = false;
         setIsInErrorState?.(true);
@@ -1097,9 +1100,9 @@ export function DocViewer({
 
     // The core-worker *handshake*: (re)create the worker and run the cheap,
     // roughly size-independent init round-trips (set source/flags, initialize
-    // the JS core). This is the phase a #2957 stall lives in, so `startCore`
-    // wraps it in a watchdog. The expensive `generateDast` step happens AFTER
-    // this returns and is deliberately NOT watchdogged.
+    // the JS core). This is the phase a Doenet/DoenetApps#2957 stall lives in,
+    // so `startCore` wraps it in a watchdog. The expensive `generateDast` step
+    // happens AFTER this returns and is deliberately NOT watchdogged.
     async function handshakeCore(attempt: number): Promise<Remote<CoreWorker>> {
         let thisCoreWorker = coreWorker.current;
 
@@ -1134,8 +1137,9 @@ export function DocViewer({
             });
         }
 
-        // [#2957] Test seam — simulate a handshake-phase stall/failure (worker
-        // created, but a boot round-trip never settles). Inert in production.
+        // [Doenet/DoenetApps#2957] Test seam — simulate a handshake-phase
+        // stall/failure (worker created, but a boot round-trip never settles).
+        // Inert in production.
         if (doenetGlobalConfig.__doenetTestCoreInitHook) {
             await doenetGlobalConfig.__doenetTestCoreInitHook(
                 "handshake",
@@ -1160,7 +1164,7 @@ export function DocViewer({
 
         // --- Phase 1: handshake — watchdogged and retried ---
         // Only this cheap, size-independent phase is time-boxed. A stall here
-        // means a hung/wedged worker (#2957), not slow work.
+        // means a hung/wedged worker (Doenet/DoenetApps#2957), not slow work.
         let thisCoreWorker: Remote<CoreWorker> | null = null;
         let handshakeSucceeded = false;
 
@@ -1215,9 +1219,9 @@ export function DocViewer({
             ReturnType<Remote<CoreWorker>["generateJavascriptDast"]>
         >;
         try {
-            // [#2957] Test seam — simulate a slow-but-alive evaluation. Runs in
-            // the un-watchdogged phase, so a delay here must NOT abort the
-            // load. Inert in production.
+            // [Doenet/DoenetApps#2957] Test seam — simulate a slow-but-alive
+            // evaluation. Runs in the un-watchdogged phase, so a delay here
+            // must NOT abort the load. Inert in production.
             if (doenetGlobalConfig.__doenetTestCoreInitHook) {
                 await doenetGlobalConfig.__doenetTestCoreInitHook(
                     "generate",
@@ -1306,8 +1310,8 @@ export function DocViewer({
     // `startCore` is always launched fire-and-forget (never awaited — e.g. from
     // render-phase code and event listeners), so wrap it: it already surfaces
     // boot failures itself, but an *unexpected* throw must still become a
-    // visible error rather than an unhandled rejection (#2957, and AGENTS.md
-    // "no fire-and-forget promises").
+    // visible error rather than an unhandled rejection
+    // (Doenet/DoenetApps#2957, and AGENTS.md "no fire-and-forget promises").
     function startCoreSafely() {
         startCore().catch((e) => {
             console.warn("DocViewer: startCore failed unexpectedly", e);

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -30,6 +30,15 @@ import {
     useAppDispatch,
 } from "../state";
 import { renderersLoadComponent } from "./renderersLoadComponent";
+import { doenetGlobalConfig } from "../global-config";
+import {
+    withTimeout,
+    disposeCoreWorker,
+    DEFAULT_CORE_BOOT_MAX_ATTEMPTS,
+    DEFAULT_CORE_HANDSHAKE_WATCHDOG_MS,
+    CORE_BOOT_RETRY_DELAY_MS,
+    CORE_START_FAILED_MESSAGE,
+} from "./coreWorkerBoot";
 
 // Re-export for back-compat: `renderersLoadComponent` was previously defined
 // here, and external consumers may deep-import it from
@@ -204,6 +213,11 @@ export function DocViewer({
     const [ignoreRendererError, setIgnoreRendererError] = useState(false);
 
     const coreWorker = useRef<Remote<CoreWorker> | null>(null);
+    // Native handle for the same worker `coreWorker` wraps, kept so a wedged
+    // worker can be force-terminated even when its Comlink `terminate()` would
+    // itself hang on the stuck queue (#2957). Set and cleared in lockstep with
+    // `coreWorker`.
+    const nativeCoreWorker = useRef<Worker | null>(null);
 
     const contextForRenderers = {
         doenetViewerUrl,
@@ -214,8 +228,19 @@ export function DocViewer({
 
     useEffect(() => {
         return () => {
-            coreWorker.current?.terminate();
+            // Best-effort graceful terminate, but always guarantee a native
+            // kill so a wedged worker (whose Comlink terminate would hang) is
+            // still released on unmount (#2957). `disposeCoreWorker` already
+            // swallows its own errors; the `.catch` is here so this
+            // fire-and-forget call can't surface an unhandled rejection if that
+            // ever changes (AGENTS.md: no fire-and-forget promises).
+            disposeCoreWorker(coreWorker.current, nativeCoreWorker.current, {
+                graceful: true,
+            }).catch((e) => {
+                console.warn("DocViewer: core worker teardown failed", e);
+            });
             coreWorker.current = null;
+            nativeCoreWorker.current = null;
             coreCreated.current = false;
         };
     }, []);
@@ -253,7 +278,7 @@ export function DocViewer({
                         processLoadedDocState(e.data.state);
 
                         if (render) {
-                            startCore();
+                            startCoreSafely();
                         } else {
                             setStage("readyToCreateCore");
                         }
@@ -419,7 +444,15 @@ export function DocViewer({
     async function reinitializeCoreAndTerminateAnimations() {
         if (coreWorker.current !== null) {
             preventMoreAnimations.current = true;
-            await coreWorker.current.terminate();
+            // Bounded graceful terminate + guaranteed native kill, so swapping
+            // in a fresh worker can't hang on a wedged predecessor (#2957).
+            await disposeCoreWorker(
+                coreWorker.current,
+                nativeCoreWorker.current,
+                { graceful: true },
+            );
+            coreWorker.current = null;
+            nativeCoreWorker.current = null;
             actionsBeforeCoreCreated.current = [];
             for (let id in animationInfo.current) {
                 cancelAnimationFrame(id);
@@ -427,14 +460,15 @@ export function DocViewer({
             animationInfo.current = {};
         }
 
-        const newCoreWorker = createCoreWorker();
-        coreWorker.current = newCoreWorker;
+        const { remote, worker } = createCoreWorker();
+        coreWorker.current = remote;
+        nativeCoreWorker.current = worker;
 
         coreCreated.current = false;
         coreCreationInProgress.current = false;
 
         await initializeCoreWorker({
-            coreWorker: newCoreWorker,
+            coreWorker: remote,
             doenetML,
             flags,
             activityId,
@@ -445,7 +479,7 @@ export function DocViewer({
             fetchExternalDoenetML,
         });
 
-        return newCoreWorker;
+        return remote;
     }
 
     function callAction({
@@ -974,7 +1008,7 @@ export function DocViewer({
         //Guard against the possibility that parameters changed while waiting
         if (coreIdWhenCalled === coreId.current) {
             if (render) {
-                startCore();
+                startCoreSafely();
             } else {
                 setStage("readyToCreateCore");
             }
@@ -1041,17 +1075,43 @@ export function DocViewer({
         initializeCounters.current = data.initializeCounters;
     }
 
-    async function startCore() {
-        let thisCoreWorker = coreWorker.current;
-        setHasInitialError(false);
+    // Put the viewer into a visible "core failed to start" error state rather
+    // than leaving it blank at stage "wait" forever (#2957). Shared by every
+    // core-start failure path.
+    function failCoreStart() {
+        coreCreationInProgress.current = false;
+        setIsInErrorState?.(true);
+        setErrMsg(CORE_START_FAILED_MESSAGE);
+        setHasInitialError(true);
+    }
 
-        if (coreCreated.current || !thisCoreWorker) {
-            //Kill the current core if it exists
+    // The core-worker *handshake*: (re)create the worker and run the cheap,
+    // roughly size-independent init round-trips (set source/flags, initialize
+    // the JS core). This is the phase a #2957 stall lives in, so `startCore`
+    // wraps it in a watchdog. The expensive `generateDast` step happens AFTER
+    // this returns and is deliberately NOT watchdogged.
+    async function handshakeCore(attempt: number): Promise<Remote<CoreWorker>> {
+        let thisCoreWorker = coreWorker.current;
+
+        if (attempt > 0 || coreCreated.current || !thisCoreWorker) {
+            // (Re)create a fresh worker when there's no reusable one to init:
+            //  - !thisCoreWorker — no worker created yet (the common first
+            //    load: with render=true the initial-pass `!render` branch that
+            //    would otherwise pre-create one never ran);
+            //  - coreCreated.current — a core already exists (e.g. the document
+            //    changed and we're rebuilding it);
+            //  - attempt > 0 — a retry, whose predecessor worker may be wedged.
+            // reinitializeCoreAndTerminateAnimations tears down any existing
+            // worker and boots + initializes a new one.
             thisCoreWorker = await reinitializeCoreAndTerminateAnimations();
         } else {
-            // otherwise, initialize core worker to give it the current DoenetML
-
-            let initializeResult = await initializeCoreWorker({
+            // attempt 0, a worker already exists, and its core isn't created —
+            // reuse that worker (skipping a fresh boot + WASM init) and just
+            // (re)initialize it with the current DoenetML. Two ways to be here:
+            // the initial-pass `!render` branch pre-created a worker to report
+            // document structure, or a document/parameter change reset
+            // `coreCreated` while keeping the existing worker.
+            await initializeCoreWorker({
                 coreWorker: thisCoreWorker,
                 doenetML,
                 flags,
@@ -1064,33 +1124,135 @@ export function DocViewer({
             });
         }
 
-        onActionCallbacks.current.clear();
+        // [#2957] Test seam — simulate a handshake-phase stall/failure (worker
+        // created, but a boot round-trip never settles). Inert in production.
+        if (doenetGlobalConfig.__doenetTestCoreInitHook) {
+            await doenetGlobalConfig.__doenetTestCoreInitHook(
+                "handshake",
+                attempt,
+            );
+        }
 
+        return thisCoreWorker;
+    }
+
+    async function startCore() {
+        setHasInitialError(false);
+
+        const maxAttempts = Math.max(
+            1,
+            doenetGlobalConfig.coreBootMaxAttempts ??
+                DEFAULT_CORE_BOOT_MAX_ATTEMPTS,
+        );
+        const handshakeWatchdogMs =
+            doenetGlobalConfig.coreHandshakeWatchdogMs ??
+            DEFAULT_CORE_HANDSHAKE_WATCHDOG_MS;
+
+        // --- Phase 1: handshake — watchdogged and retried ---
+        // Only this cheap, size-independent phase is time-boxed. A stall here
+        // means a hung/wedged worker (#2957), not slow work.
+        let thisCoreWorker: Remote<CoreWorker> | null = null;
+        let handshakeSucceeded = false;
+
+        for (let attempt = 0; attempt < maxAttempts; attempt++) {
+            try {
+                thisCoreWorker = await withTimeout(
+                    () => handshakeCore(attempt),
+                    handshakeWatchdogMs,
+                    `core worker handshake (attempt ${attempt + 1}/${maxAttempts})`,
+                );
+                handshakeSucceeded = true;
+                break;
+            } catch (err) {
+                console.warn(
+                    `DocViewer: core worker handshake attempt ${attempt + 1} ` +
+                        `of ${maxAttempts} failed` +
+                        (attempt + 1 < maxAttempts
+                            ? "; retrying with a fresh worker."
+                            : "; giving up."),
+                    err,
+                );
+                // The worker may be wedged (a hung round-trip leaves its
+                // serialization queue — and its own terminate() — stuck), so
+                // force-kill it natively and drop the refs; the next attempt
+                // starts from a brand-new Worker.
+                await disposeCoreWorker(
+                    coreWorker.current,
+                    nativeCoreWorker.current,
+                    { graceful: false },
+                );
+                coreWorker.current = null;
+                nativeCoreWorker.current = null;
+                coreCreated.current = false;
+                coreCreationInProgress.current = false;
+                if (attempt + 1 < maxAttempts) {
+                    await new Promise((resolve) =>
+                        setTimeout(resolve, CORE_BOOT_RETRY_DELAY_MS),
+                    );
+                }
+            }
+        }
+
+        if (!handshakeSucceeded || thisCoreWorker === null) {
+            // Every handshake attempt failed.
+            failCoreStart();
+            return;
+        }
+
+        // --- Phase 2: generate the DAST — NOT watchdogged ---
+        // The worker proved it is alive by completing the handshake, so a long
+        // generateDast is real, in-progress work, not a hang. Watchdogging
+        // here is what made complex documents unloadable (they time out before
+        // core finishes), so we let it run to completion however long it takes.
+        onActionCallbacks.current.clear();
         coreCreationInProgress.current = true;
 
-        const dastResult = await thisCoreWorker.generateJavascriptDast(
-            {
-                coreId: coreId.current,
-                userId,
-                cid: cid.current,
-                theme: darkMode,
-                requestedVariant: initialCoreData.current?.requestedVariant,
-                stateVariableChanges: initialCoreData.current?.coreState
-                    ? JSON.stringify(
-                          initialCoreData.current.coreState,
-                          serializedComponentsReplacer,
-                      )
-                    : undefined,
-                initializeCounters: initializeCounters.current,
-            },
-            Comlink.proxy(updateRenderers),
-            Comlink.proxy(reportScoreAndStateCallback),
-            Comlink.proxy(requestAnimationFrame),
-            Comlink.proxy(cancelAnimationFrame),
-            Comlink.proxy(copyToClipboard),
-            Comlink.proxy(sendEvent),
-            Comlink.proxy(requestSolutionView),
-        );
+        let dastResult: Awaited<
+            ReturnType<Remote<CoreWorker>["generateJavascriptDast"]>
+        >;
+        try {
+            // [#2957] Test seam — simulate a slow-but-alive evaluation. Runs in
+            // the un-watchdogged phase, so a delay here must NOT abort the
+            // load. Inert in production.
+            if (doenetGlobalConfig.__doenetTestCoreInitHook) {
+                await doenetGlobalConfig.__doenetTestCoreInitHook(
+                    "generate",
+                    0,
+                );
+            }
+
+            dastResult = await thisCoreWorker.generateJavascriptDast(
+                {
+                    coreId: coreId.current,
+                    userId,
+                    cid: cid.current,
+                    theme: darkMode,
+                    requestedVariant: initialCoreData.current?.requestedVariant,
+                    stateVariableChanges: initialCoreData.current?.coreState
+                        ? JSON.stringify(
+                              initialCoreData.current.coreState,
+                              serializedComponentsReplacer,
+                          )
+                        : undefined,
+                    initializeCounters: initializeCounters.current,
+                },
+                Comlink.proxy(updateRenderers),
+                Comlink.proxy(reportScoreAndStateCallback),
+                Comlink.proxy(requestAnimationFrame),
+                Comlink.proxy(cancelAnimationFrame),
+                Comlink.proxy(copyToClipboard),
+                Comlink.proxy(sendEvent),
+                Comlink.proxy(requestSolutionView),
+            );
+        } catch (err) {
+            // generateDast normally reports core problems via
+            // `{ success: false }` (handled below); a *rejection* here is an
+            // unexpected failure (e.g. the worker died mid-evaluation). Surface
+            // it rather than stalling.
+            console.warn("DocViewer: generateJavascriptDast failed", err);
+            failCoreStart();
+            return;
+        }
 
         if (dastResult.success) {
             if (
@@ -1135,6 +1297,17 @@ export function DocViewer({
         }
         setStage("coreCreated");
         initializedCallback?.({ activityId, docId });
+    }
+
+    // `startCore` is launched fire-and-forget from render-phase code, so wrap
+    // it: it already surfaces boot failures itself, but an *unexpected* throw
+    // must still become a visible error rather than an unhandled rejection
+    // (#2957, and AGENTS.md "no fire-and-forget promises").
+    function startCoreSafely() {
+        startCore().catch((e) => {
+            console.warn("DocViewer: startCore failed unexpectedly", e);
+            failCoreStart();
+        });
     }
 
     function requestAnimationFrame({
@@ -1304,10 +1477,14 @@ export function DocViewer({
     // then just initialize the core worker so that can return document structure
     // but core itself won't actually start
     if (initialPass && !render) {
-        let newCoreWorker = createCoreWorker();
-        coreWorker.current = newCoreWorker;
+        const { remote, worker } = createCoreWorker();
+        coreWorker.current = remote;
+        nativeCoreWorker.current = worker;
+        // Fire-and-forget: this only primes the worker so it can report the
+        // document structure; core itself isn't started until `render` flips
+        // true. Surface failures rather than swallowing the promise.
         initializeCoreWorker({
-            coreWorker: newCoreWorker,
+            coreWorker: remote,
             doenetML,
             flags,
             activityId,
@@ -1316,6 +1493,11 @@ export function DocViewer({
             attemptNumber,
             documentStructureCallback,
             fetchExternalDoenetML,
+        }).catch((e) => {
+            console.warn(
+                "DocViewer: core worker initialization (no-render path) failed",
+                e,
+            );
         });
         return null;
     }
@@ -1364,7 +1546,10 @@ export function DocViewer({
 
         setStage("wait");
 
-        loadStateAndInitialize();
+        loadStateAndInitialize().catch((e) => {
+            console.warn("DocViewer: loadStateAndInitialize failed", e);
+            failCoreStart();
+        });
 
         return null;
     }
@@ -1388,7 +1573,7 @@ export function DocViewer({
     }
 
     if (stage === "readyToCreateCore" && render) {
-        startCore();
+        startCoreSafely();
         // XXX: this state never occurs
     } else if (stage === "waitingOnCore" && !render && !coreCreated.current) {
         // we've moved off this doc, but core is still being created

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -216,8 +216,30 @@ export function DocViewer({
     // Native handle for the same worker `coreWorker` wraps, kept so a wedged
     // worker can be force-terminated even when its Comlink `terminate()` would
     // itself hang on the stuck queue (#2957). Set and cleared in lockstep with
-    // `coreWorker`.
+    // `coreWorker` (always via `attachNewCoreWorker`/`teardownCurrentCoreWorker`).
     const nativeCoreWorker = useRef<Worker | null>(null);
+
+    // Spin up a fresh core worker and store its Comlink remote and native
+    // handle in lockstep. Returns the remote for the caller to drive.
+    function attachNewCoreWorker(): Remote<CoreWorker> {
+        const { remote, worker } = createCoreWorker();
+        coreWorker.current = remote;
+        nativeCoreWorker.current = worker;
+        return remote;
+    }
+
+    // Tear down whatever worker the refs currently point at and clear them
+    // (keeping the two refs in lockstep). Refs are cleared up front so a
+    // worker that's being terminated is never reachable mid-teardown; the
+    // returned promise settles once `disposeCoreWorker` has finished, for
+    // callers that need to await the teardown before swapping in a replacement.
+    function teardownCurrentCoreWorker({ graceful }: { graceful: boolean }) {
+        const remote = coreWorker.current;
+        const native = nativeCoreWorker.current;
+        coreWorker.current = null;
+        nativeCoreWorker.current = null;
+        return disposeCoreWorker(remote, native, { graceful });
+    }
 
     const contextForRenderers = {
         doenetViewerUrl,
@@ -234,13 +256,9 @@ export function DocViewer({
             // swallows its own errors; the `.catch` is here so this
             // fire-and-forget call can't surface an unhandled rejection if that
             // ever changes (AGENTS.md: no fire-and-forget promises).
-            disposeCoreWorker(coreWorker.current, nativeCoreWorker.current, {
-                graceful: true,
-            }).catch((e) => {
+            teardownCurrentCoreWorker({ graceful: true }).catch((e) => {
                 console.warn("DocViewer: core worker teardown failed", e);
             });
-            coreWorker.current = null;
-            nativeCoreWorker.current = null;
             coreCreated.current = false;
         };
     }, []);
@@ -446,13 +464,7 @@ export function DocViewer({
             preventMoreAnimations.current = true;
             // Bounded graceful terminate + guaranteed native kill, so swapping
             // in a fresh worker can't hang on a wedged predecessor (#2957).
-            await disposeCoreWorker(
-                coreWorker.current,
-                nativeCoreWorker.current,
-                { graceful: true },
-            );
-            coreWorker.current = null;
-            nativeCoreWorker.current = null;
+            await teardownCurrentCoreWorker({ graceful: true });
             actionsBeforeCoreCreated.current = [];
             for (let id in animationInfo.current) {
                 cancelAnimationFrame(id);
@@ -460,9 +472,7 @@ export function DocViewer({
             animationInfo.current = {};
         }
 
-        const { remote, worker } = createCoreWorker();
-        coreWorker.current = remote;
-        nativeCoreWorker.current = worker;
+        const remote = attachNewCoreWorker();
 
         coreCreated.current = false;
         coreCreationInProgress.current = false;
@@ -1176,13 +1186,7 @@ export function DocViewer({
                 // serialization queue — and its own terminate() — stuck), so
                 // force-kill it natively and drop the refs; the next attempt
                 // starts from a brand-new Worker.
-                await disposeCoreWorker(
-                    coreWorker.current,
-                    nativeCoreWorker.current,
-                    { graceful: false },
-                );
-                coreWorker.current = null;
-                nativeCoreWorker.current = null;
+                await teardownCurrentCoreWorker({ graceful: false });
                 coreCreated.current = false;
                 coreCreationInProgress.current = false;
                 if (attempt + 1 < maxAttempts) {
@@ -1477,9 +1481,7 @@ export function DocViewer({
     // then just initialize the core worker so that can return document structure
     // but core itself won't actually start
     if (initialPass && !render) {
-        const { remote, worker } = createCoreWorker();
-        coreWorker.current = remote;
-        nativeCoreWorker.current = worker;
+        const remote = attachNewCoreWorker();
         // Fire-and-forget: this only primes the worker so it can report the
         // document structure; core itself isn't started until `render` flips
         // true. Surface failures rather than swallowing the promise.

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -1303,10 +1303,11 @@ export function DocViewer({
         initializedCallback?.({ activityId, docId });
     }
 
-    // `startCore` is launched fire-and-forget from render-phase code, so wrap
-    // it: it already surfaces boot failures itself, but an *unexpected* throw
-    // must still become a visible error rather than an unhandled rejection
-    // (#2957, and AGENTS.md "no fire-and-forget promises").
+    // `startCore` is always launched fire-and-forget (never awaited — e.g. from
+    // render-phase code and event listeners), so wrap it: it already surfaces
+    // boot failures itself, but an *unexpected* throw must still become a
+    // visible error rather than an unhandled rejection (#2957, and AGENTS.md
+    // "no fire-and-forget promises").
     function startCoreSafely() {
         startCore().catch((e) => {
             console.warn("DocViewer: startCore failed unexpectedly", e);

--- a/packages/doenetml/src/Viewer/coreWorkerBoot.ts
+++ b/packages/doenetml/src/Viewer/coreWorkerBoot.ts
@@ -1,0 +1,120 @@
+import type { Remote } from "comlink";
+import type { CoreWorker } from "@doenet/doenetml-worker";
+
+// --- Core-worker boot resilience (Doenet/DoenetApps#2957) -----------------
+//
+// Helpers used by `DocViewer.startCore` to bring up the core worker robustly.
+// Bringing up the core worker has two very different phases:
+//
+//   1. Handshake — (re)create the worker and run the cheap, roughly
+//      document-size-independent init round-trips (set source/flags,
+//      initialize the JS core). Empirically a few hundred ms regardless of
+//      document size. A #2957 stall lives HERE: a worker that never loads or
+//      wedges leaves these awaits unsettled, and because the worker serializes
+//      everything through one internal promise queue, a stall there wedges the
+//      queue so even the worker's own `terminate()` never returns.
+//
+//   2. generateDast — the actual evaluation. Legitimately slow and scales with
+//      document size (seconds to minutes on complex documents).
+//
+// So `DocViewer.startCore` time-boxes ONLY the handshake (force-killing a
+// wedged worker natively and retrying), then lets generateDast run to
+// completion however long it takes. Time-boxing generateDast would be wrong:
+// it can't tell a slow-but-working core from a hung one, and would make large
+// documents unloadable. Once the handshake completes, the worker has proven it
+// is alive, so a long evaluation is real work — not a hang.
+
+export const DEFAULT_CORE_BOOT_MAX_ATTEMPTS = 3;
+// Sized to clear any *healthy* handshake with wide margin while still
+// recovering from a genuine hang reasonably quickly. The handshake is
+// fixed-size work (parse the worker bundle, compile the WASM, init the JS
+// core) — not something that scales with document size — and it stays bounded
+// under CPU pressure: measured ~0.4s idle and only ~2s with 24 workers booting
+// at once. 15s is therefore many times any realistic healthy handshake.
+//
+// Caveat: when a document uses `fetchExternalDoenetML`, the (network)
+// expansion of external references runs inside this phase too, so a deployment
+// that relies on slow/large external references may want to raise this via
+// `doenetGlobalConfig.coreHandshakeWatchdogMs`. Erring high is deliberate: a
+// watchdog *shorter* than a healthy handshake makes the document unloadable on
+// exactly the slow/contended runners this guard exists for, whereas erring
+// long only delays recovery from a (rare) true hang.
+export const DEFAULT_CORE_HANDSHAKE_WATCHDOG_MS = 15_000;
+export const CORE_BOOT_RETRY_DELAY_MS = 250;
+const GRACEFUL_TERMINATE_TIMEOUT_MS = 2_000;
+
+// Shown in the viewer when the core worker can't be started after retries,
+// instead of leaving the pane blank (#2957). One canonical string so the
+// message — which a test also matches on — stays consistent across the several
+// failure paths in DocViewer.startCore.
+export const CORE_START_FAILED_MESSAGE =
+    "The document viewer could not be started. Please reload the page.";
+
+/**
+ * Resolve/reject with `task()`, but reject with a timeout error if it does
+ * not settle within `ms`. The underlying promise is left to settle on its
+ * own — we attach a (post-timeout no-op) handler so a late rejection is never
+ * reported as unhandled. Callers that time out are responsible for tearing
+ * down whatever the task was waiting on.
+ */
+export function withTimeout<T>(
+    task: () => Promise<T>,
+    ms: number,
+    label: string,
+): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        let settled = false;
+        const timer = setTimeout(() => {
+            if (!settled) {
+                settled = true;
+                reject(new Error(`${label} timed out after ${ms}ms`));
+            }
+        }, ms);
+        task().then(
+            (value) => {
+                if (!settled) {
+                    settled = true;
+                    clearTimeout(timer);
+                    resolve(value);
+                }
+            },
+            (err) => {
+                if (!settled) {
+                    settled = true;
+                    clearTimeout(timer);
+                    reject(err);
+                }
+            },
+        );
+    });
+}
+
+/**
+ * Tear down a core worker. When `graceful`, first give the Comlink
+ * `terminate()` a bounded chance to run its cleanup (it frees the Rust core
+ * and the JS core); regardless, always follow with a native
+ * `worker.terminate()` so a wedged worker — whose Comlink terminate would
+ * itself hang on the stuck queue — is still guaranteed to die.
+ */
+export async function disposeCoreWorker(
+    remote: Remote<CoreWorker> | null,
+    nativeWorker: Worker | null,
+    { graceful }: { graceful: boolean },
+) {
+    if (graceful && remote) {
+        try {
+            await withTimeout(
+                () => remote.terminate(),
+                GRACEFUL_TERMINATE_TIMEOUT_MS,
+                "core worker graceful terminate",
+            );
+        } catch {
+            // fall through to the guaranteed native kill below
+        }
+    }
+    try {
+        nativeWorker?.terminate();
+    } catch {
+        // best-effort; nothing more we can do
+    }
+}

--- a/packages/doenetml/src/Viewer/coreWorkerBoot.ts
+++ b/packages/doenetml/src/Viewer/coreWorkerBoot.ts
@@ -9,10 +9,11 @@ import type { CoreWorker } from "@doenet/doenetml-worker";
 //   1. Handshake — (re)create the worker and run the cheap, roughly
 //      document-size-independent init round-trips (set source/flags,
 //      initialize the JS core). Empirically a few hundred ms regardless of
-//      document size. A #2957 stall lives HERE: a worker that never loads or
-//      wedges leaves these awaits unsettled, and because the worker serializes
-//      everything through one internal promise queue, a stall there wedges the
-//      queue so even the worker's own `terminate()` never returns.
+//      document size. A Doenet/DoenetApps#2957 stall lives HERE: a worker that
+//      never loads or wedges leaves these awaits unsettled, and because the
+//      worker serializes everything through one internal promise queue, a
+//      stall there wedges the queue so even the worker's own `terminate()`
+//      never returns.
 //
 //   2. generateDast — the actual evaluation. Legitimately slow and scales with
 //      document size (seconds to minutes on complex documents).
@@ -44,9 +45,9 @@ export const CORE_BOOT_RETRY_DELAY_MS = 250;
 const GRACEFUL_TERMINATE_TIMEOUT_MS = 2_000;
 
 // Shown in the viewer when the core worker can't be started after retries,
-// instead of leaving the pane blank (#2957). One canonical string so the
-// message — which a test also matches on — stays consistent across the several
-// failure paths in DocViewer.startCore.
+// instead of leaving the pane blank (Doenet/DoenetApps#2957). One canonical
+// string so the message — which a test also matches on — stays consistent
+// across the several failure paths in DocViewer.startCore.
 export const CORE_START_FAILED_MESSAGE =
     "The document viewer could not be started. Please reload the page.";
 

--- a/packages/doenetml/src/global-config.ts
+++ b/packages/doenetml/src/global-config.ts
@@ -6,7 +6,45 @@ if (typeof window === "undefined") {
 /**
  * Global configuration object for DoenetML.
  */
-export const doenetGlobalConfig = {
+export const doenetGlobalConfig: {
+    doenetWorkerUrl: string;
+    /**
+     * Maximum number of times `DocViewer` will retry the core-worker
+     * *handshake* before giving up and surfacing an error. Each handshake
+     * that fails to complete within `coreHandshakeWatchdogMs` is abandoned
+     * and retried with a fresh worker. Falls back to a built-in default when
+     * unset.
+     */
+    coreBootMaxAttempts?: number;
+    /**
+     * Per-attempt watchdog, in milliseconds, for the core-worker *handshake*
+     * in `DocViewer` — i.e. (re)creating the worker and running the cheap,
+     * roughly size-independent init round-trips (set source/flags, initialize
+     * the JS core). A handshake that neither resolves nor rejects within this
+     * window is treated as a stalled/wedged worker (Doenet/DoenetApps#2957):
+     * the worker is force-terminated and the handshake retried.
+     *
+     * This watchdog deliberately does NOT cover the subsequent `generateDast`
+     * step, which is the legitimately slow, document-size-dependent phase
+     * (seconds to minutes on complex documents). Time-boxing that phase would
+     * make large documents unloadable, so once the handshake completes — the
+     * worker having proven it is alive — the evaluation runs to completion
+     * however long it takes. Falls back to a built-in default when unset.
+     */
+    coreHandshakeWatchdogMs?: number;
+    /**
+     * Test-only seam. When set, `DocViewer` awaits this at each core-init
+     * phase: `"handshake"` (covered by the watchdog) and `"generate"` (the
+     * un-watchdogged evaluation). Throwing, rejecting, or returning a
+     * never-resolving promise lets a test deterministically simulate either a
+     * hung/wedged worker handshake or a slow-but-alive evaluation
+     * (Doenet/DoenetApps#2957). Always `undefined` in production.
+     */
+    __doenetTestCoreInitHook?: (
+        phase: "handshake" | "generate",
+        attempt: number,
+    ) => void | Promise<void>;
+} = {
     doenetWorkerUrl: getWorkerUrl(),
 };
 // We want this to be available in the global scope

--- a/packages/doenetml/src/utils/docUtils.ts
+++ b/packages/doenetml/src/utils/docUtils.ts
@@ -8,14 +8,33 @@ import {
     normalizeDocumentDast,
 } from "@doenet/parser";
 
+export type CoreWorkerHandle = {
+    /** The Comlink-wrapped async API for the core worker. */
+    remote: Comlink.Remote<CoreWorker>;
+    /**
+     * The underlying native `Worker`. Retained so a *wedged* worker can be
+     * force-killed with `worker.terminate()`. The Comlink `remote.terminate()`
+     * call routes through the worker's own serialization queue, so if that
+     * queue is stuck (e.g. a hung WASM init), the Comlink terminate hangs too
+     * — leaving no way to recover. See Doenet/DoenetApps#2957.
+     */
+    worker: Worker;
+};
+
 /**
  * Create a DoenetCoreWorker that is wrapped in Comlink for a nice async API.
+ *
+ * Returns both the Comlink `remote` (the normal async API) and the native
+ * `worker` handle. Callers should drive the worker through `remote`; the
+ * native `worker` is only for `terminate()` as a guaranteed kill switch when
+ * the worker has stopped responding.
  */
-export function createCoreWorker() {
+export function createCoreWorker(): CoreWorkerHandle {
     const worker = new Worker(doenetGlobalConfig.doenetWorkerUrl, {
         type: "classic",
     });
-    return Comlink.wrap(worker) as Comlink.Remote<CoreWorker>;
+    const remote = Comlink.wrap(worker) as Comlink.Remote<CoreWorker>;
+    return { remote, worker };
 }
 
 export async function initializeCoreWorker({

--- a/packages/doenetml/test/cypress/component/DoenetEditor.viewerRenderStall.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.viewerRenderStall.cy.tsx
@@ -1,0 +1,176 @@
+import React from "react";
+import { DoenetEditor } from "../../../src/doenetml-inline-worker";
+import { doenetGlobalConfig } from "../../../src/global-config";
+
+// Regression coverage for the "editor renders but viewer never does" stall
+// (Doenet/DoenetApps#2957) AND its follow-up: don't conflate a slow core with
+// a hung one.
+//
+// Two distinct core-init phases (see DocViewer.startCore):
+//   - "handshake": (re)create the worker + cheap, size-independent init
+//     round-trips. A #2957 stall lives here (worker silent). This phase IS
+//     watchdogged + retried.
+//   - "generate": the actual evaluation. Legitimately slow on complex
+//     documents (seconds to minutes). This phase is NOT watchdogged — once the
+//     handshake succeeds the worker has proven it is alive.
+//
+// Both phases are driven deterministically through the
+// `doenetGlobalConfig.__doenetTestCoreInitHook` seam (inert in production)
+// rather than relying on flaky CPU throttling or real slow documents.
+
+const SAMPLE_DOENETML = "<p>hello viewer</p>";
+
+function Harness() {
+    return (
+        <div style={{ height: "500px", width: "900px" }}>
+            <DoenetEditor
+                doenetML={SAMPLE_DOENETML}
+                addVirtualKeyboard={false}
+            />
+        </div>
+    );
+}
+
+describe("DoenetEditor viewer render stall (#2957)", () => {
+    afterEach(() => {
+        delete doenetGlobalConfig.__doenetTestCoreInitHook;
+        delete doenetGlobalConfig.coreHandshakeWatchdogMs;
+        delete doenetGlobalConfig.coreBootMaxAttempts;
+    });
+
+    it("baseline: viewer renders without any injected fault", () => {
+        cy.mount(<Harness />);
+
+        cy.get(".cm-editor", { timeout: 20000 }).should("exist");
+        cy.get(".doenet-viewer", { timeout: 20000 }).should("exist");
+        cy.get(".doenet-viewer").should("contain.text", "hello viewer");
+    });
+
+    it("recovers from a hung handshake (watchdog + retry)", () => {
+        let handshakeAttempts = 0;
+        // Hang forever on the first handshake attempt (emulates a worker whose
+        // boot round-trip never settles under load); let later attempts and
+        // the evaluation phase proceed.
+        doenetGlobalConfig.__doenetTestCoreInitHook = (phase, attempt) => {
+            if (phase === "handshake") {
+                handshakeAttempts = Math.max(handshakeAttempts, attempt + 1);
+                if (attempt === 0) {
+                    return new Promise<void>(() => {
+                        /* never resolves */
+                    });
+                }
+            }
+        };
+        // Generous enough that the real first handshake completes before the
+        // injected hang, so the watchdog fires on the *hang*, not on a
+        // slow-but-healthy handshake.
+        doenetGlobalConfig.coreHandshakeWatchdogMs = 4000;
+
+        cy.mount(<Harness />);
+
+        // Editor shell still comes up immediately.
+        cy.get(".cm-editor", { timeout: 20000 }).should("exist");
+
+        // The watchdog + retry recovers and the viewer renders. (Pre-fix the
+        // first handshake hung forever and the viewer stayed blank.)
+        cy.get(".doenet-viewer", { timeout: 20000 }).should("exist");
+        cy.get(".doenet-viewer").should("contain.text", "hello viewer");
+
+        cy.then(() => {
+            expect(
+                handshakeAttempts,
+                "handshake was retried after the hung first attempt",
+            ).to.be.greaterThan(1);
+        });
+    });
+
+    it("recovers from a rejected handshake (retry)", () => {
+        let handshakeAttempts = 0;
+        // Reject the first handshake synchronously (emulates a transient
+        // WASM-init/throw); a reject should retry immediately without waiting
+        // for the watchdog.
+        doenetGlobalConfig.__doenetTestCoreInitHook = (phase, attempt) => {
+            if (phase === "handshake") {
+                handshakeAttempts = Math.max(handshakeAttempts, attempt + 1);
+                if (attempt === 0) {
+                    throw new Error("simulated transient handshake failure");
+                }
+            }
+        };
+        // Long watchdog so this proves the retry came from the *reject*, not a
+        // timeout.
+        doenetGlobalConfig.coreHandshakeWatchdogMs = 60000;
+
+        cy.mount(<Harness />);
+
+        cy.get(".cm-editor", { timeout: 20000 }).should("exist");
+        cy.get(".doenet-viewer", { timeout: 20000 }).should("exist");
+        cy.get(".doenet-viewer").should("contain.text", "hello viewer");
+
+        cy.then(() => {
+            expect(
+                handshakeAttempts,
+                "handshake was retried after the rejected first attempt",
+            ).to.be.greaterThan(1);
+        });
+    });
+
+    it("surfaces a visible error when every handshake attempt fails", () => {
+        // Hang on every handshake attempt: the viewer must give up and show an
+        // error rather than stalling silently with a blank pane.
+        doenetGlobalConfig.__doenetTestCoreInitHook = (phase) => {
+            if (phase === "handshake") {
+                return new Promise<void>(() => {
+                    /* never resolves */
+                });
+            }
+        };
+        doenetGlobalConfig.coreHandshakeWatchdogMs = 2000;
+        doenetGlobalConfig.coreBootMaxAttempts = 2;
+
+        cy.mount(<Harness />);
+
+        // Editor unaffected.
+        cy.get(".cm-editor", { timeout: 20000 }).should("exist");
+
+        // A visible error is surfaced (2 attempts × 2s watchdog ≈ 4s).
+        cy.contains(/reload the page/i, { timeout: 20000 }).should("exist");
+
+        // And it is an error, not a silently-rendered empty viewer.
+        cy.get(".doenet-viewer").should("not.exist");
+    });
+
+    it("does not abort a slow-but-alive evaluation", () => {
+        // The crux of the #2957 follow-up: a long evaluation must NOT be killed
+        // by the handshake watchdog. Here the handshake is healthy/fast but the
+        // evaluation takes far longer than the (deliberately short) handshake
+        // watchdog. A total-elapsed watchdog over the boot would abort this and
+        // make the document unloadable; a handshake-only watchdog must let it
+        // finish.
+        let generatePhaseRan = false;
+        doenetGlobalConfig.__doenetTestCoreInitHook = (phase) => {
+            if (phase === "generate") {
+                generatePhaseRan = true;
+                return new Promise<void>((resolve) =>
+                    setTimeout(resolve, 4000),
+                );
+            }
+        };
+        // Short watchdog: the real ~hundreds-of-ms handshake fits comfortably,
+        // but the 4s evaluation delay does NOT — so if the watchdog covered the
+        // evaluation, the load would be aborted.
+        doenetGlobalConfig.coreHandshakeWatchdogMs = 2500;
+
+        cy.mount(<Harness />);
+
+        cy.get(".cm-editor", { timeout: 20000 }).should("exist");
+
+        // Evaluation runs long but the viewer still renders.
+        cy.get(".doenet-viewer", { timeout: 20000 }).should("exist");
+        cy.get(".doenet-viewer").should("contain.text", "hello viewer");
+
+        cy.then(() => {
+            expect(generatePhaseRan, "evaluation phase ran").to.be.true;
+        });
+    });
+});

--- a/packages/doenetml/test/cypress/component/DoenetEditor.viewerRenderStall.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.viewerRenderStall.cy.tsx
@@ -8,8 +8,8 @@ import { doenetGlobalConfig } from "../../../src/global-config";
 //
 // Two distinct core-init phases (see DocViewer.startCore):
 //   - "handshake": (re)create the worker + cheap, size-independent init
-//     round-trips. A #2957 stall lives here (worker silent). This phase IS
-//     watchdogged + retried.
+//     round-trips. A Doenet/DoenetApps#2957 stall lives here (worker silent).
+//     This phase IS watchdogged + retried.
 //   - "generate": the actual evaluation. Legitimately slow on complex
 //     documents (seconds to minutes). This phase is NOT watchdogged — once the
 //     handshake succeeds the worker has proven it is alive.
@@ -31,7 +31,7 @@ function Harness() {
     );
 }
 
-describe("DoenetEditor viewer render stall (#2957)", () => {
+describe("DoenetEditor viewer render stall (Doenet/DoenetApps#2957)", () => {
     afterEach(() => {
         delete doenetGlobalConfig.__doenetTestCoreInitHook;
         delete doenetGlobalConfig.coreHandshakeWatchdogMs;
@@ -141,12 +141,12 @@ describe("DoenetEditor viewer render stall (#2957)", () => {
     });
 
     it("does not abort a slow-but-alive evaluation", () => {
-        // The crux of the #2957 follow-up: a long evaluation must NOT be killed
-        // by the handshake watchdog. Here the handshake is healthy/fast but the
-        // evaluation takes far longer than the (deliberately short) handshake
-        // watchdog. A total-elapsed watchdog over the boot would abort this and
-        // make the document unloadable; a handshake-only watchdog must let it
-        // finish.
+        // The crux of the Doenet/DoenetApps#2957 follow-up: a long evaluation
+        // must NOT be killed by the handshake watchdog. Here the handshake is
+        // healthy/fast but the evaluation takes far longer than the
+        // (deliberately short) handshake watchdog. A total-elapsed watchdog
+        // over the boot would abort this and make the document unloadable; a
+        // handshake-only watchdog must let it finish.
         let generatePhaseRan = false;
         doenetGlobalConfig.__doenetTestCoreInitHook = (phase) => {
             if (phase === "generate") {


### PR DESCRIPTION
## Problem

Under CPU/timing pressure (notably concurrent CI runners), `<DoenetEditor>` / `<DoenetViewer>` could end up with the editor shell mounted (CodeMirror present) but the **viewer pane permanently blank** — no `.doenet-viewer`, no `.doenet-loading`, no error, and "Update" disabled. It surfaced from the DoenetTools side as flaky e2e failures (Doenet/DoenetApps#2957); the root cause is in the engine layer.

`DocViewer.startCore()` awaited the core-worker round-trips (init + `generateDast`) with **no timeout, no retry, and no error surfacing**, fire-and-forget from render-phase code. A single hung or failed boot pinned `DocViewer` at `stage="wait"` (rendering `null`) forever. Compounding it, a wedged worker couldn't even be torn down: the worker serializes everything through one promise queue, so its own Comlink `terminate()` hangs on the same stuck queue — and the native `Worker` handle had been discarded.

## Fix

Core bring-up is now two phases, and **only the first is watchdogged**:

1. **Handshake** — create the worker + run the cheap, roughly size-independent init round-trips. Measured ~0.4s idle and ~2s even with 24 workers booting at once, so a stall here means a hung/wedged worker, not slow work. It is time-boxed; on timeout the worker is **force-terminated via its native handle** and the handshake retried, and after repeated failures the viewer shows a visible "reload the page" error instead of staying blank.
2. **Evaluation (`generateDast`)** — legitimately scales with document size (seconds to minutes). This phase is **not** time-limited: once the handshake completes the worker has proven it is alive, so a long evaluation is real work. (Time-boxing it was what would otherwise make complex documents unloadable.)

Supporting changes:

- `createCoreWorker` now returns the native `Worker` handle (needed to kill a wedged worker).
- `CoreWorker.setSource`/`setFlags` release their serialization queue in `finally`, so a transient WASM-init failure can't permanently deadlock the worker.
- Boot-resilience helpers (`withTimeout`, `disposeCoreWorker`, the constants, and the error message) live in a new `coreWorkerBoot.ts` to keep `DocViewer` focused.
- The watchdog timeout / attempt count and a production-inert test seam are configurable on `doenetGlobalConfig`.

## Testing

New deterministic Cypress component spec (`DoenetEditor.viewerRenderStall.cy.tsx`) drives the failure through a gated, production-inert seam:

- baseline renders normally
- recovers from a hung handshake (watchdog + retry)
- recovers from a rejected handshake (retry)
- surfaces a visible error when every handshake attempt fails
- does not abort a slow-but-alive evaluation

All pass; the pre-existing editor component specs are unaffected. Also confirmed against a real slow document (`repeatForSequence`): with the handshake-only watchdog it loads, whereas a watchdog over the evaluation makes it unloadable (reproducing the regression this design avoids).

Relates to Doenet/DoenetApps#2957.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
