### PR TITLE
Fix duplicate id on the editor-viewer viewer panel

### DIFF
--- a/packages/doenetml/src/EditorViewer/EditorViewer.tsx
+++ b/packages/doenetml/src/EditorViewer/EditorViewer.tsx
@@ -1020,7 +1020,7 @@ export const EditorViewer = React.forwardRef<
     }
 
     const viewerPanel = (
-        <div className="viewer-panel" id={id + "-viewer"}>
+        <div className="viewer-panel" id={id + "-viewer-panel"}>
             <ViewerControlsBar
                 id={id}
                 readOnly={readOnly}


### PR DESCRIPTION
## Summary

In `doenetml`'s `EditorViewer`, two DOM elements were rendered with the **same id** on every editor instance:

```tsx
<div className="viewer-panel" id={id + "-viewer"}>   // outer wrapper
    ...
    <div className="viewer" id={id + "-viewer"} ref={viewerContainer}>  // inner rendered-doc container
```

Duplicate ids are invalid HTML and make `document.getElementById(`${id}-viewer`)` ambiguous — it returns only the first match in document order.

## Fix

Give the outer wrapper a distinct id matching its className (`${id}-viewer-panel`) and keep `${id}-viewer` on the inner `.viewer` div (the rendered-document container).

## Why this is safe

- **No source code** looks up the `${id}-viewer` element via `getElementById`/`querySelector` (the only `getElementById` call targets the editor panel, `id`).
- **No CSS** uses an id selector for it.
- The one test reference — `cy.get("#editor-viewer")` in `codeeditor.cy.js` — now resolves to a **single** element, the inner `.viewer` that actually holds the rendered content asserted on (`"Circular dependency"`). So the test keeps passing and is now deterministic.

This is a standalone cleanup, independent of the Ctrl/Cmd+S shortcut work in #1340.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)