### PR TITLE
docs: add "Writing Mathematical Questions" guides (basic + advanced)

### DIFF
--- a/packages/docs-nextra/pages/guides/_meta.ts
+++ b/packages/docs-nextra/pages/guides/_meta.ts
@@ -1,5 +1,7 @@
 export default {
     "multiple-choice-questions": "Multiple Choice Questions",
+    "mathematical-questions": "Mathematical Questions",
+    "advanced-mathematical-questions": "Advanced Mathematical Questions",
     "styling-components": "Styling Components",
     "accessible-activities": "Writing Accessible Activities",
     "check-accessibility": "Checking Accessibility",

--- a/packages/docs-nextra/pages/guides/advanced-mathematical-questions.mdx
+++ b/packages/docs-nextra/pages/guides/advanced-mathematical-questions.mdx
@@ -1,0 +1,146 @@
+import { Callout } from "nextra/components"
+import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
+
+
+# Advanced Mathematical Questions
+
+[Writing Mathematical Questions](mathematical-questions) covers the everyday math `<answer>{:dn}` — equivalent forms, partial credit, tolerances, and lists — where the response is matched against a correct value. This guide steps up to the [`<award>{:dn}`](../reference/award2a) + [`<when>{:dn}`](../reference/when) construction, which grades a *condition* on the response instead of matching a fixed value: accepting any value that fits a rule, combining several inputs, checking that an expression is factored, comparing sets and intervals, and handling a question whose number of blanks depends on the reader.
+
+It assumes you've read the basics guide. As before, every example is live: edit the source on the left and the result updates on the right.
+
+---
+
+## Accept any answer that fits a condition
+
+Sometimes there is no single right answer — any value with a certain property will do. Validate the response with an [`<award>{:dn}`](../reference/award2a) whose [`<when>{:dn}`](../reference/when) child states the condition. Name the [`<mathInput>{:dn}`](../reference/mathInput) so the `<when>{:dn}` can refer to it.
+
+```doenet-editor-horiz
+<answer>
+  <mathInput name="n">
+    <label>Enter a number between 2 and 7.</label>
+  </mathInput>
+  <award><when>2 <= $n <= 7</when></award>
+</answer>
+```
+
+The condition inside `<when>{:dn}` can use any math operators. For example, use `<mod>{:dn}` to test divisibility:
+
+```doenet-editor-horiz
+<answer>
+  <mathInput name="m">
+    <label>Enter an even number greater than 6.</label>
+  </mathInput>
+  <award><when>$m > 6 and <mod>$m 2</mod> = 0</when></award>
+</answer>
+```
+
+Because the input is written out explicitly here, the `<label>{:dn}` goes **on the `<mathInput>{:dn}`**, not on the `<answer>{:dn}`.
+
+---
+
+## Use several input boxes for one answer
+
+Put more than one [`<mathInput>{:dn}`](../reference/mathInput) inside the `<answer>{:dn}` and validate them together with an [`<award>{:dn}`](../reference/award2a) whose [`<when>{:dn}`](../reference/when) condition refers to each one.
+
+```doenet-editor-horiz
+<p>Enter two numbers that add up to 5:
+  <answer>
+    <mathInput name="a"><shortDescription>first number</shortDescription></mathInput>
+    <mathInput name="b"><shortDescription>second number</shortDescription></mathInput>
+    <award><when>$a + $b = 5</when></award>
+  </answer>
+</p>
+```
+
+The `<when>{:dn}` refers to each input by name. Give each one a `<shortDescription>{:dn}` so a screen reader can tell the boxes apart.
+
+<Callout type="info">
+**What counts as a "response"?** A `<when>{:dn}` can reference *any* named component — an input, a point, a computed value — whether or not it is marked as a response, so the examples here work as written. A **response** is a separate idea: the value Doenet records as what the student submitted, so an instructor can later review what each student tried (it does not affect grading). Inputs *inside* the `<answer>{:dn}` are recorded as responses automatically; to record an input or value that lives elsewhere, link it with `forAnswer="$ans"{:dn}`, or flag it with `referencesAreResponses{:dn}` on the `<award>{:dn}` or a `<considerAsResponses>{:dn}` child. For the details, see the [advanced answer examples](../reference/answer4).
+</Callout>
+
+---
+
+## Check that an expression is factored
+
+Asking the reader to *factor* is tricky, because the unfactored form is mathematically equal to the factored one — a plain answer would accept either. [`<hasSameFactoring>{:dn}`](../reference/hasSameFactoring) returns true only when the response is equivalent **and** broken into the same factors.
+
+```doenet-editor-horiz
+<setup>
+  <math name="expr">(x + 1)(x + 2)</math>
+</setup>
+<answer>
+  <mathInput name="response">
+    <label>Factor <math extend="$expr" expand /></label>
+  </mathInput>
+  <award><when><hasSameFactoring>$response $expr</hasSameFactoring></when></award>
+</answer>
+```
+
+The label shows the expanded form (`x^2 + 3x + 2{:dn}`) via `<math extend="$expr" expand />{:dn}`, and the `<award>{:dn}` fires only for a genuinely factored response such as `(x+1)(x+2){:dn}` — the expanded form is rejected even though it's equal. Attributes on `<hasSameFactoring>{:dn}` can tighten this further (for example, requiring matching monomial factors).
+
+---
+
+## Accept any form of an interval or set
+
+A reader might describe the same set of numbers as an interval, a chained inequality, or set notation. Wrap both the response and the expected answer in [`<subsetOfReals>{:dn}`](../reference/subsetOfReals) and the `=` comparison checks whether they're the **same set**, regardless of how it's written.
+
+```doenet-editor-horiz
+<answer>
+  <mathInput name="interval">
+    <label>Enter the interval <m>(-2, 5]</m>.</label>
+  </mathInput>
+  <award><when>
+    <subsetOfReals>$interval</subsetOfReals> = <subsetOfReals>(-2, 5]</subsetOfReals>
+  </when></award>
+</answer>
+```
+
+All of these responses are accepted:
+
+- $(-2, 5]$
+- $-2 < x \le 5$
+- $x \in (-2, 5]$
+
+To have the reader build the set on a number line instead of typing it, use the [`<subsetOfRealsInput>{:dn}`](../reference/subsetOfRealsInput) widget and compare its value the same way.
+
+---
+
+## A varying number of answer blanks
+
+Sometimes you don't want to reveal how many answers there should be — you want the student to determine that. Accomplishing this effect currently requires a combination of DoenetML components. Use a [`<mathInput>{:dn}`](../reference/mathInput) to ask "how many?", a [`<repeatForSequence>{:dn}`](../reference/repeatForSequence) to produce that many answer boxes, and [`<collect>{:dn}`](../reference/collect) to gather their values into a [`<mathList>{:dn}`](../reference/mathList) for grading.
+
+```doenet-editor-horiz
+<p>Let <m>f(x) = (x-2)(x+5)</m>. Solve <m>f(x) = 0</m>.</p>
+
+<p>How many solutions are there?
+  <mathInput name="n"><shortDescription>number of solutions</shortDescription></mathInput>
+</p>
+
+<p>The solutions are
+  <repeatForSequence from="1" to="$n" valueName="i" name="r">
+    <m>x = </m>
+    <mathInput name="v"><shortDescription>solution number $i</shortDescription></mathInput>
+  </repeatForSequence>.
+</p>
+
+<setup>
+  <collect from="$r" componentType="mathInput" name="c" />
+  <mathList name="values" extend="$c.value" />
+</setup>
+
+<answer unorderedCompare matchPartial>
+  <award><when>$values = <mathList>2 -5</mathList></when></award>
+</answer>
+```
+
+Typing a number into the first input creates that many solution boxes. `<collect>{:dn}` gathers them, and the `<mathList>{:dn}` of their values is compared — `unorderedCompare{:dn}` so order doesn't matter, `matchPartial{:dn}` so a partly-right set earns partial credit — against the expected solutions `2{:dn}` and `-5{:dn}`.
+
+---
+
+## Where to go next
+
+- [Writing Mathematical Questions](mathematical-questions) — the basics this guide builds on.
+- [`<award>{:dn}`](../reference/award2a) and [`<when>{:dn}`](../reference/when) reference — the building blocks of every example here.
+- [`<answer>{:dn}`](../reference/answer1) reference — every `<answer>{:dn}` attribute and property, plus the [advanced answer examples](../reference/answer4) on designating responses.
+- [`<hasSameFactoring>{:dn}`](../reference/hasSameFactoring), [`<subsetOfReals>{:dn}`](../reference/subsetOfReals), and [`<subsetOfRealsInput>{:dn}`](../reference/subsetOfRealsInput) reference pages.
+- [Writing Accessible Activities](accessible-activities) — labeling inputs so every reader can use your questions.

--- a/packages/docs-nextra/pages/guides/mathematical-questions.mdx
+++ b/packages/docs-nextra/pages/guides/mathematical-questions.mdx
@@ -1,0 +1,187 @@
+import { Callout } from "nextra/components"
+import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
+
+
+# Writing Mathematical Questions
+
+A math question in DoenetML is just an [`<answer>{:dn}`](../reference/answer1) with the correct expression inside it — type the answer, and Doenet grades whatever the reader enters, accepting *any mathematically equivalent form* by default. This guide starts from that one-line version and then walks through the attributes and children that change how the answer is graded: accepting several answers, awarding partial credit, requiring an exact form, allowing rounding, checking a list of values, and letting Doenet compute the answer key. Each section shows a live example — editable source beside its result — and explains what it actually does.
+
+It assumes you already know the basics of writing DoenetML — tags, attributes, and children. For the complete list of every attribute and property, see the [`<answer>{:dn}`](../reference/answer1) reference pages. See [Advanced Mathematical Questions](advanced-mathematical-questions) for a follow-up guide.
+
+---
+
+## The simplest version
+
+Put the question in a [`<label>{:dn}`](../reference/label) and the correct answer in an [`<award>{:dn}`](../reference/award2a). That is the whole recipe.
+
+```doenet-editor-horiz
+<answer>
+  <label>What is <m>x + x</m>?</label>
+  <award>2x</award>
+</answer>
+```
+
+A few things are worth noticing:
+
+- **The `<label>{:dn}` is the question; the `<award>{:dn}` is a correct answer.** Because the `<answer>{:dn}` has no input of its own, it creates one automatically, and the `<label>{:dn}` both displays the prompt *and* ties it to that input so a screen reader announces the question.
+- **For a single answer, the `<award>{:dn}` is optional.** Writing the value as bare math does the same thing — `<answer><label>…</label>2x</answer>{:dn}` — but spelling it out with `<award>{:dn}` is the form every section below builds on. Either way, keep the `<label>{:dn}`: `<answer>2x</answer>{:dn}` works but leaves the input unlabeled.
+- **Doenet accepts any equivalent form.** By default a math answer uses a numerical checker with a liberal notion of equality, so `2x{:dn}`, `x + x{:dn}`, and `2*x{:dn}` are all marked correct. The sections below show how to tighten that up.
+
+<Callout type="info">
+**Shortcut:** in the Doenet editor, open the autocomplete menu (**Ctrl+Space**) anywhere an `<answer>{:dn}` can go and choose the **`answer-labeled`** template. It drops in an `<answer>{:dn}` with an empty `<label>{:dn}`, ready for your question and answer.
+</Callout>
+
+---
+
+## When the question is part of the sentence
+
+If the surrounding text already asks the question, a visible `<label>{:dn}` would only repeat it. Drop the `<answer>{:dn}` into the sentence and give it a [`<shortDescription>{:dn}`](../reference/shortDescription) instead — invisible on screen, but read aloud so the input is not announced as an unlabeled control.
+
+```doenet-editor-horiz
+<p>The value of <m>2^3</m> is
+  <answer>
+    <shortDescription>two cubed</shortDescription>
+    <award>8</award>
+  </answer>.
+</p>
+```
+
+---
+
+## Accept several correct answers
+
+One `<award>{:dn}` accepts one response. Give the `<answer>{:dn}` several and any of them counts as correct.
+
+```doenet-editor-horiz
+<answer>
+  <label>Enter a prime number between 0 and 10.</label>
+  <award>2</award>
+  <award>3</award>
+  <award>5</award>
+  <award>7</award>
+</answer>
+```
+
+Each `<award>{:dn}` holds one acceptable response. When the reader matches any award, they earn its credit (full credit, here).
+
+---
+
+## Give partial credit
+
+Add a `credit{:dn}` attribute to an `<award>{:dn}` to grant a fraction of the points for an incomplete answer.
+
+```doenet-editor-horiz
+<answer>
+  <label>Find <m>\int x^2 \, dx</m>.</label>
+  <award>x^3/3 + C</award>
+  <award credit="0.5">x^3/3</award>
+</answer>
+```
+
+Here the full antiderivative earns full credit, while forgetting the constant of integration earns half. If several awards match, Doenet credits the highest-scoring one. (Note that `C{:dn}` is a specific symbol — a reader who writes `+ K{:dn}` is *not* equivalent, so add more awards if you want to accept other letters.)
+
+---
+
+## Show targeted feedback
+
+To respond to a specific wrong answer, give that `<award>{:dn}` a `name{:dn}`, then add a [`<feedback>{:dn}`](../reference/feedback) whose `condition{:dn}` references the award. When the award matches, the feedback appears wherever you placed the `<feedback>{:dn}` block.
+
+```doenet-editor-horiz
+<answer name="ans">
+  <label>Solve <m>2x = 10</m> for <m>x</m>.</label>
+  <award>5</award>
+  <award name="commonError" credit="0">20</award>
+</answer>
+
+<feedback condition="$commonError">
+  <p>Careful — divide both sides by 2, don't multiply.</p>
+</feedback>
+```
+
+Submit `20{:dn}` (multiplying instead of dividing) and the feedback appears; submit `5{:dn}` and it doesn't. The `<award credit="0">{:dn}` grants no credit — it exists only to recognize the mistake and trigger the message.
+
+For feedback on several different responses, see [`<feedback>{:dn}` tied to an `<award>{:dn}`](../reference/feedback#example-feedbackdn-tied-to-an-awarddn) in the reference.
+
+---
+
+## Require the exact form
+
+By default `(x+1)^2{:dn}` is accepted as the answer to "expand `(x+1)^2{:dn}`," because it *is* equivalent. To force the reader to actually do the work, add `symbolicEquality{:dn}`, which compares the written form rather than the value.
+
+```doenet-editor-horiz
+<answer symbolicEquality>
+  <label>Expand <m>(x+1)^2</m>.</label>
+  <award>x^2 + 2x + 1</award>
+</answer>
+```
+
+On its own, `symbolicEquality{:dn}` is strict about *order* too: `1 + 2x + x^2{:dn}` would be marked wrong. Add `simplifyOnCompare{:dn}` to permit reordering and basic simplification while still requiring an expanded answer.
+
+```doenet-editor-horiz
+<answer symbolicEquality simplifyOnCompare>
+  <label>Expand <m>(x+1)^2</m>.</label>
+  <award>x^2 + 2x + 1</award>
+</answer>
+```
+
+Even now the factored form `(x+1)^2{:dn}` is rejected, because `simplifyOnCompare{:dn}` does not expand. If you *also* want to accept the factored form, add `expandOnCompare{:dn}`.
+
+`simplifyOnCompare{:dn}` has several levels — from no simplification, through simplifying only numbers or only reordering terms, up to full simplification — that let you tune exactly how much rearranging counts as the same answer. The [`simplifyOnCompare{:dn}` reference example](../reference/answer2a#example-simplifyoncompare) spells out each option and shows its effect.
+
+---
+
+## Allow for rounding
+
+When the answer is a decimal approximation, use `allowedErrorInNumbers{:dn}` to accept responses within a tolerance.
+
+```doenet-editor-horiz
+<answer allowedErrorInNumbers="0.01" allowedErrorIsAbsolute>
+  <label>Enter <m>\sqrt{2}</m> as a decimal, accurate to within <m>0.01</m>.</label>
+  <award>1.41</award>
+</answer>
+```
+
+By default the tolerance is a *fraction* of the correct value (so `allowedErrorInNumbers="0.01"{:dn}` means 1%). Adding `allowedErrorIsAbsolute{:dn}` makes it an absolute amount instead — here, anything within `0.01{:dn}` of `1.41{:dn}` is accepted.
+
+---
+
+## Ask for a list of values
+
+Write several values separated by commas and Doenet treats the answer as a list. Add `unorderedCompare{:dn}` so the order doesn't matter, and `matchPartial{:dn}` to award credit for getting some of them.
+
+```doenet-editor-horiz
+<answer unorderedCompare matchPartial>
+  <label>Let <m>f(x) = (x-2)(x+5)</m>. Solve <m>f(x) = 0</m>, separating your solutions with commas.</label>
+  <award>2, -5</award>
+</answer>
+```
+
+A reader who enters `-5, 2{:dn}` earns full credit; one who enters just `2{:dn}` earns half.
+
+---
+
+## Let Doenet compute the answer key
+
+The correct answer doesn't have to be a value you type — it can be a component that computes it. Here the answer key is whatever the [`<derivative>{:dn}`](../reference/derivative) evaluates to.
+
+```doenet-editor-horiz
+<setup>
+  <function name="f">x^3</function>
+</setup>
+<answer>
+  <label>Find the derivative of <m>f(x) = x^3</m>.</label>
+  <award><derivative>$f</derivative></award>
+</answer>
+```
+
+The reader is graded against `3x^2{:dn}` without your ever writing it — change `f{:dn}` and the answer key updates itself. (As always, equivalent forms like `3 x^2{:dn}` or `3*x^2{:dn}` are accepted.) The same idea works with any computed math: a [`<math>{:dn}`](../reference/math) built from named values, or a randomly generated quantity.
+
+---
+
+## Where to go next
+
+- [Advanced Mathematical Questions](advanced-mathematical-questions) — the `<award>{:dn}` + `<when>{:dn}` construction: accepting any value that fits a condition, combining several inputs, checking factored form, comparing intervals and sets, and a varying number of blanks.
+- [`<answer>{:dn}`](../reference/answer1) reference — the full list of `<answer>{:dn}` attributes and properties.
+- [`<mathInput>{:dn}`](../reference/mathInput) reference — for explicit control over the input box.
+- [`<feedback>{:dn}`](../reference/feedback) reference — more ways to show messages in response to an answer.
+- [Writing Accessible Activities](accessible-activities) — more on labeling inputs so every reader can use your questions.

--- a/packages/docs-nextra/pages/reference/award2b.mdx
+++ b/packages/docs-nextra/pages/reference/award2b.mdx
@@ -212,7 +212,7 @@ render the `feedbacks` property of the `<answer>{:dn}`.
 
 `feedbackText` is limited to plain text and only appears where you render the 
 `feedbacks` property.  When you want feedback that contains markup (emphasis, math 
-with `<m>{:dn}`, links) or that you place at a specific spot, omit `feedbackText`, 
+with `<m>{:dn}`, links) , omit `feedbackText`, 
 give the `<award>{:dn}` a `name`, and use a separate [`<feedback>{:dn}`](feedback) 
 component with a matching `condition`.  See 
 [`<feedback>{:dn}` tied to an `<award>{:dn}`](feedback#example-feedbackdn-tied-to-an-awarddn).

--- a/packages/docs-nextra/pages/reference/award2b.mdx
+++ b/packages/docs-nextra/pages/reference/award2b.mdx
@@ -210,6 +210,14 @@ answer when the award is matched.  To display feedbacks associate to the answer,
 render the `feedbacks` property of the `<answer>{:dn}`.
 
 
+`feedbackText` is limited to plain text and only appears where you render the 
+`feedbacks` property.  When you want feedback that contains markup (emphasis, math 
+with `<m>{:dn}`, links) or that you place at a specific spot, omit `feedbackText`, 
+give the `<award>{:dn}` a `name`, and use a separate [`<feedback>{:dn}`](feedback) 
+component with a matching `condition`.  See 
+[`<feedback>{:dn}` tied to an `<award>{:dn}`](feedback#example-feedbackdn-tied-to-an-awarddn).
+
+
 
 ---
 

--- a/packages/docs-nextra/pages/reference/award2b.mdx
+++ b/packages/docs-nextra/pages/reference/award2b.mdx
@@ -210,11 +210,11 @@ answer when the award is matched.  To display feedbacks associate to the answer,
 render the `feedbacks` property of the `<answer>{:dn}`.
 
 
-`feedbackText` is limited to plain text and only appears where you render the 
-`feedbacks` property.  When you want feedback that contains markup (emphasis, math 
-with `<m>{:dn}`, links) , omit `feedbackText`, 
-give the `<award>{:dn}` a `name`, and use a separate [`<feedback>{:dn}`](feedback) 
-component with a matching `condition`.  See 
+`feedbackText` is limited to plain text and only appears where you render the
+`feedbacks` property.  When you want feedback that contains markup (emphasis, math
+with `<m>{:dn}`, or links), omit `feedbackText`,
+give the `<award>{:dn}` a `name`, and use a separate [`<feedback>{:dn}`](feedback)
+component with a matching `condition`.  See
 [`<feedback>{:dn}` tied to an `<award>{:dn}`](feedback#example-feedbackdn-tied-to-an-awarddn).
 
 


### PR DESCRIPTION
## What

Adds two how-to guides on writing math `<answer>` questions, in the Diátaxis Guides section, plus a small supporting tweak to a reference page.

- **`pages/guides/mathematical-questions.mdx`** — *Writing Mathematical Questions* (basics). Starts from the simplest labeled `<answer>` and walks one change at a time: putting the question in a `<label>` vs. a `<shortDescription>`, several `<award>`s, partial credit, targeted feedback (`<feedback condition>`), requiring an exact form (`symbolicEquality` / `simplifyOnCompare` / `expandOnCompare`), numeric tolerance (`allowedErrorInNumbers`), lists (`unorderedCompare` / `matchPartial`), and letting Doenet compute the answer key (`<derivative>`).
- **`pages/guides/advanced-mathematical-questions.mdx`** — *Advanced Mathematical Questions*. Everything built on the `<award>` + `<when>` construction: accepting any value that fits a condition, combining several inputs, `hasSameFactoring`, `subsetOfReals` set comparison, and a varying number of blanks (`repeatForSequence` + `collect`). Includes an info callout clarifying what a "response" is.
- **`pages/guides/_meta.ts`** — registers both guides (after Multiple Choice Questions).
- **`pages/reference/award2b.mdx`** — adds a note to the `feedbackText` example explaining when an explicit `<feedback condition>` is preferable, linking to the existing `<feedback>`-tied-to-`<award>` example.

## Design notes

- The split between the two guides is the `<award><when>` boundary: the basics guide matches a response against a correct value; the advanced guide grades a *condition* on the response. The two cross-link each other.
- Every example was checked against `doenet-schema.json` and follows the accessibility conventions (labels on inputs, `<shortDescription>` where the prompt is in surrounding prose, no graph-validation examples — those belong to a future graphical-answers guide).
- Examples use `doenet-editor-horiz` live editor/viewer pairs; math in prose uses KaTeX (`$…$`), `<m>` only inside fences.

## Verification

- `npm run build -w packages/docs-nextra` passes; both pages prerender, KaTeX renders, and all live editors mount.
- No new reference page (only prose added to `award2b.mdx`), so no schema rebuild or docs-coverage change.

## Related

- Follows up #1240 (accessibility guides) and #1243 (multiple-choice guide), reusing the same Guides-section pattern.
- A `feedbackText`/`<feedback>` propagation test landed in #1246.
- Issue #1248 tracks dedicated concept + how-to pages on answer *responses*; the advanced guide's response callout links to the `<answer>` reference as a stopgap until those exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
