### PR TITLE
Resolve doenet: image sources against a configurable media URL

### DIFF
--- a/.changeset/image-doenet-media-url.md
+++ b/.changeset/image-doenet-media-url.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Image: resolve `source="doenet:<id>"` against a configurable media URL.
+
+When an `<image>` specifies `source="doenet:abcdefg"`, the image now loads from `doenetMediaUrl + "/" + imageId` (the middle slash is omitted when `doenetMediaUrl` already ends with `/`). The `doenetMediaUrl` is a new optional prop on `<DoenetViewer>` and `<DoenetEditor>` (defaulting to `https://doenet.org/api/media`), mirroring the existing `doenetViewerUrl` prop.

--- a/.changeset/image-doenet-media-url.md
+++ b/.changeset/image-doenet-media-url.md
@@ -9,3 +9,5 @@
 Image: resolve `source="doenet:<id>"` against a configurable media URL.
 
 When an `<image>` specifies `source="doenet:abcdefg"`, the image now loads from `doenetMediaUrl + "/" + imageId` (the middle slash is omitted when `doenetMediaUrl` already ends with `/`). The `doenetMediaUrl` is a new optional prop on `<DoenetViewer>` and `<DoenetEditor>` (defaulting to `https://doenet.org/api/media`), mirroring the existing `doenetViewerUrl` prop.
+
+Only a source that is exactly `doenet:<id>` (an alphanumeric id) is treated as a media reference; any other `doenet:` source (such as a legacy `doenet:cid=<hash>` form) renders the image placeholder rather than requesting an unknown URL.

--- a/packages/doenetml-worker-javascript/src/components/Image.js
+++ b/packages/doenetml-worker-javascript/src/components/Image.js
@@ -753,7 +753,7 @@ export default class Image extends BlockComponent {
             },
         };
 
-        stateVariableDefinitions.cid = {
+        stateVariableDefinitions.imageId = {
             forRenderer: true,
 
             returnDependencies: () => ({
@@ -763,24 +763,17 @@ export default class Image extends BlockComponent {
                 },
             }),
             definition: function ({ dependencyValues }) {
-                if (
-                    !dependencyValues.source ||
-                    dependencyValues.source.substring(0, 7).toLowerCase() !==
-                        "doenet:"
-                ) {
+                const result = dependencyValues.source.match(
+                    /^doenet:([a-zA-Z0-9]+)/i,
+                );
+
+                if (result) {
+                    return { setValue: { imageId: result[1] } };
+                } else {
                     return {
-                        setValue: { cid: null },
+                        setValue: { imageId: null },
                     };
                 }
-
-                let cid = null;
-
-                let result = dependencyValues.source.match(/[:&]cid=([^&]+)/i);
-                if (result) {
-                    cid = result[1];
-                }
-
-                return { setValue: { cid } };
             },
         };
 

--- a/packages/doenetml-worker-javascript/src/components/Image.js
+++ b/packages/doenetml-worker-javascript/src/components/Image.js
@@ -763,17 +763,14 @@ export default class Image extends BlockComponent {
                 },
             }),
             definition: function ({ dependencyValues }) {
+                // A `doenet:<id>` source references an image in Doenet's media
+                // library; expose the `<id>` so the renderer can build its URL.
+                // Any other source (an ordinary URL/path, or none) has no id.
                 const result = dependencyValues.source.match(
                     /^doenet:([a-zA-Z0-9]+)/i,
                 );
 
-                if (result) {
-                    return { setValue: { imageId: result[1] } };
-                } else {
-                    return {
-                        setValue: { imageId: null },
-                    };
-                }
+                return { setValue: { imageId: result ? result[1] : null } };
             },
         };
 

