### PR TITLE
fix(viewer): flow inputs and their labels inline with surrounding text

### DIFF
--- a/.changeset/input-label-wrap-alignment.md
+++ b/.changeset/input-label-wrap-alignment.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Flow inputs and their labels inline with the surrounding text.
+
+Inputs (`<mathInput>`, `<textInput>`, `<booleanInput>`, `<matrixInput>`, an inline `<choiceInput>`, and `<answer>`) now lay their label and input out as ordinary inline content. A label long enough to wrap breaks across lines with the input following its end, instead of the input sitting beside the label's first line where it could read as though it belonged in the middle of the label text. Text before and after an input in the same paragraph also wraps together with it. A single tall label, such as one containing tall math, still aligns with the input as before.

--- a/packages/doenetml/src/Viewer/renderers/answer.tsx
+++ b/packages/doenetml/src/Viewer/renderers/answer.tsx
@@ -125,9 +125,15 @@ export default React.memo(function Answer(props: UseDoenetRendererProps) {
             // then add the label to the check work component
             checkWorkComponent = (
                 <label
+                    // Here the label is the answer's own (it was not moved onto
+                    // an input child), so it sits beside the check-work button
+                    // rather than an input box. `display: inline` keeps the
+                    // label and button flowing with the surrounding paragraph,
+                    // and keeps the button from being stranded beside a wrapped
+                    // label's first line — the same treatment the inputs apply
+                    // for #1245.
                     style={{
-                        display: "inline-flex",
-                        maxWidth: "100%",
+                        display: "inline",
                     }}
                 >
                     <span style={{ marginRight: "4px" }}>{label}</span>
@@ -141,11 +147,17 @@ export default React.memo(function Answer(props: UseDoenetRendererProps) {
         <span
             id={id}
             style={{
+                // `marginBottom` and `alignItems` only take effect in the
+                // `flex` (block-input) branch below; an inline box ignores
+                // vertical margins and `align-items`.
                 marginBottom: "4px",
+                // Inline (not inline-flex) in the inline case so the answer's
+                // input(s) and check-work button flow with the surrounding
+                // paragraph — text before and after the answer wraps together
+                // with the label and input (#1245). Block-input answers keep
+                // flex for their stacked layout.
                 display:
-                    SVs.inline || !SVs.haveBlockInputChild
-                        ? "inline-flex"
-                        : "flex",
+                    SVs.inline || !SVs.haveBlockInputChild ? "inline" : "flex",
                 alignItems: "start",
             }}
         >

--- a/packages/doenetml/src/Viewer/renderers/booleanInput.css
+++ b/packages/doenetml/src/Viewer/renderers/booleanInput.css
@@ -1,6 +1,7 @@
 /* Customize the label (the container) */
 .doenet-viewer .boolean-container {
-    /* display: inline-block; */
+    /* `display: inline-block` and `vertical-align` are set inline in
+       booleanInput.tsx so the checkbox flows beside a wrapping label (#1245). */
     position: relative;
     padding-left: 24px;
     margin-bottom: 4px;

--- a/packages/doenetml/src/Viewer/renderers/booleanInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/booleanInput.tsx
@@ -571,6 +571,12 @@ export default React.memo(function BooleanInput(props: UseDoenetRendererProps) {
         const checkboxControl = (
             <span
                 className={containerClass}
+                // Inline-block so the checkbox flows as inline content beside a
+                // (possibly wrapping) label and baseline-aligns with it. As a
+                // former flex item it was blockified; this keeps its box model
+                // and alignment unchanged now that the container is
+                // `display: inline` (#1245).
+                style={{ display: "inline-block", verticalAlign: "baseline" }}
                 onMouseDown={(e) => {
                     if (e.target instanceof HTMLInputElement) {
                         return;
@@ -627,9 +633,12 @@ export default React.memo(function BooleanInput(props: UseDoenetRendererProps) {
     return (
         <span
             id={id}
+            // `display: inline` so the label and checkbox flow with the
+            // surrounding paragraph text and a wrapping label keeps the
+            // checkbox after its end rather than beside its first line (#1245).
+            // See mathInput.tsx for the full rationale.
             style={{
-                display: "inline-flex",
-                alignItems: "baseline",
+                display: "inline",
             }}
         >
             {SVs.labelPosition === "left" ? labelComponent : null}

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -455,6 +455,10 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                 style={{
                     display: "inline-flex",
                     alignItems: "flex-start",
+                    // The input row flows as inline content (see the container
+                    // comment). `vertical-align: baseline` aligns it with the
+                    // text baseline of its line.
+                    verticalAlign: "baseline",
                 }}
             >
                 {selectWithDynamicWidth}
@@ -465,10 +469,12 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
 
         return (
             <span
+                // `display: inline` so the label and select flow with the
+                // surrounding paragraph text and a wrapping label keeps the
+                // select after its end rather than beside its first line
+                // (#1245). See mathInput.tsx for the full rationale.
                 style={{
-                    display: "inline-flex",
-                    maxWidth: "100%",
-                    alignItems: "baseline",
+                    display: "inline",
                 }}
                 id={id + "-container"}
                 onFocus={(e) => {

--- a/packages/doenetml/src/Viewer/renderers/mathInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/mathInput.tsx
@@ -758,6 +758,11 @@ export default function MathInput(props: UseDoenetRendererProps) {
             style={{
                 display: "inline-flex",
                 alignItems: "flex-start",
+                // The input row flows as inline content (see the container
+                // comment). `vertical-align: baseline` aligns it with the text
+                // baseline of its line, keeping a single tall-math label
+                // aligned with the input (#945).
+                verticalAlign: "baseline",
             }}
         >
             {/* Visually hidden span referenced by aria-labelledby when shortDescription is the fallback label */}
@@ -843,10 +848,19 @@ export default function MathInput(props: UseDoenetRendererProps) {
         <React.Fragment>
             <span
                 id={id}
+                // `display: inline` keeps the label and input row as ordinary
+                // inline content so the whole input flows with its paragraph:
+                // text before and after the input wraps together with the label
+                // and input box, and a long label wraps across lines with the
+                // input following its end rather than baseline-aligning to the
+                // label's *first* line, where it looked embedded in the label
+                // text (#1245). (inline-block would instead make the label and
+                // input an atomic box that surrounding paragraph text cannot
+                // wrap together with.) A single tall label (e.g. tall math)
+                // still aligns with the input via the input row's
+                // `vertical-align: baseline` (preserving #945).
                 style={{
-                    display: "inline-flex",
-                    maxWidth: "100%",
-                    alignItems: "baseline",
+                    display: "inline",
                 }}
             >
                 {SVs.labelPosition === "right" ? (

--- a/packages/doenetml/src/Viewer/renderers/matrixInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/matrixInput.tsx
@@ -215,7 +215,16 @@ export default React.memo(function MatrixInput(props: UseDoenetRendererProps) {
     ) : null;
 
     const matrixInputRow = (
-        <span style={{ display: "inline-flex", alignItems: "flex-start" }}>
+        <span
+            style={{
+                display: "inline-flex",
+                alignItems: "flex-start",
+                // The input row flows as inline content (see the container
+                // comment). `vertical-align: baseline` aligns it with the text
+                // baseline of its line.
+                verticalAlign: "baseline",
+            }}
+        >
             <div className="matrix-input" id={id}>
                 <table
                     aria-labelledby={groupLabelledByIds || undefined}
@@ -241,11 +250,15 @@ export default React.memo(function MatrixInput(props: UseDoenetRendererProps) {
     return (
         <React.Fragment>
             <div
+                // `display: inline` so the label and matrix flow with the
+                // surrounding paragraph text and a wrapping label keeps the
+                // matrix after its end rather than beside its first line
+                // (#1245). See mathInput.tsx for the full rationale.
                 style={{
-                    display: "inline-flex",
-                    maxWidth: "100%",
-                    margin: "0px 4px 4px 4px",
-                    alignItems: "baseline",
+                    display: "inline",
+                    // Only the horizontal gutters take effect; the container is
+                    // inline, which ignores vertical margins.
+                    margin: "0 4px",
                 }}
                 id={`${id}-container`}
             >

--- a/packages/doenetml/src/Viewer/renderers/textInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/textInput.tsx
@@ -695,6 +695,10 @@ export default function TextInput(props: UseDoenetRendererProps) {
             style={{
                 display: "inline-flex",
                 alignItems: "flex-start",
+                // The input row flows as inline content (see the container
+                // comment). `vertical-align: baseline` aligns it with the text
+                // baseline of its line.
+                verticalAlign: "baseline",
             }}
         >
             {input}
@@ -719,10 +723,13 @@ export default function TextInput(props: UseDoenetRendererProps) {
     return (
         <span
             id={id}
+            // `display: inline` so the label and input flow with the
+            // surrounding paragraph text: text before and after the input wraps
+            // together with it, and a wrapping label keeps the input after its
+            // end rather than beside its first line (#1245). See mathInput.tsx
+            // for the full rationale.
             style={{
-                display: "inline-flex",
-                maxWidth: "100%",
-                alignItems: "baseline",
+                display: "inline",
             }}
         >
             {SVs.labelPosition === "right" ? (

--- a/packages/test-cypress/cypress/e2e/tagSpecific/answer.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/answer.cy.js
@@ -3032,12 +3032,12 @@ describe("Answer Tag Tests", { tags: ["@group1"] }, function () {
             );
         });
 
-        cy.get("#ans1").should("have.css", "display", "inline-flex");
+        cy.get("#ans1").should("have.css", "display", "inline");
         cy.get("#ans2").should("have.css", "display", "flex");
-        cy.get("#ans3").should("have.css", "display", "inline-flex");
+        cy.get("#ans3").should("have.css", "display", "inline");
         cy.get("#ans4").should("have.css", "display", "flex");
-        cy.get("#ans5").should("have.css", "display", "inline-flex");
-        cy.get("#ans6").should("have.css", "display", "inline-flex");
+        cy.get("#ans5").should("have.css", "display", "inline");
+        cy.get("#ans6").should("have.css", "display", "inline");
     });
 
     it("input's border color changes with correctness by default", () => {

--- a/packages/test-cypress/cypress/e2e/tagSpecific/mathinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/mathinput.cy.js
@@ -763,6 +763,39 @@ describe("MathInput Tag Tests", { tags: ["@group2"] }, function () {
             .should("have.attr", "id", "mr-input-label");
     });
 
+    it("input follows the last line of a wrapped label, not the first (#1245)", () => {
+        // Regression test for #1245: when a label is long enough to wrap, the
+        // input box must flow after the label's last word rather than
+        // baseline-aligning to the label's first line (which left the input
+        // embedded in the middle of the label text).
+        cy.viewport(350, 700);
+        postDoenetML(`
+    <p><mathInput name="mi"><label>Enter a prime number that is strictly between zero and ten for this problem.</label></mathInput></p>
+        `);
+
+        cy.get("#mi .mathInputWrapper").should("exist");
+
+        cy.get("#mi-input-label").then(($label) => {
+            const labelRect = $label[0].getBoundingClientRect();
+            cy.get("#mi .mathInputWrapper").then(($input) => {
+                const inputRect = $input[0].getBoundingClientRect();
+                // The label must actually wrap for this assertion to mean
+                // anything (one line is roughly 20px tall).
+                expect(
+                    labelRect.height,
+                    "label should wrap to multiple lines at this viewport width",
+                ).to.be.greaterThan(34);
+                // Fixed layout: the input drops onto the label's last line, so
+                // its top is well below the label's top. Broken (first-line)
+                // layout would put the input's top at ~the label's top.
+                expect(
+                    inputRect.top - labelRect.top,
+                    "input should follow the label's last line, not its first",
+                ).to.be.greaterThan(0.4 * labelRect.height);
+            });
+        });
+    });
+
     it("additionalFunctionNames and removedFunctionNames flow through to MathQuill auto-formatting", () => {
         // Locks in the worker -> renderer -> MathQuill pipeline for the
         // additional/removed deltas. The LSP-side breakdown logic is


### PR DESCRIPTION
## Summary

When an input rendered a `<label>` long enough to wrap, the input box aligned to the label's **first** line and ended up embedded in the middle of the label text instead of following the end of the label:

```
Enter a prime number between 0 and [ input ][↵]
10.
```

This reads as though the learner should enter the upper bound of the range ("between 0 and ___"), with "10." stranded on the next line as unrelated text.

## Root cause

The label and the input row were rendered as two separate flex items inside an `inline-flex` / `align-items: baseline` container. A multi-line flex item exposes only its **first** line's baseline, so the input baseline-aligned to the label's first line rather than following its last word. The container was also atomic, so any text after the input in the same paragraph was pushed to its own line.

## Fix

Lay the label and input out as ordinary **inline content** (`display: inline`) so the whole input participates in its paragraph's text flow:

- A label long enough to wrap breaks across lines with the input following its end (continuing on the last line, or dropping below if it doesn't fit) instead of beside its first line.
- Text **before and after** the input in the same paragraph wraps together with the label and input box, rather than starting on its own line.
- The input row keeps `vertical-align: baseline`, so a single tall label (e.g. tall math) still aligns with the input.

Applied to all affected inputs:

- `mathInput`
- `textInput`
- `matrixInput`
- inline `choiceInput`
- `booleanInput`
- `answer` (both the sugared input and the label-beside-check-work layout)

(`subsetOfRealsInput` / `orbitalDiagramInput` don't render a label; `choiceInput`'s block/fieldset variant already stacks the legend above the choices, and block-input answers keep their flex layout.)

## Preserves recent label work

- **#945 / #946** — tall math labels baseline-align with the input: preserved via `vertical-align: baseline` (verified visually).
- **#946** — `labelPosition` left/right: DOM order unchanged; verified inline-flow both ways.
- **#978** — external `for` labels, and **#892** — sugared-answer label (the exact reproduction here): `htmlFor` / `aria-*` wiring untouched.

## Testing

- All existing `mathInput` / `textInput` / `booleanInput` / `matrixInput` / `choiceInput` specs and the accessibility spec pass.
- Verified via headless Cypress screenshots: the reported wrap case, full-paragraph inline flow (wide and narrow, `labelPosition` left and right, text before and after), and the tall-math case.
- Added a geometric regression test to `mathinput.cy.js` asserting the input drops below a wrapped label's first line.

Closes #1245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
