### PR TITLE
Support Ctrl/Cmd+S to refresh the editor-viewer

### DIFF
--- a/.changeset/editor-viewer-ctrl-s-refresh.md
+++ b/.changeset/editor-viewer-ctrl-s-refresh.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Editor: Ctrl/Cmd+S now refreshes the rendered viewer when focus is anywhere in the editor-viewer, including the rendered document (previously the shortcut only fired when focus was in the code editor panel).
+
+The shortcut follows the platform convention used by the code editor — Cmd+S on macOS, Ctrl+S elsewhere — and ignores AltGr/Alt combinations so AltGr+S still inserts a character.

--- a/.changeset/prototype-editor-viewer-ctrl-s.md
+++ b/.changeset/prototype-editor-viewer-ctrl-s.md
@@ -1,7 +1,0 @@
----
-"@doenet/doenetml-prototype": patch
----
-
-Prototype: add a Ctrl/Cmd+S shortcut to the editor-viewer that refreshes the rendered output, equivalent to clicking the Refresh button.
-
-The shortcut follows the platform convention used by the code editor — Cmd+S on macOS, Ctrl+S elsewhere — and ignores AltGr/Alt combinations so AltGr+S still inserts a character.

--- a/.changeset/prototype-editor-viewer-ctrl-s.md
+++ b/.changeset/prototype-editor-viewer-ctrl-s.md
@@ -1,0 +1,7 @@
+---
+"@doenet/doenetml-prototype": patch
+---
+
+Prototype: add a Ctrl/Cmd+S shortcut to the editor-viewer that refreshes the rendered output, equivalent to clicking the Refresh button.
+
+The shortcut follows the platform convention used by the code editor — Cmd+S on macOS, Ctrl+S elsewhere — and ignores AltGr/Alt combinations so AltGr+S still inserts a character.

--- a/packages/doenetml-prototype/src/editor/editor-viewer.tsx
+++ b/packages/doenetml-prototype/src/editor/editor-viewer.tsx
@@ -17,6 +17,7 @@ import { DownloadPretextDropdownItem } from "./components/download-pretext";
 import { DownloadInspector } from "./components/download-inspector";
 import Alert from "react-bootstrap/Alert";
 import type { CoreType } from "../state/redux-slices/core/slice";
+import { isSaveShortcutKeydown } from "@doenet/utils";
 
 // Injected by vite
 declare const DOENETML_VERSION: string;