--- a/packages/doenetml-worker-javascript/src/components/Image.js
+++ b/packages/doenetml-worker-javascript/src/components/Image.js
@@ -765,10 +765,12 @@ export default class Image extends BlockComponent {
             definition: function ({ dependencyValues }) {
                 // A `doenet:<id>` source references an image in Doenet's media
                 // library; expose the `<id>` so the renderer can build its URL.
-                // Any other source (an ordinary URL/path, or none) has no id.
-                const result = dependencyValues.source.match(
-                    /^doenet:([a-zA-Z0-9]+)/i,
-                );
+                // The whole source must be exactly `doenet:<id>` (an
+                // alphanumeric id) — any other source, including unsupported
+                // `doenet:` forms like `doenet:cid=<hash>`, has no id.
+                const result = dependencyValues.source
+                    .trim()
+                    .match(/^doenet:([a-zA-Z0-9]+)$/i);
 
                 return { setValue: { imageId: result ? result[1] : null } };
             },

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/image.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/image.test.ts
@@ -551,6 +551,7 @@ describe("Image tag tests @group3", async () => {
             doenetML: `
     <image name="withId" source="doenet:abcDEF123" />
     <image name="upperPrefix" source="DOENET:xyz789" />
+    <image name="emptyId" source="doenet:" />
     <image name="external" source="./some_image.png" />
     <image name="noSource" />
     `,
@@ -569,6 +570,12 @@ describe("Image tag tests @group3", async () => {
             stateVariables[await resolvePathToNodeIdx("upperPrefix")]
                 .stateValues.imageId,
         ).eq("xyz789");
+
+        // a doenet: prefix with no id is not treated as a media reference
+        expect(
+            stateVariables[await resolvePathToNodeIdx("emptyId")].stateValues
+                .imageId,
+        ).eq(null);
 
         // an ordinary URL source has no imageId
         expect(

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/image.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/image.test.ts
@@ -545,4 +545,41 @@ describe("Image tag tests @group3", async () => {
                 .stateValues.licenseUrls,
         ).eqls(["https://example.com/license"]);
     });
+
+    it("imageId is derived from a doenet: source", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <image name="withId" source="doenet:abcDEF123" />
+    <image name="upperPrefix" source="DOENET:xyz789" />
+    <image name="external" source="./some_image.png" />
+    <image name="noSource" />
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+
+        // a doenet: source exposes the trailing identifier as imageId
+        expect(
+            stateVariables[await resolvePathToNodeIdx("withId")].stateValues
+                .imageId,
+        ).eq("abcDEF123");
+
+        // the doenet: prefix is matched case-insensitively
+        expect(
+            stateVariables[await resolvePathToNodeIdx("upperPrefix")]
+                .stateValues.imageId,
+        ).eq("xyz789");
+
+        // an ordinary URL source has no imageId
+        expect(
+            stateVariables[await resolvePathToNodeIdx("external")].stateValues
+                .imageId,
+        ).eq(null);
+
+        // a missing source has no imageId
+        expect(
+            stateVariables[await resolvePathToNodeIdx("noSource")].stateValues
+                .imageId,
+        ).eq(null);
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/image.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/image.test.ts
@@ -552,6 +552,7 @@ describe("Image tag tests @group3", async () => {
     <image name="withId" source="doenet:abcDEF123" />
     <image name="upperPrefix" source="DOENET:xyz789" />
     <image name="emptyId" source="doenet:" />
+    <image name="legacyCid" source="doenet:cid=bafkreiabc123" />
     <image name="external" source="./some_image.png" />
     <image name="noSource" />
     `,
@@ -574,6 +575,13 @@ describe("Image tag tests @group3", async () => {
         // a doenet: prefix with no id is not treated as a media reference
         expect(
             stateVariables[await resolvePathToNodeIdx("emptyId")].stateValues
+                .imageId,
+        ).eq(null);
+
+        // an unsupported doenet: form (e.g. a legacy cid reference) is not
+        // partially matched into an imageId
+        expect(
+            stateVariables[await resolvePathToNodeIdx("legacyCid")].stateValues
                 .imageId,
         ).eq(null);
 

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -82,6 +82,7 @@ type EditorViewerProps = {
     activityId?: string;
     prefixForIds?: string;
     doenetViewerUrl?: string;
+    doenetMediaUrl?: string;
     darkMode?: "dark" | "light";
     showAnswerResponseButton?: boolean;
     answerResponseCounts?: Record<string, number>;
@@ -141,6 +142,7 @@ export const EditorViewer = React.forwardRef<
         activityId: specifiedActivityId,
         prefixForIds = "",
         doenetViewerUrl,
+        doenetMediaUrl,
         darkMode = "light",
         showAnswerResponseButton = false,
         answerResponseCounts = {},
@@ -1061,6 +1063,7 @@ export const EditorViewer = React.forwardRef<
                         documentStructureThenChangeCallback
                     }
                     doenetViewerUrl={doenetViewerUrl}
+                    doenetMediaUrl={doenetMediaUrl}
                     darkMode={darkMode}
                     showAnswerResponseButton={showAnswerResponseButton}
                     answerResponseCounts={answerResponseCounts}

--- a/packages/doenetml/src/Viewer/DocViewer.tsx
+++ b/packages/doenetml/src/Viewer/DocViewer.tsx
@@ -47,6 +47,7 @@ export { renderersLoadComponent } from "./renderersLoadComponent";
 
 export const DocContext = createContext<{
     doenetViewerUrl?: string;
+    doenetMediaUrl?: string;
     darkMode?: "dark" | "light";
     showAnswerResponseButton?: boolean;
     answerResponseCounts?: Record<string, number>;
@@ -75,6 +76,7 @@ export function DocViewer({
     setIsInErrorState,
     prefixForIds = "",
     doenetViewerUrl,
+    doenetMediaUrl,
     darkMode,
     showAnswerResponseButton = false,
     answerResponseCounts = {},
@@ -112,6 +114,7 @@ export function DocViewer({
     setIsInErrorState?: Function;
     prefixForIds?: string;
     doenetViewerUrl?: string;
+    doenetMediaUrl?: string;
     darkMode?: "dark" | "light";
     showAnswerResponseButton?: boolean;
     answerResponseCounts?: Record<string, number>;
@@ -244,6 +247,7 @@ export function DocViewer({
 
     const contextForRenderers = {
         doenetViewerUrl,
+        doenetMediaUrl,
         darkMode,
         showAnswerResponseButton,
         answerResponseCounts,

--- a/packages/doenetml/src/Viewer/renderers/image.tsx
+++ b/packages/doenetml/src/Viewer/renderers/image.tsx
@@ -83,6 +83,10 @@ export default React.memo(function Image(props: UseDoenetRendererProps) {
 
     let imageJXG = useRef<JXGImage | null>(null);
     let anchorPointJXG = useRef<JXGPoint | null>(null);
+    // The `url` used to create the current JSXGraph image, so a later change
+    // (e.g. `source`/`imageId` becomes a different value, or resolves to the
+    // empty "missing" URL) can be detected and the graph image rebuilt/removed.
+    let lastUrl = useRef<string>("");
 
     const board = useContext(BoardContext);
 
@@ -267,6 +271,7 @@ export default React.memo(function Image(props: UseDoenetRendererProps) {
 
         imageJXG.current = newImageJXG;
         anchorPointJXG.current = newAnchorPointJXG;
+        lastUrl.current = url;
         previousPositionFromAnchor.current = SVs.positionFromAnchor;
         currentSize.current = [width, height];
 
@@ -293,6 +298,20 @@ export default React.memo(function Image(props: UseDoenetRendererProps) {
             // An empty `url` (e.g. an unsupported `doenet:` source mapped to
             // "missing") would otherwise be handed to JSXGraph, which can
             // request the current document like `<img src="">`.
+            if (url) {
+                createImageJXG();
+            }
+        } else if (url !== lastUrl.current) {
+            // The resolved URL changed after the image was created. Remove the
+            // stale image (and its anchor point) and rebuild from the new URL,
+            // or leave it removed when the URL is now empty/unsupported so the
+            // graph doesn't keep showing an image that should be suppressed.
+            detachAnchoredGraphElement(imageJXG, board);
+            if (anchorPointJXG.current) {
+                board.removeObject(anchorPointJXG.current);
+                anchorPointJXG.current = null;
+            }
+            lastUrl.current = url;
             if (url) {
                 createImageJXG();
             }

--- a/packages/doenetml/src/Viewer/renderers/image.tsx
+++ b/packages/doenetml/src/Viewer/renderers/image.tsx
@@ -113,7 +113,7 @@ export default React.memo(function Image(props: UseDoenetRendererProps) {
     const url = useMemo(
         () =>
             getUrlForImage({
-                url: SVs.source,
+                source: SVs.source,
                 imageId: SVs.imageId,
                 doenetMediaUrl,
             }),
@@ -727,12 +727,20 @@ function renderImageAttribution({
     );
 }
 
+/**
+ * Resolve the URL to use for an image.
+ *
+ * When the image references a Doenet-hosted media item (`source="doenet:<id>"`),
+ * `imageId` holds the `<id>` and the URL is built from `doenetMediaUrl` and that
+ * id (avoiding a doubled slash when `doenetMediaUrl` already ends with `/`).
+ * Otherwise the `source` is an ordinary URL/path and is returned unchanged.
+ */
 function getUrlForImage({
-    url,
+    source,
     imageId,
     doenetMediaUrl = "https://doenet.org/api/media",
 }: {
-    url: string;
+    source: string;
     imageId: string | null;
     doenetMediaUrl?: string;
 }) {
@@ -740,6 +748,6 @@ function getUrlForImage({
         const separator = doenetMediaUrl.endsWith("/") ? "" : "/";
         return doenetMediaUrl + separator + imageId;
     } else {
-        return url;
+        return source;
     }
 }

--- a/packages/doenetml/src/Viewer/renderers/image.tsx
+++ b/packages/doenetml/src/Viewer/renderers/image.tsx
@@ -289,7 +289,13 @@ export default React.memo(function Image(props: UseDoenetRendererProps) {
         lastPositionFromCore.current = anchorCoords;
 
         if (imageJXG.current === null) {
-            createImageJXG();
+            // Don't create the JSXGraph image until we have a non-empty URL.
+            // An empty `url` (e.g. an unsupported `doenet:` source mapped to
+            // "missing") would otherwise be handed to JSXGraph, which can
+            // request the current document like `<img src="">`.
+            if (url) {
+                createImageJXG();
+            }
         } else {
             anchorPointJXG.current?.coords.setCoordinates(
                 JXG.COORDS_BY_USER,

--- a/packages/doenetml/src/Viewer/renderers/image.tsx
+++ b/packages/doenetml/src/Viewer/renderers/image.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useContext, useRef } from "react";
+import React, { useContext, useMemo, useRef } from "react";
 import JXG from "jsxgraph";
 import { BoardContext, IMAGE_LAYER_OFFSET } from "./graph";
 import useDoenetRenderer, {
@@ -24,6 +24,7 @@ import {
     type MediaLicenseKind,
     type CreativeCommonsVersion,
 } from "@doenet/utils";
+import { DocContext } from "../DocViewer";
 
 interface ImageSVs {
     hidden: boolean;
@@ -33,7 +34,7 @@ interface ImageSVs {
     draggable: boolean;
     anchor: any;
     positionFromAnchor: any;
-    cid?: string;
+    imageId: string | null;
     source: string;
     widthForGraph?: { size: number };
     aspectRatio?: number;
@@ -74,10 +75,11 @@ type JXGTransform = JXGElement & {
 export default React.memo(function Image(props: UseDoenetRendererProps) {
     let { componentIdx, id, SVs, children, actions, callAction } =
         useDoenetRenderer<ImageSVs>(props, false);
-    let [url, setUrl] = useState<string | null>(null);
 
     // @ts-ignore
     Image.ignoreActionsWithoutCore = () => true;
+
+    const { doenetMediaUrl } = useContext(DocContext) || {};
 
     let imageJXG = useRef<JXGImage | null>(null);
     let anchorPointJXG = useRef<JXGPoint | null>(null);
@@ -108,17 +110,19 @@ export default React.memo(function Image(props: UseDoenetRendererProps) {
         destroy: () => detachAnchoredGraphElement(imageJXG, board),
     });
 
-    const urlOrSource = (SVs.cid ? url : SVs.source) || "";
+    const url = useMemo(
+        () =>
+            getUrlForImage({
+                url: SVs.source,
+                imageId: SVs.imageId,
+                doenetMediaUrl,
+            }),
+        [SVs.source, SVs.imageId, doenetMediaUrl],
+    );
 
     const ref = useRef<HTMLDivElement | null>(null);
 
     useRecordVisibilityChanges(ref, callAction, actions);
-
-    useEffect(() => {
-        if (SVs.cid) {
-            // TODO: need new approach for getting media
-        }
-    }, []);
 
     function createImageJXG() {
         if (board === null) {
@@ -195,7 +199,7 @@ export default React.memo(function Image(props: UseDoenetRendererProps) {
 
         let newImageJXG = board.create(
             "image",
-            [urlOrSource, offset, [width, height]],
+            [url, offset, [width, height]],
             jsxImageAttributes,
         ) as JXGImage;
 
@@ -285,9 +289,6 @@ export default React.memo(function Image(props: UseDoenetRendererProps) {
         lastPositionFromCore.current = anchorCoords;
 
         if (imageJXG.current === null) {
-            if (SVs.cid && !url) {
-                return null;
-            }
             createImageJXG();
         } else {
             anchorPointJXG.current?.coords.setCoordinates(
@@ -442,7 +443,7 @@ export default React.memo(function Image(props: UseDoenetRendererProps) {
         imageStyle.aspectRatio = String(SVs.aspectRatio);
     }
 
-    if (!urlOrSource) {
+    if (!url) {
         imageStyle.border = "var(--mainBorder)";
     }
 
@@ -496,10 +497,10 @@ export default React.memo(function Image(props: UseDoenetRendererProps) {
             );
     }
 
-    const media = urlOrSource ? (
+    const media = url ? (
         <img
             id={id}
-            src={urlOrSource}
+            src={url}
             style={imageStyle}
             alt={shortDescription}
             aria-details={descriptionId}
@@ -724,4 +725,21 @@ function renderImageAttribution({
             {sentence}
         </p>
     );
+}
+
+function getUrlForImage({
+    url,
+    imageId,
+    doenetMediaUrl = "https://doenet.org/api/media",
+}: {
+    url: string;
+    imageId: string | null;
+    doenetMediaUrl?: string;
+}) {
+    if (imageId) {
+        const separator = doenetMediaUrl.endsWith("/") ? "" : "/";
+        return doenetMediaUrl + separator + imageId;
+    } else {
+        return url;
+    }
 }

--- a/packages/doenetml/src/Viewer/renderers/image.tsx
+++ b/packages/doenetml/src/Viewer/renderers/image.tsx
@@ -733,7 +733,12 @@ function renderImageAttribution({
  * When the image references a Doenet-hosted media item (`source="doenet:<id>"`),
  * `imageId` holds the `<id>` and the URL is built from `doenetMediaUrl` and that
  * id (avoiding a doubled slash when `doenetMediaUrl` already ends with `/`).
- * Otherwise the `source` is an ordinary URL/path and is returned unchanged.
+ *
+ * A `doenet:` source that did not yield an `imageId` is an unsupported media
+ * reference (e.g. a legacy `doenet:cid=<hash>` form); rather than passing the
+ * `doenet:` URI through to `<img src>` (which would request an unknown scheme
+ * and show a broken-image icon), treat it as missing so the placeholder UI is
+ * used. Any other source is an ordinary URL/path and is returned unchanged.
  */
 function getUrlForImage({
     source,
@@ -747,6 +752,8 @@ function getUrlForImage({
     if (imageId) {
         const separator = doenetMediaUrl.endsWith("/") ? "" : "/";
         return doenetMediaUrl + separator + imageId;
+    } else if (/^\s*doenet:/i.test(source)) {
+        return "";
     } else {
         return source;
     }

--- a/packages/doenetml/src/doenetml.tsx
+++ b/packages/doenetml/src/doenetml.tsx
@@ -86,6 +86,7 @@ export function DoenetViewer({
     addVirtualKeyboard = true,
     externalVirtualKeyboardProvided = false,
     doenetViewerUrl,
+    doenetMediaUrl,
     darkMode = "light",
     showAnswerResponseButton = false,
     answerResponseCounts = {},
@@ -133,6 +134,7 @@ export function DoenetViewer({
     addVirtualKeyboard?: boolean;
     externalVirtualKeyboardProvided?: boolean;
     doenetViewerUrl?: string;
+    doenetMediaUrl?: string;
     darkMode?: "dark" | "light";
     showAnswerResponseButton?: boolean;
     answerResponseCounts?: Record<string, number>;
@@ -276,6 +278,7 @@ export function DoenetViewer({
             forceShowSolution={forceShowSolution}
             forceUnsuppressCheckWork={forceUnsuppressCheckWork}
             doenetViewerUrl={doenetViewerUrl}
+            doenetMediaUrl={doenetMediaUrl}
             darkMode={darkMode}
             showAnswerResponseButton={showAnswerResponseButton}
             answerResponseCounts={answerResponseCounts}
@@ -318,6 +321,7 @@ type DoenetEditorProps = {
     addVirtualKeyboard?: boolean;
     externalVirtualKeyboardProvided?: boolean;
     doenetViewerUrl?: string;
+    doenetMediaUrl?: string;
     darkMode?: "dark" | "light";
     showAnswerResponseButton?: boolean;
     answerResponseCounts?: Record<string, number>;
@@ -371,6 +375,7 @@ export const DoenetEditor = React.forwardRef<
         addVirtualKeyboard = true,
         externalVirtualKeyboardProvided = false,
         doenetViewerUrl,
+        doenetMediaUrl,
         darkMode = "light",
         showAnswerResponseButton = false,
         answerResponseCounts = {},
@@ -444,6 +449,7 @@ export const DoenetEditor = React.forwardRef<
             activityId={activityId}
             prefixForIds={prefixForIds}
             doenetViewerUrl={doenetViewerUrl}
+            doenetMediaUrl={doenetMediaUrl}
             darkMode={darkMode}
             showAnswerResponseButton={showAnswerResponseButton}
             answerResponseCounts={answerResponseCounts}

--- a/packages/test-cypress/cypress/e2e/tagSpecific/image.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/image.cy.js
@@ -767,4 +767,23 @@ describe("Image Tag Tests", { tags: ["@group1"] }, function () {
             .should("have.attr", "src")
             .and("match", /Doenet_Logo_Frontpage\.png$/);
     });
+
+    it("an unsupported doenet: source renders the placeholder, not a broken image", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <image name="image" source="doenet:cid=bafkreiabc123">
+    <shortDescription>A legacy media reference</shortDescription>
+  </image>
+  `,
+                },
+                "*",
+            );
+        });
+
+        // the unsupported doenet: URI must not be passed through to an <img>
+        cy.get("#image").should("be.visible");
+        cy.get("img#image").should("not.exist");
+    });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/image.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/image.cy.js
@@ -688,4 +688,83 @@ describe("Image Tag Tests", { tags: ["@group1"] }, function () {
             .contains("a", "Jane Doe")
             .should("have.attr", "href", "https://example.com/jane");
     });
+
+    it("doenet: source resolves against the default media URL", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <image name="image" source="doenet:abcDEF123">
+    <shortDescription>A Doenet-hosted image</shortDescription>
+  </image>
+  `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#image")
+            .should("have.attr", "src")
+            .and("eq", "https://doenet.org/api/media/abcDEF123");
+    });
+
+    it("doenet: source resolves against a custom doenetMediaUrl", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <image name="image" source="doenet:abcDEF123">
+    <shortDescription>A Doenet-hosted image</shortDescription>
+  </image>
+  `,
+                    doenetMediaUrl: "https://example.com/media",
+                },
+                "*",
+            );
+        });
+
+        cy.get("#image")
+            .should("have.attr", "src")
+            .and("eq", "https://example.com/media/abcDEF123");
+    });
+
+    it("trailing slash on doenetMediaUrl is not doubled", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <image name="image" source="doenet:abcDEF123">
+    <shortDescription>A Doenet-hosted image</shortDescription>
+  </image>
+  `,
+                    doenetMediaUrl: "https://example.com/media/",
+                },
+                "*",
+            );
+        });
+
+        cy.get("#image")
+            .should("have.attr", "src")
+            .and("eq", "https://example.com/media/abcDEF123");
+    });
+
+    it("an ordinary source URL is used unchanged", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <image name="image" source="./Doenet_Logo_Frontpage.png">
+    <shortDescription>The Doenet logo</shortDescription>
+  </image>
+  `,
+                    doenetMediaUrl: "https://example.com/media",
+                },
+                "*",
+            );
+        });
+
+        cy.get("#image")
+            .should("have.attr", "src")
+            .and("match", /Doenet_Logo_Frontpage\.png$/);
+    });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/image.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/image.cy.js
@@ -824,4 +824,73 @@ describe("Image Tag Tests", { tags: ["@group1"] }, function () {
             });
         });
     });
