### PR TITLE
Import needed functions directly from mathjs

### DIFF
--- a/packages/doenetml-worker-javascript/src/components/AnimateFromSequence.js
+++ b/packages/doenetml-worker-javascript/src/components/AnimateFromSequence.js
@@ -5,7 +5,7 @@ import {
     returnStandardSequenceStateVariableDefinitions,
 } from "../utils/sequence";
 import me from "math-expressions";
-import { mod } from "mathjs";
+const { mod } = me.math;
 import { nanoid } from "nanoid";
 
 export default class AnimateFromSequence extends BaseComponent {

--- a/packages/doenetml-worker-javascript/src/components/AnimateFromSequence.js
+++ b/packages/doenetml-worker-javascript/src/components/AnimateFromSequence.js
@@ -5,6 +5,7 @@ import {
     returnStandardSequenceStateVariableDefinitions,
 } from "../utils/sequence";
 import me from "math-expressions";
+import { mod } from "mathjs";
 import { nanoid } from "nanoid";
 
 export default class AnimateFromSequence extends BaseComponent {
@@ -178,7 +179,7 @@ export default class AnimateFromSequence extends BaseComponent {
                         {
                             setEssentialValue: "selectedIndex",
                             value:
-                                me.math.mod(
+                                mod(
                                     desiredStateVariableValues.selectedIndex -
                                         1,
                                     await stateValues.numValues,
@@ -669,7 +670,7 @@ export default class AnimateFromSequence extends BaseComponent {
                 let additionalInstructions =
                     await this.getUpdateInstructionsToSetTargetsToValue(
                         (await this.stateValues.possibleValues)[
-                            me.math.mod(startIndex - 1, numValues)
+                            mod(startIndex - 1, numValues)
                         ],
                     );
                 updateInstructions.push(...additionalInstructions);
@@ -877,10 +878,7 @@ export default class AnimateFromSequence extends BaseComponent {
         let additionalInstructions =
             await this.getUpdateInstructionsToSetTargetsToValue(
                 (await this.stateValues.possibleValues)[
-                    me.math.mod(
-                        newSelectedIndex - 1,
-                        await this.stateValues.numValues,
-                    )
+                    mod(newSelectedIndex - 1, await this.stateValues.numValues)
                 ],
             );
         updateInstructions.push(...additionalInstructions);

--- a/packages/doenetml-worker-javascript/src/components/BestFitLine.js
+++ b/packages/doenetml-worker-javascript/src/components/BestFitLine.js
@@ -1,6 +1,7 @@
 import { returnNumberDisplayAttributeComponentShadowing } from "../utils/numberDisplay";
 import Line from "./Line";
 import me from "math-expressions";
+import { matrix, transpose, multiply, lusolve, subset, index } from "mathjs";
 
 export default class BestFitLine extends Line {
     static componentType = "bestFitLine";
@@ -127,18 +128,18 @@ export default class BestFitLine extends Line {
                 };
             }
 
-            X = me.math.matrix(X);
-            Y = me.math.matrix(Y);
-            let Xt = me.math.transpose(X);
+            X = matrix(X);
+            Y = matrix(Y);
+            let Xt = transpose(X);
 
-            let b = me.math.multiply(Xt, Y);
+            let b = multiply(Xt, Y);
 
-            let A = me.math.multiply(Xt, X);
+            let A = multiply(Xt, X);
 
-            let s = me.math.lusolve(A, b);
+            let s = lusolve(A, b);
 
-            let coeff0 = me.fromAst(me.math.subset(s, me.math.index(0, 0)));
-            let coeffvar1 = me.fromAst(me.math.subset(s, me.math.index(1, 0)));
+            let coeff0 = me.fromAst(subset(s, index(0, 0)));
+            let coeffvar1 = me.fromAst(subset(s, index(1, 0)));
             let coeffvar2 = me.fromAst(-1);
 
             let variables = dependencyValues.variables;

--- a/packages/doenetml-worker-javascript/src/components/BestFitLine.js
+++ b/packages/doenetml-worker-javascript/src/components/BestFitLine.js
@@ -1,7 +1,7 @@
 import { returnNumberDisplayAttributeComponentShadowing } from "../utils/numberDisplay";
 import Line from "./Line";
 import me from "math-expressions";
-import { matrix, transpose, multiply, lusolve, subset, index } from "mathjs";
+const { matrix, transpose, multiply, lusolve, subset, index } = me.math;
 
 export default class BestFitLine extends Line {
     static componentType = "bestFitLine";

--- a/packages/doenetml-worker-javascript/src/components/MathOperators.js
+++ b/packages/doenetml-worker-javascript/src/components/MathOperators.js
@@ -2,6 +2,7 @@ import { returnNumberDisplayStateVariableDefinitions } from "../utils/numberDisp
 import MathBaseOperator from "./abstract/MathBaseOperator";
 import MathBaseOperatorOneInput from "./abstract/MathBaseOperatorOneInput";
 import me from "math-expressions";
+import { mod, median } from "mathjs";
 
 export class Sum extends MathBaseOperator {
     static componentType = "sum";
@@ -272,8 +273,7 @@ function makePeriodic({ value, lowerValue, upperValue }) {
     }
 
     return me.fromAst(
-        lowerValue +
-            me.math.mod(numericValue - lowerValue, upperValue - lowerValue),
+        lowerValue + mod(numericValue - lowerValue, upperValue - lowerValue),
     );
 }
 
@@ -723,7 +723,7 @@ export class Median extends MathBaseOperator {
             definition: () => ({
                 setValue: {
                     numericOperator: function (inputs) {
-                        return me.math.median(inputs);
+                        return median(inputs);
                     },
                 },
             }),
@@ -1123,7 +1123,7 @@ export class Mod extends MathBaseOperator {
                         if (inputs.length !== 2) {
                             return NaN;
                         }
-                        return me.math.mod(inputs[0], inputs[1]);
+                        return mod(inputs[0], inputs[1]);
                     },
                 },
             }),

--- a/packages/doenetml-worker-javascript/src/components/MathOperators.js
+++ b/packages/doenetml-worker-javascript/src/components/MathOperators.js
@@ -2,7 +2,7 @@ import { returnNumberDisplayStateVariableDefinitions } from "../utils/numberDisp
 import MathBaseOperator from "./abstract/MathBaseOperator";
 import MathBaseOperatorOneInput from "./abstract/MathBaseOperatorOneInput";
 import me from "math-expressions";
-import { mod, median } from "mathjs";
+const { mod, median } = me.math;
 
 export class Sum extends MathBaseOperator {
     static componentType = "sum";

--- a/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
@@ -20,7 +20,7 @@ import {
     mergeContainingNumberCombinations,
 } from "../utils/excludeCombinations";
 import me from "math-expressions";
-import { gcd } from "mathjs";
+const { gcd } = me.math;
 
 export default class SelectFromSequence extends Sequence {
     static componentType = "selectFromSequence";

--- a/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
+++ b/packages/doenetml-worker-javascript/src/components/SelectFromSequence.js
@@ -20,6 +20,7 @@ import {
     mergeContainingNumberCombinations,
 } from "../utils/excludeCombinations";
 import me from "math-expressions";
+import { gcd } from "mathjs";
 
 export default class SelectFromSequence extends Sequence {
     static componentType = "selectFromSequence";
@@ -1025,7 +1026,7 @@ function makeSelection({ dependencyValues }) {
                 errorMessage =
                     "Cannot select coprime combinations as not selecting positive integers.";
             } else if (
-                me.math.gcd(dependencyValues.from, dependencyValues.step) !== 1
+                gcd(dependencyValues.from, dependencyValues.step) !== 1
             ) {
                 errorMessage = `Cannot select coprime numbers. All possible values share a common factor. (Specified values of "from" or "to" must be coprime with "step".)`;
             } else if (dependencyValues.numToSelect === 1) {
@@ -1246,7 +1247,7 @@ function makeSelection({ dependencyValues }) {
                 continue;
             }
 
-            if (coprime && me.math.gcd(...selectedValues) !== 1) {
+            if (coprime && gcd(...selectedValues) !== 1) {
                 continue;
             }
 

--- a/packages/doenetml-worker-javascript/src/components/SideBySide.js
+++ b/packages/doenetml-worker-javascript/src/components/SideBySide.js
@@ -1,6 +1,7 @@
 import { returnPassThroughListItemChildStateVariableDefinitions } from "../utils/listItemChild";
 import BlockComponent from "./abstract/BlockComponent";
 import me from "math-expressions";
+import { max } from "mathjs";
 
 export class SideBySide extends BlockComponent {
     constructor(args) {
@@ -1375,7 +1376,7 @@ export class SbsGroup extends BlockComponent {
                         maxNPanelsPerRow:
                             dependencyValues.sideBySideChildren.length === 0
                                 ? 0
-                                : me.math.max(
+                                : max(
                                       dependencyValues.sideBySideChildren.map(
                                           (x) => x.stateValues.numPanels,
                                       ),

--- a/packages/doenetml-worker-javascript/src/components/SideBySide.js
+++ b/packages/doenetml-worker-javascript/src/components/SideBySide.js
@@ -1,7 +1,7 @@
 import { returnPassThroughListItemChildStateVariableDefinitions } from "../utils/listItemChild";
 import BlockComponent from "./abstract/BlockComponent";
 import me from "math-expressions";
-import { max } from "mathjs";
+const { max } = me.math;
 
 export class SideBySide extends BlockComponent {
     constructor(args) {

--- a/packages/doenetml-worker-javascript/src/components/StickyGroup.js
+++ b/packages/doenetml-worker-javascript/src/components/StickyGroup.js
@@ -11,6 +11,7 @@ import {
 import { findFiniteNumericalValue } from "../utils/math";
 import GraphicalComponent from "./abstract/GraphicalComponent";
 import me from "math-expressions";
+import { mod } from "mathjs";
 
 export default class StickyGroup extends GraphicalComponent {
     static componentType = "stickyGroup";
@@ -1039,10 +1040,7 @@ function rotateToAttractAngles({
 
         for (let attractingAngle of anglesToAttract) {
             let dAngle =
-                me.math.mod(
-                    attractingAngle - edgeAngle + Math.PI / 2,
-                    Math.PI,
-                ) -
+                mod(attractingAngle - edgeAngle + Math.PI / 2, Math.PI) -
                 Math.PI / 2;
 
             if (Math.abs(dAngle) < Math.abs(minDAngle)) {
@@ -1098,8 +1096,7 @@ function rotateIfClose({
     );
 
     let dAngle =
-        me.math.mod(attractingAngle - edgeAngle + Math.PI / 2, Math.PI) -
-        Math.PI / 2;
+        mod(attractingAngle - edgeAngle + Math.PI / 2, Math.PI) - Math.PI / 2;
 
     if (!(Math.abs(dAngle) < angleThreshold)) {
         return null;

--- a/packages/doenetml-worker-javascript/src/components/StickyGroup.js
+++ b/packages/doenetml-worker-javascript/src/components/StickyGroup.js
@@ -11,7 +11,7 @@ import {
 import { findFiniteNumericalValue } from "../utils/math";
 import GraphicalComponent from "./abstract/GraphicalComponent";
 import me from "math-expressions";
-import { mod } from "mathjs";
+const { mod } = me.math;
 
 export default class StickyGroup extends GraphicalComponent {
     static componentType = "stickyGroup";

--- a/packages/doenetml-worker-javascript/src/components/SummaryStatistics.js
+++ b/packages/doenetml-worker-javascript/src/components/SummaryStatistics.js
@@ -267,11 +267,11 @@ export default class SummaryStatistics extends BlockComponent {
                 },
             }),
             definition({ dependencyValues }) {
-                let mean = null;
+                let computedMean = null;
                 if (dependencyValues.dataColumn !== null) {
-                    mean = mean(dependencyValues.dataColumn);
+                    computedMean = mean(dependencyValues.dataColumn);
                 }
-                return { setValue: { mean } };
+                return { setValue: { mean: computedMean } };
             },
         };
 
@@ -290,12 +290,12 @@ export default class SummaryStatistics extends BlockComponent {
                 },
             }),
             definition({ dependencyValues }) {
-                let stdev = null;
+                let computedStdev = null;
                 if (dependencyValues.dataColumn) {
-                    stdev = std(dependencyValues.dataColumn);
+                    computedStdev = std(dependencyValues.dataColumn);
                 }
 
-                return { setValue: { stdev } };
+                return { setValue: { stdev: computedStdev } };
             },
         };
 
@@ -314,12 +314,12 @@ export default class SummaryStatistics extends BlockComponent {
                 },
             }),
             definition({ dependencyValues }) {
-                let variance = null;
+                let computedVariance = null;
                 if (dependencyValues.dataColumn) {
-                    variance = variance(dependencyValues.dataColumn);
+                    computedVariance = variance(dependencyValues.dataColumn);
                 }
 
-                return { setValue: { variance } };
+                return { setValue: { variance: computedVariance } };
             },
         };
 
@@ -414,11 +414,11 @@ export default class SummaryStatistics extends BlockComponent {
                 },
             }),
             definition({ dependencyValues }) {
-                let median = null;
+                let computedMedian = null;
                 if (dependencyValues.dataColumn) {
-                    median = median(dependencyValues.dataColumn);
+                    computedMedian = median(dependencyValues.dataColumn);
                 }
-                return { setValue: { median } };
+                return { setValue: { median: computedMedian } };
             },
         };
 

--- a/packages/doenetml-worker-javascript/src/components/SummaryStatistics.js
+++ b/packages/doenetml-worker-javascript/src/components/SummaryStatistics.js
@@ -1,6 +1,6 @@
 import BlockComponent from "./abstract/BlockComponent";
 import me from "math-expressions";
-import { mean, std, variance, median, quantileSeq } from "mathjs";
+const { mean, std, variance, median, quantileSeq } = me.math;
 import { roundForDisplay } from "../utils/math";
 import {
     returnNumberDisplayAttributeComponentShadowing,

--- a/packages/doenetml-worker-javascript/src/components/SummaryStatistics.js
+++ b/packages/doenetml-worker-javascript/src/components/SummaryStatistics.js
@@ -1,5 +1,6 @@
 import BlockComponent from "./abstract/BlockComponent";
 import me from "math-expressions";
+import { mean, std, variance, median, quantileSeq } from "mathjs";
 import { roundForDisplay } from "../utils/math";
 import {
     returnNumberDisplayAttributeComponentShadowing,
@@ -268,7 +269,7 @@ export default class SummaryStatistics extends BlockComponent {
             definition({ dependencyValues }) {
                 let mean = null;
                 if (dependencyValues.dataColumn !== null) {
-                    mean = me.math.mean(dependencyValues.dataColumn);
+                    mean = mean(dependencyValues.dataColumn);
                 }
                 return { setValue: { mean } };
             },
@@ -291,7 +292,7 @@ export default class SummaryStatistics extends BlockComponent {
             definition({ dependencyValues }) {
                 let stdev = null;
                 if (dependencyValues.dataColumn) {
-                    stdev = me.math.std(dependencyValues.dataColumn);
+                    stdev = std(dependencyValues.dataColumn);
                 }
 
                 return { setValue: { stdev } };
@@ -315,7 +316,7 @@ export default class SummaryStatistics extends BlockComponent {
             definition({ dependencyValues }) {
                 let variance = null;
                 if (dependencyValues.dataColumn) {
-                    variance = me.math.variance(dependencyValues.dataColumn);
+                    variance = variance(dependencyValues.dataColumn);
                 }
 
                 return { setValue: { variance } };
@@ -415,7 +416,7 @@ export default class SummaryStatistics extends BlockComponent {
             definition({ dependencyValues }) {
                 let median = null;
                 if (dependencyValues.dataColumn) {
-                    median = me.math.median(dependencyValues.dataColumn);
+                    median = median(dependencyValues.dataColumn);
                 }
                 return { setValue: { median } };
             },
@@ -438,10 +439,7 @@ export default class SummaryStatistics extends BlockComponent {
             definition({ dependencyValues }) {
                 let quartile1 = null;
                 if (dependencyValues.dataColumn) {
-                    quartile1 = me.math.quantileSeq(
-                        dependencyValues.dataColumn,
-                        0.25,
-                    );
+                    quartile1 = quantileSeq(dependencyValues.dataColumn, 0.25);
                 }
                 return { setValue: { quartile1 } };
             },
@@ -464,10 +462,7 @@ export default class SummaryStatistics extends BlockComponent {
             definition({ dependencyValues }) {
                 let quartile3 = null;
                 if (dependencyValues.dataColumn) {
-                    quartile3 = me.math.quantileSeq(
-                        dependencyValues.dataColumn,
-                        0.75,
-                    );
+                    quartile3 = quantileSeq(dependencyValues.dataColumn, 0.75);
                 }
                 return { setValue: { quartile3 } };
             },

--- a/packages/doenetml-worker-javascript/src/components/chemistry/IonicCompound.js
+++ b/packages/doenetml-worker-javascript/src/components/chemistry/IonicCompound.js
@@ -1,5 +1,6 @@
 import InlineComponent from "../abstract/InlineComponent";
 import me from "math-expressions";
+import { gcd } from "mathjs";
 import {
     returnSelectedStyleStateVariableDefinition,
     returnTextStyleDescriptionDefinitions,
@@ -99,7 +100,7 @@ export default class IonicCompound extends InlineComponent {
                 let n1 = Math.abs(charges[1]);
                 let n2 = Math.abs(charges[0]);
 
-                let gcd = me.math.gcd(n1, n2);
+                let gcd = gcd(n1, n2);
                 n1 /= gcd;
                 n2 /= gcd;
 

--- a/packages/doenetml-worker-javascript/src/components/chemistry/IonicCompound.js
+++ b/packages/doenetml-worker-javascript/src/components/chemistry/IonicCompound.js
@@ -1,6 +1,6 @@
 import InlineComponent from "../abstract/InlineComponent";
 import me from "math-expressions";
-import { gcd } from "mathjs";
+const { gcd } = me.math;
 import {
     returnSelectedStyleStateVariableDefinition,
     returnTextStyleDescriptionDefinitions,

--- a/packages/doenetml-worker-javascript/src/components/chemistry/IonicCompound.js
+++ b/packages/doenetml-worker-javascript/src/components/chemistry/IonicCompound.js
@@ -1,6 +1,6 @@
 import InlineComponent from "../abstract/InlineComponent";
 import me from "math-expressions";
-const { gcd: mathGcd } = me.math;
+const { gcd } = me.math;
 import {
     returnSelectedStyleStateVariableDefinition,
     returnTextStyleDescriptionDefinitions,
@@ -100,9 +100,9 @@ export default class IonicCompound extends InlineComponent {
                 let n1 = Math.abs(charges[1]);
                 let n2 = Math.abs(charges[0]);
 
-                let gcd = mathGcd(n1, n2);
-                n1 /= gcd;
-                n2 /= gcd;
+                let computedGcd = gcd(n1, n2);
+                n1 /= computedGcd;
+                n2 /= computedGcd;
 
                 let ionicCompound = [
                     {

--- a/packages/doenetml-worker-javascript/src/components/chemistry/IonicCompound.js
+++ b/packages/doenetml-worker-javascript/src/components/chemistry/IonicCompound.js
@@ -1,6 +1,6 @@
 import InlineComponent from "../abstract/InlineComponent";
 import me from "math-expressions";
-const { gcd } = me.math;
+const { gcd: mathGcd } = me.math;
 import {
     returnSelectedStyleStateVariableDefinition,
     returnTextStyleDescriptionDefinitions,
@@ -100,7 +100,7 @@ export default class IonicCompound extends InlineComponent {
                 let n1 = Math.abs(charges[1]);
                 let n2 = Math.abs(charges[0]);
 
-                let gcd = gcd(n1, n2);
+                let gcd = mathGcd(n1, n2);
                 n1 /= gcd;
                 n2 /= gcd;
 

--- a/packages/doenetml-worker-javascript/src/components/dynamicalSystems/ODESystem.js
+++ b/packages/doenetml-worker-javascript/src/components/dynamicalSystems/ODESystem.js
@@ -1,5 +1,6 @@
 import InlineComponent from "../abstract/InlineComponent";
 import me from "math-expressions";
+const { dopri } = me.math;
 import {
     returnSelectedStyleStateVariableDefinition,
     returnTextStyleDescriptionDefinitions,
@@ -863,7 +864,7 @@ export default class ODESystem extends InlineComponent {
                                     x0 = x0s;
                                 }
                                 let t0shifted = t0 + tind * chunkSize;
-                                let result = me.math.dopri(
+                                let result = dopri(
                                     t0shifted,
                                     t0shifted + chunkSize,
                                     x0,

--- a/packages/doenetml-worker-javascript/src/components/linearAlgebra/EigenDecomposition.js
+++ b/packages/doenetml-worker-javascript/src/components/linearAlgebra/EigenDecomposition.js
@@ -5,7 +5,7 @@ import {
 } from "../../utils/numberDisplay";
 import BaseComponent from "../abstract/BaseComponent";
 import me from "math-expressions";
-import { eigs, square, abs, divide } from "mathjs";
+const { eigs, square, abs, divide } = me.math;
 
 export default class EigenDecomposition extends BaseComponent {
     static componentType = "eigenDecomposition";

--- a/packages/doenetml-worker-javascript/src/components/linearAlgebra/EigenDecomposition.js
+++ b/packages/doenetml-worker-javascript/src/components/linearAlgebra/EigenDecomposition.js
@@ -5,6 +5,7 @@ import {
 } from "../../utils/numberDisplay";
 import BaseComponent from "../abstract/BaseComponent";
 import me from "math-expressions";
+import { eigs, square, abs, divide } from "mathjs";
 
 export default class EigenDecomposition extends BaseComponent {
     static componentType = "eigenDecomposition";
@@ -129,7 +130,7 @@ export default class EigenDecomposition extends BaseComponent {
 
                 let result;
                 try {
-                    result = me.math.eigs(matrixArray);
+                    result = eigs(matrixArray);
                 } catch (e) {
                     console.error(
                         "Could nt calculate eigenvalues of matrix",
@@ -355,10 +356,10 @@ export default class EigenDecomposition extends BaseComponent {
                             globalDependencyValues.decomposition.eigenvectors[i]
                                 .vector[j];
                         vector.push(val);
-                        vectorMag += me.math.square(me.math.abs(val));
+                        vectorMag += square(abs(val));
                     }
                     vectorMag = Math.sqrt(vectorMag);
-                    vector = vector.map((x) => me.math.divide(x, vectorMag));
+                    vector = vector.map((x) => divide(x, vectorMag));
 
                     for (let j = 0; j < arraySize[1]; j++) {
                         eigenvectors[`${i},${j}`] = vector[j];

--- a/packages/doenetml-worker-javascript/src/test/linearAlgebra/eigenDecomposition.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/linearAlgebra/eigenDecomposition.test.ts
@@ -3,6 +3,7 @@ import { createTestCore, ResolvePathToNodeIdx } from "../utils/test-core";
 //@ts-expect-error no type declaration
 import me from "math-expressions";
 import { PublicDoenetMLCore } from "../../CoreWorker";
+import { complex, conj, divide } from "mathjs";
 
 const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);
@@ -11,9 +12,9 @@ vi.mock("hyperformula");
 describe("EigenDecomposition Tag Tests @group1", async () => {
     function reviveComplex(num: number | { re: number; im: number }) {
         if (typeof num === "number") {
-            return me.math.complex({ re: num, im: 0 });
+            return complex({ re: num, im: 0 });
         } else {
-            return me.math.complex({ re: num.re, im: num.im });
+            return complex({ re: num.re, im: num.im });
         }
     }
 
@@ -202,7 +203,7 @@ describe("EigenDecomposition Tag Tests @group1", async () => {
                 .value.im,
         ).closeTo(-2, 1e-14);
 
-        let ratio = me.math.divide(
+        let ratio = divide(
             reviveComplex(
                 stateVariables[await resolvePathToNodeIdx("Bd")].stateValues
                     .eigenvectors[0][1],
@@ -214,7 +215,7 @@ describe("EigenDecomposition Tag Tests @group1", async () => {
         );
         expect(ratio.re).closeTo(0, 1e-14);
         expect(ratio.im).closeTo(1, 1e-14);
-        ratio = me.math.divide(
+        ratio = divide(
             reviveComplex(
                 stateVariables[await resolvePathToNodeIdx("Bd")].stateValues
                     .eigenvectors[1][1],
@@ -227,7 +228,7 @@ describe("EigenDecomposition Tag Tests @group1", async () => {
         expect(ratio.re).closeTo(0, 1e-14);
         expect(ratio.im).closeTo(-1, 1e-14);
 
-        ratio = me.math.divide(
+        ratio = divide(
             me
                 .fromAst(
                     stateVariables[await resolvePathToNodeIdx("Bevec1")]
@@ -244,7 +245,7 @@ describe("EigenDecomposition Tag Tests @group1", async () => {
         expect(ratio.re).closeTo(0, 1e-14);
         expect(ratio.im).closeTo(1, 1e-14);
 
-        ratio = me.math.divide(
+        ratio = divide(
             me
                 .fromAst(
                     stateVariables[await resolvePathToNodeIdx("Bevecsa[1]")]
@@ -261,7 +262,7 @@ describe("EigenDecomposition Tag Tests @group1", async () => {
         expect(ratio.re).closeTo(0, 1e-14);
         expect(ratio.im).closeTo(1, 1e-14);
 
-        ratio = me.math.divide(
+        ratio = divide(
             me
                 .fromAst(
                     stateVariables[await resolvePathToNodeIdx("Bevec2")]
@@ -278,7 +279,7 @@ describe("EigenDecomposition Tag Tests @group1", async () => {
         expect(ratio.re).closeTo(0, 1e-14);
         expect(ratio.im).closeTo(-1, 1e-14);
 
-        ratio = me.math.divide(
+        ratio = divide(
             me
                 .fromAst(
                     stateVariables[await resolvePathToNodeIdx("Bevecsa[2]")]
@@ -295,7 +296,7 @@ describe("EigenDecomposition Tag Tests @group1", async () => {
         expect(ratio.re).closeTo(0, 1e-14);
         expect(ratio.im).closeTo(-1, 1e-14);
 
-        ratio = me.math.divide(
+        ratio = divide(
             reviveComplex(
                 stateVariables[await resolvePathToNodeIdx("Bevec1y")]
                     .stateValues.value,
@@ -493,7 +494,7 @@ describe("EigenDecomposition Tag Tests @group1", async () => {
                 .value.im,
         ).closeTo(-2, 1e-14);
 
-        let ratio = me.math.divide(
+        let ratio = divide(
             reviveComplex(
                 stateVariables[await resolvePathToNodeIdx("Bd")].stateValues
                     .eigenvectors[0][1],
@@ -505,7 +506,7 @@ describe("EigenDecomposition Tag Tests @group1", async () => {
         );
         expect(ratio.re).closeTo(0, 1e-14);
         expect(ratio.im).closeTo(1, 1e-14);
-        ratio = me.math.divide(
+        ratio = divide(
             reviveComplex(
                 stateVariables[await resolvePathToNodeIdx("Bd")].stateValues
                     .eigenvectors[1][1],
@@ -518,7 +519,7 @@ describe("EigenDecomposition Tag Tests @group1", async () => {
         expect(ratio.re).closeTo(0, 1e-14);
         expect(ratio.im).closeTo(-1, 1e-14);
 
-        ratio = me.math.divide(
+        ratio = divide(
             me
                 .fromAst(
                     stateVariables[await resolvePathToNodeIdx("Bevec1")]
@@ -535,7 +536,7 @@ describe("EigenDecomposition Tag Tests @group1", async () => {
         expect(ratio.re).closeTo(0, 1e-14);
         expect(ratio.im).closeTo(1, 1e-14);
 
-        ratio = me.math.divide(
+        ratio = divide(
             me
                 .fromAst(
                     stateVariables[await resolvePathToNodeIdx("Bevecsa[1]")]
@@ -552,7 +553,7 @@ describe("EigenDecomposition Tag Tests @group1", async () => {
         expect(ratio.re).closeTo(0, 1e-14);
         expect(ratio.im).closeTo(1, 1e-14);
 
-        ratio = me.math.divide(
+        ratio = divide(
             me
                 .fromAst(
                     stateVariables[await resolvePathToNodeIdx("Bevec2")]
@@ -569,7 +570,7 @@ describe("EigenDecomposition Tag Tests @group1", async () => {
         expect(ratio.re).closeTo(0, 1e-14);
         expect(ratio.im).closeTo(-1, 1e-14);
 
-        ratio = me.math.divide(
+        ratio = divide(
             me
                 .fromAst(
                     stateVariables[await resolvePathToNodeIdx("Bevecsa[2]")]
@@ -586,7 +587,7 @@ describe("EigenDecomposition Tag Tests @group1", async () => {
         expect(ratio.re).closeTo(0, 1e-14);
         expect(ratio.im).closeTo(-1, 1e-14);
 
-        ratio = me.math.divide(
+        ratio = divide(
             reviveComplex(
                 stateVariables[await resolvePathToNodeIdx("Bevec1y")]
                     .stateValues.value,
@@ -673,11 +674,8 @@ describe("EigenDecomposition Tag Tests @group1", async () => {
             expect(actualEvals[i].im).closeTo(evals[i].im, 1e-12);
 
             for (let j = 1; j < n; j++) {
-                let ratio = me.math.divide(evecs[i][0], evecs[i][j]);
-                let actualRatio = me.math.divide(
-                    actualEvecs[i][0],
-                    actualEvecs[i][j],
-                );
+                let ratio = divide(evecs[i][0], evecs[i][j]);
+                let actualRatio = divide(actualEvecs[i][0], actualEvecs[i][j]);
                 expect(actualRatio.re).closeTo(ratio.re, 1e-12);
                 expect(actualRatio.im).closeTo(ratio.im, 1e-12);
             }
@@ -729,27 +727,27 @@ describe("EigenDecomposition Tag Tests @group1", async () => {
         });
 
         // Center
-        let evals = [me.math.complex({ re: 0, im: 14.78846823004614 })];
-        evals.push(me.math.conj(evals[0]));
-        evals.push(me.math.complex({ re: -22, im: 0 }));
+        let evals = [complex({ re: 0, im: 14.78846823004614 })];
+        evals.push(conj(evals[0]));
+        evals.push(complex({ re: -22, im: 0 }));
 
         let evecs = [
             [
-                me.math.complex({
+                complex({
                     re: -0.426486035260864,
                     im: -0.270682079730474,
                 }),
-                me.math.complex({ re: 0.627291349345459, im: 0 }),
-                me.math.complex({
+                complex({ re: 0.627291349345459, im: 0 }),
+                complex({
                     re: -0.173343062597144,
                     im: 0.566832090769437,
                 }),
             ],
         ];
-        evecs.push(evecs[0].map((v) => me.math.conj(v)));
+        evecs.push(evecs[0].map((v) => conj(v)));
         evecs.push(
             [-0.725759948499824, -0.487701621853287, -0.485200603044974].map(
-                (v) => me.math.complex({ re: v, im: 0 }),
+                (v) => complex({ re: v, im: 0 }),
             ),
         );
         await check_eigendecomposition({
@@ -762,30 +760,30 @@ describe("EigenDecomposition Tag Tests @group1", async () => {
 
         // Stable spiral
         evals = [
-            me.math.complex({ re: -0.048287227932923, im: 14.703099997319454 }),
-            me.math.complex({
+            complex({ re: -0.048287227932923, im: 14.703099997319454 }),
+            complex({
                 re: -0.048287227932923,
                 im: -14.703099997319454,
             }),
-            me.math.complex({ re: -21.903425544134173, im: 0 }),
+            complex({ re: -21.903425544134173, im: 0 }),
         ];
         evecs = [
             [
-                me.math.complex({
+                complex({
                     re: -0.427048386266709,
                     im: -0.269189626634008,
                 }),
-                me.math.complex({ re: 0.627621340142377, im: 0 }),
-                me.math.complex({
+                complex({ re: 0.627621340142377, im: 0 }),
+                complex({
                     re: -0.172635887510845,
                     im: 0.566969950209772,
                 }),
             ],
         ];
-        evecs.push(evecs[0].map((v) => me.math.conj(v)));
+        evecs.push(evecs[0].map((v) => conj(v)));
         evecs.push(
             [-0.726546459838247, -0.48712036969194, -0.484607044034337].map(
-                (v) => me.math.complex({ re: v, im: 0 }),
+                (v) => complex({ re: v, im: 0 }),
             ),
         );
 
@@ -799,27 +797,27 @@ describe("EigenDecomposition Tag Tests @group1", async () => {
 
         // Unstable spiral
         evals = [
-            me.math.complex({ re: 0.048306535292557, im: 14.873845525216694 }),
-            me.math.complex({ re: 0.048306535292557, im: -14.873845525216694 }),
-            me.math.complex({ re: -22.0966130705851, im: 0 }),
+            complex({ re: 0.048306535292557, im: 14.873845525216694 }),
+            complex({ re: 0.048306535292557, im: -14.873845525216694 }),
+            complex({ re: -22.0966130705851, im: 0 }),
         ];
         evecs = [
             [
-                me.math.complex({
+                complex({
                     re: -0.425927192657446,
                     im: -0.272156678632516,
                 }),
-                me.math.complex({ re: 0.626965239909586, im: 0 }),
-                me.math.complex({
+                complex({ re: 0.626965239909586, im: 0 }),
+                complex({
                     re: -0.174042517907594,
                     im: 0.566692649269571,
                 }),
             ],
         ];
-        evecs.push(evecs[0].map((v) => me.math.conj(v)));
+        evecs.push(evecs[0].map((v) => conj(v)));
         evecs.push(
             [-0.724981295406814, -0.488275620239871, -0.485787031516515].map(
-                (v) => me.math.complex({ re: v, im: 0 }),
+                (v) => complex({ re: v, im: 0 }),
             ),
         );
 

--- a/packages/doenetml-worker-javascript/src/test/linearAlgebra/eigenDecomposition.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/linearAlgebra/eigenDecomposition.test.ts
@@ -3,7 +3,16 @@ import { createTestCore, ResolvePathToNodeIdx } from "../utils/test-core";
 //@ts-expect-error no type declaration
 import me from "math-expressions";
 import { PublicDoenetMLCore } from "../../CoreWorker";
-import { complex, conj, divide } from "mathjs";
+import type {
+    complex as ComplexType,
+    conj as ConjType,
+    divide as DivideType,
+} from "mathjs";
+const { complex, conj, divide } = me.math as {
+    complex: ComplexType;
+    conj: ConjType;
+    divide: DivideType;
+};
 
 const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/evaluate.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/evaluate.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../utils/actions";
 import me from "math-expressions";
 import { getDiagnosticsByType } from "../utils/diagnostics";
+import { round } from "mathjs";
 
 const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);
@@ -3064,20 +3065,19 @@ describe("Evaluate tag tests @group2", async () => {
             stateVariables[
                 await resolvePathToNodeIdx("result_numeric")
             ].stateValues.value.tree.map((x) =>
-                typeof x === "number" && me.math.round(x, 10) === 0 ? 0 : x,
+                typeof x === "number" && round(x, 10) === 0 ? 0 : x,
             ),
         ).eqls(["vector", 0, -1]);
         expect(
             stateVariables[result_numeric2_name].stateValues.value.tree.map(
-                (x) =>
-                    typeof x === "number" && me.math.round(x, 10) === 0 ? 0 : x,
+                (x) => (typeof x === "number" && round(x, 10) === 0 ? 0 : x),
             ),
         ).eqls(["vector", 0, -1]);
         expect(
             stateVariables[
                 await resolvePathToNodeIdx("result_numeric3")
             ].stateValues.value.tree.map((x) =>
-                typeof x === "number" && me.math.round(x, 10) === 0 ? 0 : x,
+                typeof x === "number" && round(x, 10) === 0 ? 0 : x,
             ),
         ).eqls(["vector", 0, -1]);
         expect(
@@ -3093,7 +3093,7 @@ describe("Evaluate tag tests @group2", async () => {
             stateVariables[
                 await resolvePathToNodeIdx("result_force_numeric_symbolic")
             ].stateValues.value.tree.map((x) =>
-                typeof x === "number" && me.math.round(x, 10) === 0 ? 0 : x,
+                typeof x === "number" && round(x, 10) === 0 ? 0 : x,
             ),
         ).eqls(["vector", 0, -1]);
 
@@ -3210,20 +3210,19 @@ describe("Evaluate tag tests @group2", async () => {
             stateVariables[
                 await resolvePathToNodeIdx("result_numeric")
             ].stateValues.value.tree.map((x) =>
-                typeof x === "number" && me.math.round(x, 10) === 0 ? 0 : x,
+                typeof x === "number" && round(x, 10) === 0 ? 0 : x,
             ),
         ).eqls(["vector", 0, -1]);
         expect(
             stateVariables[result_numeric2_name].stateValues.value.tree.map(
-                (x) =>
-                    typeof x === "number" && me.math.round(x, 10) === 0 ? 0 : x,
+                (x) => (typeof x === "number" && round(x, 10) === 0 ? 0 : x),
             ),
         ).eqls(["vector", 0, -1]);
         expect(
             stateVariables[
                 await resolvePathToNodeIdx("result_numeric3")
             ].stateValues.value.tree.map((x) =>
-                typeof x === "number" && me.math.round(x, 10) === 0 ? 0 : x,
+                typeof x === "number" && round(x, 10) === 0 ? 0 : x,
             ),
         ).eqls(["vector", 0, -1]);
         expect(
@@ -3239,7 +3238,7 @@ describe("Evaluate tag tests @group2", async () => {
             stateVariables[
                 await resolvePathToNodeIdx("result_force_numeric_symbolic")
             ].stateValues.value.tree.map((x) =>
-                typeof x === "number" && me.math.round(x, 10) === 0 ? 0 : x,
+                typeof x === "number" && round(x, 10) === 0 ? 0 : x,
             ),
         ).eqls(["vector", 0, -1]);
     });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/evaluate.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/evaluate.test.ts
@@ -8,7 +8,8 @@ import {
 } from "../utils/actions";
 import me from "math-expressions";
 import { getDiagnosticsByType } from "../utils/diagnostics";
-import { round } from "mathjs";
+import type { round as RoundType } from "mathjs";
+const { round } = me.math as { round: RoundType };
 
 const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/functioniterates.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/functioniterates.test.ts
@@ -5,6 +5,7 @@ import { updateMathInputValue } from "../utils/actions";
 import me from "math-expressions";
 import { PublicDoenetMLCore } from "../../CoreWorker";
 import { getDiagnosticsByType } from "../utils/diagnostics";
+import { index, matrix, multiply, subset } from "mathjs";
 
 const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);
@@ -282,20 +283,20 @@ describe("FunctionIterates tag tests @group2", async () => {
                 true,
             );
 
-            let A = me.math.matrix([
+            let A = matrix([
                 [a, b],
                 [c, d],
             ]);
-            let x = me.math.matrix([[u1], [u2]]);
+            let x = matrix([[u1], [u2]]);
 
             let iterNames = stateVariables[
                 await resolvePathToNodeIdx("iterates")
             ].replacements!.map((x) => x.componentIdx);
 
             for (let i = 0; i < n; i++) {
-                x = me.math.multiply(A, x);
-                let x1 = me.math.subset(x, me.math.index(0, 0));
-                let x2 = me.math.subset(x, me.math.index(1, 0));
+                x = multiply(A, x);
+                let x1 = subset(x, index(0, 0));
+                let x2 = subset(x, index(1, 0));
                 expect(
                     stateVariables[iterNames[i]].stateValues.value.tree,
                 ).eqls(["vector", x1, x2]);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/functioniterates.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/functioniterates.test.ts
@@ -5,7 +5,18 @@ import { updateMathInputValue } from "../utils/actions";
 import me from "math-expressions";
 import { PublicDoenetMLCore } from "../../CoreWorker";
 import { getDiagnosticsByType } from "../utils/diagnostics";
-import { index, matrix, multiply, subset } from "mathjs";
+import type {
+    index as IndexType,
+    matrix as MatrixType,
+    multiply as MultiplyType,
+    subset as SubsetType,
+} from "mathjs";
+const { index, matrix, multiply, subset } = me.math as {
+    index: IndexType;
+    matrix: MatrixType;
+    multiply: MultiplyType;
+    subset: SubsetType;
+};
 
 const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/functionoperators.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/functionoperators.test.ts
@@ -3,6 +3,7 @@ import { createTestCore, ResolvePathToNodeIdx } from "../utils/test-core";
 import { movePoint, updateMathInputValue } from "../utils/actions";
 import me from "math-expressions";
 import { PublicDoenetMLCore } from "../../CoreWorker";
+import { mod, round } from "mathjs";
 
 const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);
@@ -151,8 +152,8 @@ describe("Function Operator tag tests @group1", async () => {
             symbolic: true,
             f1Markup: `<wrapFunctionPeriodic name="f1" domain="[-2,2]">$f</wrapFunctionPeriodic>`,
             f2Markup: `<wrapFunctionPeriodic name="f2" lowerValue="-2" upperValue="3" domain="[-2,2]">$f</wrapFunctionPeriodic>`,
-            fop1: (x) => me.math.mod(x, 1),
-            fop2: (x) => -2 + me.math.mod(x + 2, 5),
+            fop1: (x) => mod(x, 1),
+            fop2: (x) => -2 + mod(x + 2, 5),
         });
     });
 
@@ -163,8 +164,8 @@ describe("Function Operator tag tests @group1", async () => {
             symbolic: false,
             f1Markup: `<wrapFunctionPeriodic name="f1" domain="[-2,2]">$f</wrapFunctionPeriodic>`,
             f2Markup: `<wrapFunctionPeriodic name="f2" lowerValue="-2" upperValue="3" domain="[-2,2]">$f</wrapFunctionPeriodic>`,
-            fop1: (x) => me.math.mod(x, 1),
-            fop2: (x) => -2 + me.math.mod(x + 2, 5),
+            fop1: (x) => mod(x, 1),
+            fop2: (x) => -2 + mod(x + 2, 5),
         });
     });
 
@@ -3569,20 +3570,20 @@ describe("Function Operator tag tests @group1", async () => {
             expect(
                 stateVariables[await resolvePathToNodeIdx("min[1]")].stateValues
                     .text,
-            ).eq(`( ${minima[0][0]}, ${me.math.round(minima[0][1], 5)} )`);
+            ).eq(`( ${minima[0][0]}, ${round(minima[0][1], 5)} )`);
             expect(
                 stateVariables[await resolvePathToNodeIdx("min2[1]")]
                     .stateValues.text,
-            ).eq(`( ${minima[0][0]}, ${me.math.round(minima[0][1], 5)} )`);
+            ).eq(`( ${minima[0][0]}, ${round(minima[0][1], 5)} )`);
             if (nMinima === 2) {
                 expect(
                     stateVariables[await resolvePathToNodeIdx("min[2]")]
                         .stateValues.text,
-                ).eq(`( ${minima[1][0]}, ${me.math.round(minima[1][1], 5)} )`);
+                ).eq(`( ${minima[1][0]}, ${round(minima[1][1], 5)} )`);
                 expect(
                     stateVariables[await resolvePathToNodeIdx("min2[2]")]
                         .stateValues.text,
-                ).eq(`( ${minima[1][0]}, ${me.math.round(minima[1][1], 5)} )`);
+                ).eq(`( ${minima[1][0]}, ${round(minima[1][1], 5)} )`);
             } else {
                 expect(stateVariables[await resolvePathToNodeIdx("min[2]")]).eq(
                     undefined,
@@ -3604,20 +3605,20 @@ describe("Function Operator tag tests @group1", async () => {
             expect(
                 stateVariables[await resolvePathToNodeIdx("max[1]")].stateValues
                     .text,
-            ).eq(`( ${maxima[0][0]}, ${me.math.round(maxima[0][1], 5)} )`);
+            ).eq(`( ${maxima[0][0]}, ${round(maxima[0][1], 5)} )`);
             expect(
                 stateVariables[await resolvePathToNodeIdx("max2[1]")]
                     .stateValues.text,
-            ).eq(`( ${maxima[0][0]}, ${me.math.round(maxima[0][1], 5)} )`);
+            ).eq(`( ${maxima[0][0]}, ${round(maxima[0][1], 5)} )`);
             if (nMaxima === 2) {
                 expect(
                     stateVariables[await resolvePathToNodeIdx("max[2]")]
                         .stateValues.text,
-                ).eq(`( ${maxima[1][0]}, ${me.math.round(maxima[1][1], 5)} )`);
+                ).eq(`( ${maxima[1][0]}, ${round(maxima[1][1], 5)} )`);
                 expect(
                     stateVariables[await resolvePathToNodeIdx("max2[2]")]
                         .stateValues.text,
-                ).eq(`( ${maxima[1][0]}, ${me.math.round(maxima[1][1], 5)} )`);
+                ).eq(`( ${maxima[1][0]}, ${round(maxima[1][1], 5)} )`);
             } else {
                 expect(stateVariables[await resolvePathToNodeIdx("max[2]")]).eq(
                     undefined,
@@ -3805,32 +3806,32 @@ describe("Function Operator tag tests @group1", async () => {
         expect(
             stateVariables[await resolvePathToNodeIdx("max[1]")].stateValues
                 .text,
-        ).eq(`( ${max1x}, ${me.math.round(fp(max1x), 5)} )`);
+        ).eq(`( ${max1x}, ${round(fp(max1x), 5)} )`);
         expect(
             stateVariables[await resolvePathToNodeIdx("max2[1]")].stateValues
                 .text,
-        ).eq(`( ${max1x}, ${me.math.round(fp(max1x), 5)} )`);
+        ).eq(`( ${max1x}, ${round(fp(max1x), 5)} )`);
 
         let min1x = (-3 + 0) / 2;
 
         expect(
             stateVariables[await resolvePathToNodeIdx("min[1]")].stateValues
                 .text,
-        ).eq(`( ${min1x}, ${me.math.round(fp(min1x), 5)} )`);
+        ).eq(`( ${min1x}, ${round(fp(min1x), 5)} )`);
         expect(
             stateVariables[await resolvePathToNodeIdx("min2[1]")].stateValues
                 .text,
-        ).eq(`( ${min1x}, ${me.math.round(fp(min1x), 5)} )`);
+        ).eq(`( ${min1x}, ${round(fp(min1x), 5)} )`);
 
         let max2x = (0 + 6) / 2;
         expect(
             stateVariables[await resolvePathToNodeIdx("max[2]")].stateValues
                 .text,
-        ).eq(`( ${max2x}, ${me.math.round(fp(max2x), 5)} )`);
+        ).eq(`( ${max2x}, ${round(fp(max2x), 5)} )`);
         expect(
             stateVariables[await resolvePathToNodeIdx("max2[2]")].stateValues
                 .text,
-        ).eq(`( ${max2x}, ${me.math.round(fp(max2x), 5)} )`);
+        ).eq(`( ${max2x}, ${round(fp(max2x), 5)} )`);
     });
 
     it("handle no child", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/functionoperators.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/functionoperators.test.ts
@@ -3,7 +3,8 @@ import { createTestCore, ResolvePathToNodeIdx } from "../utils/test-core";
 import { movePoint, updateMathInputValue } from "../utils/actions";
 import me from "math-expressions";
 import { PublicDoenetMLCore } from "../../CoreWorker";
-import { mod, round } from "mathjs";
+import type { mod as ModType, round as RoundType } from "mathjs";
+const { mod, round } = me.math as { mod: ModType; round: RoundType };
 
 const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/mathoperators.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/mathoperators.test.ts
@@ -3,7 +3,16 @@ import { createTestCore } from "../utils/test-core";
 import me from "math-expressions";
 import { movePoint, updateMathInputValue } from "../utils/actions";
 import { getDiagnosticsByType } from "../utils/diagnostics";
-import { mod, std, variance } from "mathjs";
+import type {
+    mod as ModType,
+    std as StdType,
+    variance as VarianceType,
+} from "mathjs";
+const { mod, std, variance } = me.math as {
+    mod: ModType;
+    std: StdType;
+    variance: VarianceType;
+};
 
 const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/mathoperators.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/mathoperators.test.ts
@@ -3,6 +3,7 @@ import { createTestCore } from "../utils/test-core";
 import me from "math-expressions";
 import { movePoint, updateMathInputValue } from "../utils/actions";
 import { getDiagnosticsByType } from "../utils/diagnostics";
+import { mod, std, variance } from "mathjs";
 
 const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);
@@ -2636,7 +2637,7 @@ describe("Math operator tests @group2", async () => {
         });
 
         let clamp = (x) => Math.min(5, Math.max(-2, x));
-        let wrap = (x) => -2 + me.math.mod(x + 2, 7);
+        let wrap = (x) => -2 + mod(x + 2, 7);
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         let x = 6,
@@ -4749,7 +4750,7 @@ describe("Math operator tests @group2", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
 
-        let theVariance = me.math.variance([3, 17, 1]);
+        let theVariance = variance([3, 17, 1]);
         let theVarianceString = theVariance.toString();
 
         expect(
@@ -4874,7 +4875,7 @@ describe("Math operator tests @group2", async () => {
         expect(
             stateVariables[await resolvePathToNodeIdx("withNumberVariance")]
                 .stateValues.value.tree,
-        ).eq(me.math.variance([3, me.math.variance([17, 1])]));
+        ).eq(variance([3, variance([17, 1])]));
         expect(
             stateVariables[await resolvePathToNodeIdx("withNumberVariance")]
                 .stateValues.isNumericOperator,
@@ -4968,7 +4969,7 @@ describe("Math operator tests @group2", async () => {
       `,
         });
 
-        let theVariance = me.math.variance([3, 17, 1]);
+        let theVariance = variance([3, 17, 1]);
         let theVarianceString = theVariance.toString();
 
         let stateVariables = await core.returnAllStateVariables(false, true);
@@ -5314,8 +5315,8 @@ describe("Math operator tests @group2", async () => {
       `,
         });
 
-        let theVariance = me.math.variance([3, 17, 1]);
-        let theVariance2 = me.math.variance([3, 17, 1, 3, 17, 13]);
+        let theVariance = variance([3, 17, 1]);
+        let theVariance2 = variance([3, 17, 1, 3, 17, 13]);
 
         let stateVariables = await core.returnAllStateVariables(false, true);
 
@@ -5508,8 +5509,8 @@ describe("Math operator tests @group2", async () => {
     `,
         });
 
-        let variancePrimes = me.math.variance(2, 3, 5, 7);
-        let variance100 = me.math.variance(
+        let variancePrimes = variance(2, 3, 5, 7);
+        let variance100 = variance(
             Array.from({ length: 100 }, (_, i) => i + 1),
         );
 
@@ -5568,7 +5569,7 @@ describe("Math operator tests @group2", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
 
-        let theVariance = me.math.variance([4, 16, 1], "uncorrected");
+        let theVariance = variance([4, 16, 1], "uncorrected");
 
         expect(
             stateVariables[await resolvePathToNodeIdx("numbers")].stateValues
@@ -5692,12 +5693,7 @@ describe("Math operator tests @group2", async () => {
         expect(
             stateVariables[await resolvePathToNodeIdx("withNumberVariance")]
                 .stateValues.value.tree,
-        ).eq(
-            me.math.variance(
-                [4, me.math.variance([17, 1], "uncorrected")],
-                "uncorrected",
-            ),
-        );
+        ).eq(variance([4, variance([17, 1], "uncorrected")], "uncorrected"));
         expect(
             stateVariables[await resolvePathToNodeIdx("withNumberVariance")]
                 .stateValues.isNumericOperator,
@@ -5772,8 +5768,8 @@ describe("Math operator tests @group2", async () => {
     `,
         });
 
-        let variancePrimes = me.math.variance([2, 3, 5, 7], "uncorrected");
-        let variance100 = me.math.variance(
+        let variancePrimes = variance([2, 3, 5, 7], "uncorrected");
+        let variance100 = variance(
             Array.from({ length: 100 }, (_, i) => i + 1),
             "uncorrected",
         );
@@ -5833,7 +5829,7 @@ describe("Math operator tests @group2", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
 
-        let thestandardDeviation = me.math.std([3, 17, 1]);
+        let thestandardDeviation = std([3, 17, 1]);
 
         expect(
             stateVariables[await resolvePathToNodeIdx("numbers")].stateValues
@@ -5958,7 +5954,7 @@ describe("Math operator tests @group2", async () => {
             stateVariables[
                 await resolvePathToNodeIdx("withNumberstandardDeviation")
             ].stateValues.value.tree,
-        ).closeTo(me.math.std([3, me.math.std([17, 1])]), 1e-12);
+        ).closeTo(std([3, std([17, 1])]), 1e-12);
         expect(
             stateVariables[
                 await resolvePathToNodeIdx("withNumberstandardDeviation")
@@ -6067,7 +6063,7 @@ describe("Math operator tests @group2", async () => {
       `,
         });
 
-        let theStd = me.math.std([13, 25, 1]);
+        let theStd = std([13, 25, 1]);
         let theStdString = theStd.toString();
 
         let stateVariables = await core.returnAllStateVariables(false, true);
@@ -6210,8 +6206,8 @@ describe("Math operator tests @group2", async () => {
     `,
         });
 
-        let stdPrimes = me.math.std(2, 3, 5, 7);
-        let std100 = me.math.std(Array.from({ length: 100 }, (_, i) => i + 1));
+        let stdPrimes = std(2, 3, 5, 7);
+        let std100 = std(Array.from({ length: 100 }, (_, i) => i + 1));
 
         let stateVariables = await core.returnAllStateVariables(false, true);
         expect(
@@ -6269,7 +6265,7 @@ describe("Math operator tests @group2", async () => {
 
         let stateVariables = await core.returnAllStateVariables(false, true);
 
-        let thestandardDeviation = me.math.std([4, 16, 1], "uncorrected");
+        let thestandardDeviation = std([4, 16, 1], "uncorrected");
 
         expect(
             stateVariables[await resolvePathToNodeIdx("numbers")].stateValues
@@ -6394,13 +6390,7 @@ describe("Math operator tests @group2", async () => {
             stateVariables[
                 await resolvePathToNodeIdx("withNumberstandardDeviation")
             ].stateValues.value.tree,
-        ).closeTo(
-            me.math.std(
-                [3, me.math.std([17, 1], "uncorrected")],
-                "uncorrected",
-            ),
-            1e-12,
-        );
+        ).closeTo(std([3, std([17, 1], "uncorrected")], "uncorrected"), 1e-12);
         expect(
             stateVariables[
                 await resolvePathToNodeIdx("withNumberstandardDeviation")
@@ -6477,8 +6467,8 @@ describe("Math operator tests @group2", async () => {
     `,
         });
 
-        let stdPrimes = me.math.std([2, 3, 5, 7], "uncorrected");
-        let std100 = me.math.std(
+        let stdPrimes = std([2, 3, 5, 7], "uncorrected");
+        let std100 = std(
             Array.from({ length: 100 }, (_, i) => i + 1),
             "uncorrected",
         );

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/selectsamplerandomnumbers.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/selectsamplerandomnumbers.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../utils/actions";
 import me from "math-expressions";
 import { PublicDoenetMLCore } from "../../CoreWorker";
+import { mean, variance } from "mathjs";
 
 const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);
@@ -100,7 +101,7 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests @group4", async 
                     allowedMeanMid !== undefined &&
                     allowedMeanSpread !== undefined
                 ) {
-                    let meanX = me.math.mean(samples);
+                    let meanX = mean(samples);
                     if (Math.abs(meanX - allowedMeanMid) >= allowedMeanSpread) {
                         failedCriteria = true;
                     }
@@ -110,7 +111,7 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests @group4", async 
                     allowedVarianceMid !== undefined &&
                     allowedVarianceSpread !== undefined
                 ) {
-                    let varX = me.math.variance(samples, "uncorrected");
+                    let varX = variance(samples, "uncorrected");
                     if (
                         Math.abs(varX - allowedVarianceMid) >=
                         allowedVarianceSpread
@@ -156,7 +157,7 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests @group4", async 
         }
 
         if (allowedMeanMid !== undefined && allowedMeanSpread !== undefined) {
-            let meanX = me.math.mean(samples);
+            let meanX = mean(samples);
             expect(meanX).closeTo(allowedMeanMid, allowedMeanSpread);
         }
 
@@ -164,7 +165,7 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests @group4", async 
             allowedVarianceMid !== undefined &&
             allowedVarianceSpread !== undefined
         ) {
-            let varX = me.math.variance(samples, "uncorrected");
+            let varX = variance(samples, "uncorrected");
             expect(varX).closeTo(allowedVarianceMid, allowedVarianceSpread);
         }
     }
@@ -594,8 +595,8 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests @group4", async 
         ];
 
         let vals = [-3, -1, 1, 2, 3, 4, 5];
-        let mean = me.math.mean(vals);
-        let variance = me.math.variance(vals, "uncorrected");
+        let mean = mean(vals);
+        let variance = variance(vals, "uncorrected");
 
         for (let doenetML of doenetMLs) {
             await test_combined_statistics({
@@ -621,8 +622,8 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests @group4", async 
         ];
 
         let vals = [-3, -1, 1, 5];
-        let mean = me.math.mean(vals);
-        let variance = me.math.variance(vals, "uncorrected");
+        let mean = mean(vals);
+        let variance = variance(vals, "uncorrected");
 
         for (let doenetML of doenetMLs) {
             await test_combined_statistics({
@@ -835,14 +836,14 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests @group4", async 
             expect(num).lt(10);
         }
 
-        expect(me.math.mean(sample1numbers)).closeTo(5, 2);
-        expect(me.math.variance(sample1numbers, "uncorrected")).closeTo(
+        expect(mean(sample1numbers)).closeTo(5, 2);
+        expect(variance(sample1numbers, "uncorrected")).closeTo(
             10 ** 2 / 12,
             4,
         );
 
-        expect(me.math.mean(sample2numbers)).closeTo(0, 1.5);
-        expect(me.math.variance(sample2numbers, "uncorrected")).closeTo(16, 8);
+        expect(mean(sample2numbers)).closeTo(0, 1.5);
+        expect(variance(sample2numbers, "uncorrected")).closeTo(16, 8);
 
         // Get new samples when change number of samples
         await updateMathInputValue({
@@ -881,14 +882,14 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests @group4", async 
             expect(num).lt(10);
         }
 
-        expect(me.math.mean(sample1numbersb)).closeTo(5, 2);
-        expect(me.math.variance(sample1numbersb, "uncorrected")).closeTo(
+        expect(mean(sample1numbersb)).closeTo(5, 2);
+        expect(variance(sample1numbersb, "uncorrected")).closeTo(
             10 ** 2 / 12,
             4,
         );
 
-        expect(me.math.mean(sample2numbersb)).closeTo(0, 1.5);
-        expect(me.math.variance(sample2numbersb, "uncorrected")).closeTo(16, 8);
+        expect(mean(sample2numbersb)).closeTo(0, 1.5);
+        expect(variance(sample2numbersb, "uncorrected")).closeTo(16, 8);
 
         for (let ind = 0; ind < 10; ind++) {
             expect(sample1numbersb[ind]).not.eq(sample1numbers[ind]);
@@ -933,17 +934,14 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests @group4", async 
             expect(num).gte(0);
             expect(num).lt(4);
         }
-        expect(me.math.mean(sample1numbersc)).closeTo(2, 1);
-        expect(me.math.variance(sample1numbersc, "uncorrected")).closeTo(
+        expect(mean(sample1numbersc)).closeTo(2, 1);
+        expect(variance(sample1numbersc, "uncorrected")).closeTo(
             4 ** 2 / 12,
             1,
         );
 
-        expect(me.math.mean(sample2numbersc)).closeTo(0, 6);
-        expect(me.math.variance(sample2numbersc, "uncorrected")).closeTo(
-            18 ** 2,
-            150,
-        );
+        expect(mean(sample2numbersc)).closeTo(0, 6);
+        expect(variance(sample2numbersc, "uncorrected")).closeTo(18 ** 2, 150);
 
         for (let ind = 0; ind < 10; ind++) {
             expect(sample1numbersc[ind]).not.eq(sample1numbersb[ind]);
@@ -1572,8 +1570,8 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests @group4", async 
                 ].stateValues.value,
             ).closeTo(expectedStandardDeviation, 1e-12);
 
-            let resultingMean = me.math.mean(samples);
-            let resultingVariance = me.math.variance(samples);
+            let resultingMean = mean(samples);
+            let resultingVariance = variance(samples);
             let resultingStandardDeviation = Math.sqrt(resultingVariance);
 
             expect(

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/selectsamplerandomnumbers.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/selectsamplerandomnumbers.test.ts
@@ -599,8 +599,8 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests @group4", async 
         ];
 
         let vals = [-3, -1, 1, 2, 3, 4, 5];
-        let mean = mean(vals);
-        let variance = variance(vals, "uncorrected");
+        const computedMean = mean(vals);
+        const computedVariance = variance(vals, "uncorrected");
 
         for (let doenetML of doenetMLs) {
             await test_combined_statistics({
@@ -609,12 +609,12 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests @group4", async 
                 numSamplesPerComponent: 5,
                 numRepetitions: 5,
                 validValues: vals,
-                allowedMeanMid: mean,
+                allowedMeanMid: computedMean,
                 allowedMeanSpread: 0.6,
-                allowedVarianceMid: variance,
+                allowedVarianceMid: computedVariance,
                 allowedVarianceSpread: 1,
-                expectedMean: mean,
-                expectedVariance: variance,
+                expectedMean: computedMean,
+                expectedVariance: computedVariance,
             });
         }
     });
@@ -626,8 +626,8 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests @group4", async 
         ];
 
         let vals = [-3, -1, 1, 5];
-        let mean = mean(vals);
-        let variance = variance(vals, "uncorrected");
+        const computedMean = mean(vals);
+        const computedVariance = variance(vals, "uncorrected");
 
         for (let doenetML of doenetMLs) {
             await test_combined_statistics({
@@ -636,12 +636,12 @@ describe("SelectRandomNumbers and SampleRandomNumbers tag tests @group4", async 
                 numSamplesPerComponent: 10,
                 numRepetitions: 5,
                 validValues: vals,
-                allowedMeanMid: mean,
+                allowedMeanMid: computedMean,
                 allowedMeanSpread: 0.5,
-                allowedVarianceMid: variance,
+                allowedVarianceMid: computedVariance,
                 allowedVarianceSpread: 1,
-                expectedMean: mean,
-                expectedVariance: variance,
+                expectedMean: computedMean,
+                expectedVariance: computedVariance,
             });
         }
     });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/selectsamplerandomnumbers.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/selectsamplerandomnumbers.test.ts
@@ -7,7 +7,11 @@ import {
 } from "../utils/actions";
 import me from "math-expressions";
 import { PublicDoenetMLCore } from "../../CoreWorker";
-import { mean, variance } from "mathjs";
+import type { mean as MeanType, variance as VarianceType } from "mathjs";
+const { mean, variance } = me.math as {
+    mean: MeanType;
+    variance: VarianceType;
+};
 
 const Mock = vi.fn();
 vi.stubGlobal("postMessage", Mock);

--- a/packages/doenetml-worker-javascript/src/utils/constraintUtils.js
+++ b/packages/doenetml-worker-javascript/src/utils/constraintUtils.js
@@ -1,5 +1,5 @@
 import me from "math-expressions";
-import { mod } from "mathjs";
+const { mod } = me.math;
 
 // Attract the points to the line determined numericalNearestPointAsLineFunction.
 // Succeed only if each point moved less than the distance determined by threshold2.

--- a/packages/doenetml-worker-javascript/src/utils/constraintUtils.js
+++ b/packages/doenetml-worker-javascript/src/utils/constraintUtils.js
@@ -1,4 +1,5 @@
 import me from "math-expressions";
+import { mod } from "mathjs";
 
 // Attract the points to the line determined numericalNearestPointAsLineFunction.
 // Succeed only if each point moved less than the distance determined by threshold2.
@@ -142,7 +143,7 @@ function findAttractedSegmentPoints({
             Math.atan2(original_rel[1], original_rel[0]);
 
         // make dTheta be between -pi and pi
-        dTheta = me.math.mod(dTheta + Math.PI, 2 * Math.PI) - Math.PI;
+        dTheta = mod(dTheta + Math.PI, 2 * Math.PI) - Math.PI;
 
         // we had a rotation, so don't attract
         if (Math.abs(dTheta) > eps) {

--- a/packages/doenetml-worker-javascript/src/utils/periodicSetEquality.js
+++ b/packages/doenetml-worker-javascript/src/utils/periodicSetEquality.js
@@ -1,4 +1,5 @@
 import me from "math-expressions";
+import { mod, min, fraction, number as mathNumber } from "mathjs";
 
 export default function periodicSetEquality(
     expr,
@@ -99,11 +100,9 @@ export default function periodicSetEquality(
         );
 
         // use me.math.mod rather than % so it always non-negative
-        let offset_diff = me.math.mod(number_list[0] - offset, period);
+        let offset_diff = mod(number_list[0] - offset, period);
 
-        if (
-            !(me.math.min(offset_diff, period - offset_diff) < 1e-10 * period)
-        ) {
+        if (!(min(offset_diff, period - offset_diff) < 1e-10 * period)) {
             return false;
         }
 
@@ -267,14 +266,14 @@ function contained_in(tree, i_set, match_partial) {
 
         if (typeof period !== "number" || Number.isNaN(period)) return false;
 
-        let frac = me.math.fraction(period);
-        let p = me.math.number(frac.n);
+        let frac = fraction(period);
+        let p = mathNumber(frac.n);
 
         if (p > 1000) {
             return false;
         }
 
-        let q = me.math.number(frac.d);
+        let q = mathNumber(frac.d);
         data.push([p, q, offset, period]);
     }
 
@@ -296,9 +295,9 @@ function contained_in(tree, i_set, match_partial) {
 
         if (Number.isFinite(offset_diff) && Number.isFinite(period)) {
             // use me.math.mod rather than % so it always non-negative
-            offset_diff = me.math.mod(offset_diff, period);
+            offset_diff = mod(offset_diff, period);
 
-            if (me.math.min(offset_diff, period - offset_diff) < 1e-10 * period)
+            if (min(offset_diff, period - offset_diff) < 1e-10 * period)
                 return true;
         }
         data.splice(0, 1); // remove first entry from data
@@ -335,10 +334,10 @@ function contained_in(tree, i_set, match_partial) {
 
                 // use me.math.mod rather than % so it always non-negative
                 if (Number.isFinite(offset_diff) && Number.isFinite(period)) {
-                    offset_diff = me.math.mod(offset_diff, period);
+                    offset_diff = mod(offset_diff, period);
 
                     if (
-                        me.math.min(offset_diff, period - offset_diff) <
+                        min(offset_diff, period - offset_diff) <
                         1e-10 * period
                     ) {
                         for (let k = 0; k < m; k++) {

--- a/packages/doenetml-worker-javascript/src/utils/periodicSetEquality.js
+++ b/packages/doenetml-worker-javascript/src/utils/periodicSetEquality.js
@@ -1,5 +1,5 @@
 import me from "math-expressions";
-import { mod, min, fraction, number as mathNumber } from "mathjs";
+const { mod, min, fraction, number: mathNumber } = me.math;
 
 export default function periodicSetEquality(
     expr,

--- a/packages/doenetml/src/Viewer/renderers/pegboard.tsx
+++ b/packages/doenetml/src/Viewer/renderers/pegboard.tsx
@@ -5,7 +5,8 @@ import useDoenetRenderer, {
 } from "../useDoenetRenderer";
 import { BASE_LAYER_OFFSET, BoardContext } from "./graph";
 import me from "math-expressions";
-import { round } from "mathjs";
+import type { round as RoundType } from "mathjs";
+const { round } = me.math as { round: RoundType };
 import { JXGPoint } from "./jsxgraph-distrib/types";
 
 interface PegboardSVs {

--- a/packages/doenetml/src/Viewer/renderers/pegboard.tsx
+++ b/packages/doenetml/src/Viewer/renderers/pegboard.tsx
@@ -5,6 +5,7 @@ import useDoenetRenderer, {
 } from "../useDoenetRenderer";
 import { BASE_LAYER_OFFSET, BoardContext } from "./graph";
 import me from "math-expressions";
+import { round } from "mathjs";
 import { JXGPoint } from "./jsxgraph-distrib/types";
 
 interface PegboardSVs {
@@ -74,10 +75,10 @@ export default React.memo(function Pegboard(props: UseDoenetRendererProps) {
         let yind2 = (yMax - yoffset.current) / dy.current;
 
         // Note: use round from mathjs so that it rounds -0.5 to -1, not 0.
-        let minXind = me.math.round(Math.min(xind1, xind2) + 1);
-        let maxXind = me.math.round(Math.max(xind1, xind2) - 1);
-        let minYind = me.math.round(Math.min(yind1, yind2) + 1);
-        let maxYind = me.math.round(Math.max(yind1, yind2) - 1);
+        let minXind = round(Math.min(xind1, xind2) + 1);
+        let maxXind = round(Math.max(xind1, xind2) - 1);
+        let minYind = round(Math.min(yind1, yind2) + 1);
+        let maxYind = round(Math.max(yind1, yind2) - 1);
 
         previousBounds.current = [minXind, maxXind, minYind, maxYind];
 
@@ -116,10 +117,10 @@ export default React.memo(function Pegboard(props: UseDoenetRendererProps) {
             let yind2 = (yMax - yoffset.current) / dy.current;
 
             // Note: use round from mathjs so that it rounds -0.5 to -1, not 0.
-            let minXind = me.math.round(Math.min(xind1, xind2) + 1);
-            let maxXind = me.math.round(Math.max(xind1, xind2) - 1);
-            let minYind = me.math.round(Math.min(yind1, yind2) + 1);
-            let maxYind = me.math.round(Math.max(yind1, yind2) - 1);
+            let minXind = round(Math.min(xind1, xind2) + 1);
+            let maxXind = round(Math.max(xind1, xind2) - 1);
+            let minYind = round(Math.min(yind1, yind2) + 1);
+            let maxYind = round(Math.max(yind1, yind2) - 1);
 
             let [prevXmin, prevXmax, prevYmin, prevYmax] =
                 previousBounds.current!;
@@ -253,10 +254,10 @@ export default React.memo(function Pegboard(props: UseDoenetRendererProps) {
             let yind2 = (yMax - yoffset.current) / dy.current;
 
             // Note: use round from mathjs so that it rounds -0.5 to -1, not 0.
-            let minXind = me.math.round(Math.min(xind1, xind2) + 1);
-            let maxXind = me.math.round(Math.max(xind1, xind2) - 1);
-            let minYind = me.math.round(Math.min(yind1, yind2) + 1);
-            let maxYind = me.math.round(Math.max(yind1, yind2) - 1);
+            let minXind = round(Math.min(xind1, xind2) + 1);
+            let maxXind = round(Math.max(xind1, xind2) - 1);
+            let minYind = round(Math.min(yind1, yind2) + 1);
+            let maxYind = round(Math.max(yind1, yind2) - 1);
 
             recalculatePegboard(minXind, maxXind, minYind, maxYind);
 

--- a/packages/utils/src/components/enumeration.ts
+++ b/packages/utils/src/components/enumeration.ts
@@ -1,6 +1,6 @@
 import me from "math-expressions";
 import type { gcd as GcdType, lcm as LcmType } from "mathjs";
-const { gcd, lcm: mathLcm } = me.math as { gcd: GcdType; lcm: LcmType };
+const { gcd, lcm } = me.math as { gcd: typeof GcdType; lcm: typeof LcmType };
 
 // Enumerates the unique combinations of repeeated selecting an index
 // from the same set of options, with or without replacement
@@ -119,13 +119,13 @@ export function enumerateCombinations({
     // then shift second index and run sequentially for another lcm
     // if continue gcd times, will have all combinations
     if (numberOfIndices === 2) {
-        let gcd = maxGCD;
-        let lcm = mathLcm(...numberOfOptionsByIndex);
+        const gcdValue = maxGCD;
+        let computedLcm = lcm(...numberOfOptionsByIndex);
 
         let results = [];
         let numberSoFar = 0;
-        for (let offset = 0; offset < gcd; offset++) {
-            for (let ind = 0; ind < lcm; ind++) {
+        for (let offset = 0; offset < gcdValue; offset++) {
+            for (let ind = 0; ind < computedLcm; ind++) {
                 let r = [
                     ind % numberOfOptionsByIndex[0],
                     (ind + offset) % numberOfOptionsByIndex[1],
@@ -153,7 +153,7 @@ export function enumerateCombinations({
         for (let ind2 = 0; ind2 < ind1; ind2++) {
             if (gcds[ind1][ind2] > 1) {
                 m.push(
-                    mathLcm(
+                    lcm(
                         numberOfOptionsByIndex[ind1],
                         numberOfOptionsByIndex[ind2],
                     ),

--- a/packages/utils/src/components/enumeration.ts
+++ b/packages/utils/src/components/enumeration.ts
@@ -1,5 +1,6 @@
 import me from "math-expressions";
-import { gcd, lcm as mathLcm } from "mathjs";
+import type { gcd as GcdType, lcm as LcmType } from "mathjs";
+const { gcd, lcm: mathLcm } = me.math as { gcd: GcdType; lcm: LcmType };
 
 // Enumerates the unique combinations of repeeated selecting an index
 // from the same set of options, with or without replacement

--- a/packages/utils/src/components/enumeration.ts
+++ b/packages/utils/src/components/enumeration.ts
@@ -1,4 +1,5 @@
 import me from "math-expressions";
+import { gcd, lcm as mathLcm } from "mathjs";
 
 // Enumerates the unique combinations of repeeated selecting an index
 // from the same set of options, with or without replacement
@@ -88,10 +89,7 @@ export function enumerateCombinations({
         let g = [];
         for (let ind2 = 0; ind2 < ind1; ind2++) {
             g.push(
-                me.math.gcd(
-                    numberOfOptionsByIndex[ind1],
-                    numberOfOptionsByIndex[ind2],
-                ),
+                gcd(numberOfOptionsByIndex[ind1], numberOfOptionsByIndex[ind2]),
             );
         }
         gcds.push(g);
@@ -121,7 +119,7 @@ export function enumerateCombinations({
     // if continue gcd times, will have all combinations
     if (numberOfIndices === 2) {
         let gcd = maxGCD;
-        let lcm = me.math.lcm(...numberOfOptionsByIndex);
+        let lcm = mathLcm(...numberOfOptionsByIndex);
 
         let results = [];
         let numberSoFar = 0;
@@ -154,7 +152,7 @@ export function enumerateCombinations({
         for (let ind2 = 0; ind2 < ind1; ind2++) {
             if (gcds[ind1][ind2] > 1) {
                 m.push(
-                    me.math.lcm(
+                    mathLcm(
                         numberOfOptionsByIndex[ind1],
                         numberOfOptionsByIndex[ind2],
                     ),

--- a/packages/utils/src/components/function.ts
+++ b/packages/utils/src/components/function.ts
@@ -1,4 +1,6 @@
 import me from "math-expressions";
+import { mod } from "mathjs";
+const { dopri } = me.math;
 import {
     convertValueToMathExpression,
     normalizeMathExpression,
@@ -1475,7 +1477,7 @@ export const functionOperatorDefinitions: {
                 [upper, lower] = [lower, upper];
             }
 
-            return lower + me.math.mod(x - lower, upper - lower);
+            return lower + mod(x - lower, upper - lower);
         };
     },
 
@@ -1604,7 +1606,7 @@ function returnODESolutionFunction({
                     x0 = x0s;
                 }
                 let t0shifted = t0 + tind * chunkSize;
-                let result = me.math.dopri(
+                let result = dopri(
                     t0shifted,
                     t0shifted + chunkSize,
                     x0,

--- a/packages/utils/src/components/function.ts
+++ b/packages/utils/src/components/function.ts
@@ -1,5 +1,6 @@
 import me from "math-expressions";
-import { mod } from "mathjs";
+import type { mod as ModType } from "mathjs";
+const { mod } = me.math as { mod: ModType };
 const { dopri } = me.math;
 import {
     convertValueToMathExpression,


### PR DESCRIPTION
Currently mathjs is being used indirectly as bundled by math-expressions. This PR makes that use explicit for a possible future where math-expressions does not bundle the mathjs functions.