### PR TITLE
Retry npm ci in devcontainer jobs on transient network errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,11 @@ jobs:
               uses: devcontainers/ci@v0.3
               with:
                   runCmd: |
-                      for attempt in 1 2 3; do npm ci && break || (echo "npm ci attempt $attempt failed, retrying..." && sleep 15); done
+                      for attempt in 1 2 3; do
+                          npm ci && break
+                          if [ "$attempt" -eq 3 ]; then echo "npm ci failed after $attempt attempts" && exit 1; fi
+                          echo "npm ci attempt $attempt failed, retrying..." && sleep 15
+                      done
                       # This package runs tests in a headless browser. If it can run, the other tests should too.
                       npm run build -w packages/doenetml-to-pretext
                       npm run test -w packages/doenetml-to-pretext
@@ -323,7 +327,11 @@ jobs:
               uses: devcontainers/ci@v0.3
               with:
                   runCmd: |
-                      for attempt in 1 2 3; do npm ci && break || (echo "npm ci attempt $attempt failed, retrying..." && sleep 15); done
+                      for attempt in 1 2 3; do
+                          npm ci && break
+                          if [ "$attempt" -eq 3 ]; then echo "npm ci failed after $attempt attempts" && exit 1; fi
+                          echo "npm ci attempt $attempt failed, retrying..." && sleep 15
+                      done
                       npm run build -w packages/doenetml-to-pretext
                       npm run test -w packages/doenetml-to-pretext
                       npm run build -w packages/doenetml-to-pretext-python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,7 @@ jobs:
               uses: devcontainers/ci@v0.3
               with:
                   runCmd: |
-                      npm ci
+                      for attempt in 1 2 3; do npm ci && break || (echo "npm ci attempt $attempt failed, retrying..." && sleep 15); done
                       # This package runs tests in a headless browser. If it can run, the other tests should too.
                       npm run build -w packages/doenetml-to-pretext
                       npm run test -w packages/doenetml-to-pretext
@@ -323,7 +323,7 @@ jobs:
               uses: devcontainers/ci@v0.3
               with:
                   runCmd: |
-                      npm ci
+                      for attempt in 1 2 3; do npm ci && break || (echo "npm ci attempt $attempt failed, retrying..." && sleep 15); done
                       npm run build -w packages/doenetml-to-pretext
                       npm run test -w packages/doenetml-to-pretext
                       npm run build -w packages/doenetml-to-pretext-python


### PR DESCRIPTION
The `Devcontainer Runs Tests` job failed on main after the recent merge with an `ECONNRESET` during `npm ci` inside the devcontainer — a transient network blip with no retry logic.

Both devcontainer jobs (`test-doenetml-to-pretext-devcontainer` and `test-doenetml-to-pretext-full-devcontainer`) now retry `npm ci` up to 3 times with a 15-second pause between attempts before failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)