### PR TITLE
fix: keep justSubmitted set for choice with math inside a cascade repeat

### DIFF
--- a/.changeset/choice-math-cascade-just-submitted.md
+++ b/.changeset/choice-math-cascade-just-submitted.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Answer: fix the check-work button getting stuck on "Checking..." for a choice answer with inline math inside a `<cascade>`.
+
+A `<choice>` computes its `text` from its inline children's `hiddenIgnoreParent` so that it ignores the visibility it inherits from ancestors (a choice's text feeds an answer's credit-achieved dependencies, and inside a `<cascade>` ancestor visibility changes after a submission). However, `hiddenIgnoreParent` still climbed up to ancestor sections through its source composite's `hidden` — so a choice with an `<m>` placed inside a `<repeat>`/`<repeatForSequence>` within a `<cascade>` still depended on the cascade's credit-based visibility. Submitting such an answer changed its own credit-achieved dependencies, which immediately reset `justSubmitted` to `false`, leaving the "Check Work" button spinning indefinitely. `hiddenIgnoreParent` now recurses through the source composite's and adapter source's `hiddenIgnoreParent` instead of `hidden`, so it no longer depends on ancestor-section visibility.

--- a/.changeset/choice-math-cascade-just-submitted.md
+++ b/.changeset/choice-math-cascade-just-submitted.md
@@ -6,6 +6,6 @@
 "doenet-vscode-extension": patch
 ---
 
-Answer: fix the check-work button getting stuck on "Checking..." for a choice answer with inline math inside a `<cascade>`.
+Answer: fix the check-work button getting stuck on "Checking..." for a choice answer with inline math inside a repeat in a `<cascade>`.
 
 A `<choice>` computes its `text` from its inline children's `hiddenIgnoreParent` so that it ignores the visibility it inherits from ancestors (a choice's text feeds an answer's credit-achieved dependencies, and inside a `<cascade>` ancestor visibility changes after a submission). However, `hiddenIgnoreParent` still climbed up to ancestor sections through its source composite's `hidden` — so a choice with an `<m>` placed inside a `<repeat>`/`<repeatForSequence>` within a `<cascade>` still depended on the cascade's credit-based visibility. Submitting such an answer changed its own credit-achieved dependencies, which immediately reset `justSubmitted` to `false`, leaving the "Check Work" button spinning indefinitely. `hiddenIgnoreParent` now recurses through the source composite's and adapter source's `hiddenIgnoreParent` instead of `hidden`, so it no longer depends on ancestor-section visibility.

--- a/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
+++ b/packages/doenetml-worker-javascript/src/components/abstract/BaseComponent.js
@@ -560,6 +560,21 @@ export default class BaseComponent {
             },
         };
 
+        // `hiddenIgnoreParent` is whether the component is hidden by its own
+        // `hide` attribute (or by an explicitly hidden source composite/adapter
+        // source), ignoring the visibility it inherits from its parent.
+        //
+        // It deliberately recurses through `hiddenIgnoreParent` (rather than
+        // `hidden`) of the source composite and adapter source so that it never
+        // depends on the visibility of ancestor sections. If it depended on the
+        // source composite's `hidden`, then for a component created by a
+        // composite (e.g. inside a `<repeat>`), the dependency would still climb
+        // up to ancestor sections through the composite's parent. That matters
+        // because `<choice>`'s `text` uses `hiddenIgnoreParent`, and a choice's
+        // text can be a credit-achieved dependency of an answer: if the choice
+        // is inside a `<cascade>`, ancestor `hidden` changes after submission,
+        // which would otherwise make the answer's `justSubmitted` immediately
+        // become false.
         stateVariableDefinitions.hiddenIgnoreParent = {
             returnDependencies: () => ({
                 hide: {
@@ -569,11 +584,11 @@ export default class BaseComponent {
                 },
                 sourceCompositeHidden: {
                     dependencyType: "sourceCompositeStateVariable",
-                    variableName: "hidden",
+                    variableName: "hiddenIgnoreParent",
                 },
                 adapterSourceHidden: {
                     dependencyType: "adapterSourceStateVariable",
-                    variableName: "hidden",
+                    variableName: "hiddenIgnoreParent",
                 },
             }),
             definition: ({ dependencyValues }) => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
@@ -1628,4 +1628,40 @@ describe("Cascade tag tests @group4", async () => {
         });
         await check_items([true, true], [1, 1]);
     });
