### PR TITLE
fix(doenetml-iframe): don't re-initialize editor on callback-identity churn

### DIFF
--- a/.changeset/iframe-editor-callback-churn.md
+++ b/.changeset/iframe-editor-callback-churn.md
@@ -1,0 +1,7 @@
+---
+"@doenet/doenetml-iframe": patch
+---
+
+iframe `<DoenetEditor>`: stop re-initializing the editor when the parent passes new callback identities.
+
+A React parent that supplies inline callback props (e.g. `immediateDoenetmlChangeCallback`) hands the wrapper a fresh function on every render. The iframe wrapper was rebuilding the whole editor on each such change, which — when it overlapped the editor's startup — could keep the document viewer from ever finishing loading, leaving it blank with "The document viewer could not be started." The editor now holds stable internal callbacks that always dispatch to the latest function the parent passed, so callback-identity changes update behavior without re-initializing the editor or disturbing its startup.

--- a/packages/doenetml-iframe/src/iframe-editor-index.ts
+++ b/packages/doenetml-iframe/src/iframe-editor-index.ts
@@ -26,10 +26,105 @@ declare global {
 // editors inside a single iframe document — they'd alias these mutables.
 let editorControlHandle: DoenetEditorHandle | null = null;
 
-// Holds the most recent full props bag (serializable props + proxied function
-// props) so that `updateEditorProps` can produce a new merged bag and re-render
-// without re-sending the function proxies from the parent.
+// Holds the most recent full props bag (serializable props + stable function
+// dispatchers — see `currentFunctionProps`) so that `updateEditorProps` can
+// produce a new merged bag and re-render without re-sending the function
+// proxies from the parent.
 let lastAugmentedProps: Record<string, any> | null = null;
+
+// Live registry of the parent's proxied callbacks, keyed by prop name. The
+// mounted editor is never handed these proxies directly; it gets a *stable
+// dispatcher* per key (see `getFunctionPropDispatcher`) that reads from this
+// registry at call time.
+//
+// This indirection is the fix for #1244. A React parent that passes inline
+// arrow callbacks hands the wrapper a brand-new closure identity on every
+// render, so the wrapper forwards `updateEditorFunctionProps` constantly. The
+// old handler re-invoked `renderDoenetEditorToContainer` on each such change;
+// when that churn overlapped the core worker's boot window the worker never
+// finished booting and the editor showed "The document viewer could not be
+// started." Now an identity-only change just swaps the entry here — the editor
+// keeps calling the same stable dispatcher, which dereferences the new closure
+// — so no re-render happens and the boot is left undisturbed.
+let currentFunctionProps: Record<string, Function> = {};
+
+// Stable dispatcher per function-prop key. Created lazily and never replaced,
+// so the editor sees a single unchanging callback identity for the life of the
+// iframe document even as the underlying proxied closure is swapped underneath.
+const functionPropDispatchers: Record<string, Function> = {};
+
+function getFunctionPropDispatcher(key: string): Function {
+    let dispatcher = functionPropDispatchers[key];
+    if (!dispatcher) {
+        dispatcher = (...callArgs: any[]) =>
+            currentFunctionProps[key]?.(...callArgs);
+        functionPropDispatchers[key] = dispatcher;
+    }
+    return dispatcher;
+}
+
+// Parse the `key, proxy, key, proxy, …` argument list the wrapper sends
+// (Comlink can't pass proxied functions as object values, only as direct
+// args) into a map.
+function functionPropArgsToMap(
+    args: (string | Function)[],
+): Record<string, Function> {
+    const map: Record<string, Function> = {};
+    for (let i = 0; i < args.length; i += 2) {
+        const key = args[i];
+        const fn = args[i + 1];
+        if (typeof key === "string" && typeof fn === "function") {
+            map[key] = fn;
+        }
+    }
+    return map;
+}
+
+function releaseFunctionProxy(fn: Function) {
+    try {
+        (fn as any)?.[ComlinkEditor.releaseProxy]?.();
+    } catch (e) {
+        console.warn(
+            "iframe DoenetEditor: failed to release stale Comlink proxy",
+            e,
+        );
+    }
+}
+
+// Adopt `incoming` as the live callback set, releasing the Comlink port of
+// every previous proxy that is being replaced or dropped (so the parent-side
+// MessageChannel closes — Comlink also has a FinalizationRegistry fallback,
+// but explicit release avoids depending on GC timing).
+function setCurrentFunctionProps(incoming: Record<string, Function>) {
+    for (const [key, fn] of Object.entries(currentFunctionProps)) {
+        if (incoming[key] !== fn) {
+            releaseFunctionProxy(fn);
+        }
+    }
+    currentFunctionProps = incoming;
+}
+
+// Rebuild `lastAugmentedProps` so its function-typed entries exactly match the
+// dispatchers for the current callback set. Used when the *set of keys* changes
+// (a callback added or removed) — the one case that needs a re-render so the
+// editor can react to a callback's presence/absence. All function-typed entries
+// in `lastAugmentedProps` are dispatchers, so dropping them and re-adding only
+// the current keys correctly removes a vanished callback and adds a new one.
+function syncAugmentedFunctionProps() {
+    if (!lastAugmentedProps) {
+        return;
+    }
+    const next: Record<string, any> = {};
+    for (const [key, val] of Object.entries(lastAugmentedProps)) {
+        if (typeof val !== "function") {
+            next[key] = val;
+        }
+    }
+    for (const key of Object.keys(currentFunctionProps)) {
+        next[key] = getFunctionPropDispatcher(key);
+    }
+    lastAugmentedProps = next;
+}
 
 // The initial DoenetML lives in a `<script type="text/doenetml">` child of
 // `#root`. React replaces those children as soon as
@@ -105,44 +200,37 @@ ComlinkEditor.expose(
         updateEditorFunctionProps(...args: (string | Function)[]) {
             // The wrapper sends key/proxy pairs the same way
             // renderEditorWithFunctionProps does (Comlink can't pass proxies
-            // as values inside an object, only as direct arguments). Treat
-            // the args as a *full replacement* of the function-typed entries
-            // on lastAugmentedProps: drop every existing function entry
-            // (releasing its Comlink port so the parent-side MessageChannel
-            // closes — Comlink also has a FinalizationRegistry fallback, but
-            // explicit release avoids depending on GC timing) and add the
-            // new ones. This way a removed callback (parent stopped passing
-            // it) is actually removed, not silently retained.
+            // as values inside an object, only as direct arguments). Treat the
+            // args as a *full replacement* of the live callback set.
             if (!lastAugmentedProps) {
                 console.warn(
                     "iframe DoenetEditor: updateEditorFunctionProps arrived before renderEditorWithFunctionProps completed — likely a bug in the iframe wrapper's queue/replay sequencing.",
                 );
                 return;
             }
-            const next: Record<string, any> = {};
-            for (const [key, val] of Object.entries(lastAugmentedProps)) {
-                if (typeof val === "function") {
-                    try {
-                        (val as any)[ComlinkEditor.releaseProxy]?.();
-                    } catch (e) {
-                        console.warn(
-                            "iframe DoenetEditor: failed to release stale Comlink proxy",
-                            e,
-                        );
-                    }
-                } else {
-                    next[key] = val;
-                }
+            const incoming = functionPropArgsToMap(args);
+            const prevKeys = Object.keys(currentFunctionProps).sort();
+            const nextKeys = Object.keys(incoming).sort();
+            const keysChanged =
+                prevKeys.length !== nextKeys.length ||
+                prevKeys.some((key, i) => key !== nextKeys[i]);
+
+            // Swap the live callbacks (releasing replaced/removed proxies).
+            setCurrentFunctionProps(incoming);
+
+            // Identity-only change (same keys, new closures) — the common case
+            // when a parent passes inline arrow callbacks: the editor holds
+            // stable dispatchers that read `currentFunctionProps` at call time,
+            // so the swap above is sufficient. We deliberately do NOT re-render
+            // here; re-rendering on every parent render is what wedged the core
+            // worker's boot (#1244).
+            if (keysChanged) {
+                // A callback was added or removed: re-render so the editor can
+                // react to which callbacks are present. Rare and not part of
+                // the per-render identity churn.
+                syncAugmentedFunctionProps();
+                renderWithLastAugmentedProps();
             }
-            for (let i = 0; i < args.length; i += 2) {
-                const key = args[i];
-                const fn = args[i + 1];
-                if (typeof key === "string" && typeof fn === "function") {
-                    next[key] = fn;
-                }
-            }
-            lastAugmentedProps = next;
-            renderWithLastAugmentedProps();
         },
         openDiagnosticsTab(tabId: DiagnosticsTabId) {
             if (!editorControlHandle) {
@@ -189,14 +277,20 @@ ComlinkEditor.expose(
  * followed by the proxied function with that name.
  */
 function renderEditorWithFunctionProps(...args: (string | Function)[]) {
+    setCurrentFunctionProps(functionPropArgsToMap(args));
+
     const augmentedDoenetEditorProps = { ...doenetEditorProps };
     augmentedDoenetEditorProps.externalVirtualKeyboardProvided = true;
     for (const propName of doenetEditorPropsSpecified) {
-        if (!(propName in doenetEditorProps)) {
-            const idx = args.indexOf(propName);
-            if (idx !== -1) {
-                augmentedDoenetEditorProps[propName] = args[idx + 1];
-            }
+        if (
+            !(propName in doenetEditorProps) &&
+            propName in currentFunctionProps
+        ) {
+            // Hand the editor a *stable dispatcher*, not the raw proxy, so a
+            // later callback-identity swap (via updateEditorFunctionProps)
+            // updates `currentFunctionProps` without forcing a re-render.
+            augmentedDoenetEditorProps[propName] =
+                getFunctionPropDispatcher(propName);
         }
     }
 

--- a/packages/doenetml-iframe/src/iframe-editor-index.ts
+++ b/packages/doenetml-iframe/src/iframe-editor-index.ts
@@ -37,15 +37,16 @@ let lastAugmentedProps: Record<string, any> | null = null;
 // dispatcher* per key (see `getFunctionPropDispatcher`) that reads from this
 // registry at call time.
 //
-// This indirection is the fix for #1244. A React parent that passes inline
-// arrow callbacks hands the wrapper a brand-new closure identity on every
-// render, so the wrapper forwards `updateEditorFunctionProps` constantly. The
-// old handler re-invoked `renderDoenetEditorToContainer` on each such change;
-// when that churn overlapped the core worker's boot window the worker never
-// finished booting and the editor showed "The document viewer could not be
-// started." Now an identity-only change just swaps the entry here — the editor
-// keeps calling the same stable dispatcher, which dereferences the new closure
-// — so no re-render happens and the boot is left undisturbed.
+// This indirection is what keeps callback-identity churn from re-initializing
+// the editor. A React parent that passes inline arrow callbacks hands the
+// wrapper a brand-new closure identity on every render, so the wrapper forwards
+// `updateEditorFunctionProps` constantly. The old handler re-invoked
+// `renderDoenetEditorToContainer` on each such change; when that churn
+// overlapped the core worker's boot window the worker never finished booting
+// and the editor showed "The document viewer could not be started." Now an
+// identity-only change just swaps the entry here — the editor keeps calling the
+// same stable dispatcher, which dereferences the new closure — so no re-render
+// happens and the boot is left undisturbed.
 let currentFunctionProps: Record<string, Function> = {};
 
 // Stable dispatcher per function-prop key. Created lazily and never replaced,
@@ -223,7 +224,7 @@ ComlinkEditor.expose(
             // stable dispatchers that read `currentFunctionProps` at call time,
             // so the swap above is sufficient. We deliberately do NOT re-render
             // here; re-rendering on every parent render is what wedged the core
-            // worker's boot (#1244).
+            // worker's boot.
             if (keysChanged) {
                 // A callback was added or removed: re-render so the editor can
                 // react to which callbacks are present. Rare and not part of

--- a/packages/doenetml-iframe/src/iframe-editor-index.ts
+++ b/packages/doenetml-iframe/src/iframe-editor-index.ts
@@ -210,6 +210,9 @@ ComlinkEditor.expose(
                 return;
             }
             const incoming = functionPropArgsToMap(args);
+            // Compare key sets *before* swapping — `setCurrentFunctionProps`
+            // below overwrites `currentFunctionProps`, so reading `prevKeys`
+            // from it must happen first.
             const prevKeys = Object.keys(currentFunctionProps).sort();
             const nextKeys = Object.keys(incoming).sort();
             const keysChanged =

--- a/packages/doenetml-iframe/test/cypress/component/DoenetEditor.functionPropChurnDuringBoot.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetEditor.functionPropChurnDuringBoot.cy.tsx
@@ -6,8 +6,8 @@ import {
     IFRAME_READY_TIMEOUT,
 } from "./helpers";
 
-// Regression test for #1244 (the @doenet/doenetml-iframe 0.7.18 editor-boot
-// regression). A React parent that passes inline arrow callbacks hands the
+// Regression test for the @doenet/doenetml-iframe 0.7.18 editor-boot
+// regression. A React parent that passes inline arrow callbacks hands the
 // wrapper a brand-new closure identity on every render. Before the fix, each
 // identity change made the iframe re-invoke `renderDoenetEditorToContainer`;
 // when that churn overlapped the core worker's multi-second boot window the
@@ -17,15 +17,15 @@ import {
 // What this test asserts — and why it's shaped this way:
 //
 // The end-to-end "the viewer wedges" symptom does NOT reproduce reliably in a
-// component test: the standalone engine tolerates (or, post-#1244-viewer-fix,
-// recovers from) repeated re-invocations, so "assert the viewer renders" passes
-// on both broken and fixed wrappers. The *precise* regression — the root cause
-// the fix removes — is that callback-identity churn re-invokes
-// `renderDoenetEditorToContainer` at all. So the load-bearing assertion spies
-// on that function inside the iframe and requires that a storm of fresh
-// callback identities does NOT trigger re-invocations. Fixed wrapper: 0
-// re-invocations (the editor holds stable dispatchers that dereference the new
-// closures). Broken wrapper: one per churned render (dozens).
+// component test: the standalone engine tolerates (and, since the viewer-side
+// startup watchdog landed, recovers from) repeated re-invocations, so "assert
+// the viewer renders" passes on both broken and fixed wrappers. The *precise*
+// regression — the root cause the fix removes — is that callback-identity churn
+// re-invokes `renderDoenetEditorToContainer` at all. So the load-bearing
+// assertion spies on that function inside the iframe and requires that a storm
+// of fresh callback identities does NOT trigger re-invocations. Fixed wrapper:
+// 0 re-invocations (the editor holds stable dispatchers that dereference the
+// new closures). Broken wrapper: one per churned render (dozens).
 //
 // We also assert the viewer renders the doenetML and the give-up text is
 // absent — a sanity check that the editor actually works under churn.
@@ -136,8 +136,8 @@ describe("DoenetEditor (iframe wrapper) — function-prop churn during boot", ()
             .find(".doenet-viewer", { timeout: 20000 })
             .should("contain.text", "hello there");
 
-        // … and the #1244 boot give-up screen is NOT showing. (`body` is the
-        // raw iframe <body> DOM node here, so read `textContent` directly.)
+        // … and the boot give-up screen is NOT showing. (`body` is the raw
+        // iframe <body> DOM node here, so read `textContent` directly.)
         cy.get("iframe")
             .its("0.contentDocument.body")
             .should((body) => {

--- a/packages/doenetml-iframe/test/cypress/component/DoenetEditor.functionPropChurnDuringBoot.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetEditor.functionPropChurnDuringBoot.cy.tsx
@@ -126,7 +126,7 @@ describe("DoenetEditor (iframe wrapper) — function-prop churn during boot", ()
             expect(
                 counter.reinvocations,
                 "callback-identity churn must NOT re-invoke renderDoenetEditorToContainer",
-            ).to.be.lessThan(MAX_ALLOWED_REINVOCATIONS);
+            ).to.be.at.most(MAX_ALLOWED_REINVOCATIONS);
         });
 
         // Sanity: the viewer (core-worker output), not just the editor chrome,

--- a/packages/doenetml-iframe/test/cypress/component/DoenetEditor.functionPropChurnDuringBoot.cy.tsx
+++ b/packages/doenetml-iframe/test/cypress/component/DoenetEditor.functionPropChurnDuringBoot.cy.tsx
@@ -1,0 +1,150 @@
+import React, { useEffect, useState } from "react";
+import { DoenetEditor } from "../../../src/index";
+import {
+    STANDALONE_BLOB_URL,
+    STANDALONE_CSS_BLOB_URL,
+    IFRAME_READY_TIMEOUT,
+} from "./helpers";
+
+// Regression test for #1244 (the @doenet/doenetml-iframe 0.7.18 editor-boot
+// regression). A React parent that passes inline arrow callbacks hands the
+// wrapper a brand-new closure identity on every render. Before the fix, each
+// identity change made the iframe re-invoke `renderDoenetEditorToContainer`;
+// when that churn overlapped the core worker's multi-second boot window the
+// worker never finished and the editor showed DoenetML's give-up screen
+// ("The document viewer could not be started. Please reload the page.").
+//
+// What this test asserts — and why it's shaped this way:
+//
+// The end-to-end "the viewer wedges" symptom does NOT reproduce reliably in a
+// component test: the standalone engine tolerates (or, post-#1244-viewer-fix,
+// recovers from) repeated re-invocations, so "assert the viewer renders" passes
+// on both broken and fixed wrappers. The *precise* regression — the root cause
+// the fix removes — is that callback-identity churn re-invokes
+// `renderDoenetEditorToContainer` at all. So the load-bearing assertion spies
+// on that function inside the iframe and requires that a storm of fresh
+// callback identities does NOT trigger re-invocations. Fixed wrapper: 0
+// re-invocations (the editor holds stable dispatchers that dereference the new
+// closures). Broken wrapper: one per churned render (dozens).
+//
+// We also assert the viewer renders the doenetML and the give-up text is
+// absent — a sanity check that the editor actually works under churn.
+
+// The churn must keep running through the whole observation window, so make the
+// interval comfortably longer than any plausible boot + spy-install + observe
+// sequence. Cleared on unmount.
+const CHURN_INTERVAL_MS = 40;
+const CHURN_DURATION_MS = 20_000;
+// How long we watch the spy after the editor mounts. Long enough that a broken
+// wrapper racks up many re-invocations; short enough to keep the test snappy.
+const OBSERVE_MS = 2_500;
+// Fixed wrapper does zero identity-churn re-invocations; allow a tiny margin
+// for any unrelated one-shot render that might legitimately occur.
+const MAX_ALLOWED_REINVOCATIONS = 3;
+
+declare global {
+    interface Window {
+        renderDoenetEditorToContainer?: (...args: unknown[]) => unknown;
+    }
+}
+
+// Re-renders every CHURN_INTERVAL_MS, passing fresh closure identities for TWO
+// function props each render — exactly the churn a parent that uses inline
+// arrow callbacks (DoenetTools' `DocEditorEditMode`) produces.
+function ChurningHarness() {
+    const [tick, setTick] = useState(0);
+    useEffect(() => {
+        const id = setInterval(() => setTick((t) => t + 1), CHURN_INTERVAL_MS);
+        const stop = setTimeout(() => clearInterval(id), CHURN_DURATION_MS);
+        return () => {
+            clearInterval(id);
+            clearTimeout(stop);
+        };
+    }, []);
+    return (
+        <div style={{ height: "600px", width: "900px" }}>
+            <span data-test="tick">{tick}</span>
+            <DoenetEditor
+                doenetML="<p>hello there</p>"
+                standaloneUrl={STANDALONE_BLOB_URL}
+                cssUrl={STANDALONE_CSS_BLOB_URL}
+                addVirtualKeyboard={false}
+                // NEW identities every render — the regression trigger.
+                immediateDoenetmlChangeCallback={() => {
+                    void tick;
+                }}
+                doenetmlChangeCallback={() => {
+                    void tick;
+                }}
+            />
+        </div>
+    );
+}
+
+describe("DoenetEditor (iframe wrapper) — function-prop churn during boot", () => {
+    it("does not re-invoke renderDoenetEditorToContainer on callback-identity churn", () => {
+        cy.mount(<ChurningHarness />);
+
+        // Wait until the editor has mounted inside the iframe — at which point
+        // the standalone bundle has defined `renderDoenetEditorToContainer` and
+        // the churn (which only forwards updates after iframeReady) is in full
+        // swing.
+        cy.get("iframe", { timeout: IFRAME_READY_TIMEOUT })
+            .its("0.contentDocument.body", { timeout: IFRAME_READY_TIMEOUT })
+            .find(".cm-content", { timeout: IFRAME_READY_TIMEOUT })
+            .should("exist");
+
+        // Install a counting spy over the iframe's render entry point. The
+        // iframe module reads `window.renderDoenetEditorToContainer` fresh on
+        // every call, so wrapping it on the contentWindow captures every
+        // subsequent (re-)render the wrapper triggers.
+        const counter = { reinvocations: 0 };
+        cy.get("iframe").then(($iframe) => {
+            const win = ($iframe[0] as HTMLIFrameElement)
+                .contentWindow as unknown as Window;
+            const orig = win.renderDoenetEditorToContainer!;
+            win.renderDoenetEditorToContainer = function (
+                this: unknown,
+                ...args: unknown[]
+            ) {
+                counter.reinvocations += 1;
+                return orig.apply(this, args);
+            };
+        });
+
+        // Start counting from clean — only churn-driven re-invocations after
+        // the editor is already mounted should be observed.
+        cy.then(() => {
+            counter.reinvocations = 0;
+        });
+
+        // Let the churn hammer the (already-mounted) editor.
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(OBSERVE_MS);
+
+        cy.then(() => {
+            expect(
+                counter.reinvocations,
+                "callback-identity churn must NOT re-invoke renderDoenetEditorToContainer",
+            ).to.be.lessThan(MAX_ALLOWED_REINVOCATIONS);
+        });
+
+        // Sanity: the viewer (core-worker output), not just the editor chrome,
+        // actually renders the doenetML under churn …
+        cy.get("iframe")
+            .its("0.contentDocument.body")
+            .find(".doenet-viewer", { timeout: 20000 })
+            .should("contain.text", "hello there");
+
+        // … and the #1244 boot give-up screen is NOT showing. (`body` is the
+        // raw iframe <body> DOM node here, so read `textContent` directly.)
+        cy.get("iframe")
+            .its("0.contentDocument.body")
+            .should((body) => {
+                const text = (body as unknown as HTMLElement).textContent ?? "";
+                expect(text).to.not.match(
+                    /could not be started|reload the page/i,
+                );
+            });
+    });
+});


### PR DESCRIPTION
## Problem

`@doenet/doenetml-iframe@0.7.18` (from #1131) made the iframe `<DoenetEditor>` re-invoke the in-iframe `window.renderDoenetEditorToContainer(...)` on **every function-prop identity change**. A React parent that passes inline arrow callbacks (e.g. DoenetTools' `DocEditorEditMode`) hands the wrapper a brand-new closure on every render, so the iframe rebuilt the whole editor continuously. When that churn overlapped the core worker's multi-second boot window, the worker never finished booting and the editor showed DoenetML's give-up screen — *"The document viewer could not be started. Please reload the page."* — leaving the viewer pane blank and edits unsaved.

This is purely a **wrapper** regression: the standalone engine inside the iframe is unchanged.

## Fix

The mounted editor is now handed **stable dispatcher functions** (one per callback key) that read the parent's latest proxied callback from a mutable registry (`currentFunctionProps`) at call time:

- **Identity-only change** (the churn case): just swap the registry entry — **no re-render**. The editor keeps calling the same stable dispatcher, which dereferences the new closure.
- **Key-set change** (a callback added/removed): re-render once so the editor reflects which callbacks are present — rare, not part of per-render churn.

Old Comlink proxies are released on each swap, preserving existing port cleanup.

## Test

`DoenetEditor.functionPropChurnDuringBoot.cy.tsx` mounts a harness that re-renders every 40 ms with fresh identities for two callbacks. The end-to-end "viewer wedges" symptom doesn't reproduce reliably in a component test (the engine tolerates / recovers from re-invocation), so the load-bearing assertion spies on `renderDoenetEditorToContainer` inside the iframe and requires that callback-identity churn does **not** re-invoke it:

- **Before fix:** 64 re-invocations in a 2.5 s churn window → fails
- **After fix:** 0 re-invocations, viewer renders the doenetML, no give-up text → passes

All existing iframe component tests still pass: `functionPropsLive`, `propChangeDuringBoot`, `srcDocRebuildReplay`, `doenetMLInitialOnly`, `readOnly`, `width`.

## Changeset

Lists only `@doenet/doenetml-iframe` — the change is contained in the iframe wrapper, the downstream end of the `doenetml → standalone → doenetml-iframe` chain, with no in-repo consumers. The fixed-version group still bumps all members in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)