@@ -77,11 +78,7 @@ export function EditorViewer({
             return;
         }
         const handleKeyDown = (event: KeyboardEvent) => {
-            if (
-                (event.metaKey || event.ctrlKey) &&
-                !event.altKey &&
-                event.code === "KeyS"
-            ) {
+            if (isSaveShortcutKeydown(event)) {
                 event.preventDefault();
                 event.stopPropagation();
                 doRefresh();

--- a/packages/doenetml-prototype/src/editor/editor-viewer.tsx
+++ b/packages/doenetml-prototype/src/editor/editor-viewer.tsx
@@ -17,7 +17,7 @@ import { DownloadPretextDropdownItem } from "./components/download-pretext";
 import { DownloadInspector } from "./components/download-inspector";
 import Alert from "react-bootstrap/Alert";
 import type { CoreType } from "../state/redux-slices/core/slice";
-import { isSaveShortcutKeydown } from "@doenet/utils";
+import { isSaveShortcutKeydown, isMacPlatform } from "@doenet/utils";
 
 // Injected by vite
 declare const DOENETML_VERSION: string;
@@ -114,7 +114,9 @@ export function EditorViewer({
                         disabled={!canRefresh}
                         title={
                             canRefresh
-                                ? "Refresh the rendered code (Ctrl/Cmd+S)"
+                                ? `Refresh the rendered code ${
+                                      isMacPlatform() ? "cmd+s" : "ctrl+s"
+                                  }`
                                 : "The code has not changes since the last render"
                         }
                         onClick={doRefresh}

--- a/packages/doenetml-prototype/src/editor/editor-viewer.tsx
+++ b/packages/doenetml-prototype/src/editor/editor-viewer.tsx
@@ -117,7 +117,7 @@ export function EditorViewer({
                                 ? `Refresh the rendered code ${
                                       isMacPlatform() ? "cmd+s" : "ctrl+s"
                                   }`
-                                : "The code has not changes since the last render"
+                                : "The code has not changed since the last render"
                         }
                         onClick={doRefresh}
                     >

--- a/packages/doenetml-prototype/src/editor/editor-viewer.tsx
+++ b/packages/doenetml-prototype/src/editor/editor-viewer.tsx
@@ -60,10 +60,15 @@ export function EditorViewer({
     };
 
     const canRefresh = sourceInEditor !== sourceForRender;
+    // Mirror the latest editor source in a ref so `doRefresh` can stay stable
+    // (empty deps). Otherwise it would change on every keystroke, causing the
+    // keydown effect below to tear down and re-register its listener each time.
+    const sourceInEditorRef = React.useRef(sourceInEditor);
+    sourceInEditorRef.current = sourceInEditor;
     const doRefresh = React.useCallback(() => {
         setErrors([]);
-        setSourceForRender(sourceInEditor);
-    }, [sourceInEditor]);
+        setSourceForRender(sourceInEditorRef.current);
+    }, []);
 
     const editorViewerRef = React.useRef<HTMLDivElement>(null);
     React.useEffect(() => {
@@ -72,7 +77,11 @@ export function EditorViewer({
             return;
         }
         const handleKeyDown = (event: KeyboardEvent) => {
-            if ((event.metaKey || event.ctrlKey) && event.code === "KeyS") {
+            if (
+                (event.metaKey || event.ctrlKey) &&
+                !event.altKey &&
+                event.code === "KeyS"
+            ) {
                 event.preventDefault();
                 event.stopPropagation();
                 doRefresh();

--- a/packages/doenetml-prototype/src/editor/editor-viewer.tsx
+++ b/packages/doenetml-prototype/src/editor/editor-viewer.tsx
@@ -61,12 +61,19 @@ export function EditorViewer({
     };
 
     const canRefresh = sourceInEditor !== sourceForRender;
-    // Mirror the latest editor source in a ref so `doRefresh` can stay stable
-    // (empty deps). Otherwise it would change on every keystroke, causing the
-    // keydown effect below to tear down and re-register its listener each time.
+    // Mirror the latest editor and rendered source in refs so `doRefresh` can
+    // stay stable (i.e., with empty deps).
     const sourceInEditorRef = React.useRef(sourceInEditor);
     sourceInEditorRef.current = sourceInEditor;
+    const sourceForRenderRef = React.useRef(sourceForRender);
+    sourceForRenderRef.current = sourceForRender;
     const doRefresh = React.useCallback(() => {
+        // No-op unless the editor source differs from the rendered source so
+        // that triggering a refresh (e.g. via Ctrl/Cmd+S) when nothing has
+        // changed does not clear the error list or re-render needlessly.
+        if (sourceInEditorRef.current === sourceForRenderRef.current) {
+            return;
+        }
         setErrors([]);
         setSourceForRender(sourceInEditorRef.current);
     }, []);

--- a/packages/doenetml-prototype/src/editor/editor-viewer.tsx
+++ b/packages/doenetml-prototype/src/editor/editor-viewer.tsx
@@ -60,6 +60,30 @@ export function EditorViewer({
     };
 
     const canRefresh = sourceInEditor !== sourceForRender;
+    const doRefresh = React.useCallback(() => {
+        setErrors([]);
+        setSourceForRender(sourceInEditor);
+    }, [sourceInEditor]);
+
+    const editorViewerRef = React.useRef<HTMLDivElement>(null);
+    React.useEffect(() => {
+        const container = editorViewerRef.current;
+        if (!container) {
+            return;
+        }
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if ((event.metaKey || event.ctrlKey) && event.code === "KeyS") {
+                event.preventDefault();
+                event.stopPropagation();
+                doRefresh();
+            }
+        };
+        container.addEventListener("keydown", handleKeyDown);
+        return () => {
+            container.removeEventListener("keydown", handleKeyDown);
+        };
+    }, [doRefresh]);
+
     const doPrettyPrint = React.useCallback(() => {
         prettyPrint(sourceInEditor, {
             doenetSyntax: formatMode === "doenetml",
@@ -76,7 +100,7 @@ export function EditorViewer({
                 show={showDownloadInspector}
                 setShow={setShowDownloadInspector}
             />
-            <div className="editor-viewer">
+            <div className="editor-viewer" ref={editorViewerRef} tabIndex={-1}>
                 <div className="editor-viewer-header">
                     <Button
                         size="sm"
@@ -84,13 +108,10 @@ export function EditorViewer({
                         disabled={!canRefresh}
                         title={
                             canRefresh
-                                ? "Refresh the rendered code"
+                                ? "Refresh the rendered code (Ctrl/Cmd+S)"
                                 : "The code has not changes since the last render"
                         }
-                        onClick={() => {
-                            setErrors([]);
-                            setSourceForRender(sourceInEditor);
-                        }}
+                        onClick={doRefresh}
                     >
                         <VscRefresh /> Refresh
                     </Button>

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -841,8 +841,14 @@ export const EditorViewer = React.forwardRef<
     useEffect(() => {
         const handleEditorKeyDown = (event: KeyboardEvent) => {
             if (
-                (platform == "Mac" && event.metaKey && event.code === "KeyS") ||
-                (platform != "Mac" && event.ctrlKey && event.code === "KeyS")
+                (platform == "Mac" &&
+                    event.metaKey &&
+                    !event.altKey &&
+                    event.code === "KeyS") ||
+                (platform != "Mac" &&
+                    event.ctrlKey &&
+                    !event.altKey &&
+                    event.code === "KeyS")
             ) {
                 event.preventDefault();
                 event.stopPropagation();

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -173,14 +173,6 @@ export const EditorViewer = React.forwardRef<
     },
     ref,
 ) {
-    //Win, Mac or Linux
-    let platform = "Linux";
-    if (navigator.platform.indexOf("Win") != -1) {
-        platform = "Win";
-    } else if (navigator.platform.indexOf("Mac") != -1) {
-        platform = "Mac";
-    }
-
     if (readOnly) {
         showFormatter = false;
     }
@@ -1041,7 +1033,6 @@ export const EditorViewer = React.forwardRef<
                 readOnly={readOnly}
                 codeChanged={codeChanged}
                 documentInteracted={documentInteracted}
-                platform={platform as "Mac" | "Win" | "Linux"}
                 updateWord={updateWord}
                 onUpdateViewer={updateViewer}
                 variants={variants}

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -14,7 +14,11 @@ import "@doenet/codemirror/style.css";
 import { DocViewer } from "../Viewer/DocViewer";
 import { DiagnosticsResponseTabContents } from "./DiagnosticsResponseTabs";
 import type { DiagnosticsTabId } from "./DiagnosticsResponseTabs";
-import { DiagnosticRecord, nanInfinityReviver } from "@doenet/utils";
+import {
+    DiagnosticRecord,
+    nanInfinityReviver,
+    isSaveShortcutKeydown,
+} from "@doenet/utils";
 import { nanoid } from "nanoid";
 import { prettyPrint } from "@doenet/parser/pretty-printer";
 import { formatResponse } from "../utils/responses";
@@ -840,16 +844,7 @@ export const EditorViewer = React.forwardRef<
 
     useEffect(() => {
         const handleEditorKeyDown = (event: KeyboardEvent) => {
-            if (
-                (platform == "Mac" &&
-                    event.metaKey &&
-                    !event.altKey &&
-                    event.code === "KeyS") ||
-                (platform != "Mac" &&
-                    event.ctrlKey &&
-                    !event.altKey &&
-                    event.code === "KeyS")
-            ) {
+            if (isSaveShortcutKeydown(event)) {
                 event.preventDefault();
                 event.stopPropagation();
                 updateViewer();
@@ -884,7 +879,7 @@ export const EditorViewer = React.forwardRef<
                 handleEditorKeyDown,
             );
         };
-    }, [showViewer, id, updateViewer, platform]);
+    }, [showViewer, id, updateViewer]);
 
     useEffect(() => {
         return () => {

--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -851,8 +851,18 @@ export const EditorViewer = React.forwardRef<
         };
 
         let codeEditorContainer = document.getElementById(id);
+        let viewerPanelContainer = viewerContainer.current;
         if (showViewer) {
             codeEditorContainer?.addEventListener(
+                "keydown",
+                handleEditorKeyDown,
+            );
+            // Also listen on the viewer panel so the shortcut works when focus
+            // is in the rendered document. The viewer container has
+            // tabIndex={-1}, so clicking non-focusable content (e.g. plain
+            // text) keeps focus within it rather than falling back to
+            // document.body, which would bypass this listener.
+            viewerPanelContainer?.addEventListener(
                 "keydown",
                 handleEditorKeyDown,
             );
@@ -863,8 +873,12 @@ export const EditorViewer = React.forwardRef<
                 "keydown",
                 handleEditorKeyDown,
             );
+            viewerPanelContainer?.removeEventListener(
+                "keydown",
+                handleEditorKeyDown,
+            );
         };
-    }, [showViewer, id, updateViewer]);
+    }, [showViewer, id, updateViewer, platform]);
 
     useEffect(() => {
         return () => {
@@ -1037,7 +1051,12 @@ export const EditorViewer = React.forwardRef<
                 isAccessibilityReportOpen={isAccessibilityReportOpen}
                 onToggleAccessibilityReport={toggleAccessibilityReport}
             />
-            <div className="viewer" id={id + "-viewer"} ref={viewerContainer}>
+            <div
+                className="viewer"
+                id={id + "-viewer"}
+                ref={viewerContainer}
+                tabIndex={-1}
+            >
                 <DocViewer
                     doenetML={viewerDoenetML}
                     flags={{

--- a/packages/doenetml/src/EditorViewer/ViewerControlsBar.tsx
+++ b/packages/doenetml/src/EditorViewer/ViewerControlsBar.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { UiButton } from "@doenet/ui-components";
+import { isMacPlatform } from "@doenet/utils";
 import { RxUpdate } from "react-icons/rx";
 import { BsExclamationTriangleFill } from "react-icons/bs";
 import { AccessibilityStatusButton } from "./AccessibilityStatusButton";
@@ -20,7 +21,6 @@ export function ViewerControlsBar({
     readOnly,
     codeChanged,
     documentInteracted,
-    platform,
     updateWord,
     onUpdateViewer,
     variants,
@@ -35,7 +35,6 @@ export function ViewerControlsBar({
     readOnly: boolean;
     codeChanged: boolean;
     documentInteracted: boolean;
-    platform: "Mac" | "Win" | "Linux";
     updateWord: string;
     onUpdateViewer: () => void;
     variants: VariantsState;
@@ -53,7 +52,7 @@ export function ViewerControlsBar({
                     data-test="Viewer Update Button"
                     disabled={!codeChanged && !documentInteracted}
                     title={
-                        platform === "Mac"
+                        isMacPlatform()
                             ? `${updateWord} Viewer cmd+s`
                             : `${updateWord} Viewer ctrl+s`
                     }

--- a/packages/doenetml/test/cypress/component/DoenetEditor.refreshKeyboardShortcut.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.refreshKeyboardShortcut.cy.tsx
@@ -48,7 +48,11 @@ function Harness() {
  */
 function dispatchKeydown(
     el: Element,
-    { code, withModifier }: { code: string; withModifier: boolean },
+    {
+        code,
+        withModifier,
+        withShift = false,
+    }: { code: string; withModifier: boolean; withShift?: boolean },
 ) {
     const event = new KeyboardEvent("keydown", {
         code,
@@ -56,6 +60,7 @@ function dispatchKeydown(
         ctrlKey: withModifier,
         metaKey: withModifier,
         altKey: false,
+        shiftKey: withShift,
         bubbles: true,
         cancelable: true,
     });
@@ -136,6 +141,45 @@ describe("DoenetEditor Ctrl/Cmd+S refresh shortcut", () => {
                         code: "KeyS",
                         withModifier: false,
                     });
+                    expect(prevented).to.equal(false);
+                });
+
+                // No refresh: the diagnostics callback count must not grow.
+                cy.wait(500);
+                cy.get('[data-test="call-count"]')
+                    .invoke("text")
+                    .should((text) => {
+                        expect(Number(text)).to.equal(countAfterInitial);
+                    });
+            });
+    });
+
+    it("does not refresh or prevent default for Ctrl/Cmd+Shift+S (Save As)", () => {
+        cy.mount(<Harness />);
+
+        cy.get('[data-test="last-source"]').should(
+            "have.text",
+            SAMPLE_DOENETML,
+        );
+
+        cy.get('[data-test="call-count"]')
+            .invoke("text")
+            .then((countAfterInitialText) => {
+                const countAfterInitial = Number(countAfterInitialText);
+
+                // Edit the buffer so a refresh would be observable if it fired.
+                cy.get(".cm-content")
+                    .click()
+                    .type("{ctrl}{end}", { force: true })
+                    .type(" EXTRA", { force: true });
+
+                cy.get(".viewer").then(($viewer) => {
+                    const prevented = dispatchKeydown($viewer[0], {
+                        code: "KeyS",
+                        withModifier: true,
+                        withShift: true,
+                    });
+                    // "Save As" must not be hijacked.
                     expect(prevented).to.equal(false);
                 });
 

--- a/packages/doenetml/test/cypress/component/DoenetEditor.refreshKeyboardShortcut.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.refreshKeyboardShortcut.cy.tsx
@@ -1,0 +1,151 @@
+import React, { useRef, useState } from "react";
+import {
+    DoenetEditor,
+    type DoenetEditorHandle,
+} from "../../../src/doenetml-inline-worker";
+
+const SAMPLE_DOENETML = "<p>hello</p>";
+
+type DiagnosticsCall = {
+    summary: {
+        warningsCount: number;
+        errorsCount: number;
+        infosCount: number;
+        accessibilityLevel1Count: number;
+        accessibilityLevel2Count: number;
+    };
+    doenetML: string;
+};
+
+function Harness() {
+    const editorRef = useRef<DoenetEditorHandle>(null);
+    const [calls, setCalls] = useState<DiagnosticsCall[]>([]);
+
+    return (
+        <div style={{ height: "500px", width: "900px" }}>
+            <div data-test="call-count">{calls.length}</div>
+            <div data-test="last-source">
+                {calls.length > 0 ? calls[calls.length - 1].doenetML : ""}
+            </div>
+            <DoenetEditor
+                ref={editorRef}
+                doenetML={SAMPLE_DOENETML}
+                addVirtualKeyboard={false}
+                showViewer={true}
+                diagnosticsSummaryCallback={(summary, doenetML) => {
+                    setCalls((prev) => [...prev, { summary, doenetML }]);
+                }}
+            />
+        </div>
+    );
+}
+
+/**
+ * Dispatch a keydown on `el` and return whether the browser default (the
+ * "save page" dialog) was prevented. `ctrlKey` and `metaKey` are both set so
+ * the shortcut fires regardless of which platform the test runs on (the helper
+ * checks Cmd on macOS and Ctrl elsewhere).
+ */
+function dispatchKeydown(
+    el: Element,
+    { code, withModifier }: { code: string; withModifier: boolean },
+) {
+    const event = new KeyboardEvent("keydown", {
+        code,
+        key: code === "KeyS" ? "s" : code,
+        ctrlKey: withModifier,
+        metaKey: withModifier,
+        altKey: false,
+        bubbles: true,
+        cancelable: true,
+    });
+    el.dispatchEvent(event);
+    return event.defaultPrevented;
+}
+
+describe("DoenetEditor Ctrl/Cmd+S refresh shortcut", () => {
+    it("refreshes the viewer (like Update) when fired from the rendered document and prevents the browser save dialog", () => {
+        cy.mount(<Harness />);
+
+        // Wait for the initial diagnostics callback (from the first render).
+        cy.get('[data-test="call-count"]').should("not.have.text", "0");
+        cy.get('[data-test="last-source"]').should(
+            "have.text",
+            SAMPLE_DOENETML,
+        );
+
+        cy.get('[data-test="call-count"]')
+            .invoke("text")
+            .then((initialCountText) => {
+                const initialCount = Number(initialCountText);
+
+                // Edit the buffer. The 3s debounce means this alone does NOT
+                // refresh the viewer. Append plain text (no `<`/`=`) to avoid
+                // triggering autocomplete. Two `.type()` calls so the Ctrl
+                // modifier is released after jumping to the end.
+                cy.get(".cm-content")
+                    .click()
+                    .type("{ctrl}{end}", { force: true })
+                    .type(" EXTRA", { force: true });
+
+                // Fire Ctrl/Cmd+S on the rendered viewer container (focus in
+                // the rendered document, not the code editor panel).
+                cy.get(".viewer").then(($viewer) => {
+                    const prevented = dispatchKeydown($viewer[0], {
+                        code: "KeyS",
+                        withModifier: true,
+                    });
+                    // Browser "save page" dialog must be suppressed.
+                    expect(prevented).to.equal(true);
+                });
+
+                // The shortcut should have flushed the edit and refreshed the
+                // viewer, exactly like clicking Update.
+                cy.get('[data-test="last-source"]').should("contain", "EXTRA");
+                cy.get('[data-test="call-count"]')
+                    .invoke("text")
+                    .then((finalCountText) => {
+                        expect(Number(finalCountText)).to.be.greaterThan(
+                            initialCount,
+                        );
+                    });
+            });
+    });
+
+    it("does not refresh or prevent default for a plain 'S' keydown without the modifier", () => {
+        cy.mount(<Harness />);
+
+        cy.get('[data-test="last-source"]').should(
+            "have.text",
+            SAMPLE_DOENETML,
+        );
+
+        cy.get('[data-test="call-count"]')
+            .invoke("text")
+            .then((countAfterInitialText) => {
+                const countAfterInitial = Number(countAfterInitialText);
+
+                // Edit the buffer so a refresh would be observable if it fired.
+                cy.get(".cm-content")
+                    .click()
+                    .type("{ctrl}{end}", { force: true })
+                    .type(" EXTRA", { force: true });
+
+                cy.get(".viewer").then(($viewer) => {
+                    const prevented = dispatchKeydown($viewer[0], {
+                        code: "KeyS",
+                        withModifier: false,
+                    });
+                    expect(prevented).to.equal(false);
+                });
+
+                // No refresh: the diagnostics callback count must not grow.
+                cy.wait(500);
+                cy.get('[data-test="call-count"]')
+                    .invoke("text")
+                    .should((text) => {
+                        expect(Number(text)).to.equal(countAfterInitial);
+                    });
+            });
+    });
+});

--- a/packages/doenetml/test/cypress/component/DoenetEditor.refreshKeyboardShortcut.cy.tsx
+++ b/packages/doenetml/test/cypress/component/DoenetEditor.refreshKeyboardShortcut.cy.tsx
@@ -1,8 +1,5 @@
-import React, { useRef, useState } from "react";
-import {
-    DoenetEditor,
-    type DoenetEditorHandle,
-} from "../../../src/doenetml-inline-worker";
+import React, { useState } from "react";
+import { DoenetEditor } from "../../../src/doenetml-inline-worker";
 
 const SAMPLE_DOENETML = "<p>hello</p>";
 
@@ -18,7 +15,6 @@ type DiagnosticsCall = {
 };
 
 function Harness() {
-    const editorRef = useRef<DoenetEditorHandle>(null);
     const [calls, setCalls] = useState<DiagnosticsCall[]>([]);
 
     return (
@@ -28,7 +24,6 @@ function Harness() {
                 {calls.length > 0 ? calls[calls.length - 1].doenetML : ""}
             </div>
             <DoenetEditor
-                ref={editorRef}
                 doenetML={SAMPLE_DOENETML}
                 addVirtualKeyboard={false}
                 showViewer={true}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./ast/logging";
 export * from "./diagnostics/types";
+export * from "./keyboard/keyboardShortcuts";
 export * from "./media/cid";
 export * from "./media/retrieveTextFile";
 export * from "./copy/deepFunctions";

--- a/packages/utils/src/keyboard/keyboardShortcuts.ts
+++ b/packages/utils/src/keyboard/keyboardShortcuts.ts
@@ -3,8 +3,10 @@
  */
 
 /**
- * Whether the current platform is macOS, where the conventional "command"
- * modifier is Cmd (the meta key) rather than Ctrl.
+ * Whether the current platform is "Mac-like" — macOS or iOS/iPadOS — where the
+ * conventional "command" modifier is Cmd (the meta key) rather than Ctrl. iOS
+ * and iPadOS are included because external keyboards on those platforms also
+ * use Cmd for shortcuts like Cmd+S.
  *
  * Prefers the modern `navigator.userAgentData.platform` and falls back to the
  * deprecated `navigator.platform`. Returns `false` in non-browser
@@ -18,7 +20,9 @@ export function isMacPlatform(): boolean {
         navigator as Navigator & { userAgentData?: { platform?: string } }
     ).userAgentData?.platform;
     const platform = uaPlatform ?? navigator.platform ?? "";
-    return /mac/i.test(platform);
+    // iPadOS Safari reports "MacIntel" (caught by /mac/), but older iPads and
+    // iPhones report "iPad"/"iPhone"/"iPod", so match those explicitly.
+    return /mac|iphone|ipad|ipod/i.test(platform);
 }
 
 /**
@@ -32,6 +36,7 @@ export type SaveShortcutKeyboardEvent = {
     metaKey: boolean;
     ctrlKey: boolean;
     altKey: boolean;
+    shiftKey: boolean;
     code: string;
 };
 
@@ -39,7 +44,8 @@ export type SaveShortcutKeyboardEvent = {
  * Whether a keydown event is the platform's "save" shortcut: Cmd+S on macOS,
  * Ctrl+S elsewhere. AltGr/Alt combinations are excluded so that, on layouts
  * where AltGr+S produces a character (and AltGr reports `ctrlKey === true`),
- * the character is still inserted.
+ * the character is still inserted. Shift is also excluded so that Cmd/Ctrl+Shift+S
+ * ("Save As") does not trigger the shortcut.
  *
  * This mirrors the "Mod-s" convention used by code editors such as CodeMirror,
  * and is used to trigger a viewer refresh from the editor. `event.code` is used
@@ -49,5 +55,7 @@ export function isSaveShortcutKeydown(
     event: SaveShortcutKeyboardEvent,
 ): boolean {
     const modifier = isMacPlatform() ? event.metaKey : event.ctrlKey;
-    return modifier && !event.altKey && event.code === "KeyS";
+    return (
+        modifier && !event.altKey && !event.shiftKey && event.code === "KeyS"
+    );
 }

--- a/packages/utils/src/keyboard/keyboardShortcuts.ts
+++ b/packages/utils/src/keyboard/keyboardShortcuts.ts
@@ -22,6 +22,20 @@ export function isMacPlatform(): boolean {
 }
 
 /**
+ * The subset of a keyboard event that {@link isSaveShortcutKeydown} inspects.
+ *
+ * Declared structurally (rather than referencing the DOM `KeyboardEvent`) so
+ * that `@doenet/utils` stays usable in non-DOM TypeScript configs that don't
+ * include the `dom` lib. A real DOM `KeyboardEvent` satisfies this type.
+ */
+export type SaveShortcutKeyboardEvent = {
+    metaKey: boolean;
+    ctrlKey: boolean;
+    altKey: boolean;
+    code: string;
+};
+
+/**
  * Whether a keydown event is the platform's "save" shortcut: Cmd+S on macOS,
  * Ctrl+S elsewhere. AltGr/Alt combinations are excluded so that, on layouts
  * where AltGr+S produces a character (and AltGr reports `ctrlKey === true`),
@@ -31,7 +45,9 @@ export function isMacPlatform(): boolean {
  * and is used to trigger a viewer refresh from the editor. `event.code` is used
  * (rather than `event.key`) so the shortcut is keyboard-layout independent.
  */
-export function isSaveShortcutKeydown(event: KeyboardEvent): boolean {
+export function isSaveShortcutKeydown(
+    event: SaveShortcutKeyboardEvent,
+): boolean {
     const modifier = isMacPlatform() ? event.metaKey : event.ctrlKey;
     return modifier && !event.altKey && event.code === "KeyS";
 }

--- a/packages/utils/src/keyboard/keyboardShortcuts.ts
+++ b/packages/utils/src/keyboard/keyboardShortcuts.ts
@@ -28,9 +28,10 @@ export function isMacPlatform(): boolean {
         return false;
     }
     const platform = nav.userAgentData?.platform ?? nav.platform ?? "";
-    // iPadOS Safari reports "MacIntel" (caught by /mac/), but older iPads and
-    // iPhones report "iPad"/"iPhone"/"iPod", so match those explicitly.
-    return /mac|iphone|ipad|ipod/i.test(platform);
+    // iPadOS Safari reports "MacIntel" (caught by /mac/). Other Apple mobile
+    // devices report "iPad"/"iPhone"/"iPod" (legacy `navigator.platform`) or
+    // "iOS"/"iPadOS" (UA-CH `userAgentData.platform`), so match those too.
+    return /mac|iphone|ipad|ipod|ios/i.test(platform);
 }
 
 /**

--- a/packages/utils/src/keyboard/keyboardShortcuts.ts
+++ b/packages/utils/src/keyboard/keyboardShortcuts.ts
@@ -1,0 +1,37 @@
+/**
+ * Helpers for detecting platform-aware keyboard shortcuts.
+ */
+
+/**
+ * Whether the current platform is macOS, where the conventional "command"
+ * modifier is Cmd (the meta key) rather than Ctrl.
+ *
+ * Prefers the modern `navigator.userAgentData.platform` and falls back to the
+ * deprecated `navigator.platform`. Returns `false` in non-browser
+ * environments (e.g. SSR).
+ */
+export function isMacPlatform(): boolean {
+    if (typeof navigator === "undefined") {
+        return false;
+    }
+    const uaPlatform = (
+        navigator as Navigator & { userAgentData?: { platform?: string } }
+    ).userAgentData?.platform;
+    const platform = uaPlatform ?? navigator.platform ?? "";
+    return /mac/i.test(platform);
+}
+
+/**
+ * Whether a keydown event is the platform's "save" shortcut: Cmd+S on macOS,
+ * Ctrl+S elsewhere. AltGr/Alt combinations are excluded so that, on layouts
+ * where AltGr+S produces a character (and AltGr reports `ctrlKey === true`),
+ * the character is still inserted.
+ *
+ * This mirrors the "Mod-s" convention used by code editors such as CodeMirror,
+ * and is used to trigger a viewer refresh from the editor. `event.code` is used
+ * (rather than `event.key`) so the shortcut is keyboard-layout independent.
+ */
+export function isSaveShortcutKeydown(event: KeyboardEvent): boolean {
+    const modifier = isMacPlatform() ? event.metaKey : event.ctrlKey;
+    return modifier && !event.altKey && event.code === "KeyS";
+}

--- a/packages/utils/src/keyboard/keyboardShortcuts.ts
+++ b/packages/utils/src/keyboard/keyboardShortcuts.ts
@@ -13,13 +13,21 @@
  * environments (e.g. SSR).
  */
 export function isMacPlatform(): boolean {
-    if (typeof navigator === "undefined") {
+    // Access `navigator` structurally via `globalThis` so this file doesn't
+    // reference the DOM `Navigator` type (or the global `navigator` binding),
+    // keeping `@doenet/utils` usable in TS configs that omit the `dom` lib.
+    const nav = (
+        globalThis as {
+            navigator?: {
+                platform?: string;
+                userAgentData?: { platform?: string };
+            };
+        }
+    ).navigator;
+    if (!nav) {
         return false;
     }
-    const uaPlatform = (
-        navigator as Navigator & { userAgentData?: { platform?: string } }
-    ).userAgentData?.platform;
-    const platform = uaPlatform ?? navigator.platform ?? "";
+    const platform = nav.userAgentData?.platform ?? nav.platform ?? "";
     // iPadOS Safari reports "MacIntel" (caught by /mac/), but older iPads and
     // iPhones report "iPad"/"iPhone"/"iPod", so match those explicitly.
     return /mac|iphone|ipad|ipod/i.test(platform);


### PR DESCRIPTION
## Summary

Adds the Ctrl+S (Cmd+S on Mac) "refresh the rendered viewer" keyboard shortcut to the **`doenetml-prototype`** editor-viewer, and extends it in **`doenetml`** so it also fires when focus is in the rendered document — making the two packages behave consistently. Also factors the shortcut/platform logic into a small shared helper.

### `doenetml-prototype`
- Previously had no keyboard shortcut; only the **Refresh** button updated the rendered output.
- A `keydown` listener (scoped to the editor-viewer container) now triggers the same refresh as the Refresh button on Ctrl/Cmd+S, and the Refresh button + shortcut now share a single `doRefresh` callback (stabilized via a ref so the listener registers once rather than on every keystroke).

### `doenetml`
- The shortcut previously only worked when focus was inside the editor panel. A second `keydown` listener is now attached to the viewer container so it also works when focus is in the rendered document.

### The `tabIndex={-1}` detail
In both packages the container that owns the listener is given `tabIndex={-1}`. Without it, clicking **non-focusable** content (e.g. plain rendered text) moves focus to `document.body` — outside the listener's subtree — so the keydown never reaches the handler and the browser's Save dialog appears instead. Making the container focusable keeps focus within it, so the shortcut fires regardless of what was clicked.

### Shared helper + platform consolidation
- Extracted a platform-aware helper into `@doenet/utils` (`keyboard/keyboardShortcuts.ts`) exporting `isMacPlatform()` and `isSaveShortcutKeydown(event)` — Cmd+S on macOS, Ctrl+S elsewhere; uses `event.code === "KeyS"` for keyboard-layout independence; SSR-safe. Both editor-viewers now call `isSaveShortcutKeydown`, replacing the hand-rolled inline checks (which differed between the two packages).
- The shortcut now ignores Alt/AltGr combinations, so on layouts where AltGr+S produces a character the character is still inserted. This is a behavior change from the previous `doenetml` inline check, which fired on any Ctrl+S.
- Refactored `ViewerControlsBar` to derive its `cmd+s`/`ctrl+s` tooltip from `isMacPlatform()` and removed its `platform` prop, dropping the old `navigator.platform` computation and `platform={...}` pass-through in `EditorViewer.tsx`. All platform detection in the editor-viewer now flows through the shared helper.

## Notes
- Listeners are scoped to the editor/viewer containers (not `document`), so the shortcut is not hijacked globally when the components are embedded.
- A changeset is included for `@doenet/doenetml` (+ its fixed-group/embedding consumers). No changeset is included for `@doenet/doenetml-prototype`: that package isn't on the Changesets workflow yet (no generated CHANGELOG on `main`), so it isn't versioned here — the prototype editor-viewer change still ships as part of this PR.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)