+
+    it("updates the graph image when a doenet: source changes", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <graph name="g">
+    <image name="image" source="$ti" anchor="(1,1)">
+      <shortDescription>A changeable source</shortDescription>
+    </image>
+  </graph>
+  <textInput name="ti" prefill="doenet:abc123" />
+  `,
+                },
+                "*",
+            );
+        });
+
+        function imageCount(win, $g) {
+            const boardRegistry =
+                win.JXG?.boards || win.JXG?.JSXGraph?.boards || {};
+            const board = Object.values(boardRegistry).find(
+                (b) => b?.containerObj === $g[0],
+            );
+            expect(board, "JSXGraph board for graph g").to.exist;
+            return Object.values(board.objects).filter(
+                (o) => o?.elType === "image",
+            );
+        }
+
+        cy.get("#g").should("exist");
+
+        // a valid doenet: source produces one image on the board
+        cy.get("#g").then(($g) => {
+            cy.window().should((win) => {
+                const images = imageCount(win, $g);
+                expect(images, "image after valid source").to.have.length(1);
+                expect(images[0].url).to.eq(
+                    "https://doenet.org/api/media/abc123",
+                );
+            });
+        });
+
+        // changing to an unsupported doenet: form removes the stale image
+        cy.get("#ti_input").clear().type("doenet:cid=bafkreiabc123{enter}");
+        cy.get("#g").then(($g) => {
+            cy.window().should((win) => {
+                expect(
+                    imageCount(win, $g),
+                    "image after unsupported source",
+                ).to.have.length(0);
+            });
+        });
+
+        // changing back to a valid doenet: source rebuilds the image with the
+        // new resolved URL
+        cy.get("#ti_input").clear().type("doenet:xyz789{enter}");
+        cy.get("#g").then(($g) => {
+            cy.window().should((win) => {
+                const images = imageCount(win, $g);
+                expect(images, "image after new valid source").to.have.length(
+                    1,
+                );
+                expect(images[0].url).to.eq(
+                    "https://doenet.org/api/media/xyz789",
+                );
+            });
+        });
+    });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/image.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/image.cy.js
@@ -786,4 +786,42 @@ describe("Image Tag Tests", { tags: ["@group1"] }, function () {
         cy.get("#image").should("be.visible");
         cy.get("img#image").should("not.exist");
     });
+
+    it("an unsupported doenet: source in a graph creates no JSXGraph image", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+  <graph name="g">
+    <image name="image" source="doenet:cid=bafkreiabc123" anchor="(1,1)">
+      <shortDescription>A legacy media reference</shortDescription>
+    </image>
+  </graph>
+  `,
+                },
+                "*",
+            );
+        });
+
+        // the graph renders, but the unsupported doenet: source must not be
+        // handed to JSXGraph (which would request an empty URL); so no image
+        // element should be created on the board.
+        cy.get("#g").should("exist");
+
+        cy.get("#g").then(($g) => {
+            cy.window().should((win) => {
+                const boardRegistry =
+                    win.JXG?.boards || win.JXG?.JSXGraph?.boards || {};
+                const board = Object.values(boardRegistry).find(
+                    (b) => b?.containerObj === $g[0],
+                );
+                expect(board, "JSXGraph board for graph g").to.exist;
+
+                const images = Object.values(board.objects).filter(
+                    (o) => o?.elType === "image",
+                );
+                expect(images, "JSXGraph image elements").to.have.length(0);
+            });
+        });
+    });
 });

