### PR TITLE
test: cover answer→award comparison-attribute fallback

### DIFF
--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/answer.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/answer.test.ts
@@ -4131,6 +4131,46 @@ Enter any letter:
         });
     });
 
+    it("answer-level symbolicEquality propagates to an explicit award", async () => {
+        // symbolicEquality is set on the <answer>, not on the <award>.
+        // The award's symbolicEquality falls back to the answer's value,
+        // so a numerically-equal but syntactically-different response
+        // (commuted terms, or the factored form) is rejected. Without the
+        // fall-back, the default numerical checker would give full credit
+        // to all three responses below.
+        await test_math_answer({
+            doenetML: `
+<answer name="answer1" symbolicEquality>
+    <award>x^2 + 2x + 1</award>
+</answer>
+  `,
+            answers: [
+                { latex: "x^2+2x+1", credit: 1 },
+                { latex: "1+2x+x^2", credit: 0 },
+                { latex: "(x+1)^2", credit: 0 },
+            ],
+        });
+    });
+
+    it("answer-level allowedErrorInNumbers propagates to an explicit award", async () => {
+        // allowedErrorInNumbers is set on the <answer>, not on the <award>.
+        // The default tolerance is 0 (exact match), so 100.5 earns credit
+        // only because the award inherits the answer's 1% tolerance; 102 is
+        // outside that tolerance and earns nothing.
+        await test_math_answer({
+            doenetML: `
+<answer name="answer1" allowedErrorInNumbers="0.01">
+    <award>100</award>
+</answer>
+  `,
+            answers: [
+                { latex: "100", credit: 1 },
+                { latex: "100.5", credit: 1 },
+                { latex: "102", credit: 0 },
+            ],
+        });
+    });
+
     it("default is to split symbols, sugared answer", async () => {
         const doenetML = `
 <answer name="answer1">xyz</answer>


### PR DESCRIPTION
## What

Adds two `answer.test.ts` cases that pin down a behavior the suite did not previously exercise: comparison attributes set on `<answer>` propagate to an **explicit** `<award>` child.

Each comparison attribute on `<award>` declares `fallBackToParentStateVariable` pointing at the matching `<answer>` state variable (in `Award.js`), so `<answer symbolicEquality>…<award>x^2+2x+1</award>…</answer>` grades the award symbolically even though the attribute is on the answer. The implementation is correct, but the fall-back path was untested for the comparison attributes — the only `symbolicEquality` test used a bare (sugared) value, never an explicit award.

## Tests added

- **`answer-level symbolicEquality propagates to an explicit award`** — with `symbolicEquality` on the `<answer>`, an explicit `<award>x^2 + 2x + 1</award>` rejects a commuted form (`1+2x+x^2`) and the factored form (`(x+1)^2`), both of which the default numerical checker would accept. Confirms the award inherited `symbolicEquality`.
- **`answer-level allowedErrorInNumbers propagates to an explicit award`** — with `allowedErrorInNumbers="0.01"` on the `<answer>`, an explicit `<award>100</award>` accepts `100.5` (within 1%) and rejects `102`. Since the default tolerance is `0` (exact), `100.5` earning credit can only happen if the award inherited the answer's tolerance.

Both pass: `npm run test -w @doenet/doenetml-worker-javascript -- --run src/test/tagSpecific/answer.test.ts -t "propagates to an explicit award"` → 2 passed.

## Notes

- Test-only change; no published behavior changes, so no changeset.
- Surfaced while writing a how-to guide that leans on this propagation (placing the correct value in an `<award>` while keeping comparison attributes on the `<answer>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
