### PR TITLE
Use import.meta.dirname instead of __dirname in test-core

### DIFF
--- a/packages/doenetml-worker-javascript/src/test/utils/test-core.ts
+++ b/packages/doenetml-worker-javascript/src/test/utils/test-core.ts
@@ -59,7 +59,7 @@ export async function createTestCore({
 }) {
     const wasmBuffer = fs.readFileSync(
         path.resolve(
-            __dirname,
+            import.meta.dirname,
             "../../../../doenetml-worker-rust/lib-js-wasm-binding/pkg/lib_doenetml_worker_bg.wasm",
         ),
     );


### PR DESCRIPTION
`__dirname` is not available in ES modules. Replace it with `import.meta.dirname` so the WASM buffer path resolves correctly when `test-core.ts` is loaded as an ESM file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)