+
+    it("just submitted is not set to false for choice with math inside a repeat inside a cascade", async () => {
+        // Regression test: a `<choice>` containing `<m>` whose `hiddenIgnoreParent`
+        // chain climbs through its source composite (the repeat) up to the
+        // cascade's credit-based visibility. Submitting the answer changed the
+        // recursive credit-achieved dependencies, which incorrectly reset
+        // `justSubmitted` to false, leaving the check-work button stuck.
+        const doenetML = `
+<cascade>
+  <subsection>
+    <repeatForSequence from="1" to="1">
+      <choiceInput name="b" inline preselectChoice="1">
+        <choice>Crosses the <m>x</m>-axis almost linearly</choice>
+      </choiceInput>
+      <answer name="ans">
+        <award><when>$b.selectedIndex=1</when></award>
+      </answer>
+    </repeatForSequence>
+  </subsection>
+</cascade>
+  `;
+        const { core } = await createTestCore({
+            doenetML,
+        });
+
+        let stateVariables = await getStateVariables(core);
+        const ansIdx = Object.keys(stateVariables)
+            .filter((k) => stateVariables[k].componentType === "answer")
+            .map(Number)[0];
+
+        await submitAnswer({ componentIdx: ansIdx, core });
+
+        stateVariables = await getStateVariables(core);
+        expect(stateVariables[ansIdx].stateValues.justSubmitted).eq(true);
+        expect(stateVariables[ansIdx].stateValues.creditAchieved).eq(1);
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/cascade.test.ts
@@ -1630,22 +1630,24 @@ describe("Cascade tag tests @group4", async () => {
     });
 
     it("just submitted is not set to false for choice with math inside a repeat inside a cascade", async () => {
-        // Regression test: a `<choice>` containing `<m>` whose `hiddenIgnoreParent`
-        // chain climbs through its source composite (the repeat) up to the
-        // cascade's credit-based visibility. Submitting the answer changed the
-        // recursive credit-achieved dependencies, which incorrectly reset
-        // `justSubmitted` to false, leaving the check-work button stuck.
+        // Regression test: a `<choice>` containing a repeated `<m>` child whose
+        // `hiddenIgnoreParent` chain must not climb to the cascade's
+        // credit-based visibility. Submitting the answer changed the recursive
+        // credit-achieved dependencies, which incorrectly reset `justSubmitted`
+        // to false, leaving the check-work button stuck.
         const doenetML = `
 <cascade>
   <subsection>
     <repeatForSequence from="1" to="1">
-      <choiceInput name="b" inline preselectChoice="1">
-        <choice>Crosses the <m>x</m>-axis almost linearly</choice>
-      </choiceInput>
       <answer name="ans">
-        <award><when>$b.selectedIndex=1</when></award>
+        <choiceInput name="b" inline preselectChoice="1">
+          <choice credit="1">Crosses the <m>x</m>-axis almost linearly</choice>
+        </choiceInput>
       </answer>
     </repeatForSequence>
+  </subsection>
+  <subsection>
+    <p>Next section</p>
   </subsection>
 </cascade>
   `;
@@ -1654,14 +1656,24 @@ describe("Cascade tag tests @group4", async () => {
         });
 
         let stateVariables = await getStateVariables(core);
-        const ansIdx = Object.keys(stateVariables)
+        const answerIndices = Object.keys(stateVariables)
             .filter((k) => stateVariables[k].componentType === "answer")
-            .map(Number)[0];
+            .map(Number);
+        const choiceInputIndices = Object.keys(stateVariables)
+            .filter((k) => stateVariables[k].componentType === "choiceInput")
+            .map(Number);
+        expect(answerIndices.length).eq(1);
+        expect(choiceInputIndices.length).eq(1);
+        const ansIdx = answerIndices[0];
+        const choiceInputIdx = choiceInputIndices[0];
 
         await submitAnswer({ componentIdx: ansIdx, core });
 
         stateVariables = await getStateVariables(core);
         expect(stateVariables[ansIdx].stateValues.justSubmitted).eq(true);
+        expect(stateVariables[choiceInputIdx].stateValues.justSubmitted).eq(
+            true,
+        );
         expect(stateVariables[ansIdx].stateValues.creditAchieved).eq(1);
     });
 });


### PR DESCRIPTION
## Problem

A `<choiceInput>` answer whose choice contains inline math (`<m>`), placed inside a `<repeatForSequence>` within a `<cascade>`, leaves the "Check Work" button stuck on "Checking…" with a spinner after the student clicks it. There is no console error.

Minimal reproduction:

```xml
<cascade>
  <subsection>
    <repeatForSequence from="1" to="1">
      <answer name="ans">
        <choiceInput name="b" inline preselectChoice="1">
          <choice credit="1">Crosses the <m>x</m>-axis almost linearly</choice>
        </choiceInput>
      </answer>
    </repeatForSequence>
  </subsection>
  <subsection>
    <p>Next section</p>
  </subsection>
</cascade>
```

## Root cause

It isn't a true infinite loop — it's a stuck pending state. The renderer (`useDelayedSubmissionPending`) only clears the spinner once the answer's `justSubmitted` becomes `true` (or validation otherwise completes). On submit, `justSubmitted` was set to `true` and then immediately reset to `false`.

`justSubmitted` is recomputed by hashing the answer's recursive credit-achieved dependencies and comparing the value captured at submit against the current value. That hash transitively included the answer's own `creditAchieved`, forming a feedback loop:

```text
choice.text → m.hiddenIgnoreParent → (source composite) group.hidden
  → subsection/cascade visibility → cascade.numCompleted → childCreditAchieved → answer.creditAchieved
```

Submitting changed the credit, which changed the hash, which was misread as "the response changed", resetting `justSubmitted`.

`Choice.text` already deliberately uses `hiddenIgnoreParent` (not `hidden`) to avoid exactly this — with a comment about the cascade case. But `hiddenIgnoreParent` still pulled in its source composite's `hidden`, so when the choice was created by a `<repeat>`/`<repeatForSequence>` the dependency climbed back up to the cascade. That's why the regression requires the cascade, section, repeat, and inline math together.

## Fix

`hiddenIgnoreParent` (in `BaseComponent.js`) now recurses through the source composite's and adapter source's `hiddenIgnoreParent` instead of their `hidden`, so it genuinely ignores ancestor-section visibility. It is consumed only by `Choice.text`, so the change is tightly scoped.

## Testing

- Added a regression test in `cascade.test.ts` that places the repeated choice input inside the answer so the selected value/choice text participates in the answer's credit-achieved dependency hash, submits the answer, and asserts both the answer and choice input keep `justSubmitted === true` with `creditAchieved === 1`. It fails with the previous source-composite `hidden` dependency and passes with this fix.
- Verified with `npx vitest run --root packages/doenetml-worker-javascript src/test/tagSpecific/cascade.test.ts`.

Closes #1344.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)