--- a/packages/test-cypress/src/CypressTest.tsx
+++ b/packages/test-cypress/src/CypressTest.tsx
@@ -59,6 +59,7 @@ export function CypressTest() {
             attemptNumber,
             externalDoenetMLs,
             answerResponseCounts,
+            doenetMediaUrl,
         },
         setBaseState,
     ] = useState<{
@@ -66,6 +67,7 @@ export function CypressTest() {
         attemptNumber: number;
         externalDoenetMLs: Record<string, string>;
         answerResponseCounts?: Record<string, number>;
+        doenetMediaUrl?: string;
     }>({
         doenetMLstring: null,
         attemptNumber: testSettings.attemptNumber,
@@ -154,6 +156,7 @@ export function CypressTest() {
         let newExternalDoenetMLs: Record<string, string> = {};
         let newAnswerResponseCounts: Record<string, number> | undefined =
             undefined;
+        let newDoenetMediaUrl: string | undefined = undefined;
 
         if (e.data.doenetML !== undefined) {
             newDoenetMLstring = e.data.doenetML;
@@ -176,6 +179,10 @@ export function CypressTest() {
             newAnswerResponseCounts = e.data.answerResponseCounts;
         }
 
+        if (e.data.doenetMediaUrl !== undefined) {
+            newDoenetMediaUrl = e.data.doenetMediaUrl;
+        }
+
         // don't do anything if receive a message from another source (like the youtube player)
         if (
             typeof newDoenetMLstring === "string" ||
@@ -186,6 +193,7 @@ export function CypressTest() {
                 attemptNumber: newAttemptNumber,
                 externalDoenetMLs: newExternalDoenetMLs,
                 answerResponseCounts: newAnswerResponseCounts,
+                doenetMediaUrl: newDoenetMediaUrl,
             });
         }
     };
@@ -604,6 +612,7 @@ export function CypressTest() {
                 fetchExternalDoenetML={fetchExternalDoenetML}
                 showAnswerResponseButton={answerResponseCounts !== undefined}
                 answerResponseCounts={answerResponseCounts}
+                doenetMediaUrl={doenetMediaUrl}
                 readOnly={readOnly}
                 diagnosticsSummaryCallback={(
                     nextDiagnosticsSummary: Record<string, number>,
@@ -652,6 +661,7 @@ export function CypressTest() {
                 showAnswerResponseButton={answerResponseCounts !== undefined}
                 answerResponseCounts={answerResponseCounts}
                 includeVariantSelector={includeVariantSelector}
+                doenetMediaUrl={doenetMediaUrl}
             />
         );
 


### PR DESCRIPTION
## Summary

Adds support for an `<image>` whose `source` uses the `doenet:` scheme to reference an image stored in Doenet's media library. When `source="doenet:<id>"`, the rendered image URL is built as `doenetMediaUrl + "/" + <id>` (the joining slash is omitted when `doenetMediaUrl` already ends with `/`).

`doenetMediaUrl` is a new optional prop on `<DoenetViewer>` and `<DoenetEditor>` (default `https://doenet.org/api/media`), threaded through to the image renderer via `DocContext` exactly like the existing `doenetViewerUrl` prop.

## Details

- **Worker** (`Image.js`): the renderer-only state variable previously named `cid` is renamed to `imageId` and now extracts the id from a `doenet:<id>` source via `/^doenet:([a-zA-Z0-9]+)/i`. (`imageId` is `forRenderer`-only, never a public property, so this rename is not author-facing.) The old definition referenced an out-of-scope `url` variable and parsed a `cid=` query parameter that nothing produced.
- **Renderer** (`image.tsx`): resolves the URL through a new `getUrlForImage` helper (handling the trailing-slash case), reads `doenetMediaUrl` from `DocContext`, and memoizes the resolved URL so it is not recomputed on every render (e.g. while dragging an image in a `<graph>`). Removes the leftover `url`/`setUrl` state and the `// TODO` `useEffect` that never fetched media.
- **Prop plumbing**: `doenetMediaUrl` added to `DocViewer`/`DocContext`, `EditorViewer`, and both `DoenetViewer` and `DoenetEditor`.

## Tests

- **Vitest**: new test confirming `imageId` is derived from a `doenet:` source (case-insensitive prefix) and is `null` for ordinary/missing sources.
- **Cypress**: new tests verifying the rendered `<img src>` resolves against the default media URL, a custom `doenetMediaUrl`, without doubling a trailing slash, and that ordinary source URLs pass through unchanged. The Cypress harness (`CypressTest.tsx`) now forwards a `doenetMediaUrl` from the `postMessage` payload.

## Notes

- The previous `doenet:` handling never actually rendered an image (the media fetch was an unimplemented `// TODO`), so this is not a regression of working behavior. The hidden `quickStart` tutorial pages use a legacy `doenet:cid=<hash>` format that this parser does not handle; those pages are not reachable via navigation and were already non-functional. How best to document the `doenet:`/`doenetMediaUrl` feature for authors is tracked separately in #1306.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)