### PR TITLE
Use a warning icon when there are accessiblity warnings

### DIFF
--- a/packages/doenetml/src/EditorViewer/AccessibilityStatusButton.tsx
+++ b/packages/doenetml/src/EditorViewer/AccessibilityStatusButton.tsx
@@ -71,10 +71,10 @@ export function AccessibilityStatusButton({
             type="button"
             className={`accessibility-status-button ${
                 accessibilityLevel1Count > 0
-                    ? "has-level-1-issues" :
-                        accessibilityLevel2Count > 0
-                        ? "has-level-2-issues"
-                        : "no-accessibility-issues"
+                    ? "has-level-1-issues"
+                    : accessibilityLevel2Count > 0
+                      ? "has-level-2-issues"
+                      : "no-accessibility-issues"
             }`}
             onClick={onToggle}
             title={getAccessibilityStatusTitle({
@@ -93,12 +93,12 @@ export function AccessibilityStatusButton({
                     <IoWarningSharp />
                     <span>Accessibility Errors</span>
                 </>
-            ) : (accessibilityLevel2Count > 0 ? (
+            ) : accessibilityLevel2Count > 0 ? (
                 <>
                     <IoAccessibility />
                     <span>Accessibility Concerns</span>
                 </>
-            ) :
+            ) : (
                 <IoAccessibility />
             )}
         </button>

--- a/packages/doenetml/src/EditorViewer/AccessibilityStatusButton.tsx
+++ b/packages/doenetml/src/EditorViewer/AccessibilityStatusButton.tsx
@@ -71,8 +71,10 @@ export function AccessibilityStatusButton({
             type="button"
             className={`accessibility-status-button ${
                 accessibilityLevel1Count > 0
-                    ? "has-level-1-issues"
-                    : "no-level-1-issues"
+                    ? "has-level-1-issues" :
+                        accessibilityLevel2Count > 0
+                        ? "has-level-2-issues"
+                        : "no-accessibility-issues"
             }`}
             onClick={onToggle}
             title={getAccessibilityStatusTitle({
@@ -89,9 +91,14 @@ export function AccessibilityStatusButton({
             {accessibilityLevel1Count > 0 ? (
                 <>
                     <IoWarningSharp />
+                    <span>Accessibility Errors</span>
+                </>
+            ) : (accessibilityLevel2Count > 0 ? (
+                <>
+                    <IoAccessibility />
                     <span>Accessibility Concerns</span>
                 </>
-            ) : (
+            ) :
                 <IoAccessibility />
             )}
         </button>

--- a/packages/doenetml/src/EditorViewer/AccessibilityStatusButton.tsx
+++ b/packages/doenetml/src/EditorViewer/AccessibilityStatusButton.tsx
@@ -89,7 +89,7 @@ export function AccessibilityStatusButton({
             {accessibilityLevel1Count > 0 ? (
                 <>
                     <IoWarningSharp />
-                    <span>WCAG</span>
+                    <span>Accessibility Concerns</span>
                 </>
             ) : (
                 <IoAccessibility />

--- a/packages/doenetml/src/EditorViewer/AccessibilityStatusButton.tsx
+++ b/packages/doenetml/src/EditorViewer/AccessibilityStatusButton.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { IoAccessibility } from "react-icons/io5";
+import { IoAccessibility, IoWarningSharp } from "react-icons/io5";
 
 /**
  * Returns the tooltip text for the accessibility status button.
@@ -88,7 +88,7 @@ export function AccessibilityStatusButton({
         >
             {accessibilityLevel1Count > 0 ? (
                 <>
-                    <IoAccessibility />
+                    <IoWarningSharp />
                     <span>WCAG</span>
                 </>
             ) : (

--- a/packages/doenetml/src/EditorViewer/editor-viewer.css
+++ b/packages/doenetml/src/EditorViewer/editor-viewer.css
@@ -339,7 +339,13 @@
     box-shadow: inset 0 0 0 1px #ba6520;
 }
 
-.viewer-panel .accessibility-status-button.no-level-1-issues {
+.viewer-panel .accessibility-status-button.has-level-2-issues {
+    background: #fefff3;
+    color: #e6e338;
+    box-shadow: inset 0 0 0 1px #bab220;
+}
+
+.viewer-panel .accessibility-status-button.no-accessibility-issues {
     background: #ecfdf3;
     color: #027a48;
     box-shadow: inset 0 0 0 1px #6ce9a6;

--- a/packages/doenetml/src/EditorViewer/editor-viewer.css
+++ b/packages/doenetml/src/EditorViewer/editor-viewer.css
@@ -334,9 +334,9 @@
 }
 
 .viewer-panel .accessibility-status-button.has-level-1-issues {
-    background: #f5f3ff;
-    color: #5b21b6;
-    box-shadow: inset 0 0 0 1px #8b5cf6;
+    background: #fff6f3;
+    color: #e68938;
+    box-shadow: inset 0 0 0 1px #ba6520;
 }
 
 .viewer-panel .accessibility-status-button.no-level-1-issues {

--- a/packages/test-cypress/cypress/e2e/EditorViewer/editorViewerAccessibilityReport.cy.js
+++ b/packages/test-cypress/cypress/e2e/EditorViewer/editorViewerAccessibilityReport.cy.js
@@ -57,7 +57,7 @@ describe(
             );
             cy.get(".accessibility-status-button.has-level-1-issues").should(
                 "contain.text",
-                "WCAG",
+                "Accessibility Concerns",
             );
             cy.get(".accessibility-status-button")
                 .invoke("attr", "title")

--- a/packages/test-cypress/cypress/e2e/EditorViewer/editorViewerAccessibilityReport.cy.js
+++ b/packages/test-cypress/cypress/e2e/EditorViewer/editorViewerAccessibilityReport.cy.js
@@ -57,7 +57,7 @@ describe(
             );
             cy.get(".accessibility-status-button.has-level-1-issues").should(
                 "contain.text",
-                "Accessibility Concerns",
+                "Accessibility Errors",
             );
             cy.get(".accessibility-status-button")
                 .invoke("attr", "title")
@@ -78,7 +78,7 @@ describe(
             cy.get(".accessibility-status-button.has-level-1-issues").should(
                 "not.exist",
             );
-            cy.get(".accessibility-status-button.no-level-1-issues").should(
+            cy.get(".accessibility-status-button.accessibility-issues").should(
                 "exist",
             );
             cy.get(".accessibility-status-button")


### PR DESCRIPTION
Currently when there are accessibility warnings, we show the accessibility icon and make the button colored purple. Which I actually thought meant it *was* accessibile.

This change makes a warning icon appear instead to more clearly communicate there are issues to address.