### PR TITLE
Add a <fractionInput> component

### DIFF
--- a/.changeset/fraction-input.md
+++ b/.changeset/fraction-input.md
@@ -1,0 +1,13 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Add a `<fractionInput>` component.
+
+`<fractionInput>` renders a numerator input box above a denominator input box, separated by a fraction bar; each box accepts a math value like a `<mathInput>`. It exposes `numerator`, `denominator`, and `value` (the numerator divided by the denominator) properties, supports `prefillNumerator`/`prefillDenominator` attributes, and works as the input inside an `<answer>` (with check-work integration).
+
+Closes #1342.

--- a/.changeset/fraction-input.md
+++ b/.changeset/fraction-input.md
@@ -10,6 +10,6 @@ Add a `<fractionInput>` component.
 
 `<fractionInput>` renders a numerator input box above a denominator input box, separated by a fraction bar; each box accepts a math value like a `<mathInput>`. It exposes `numerator`, `denominator`, and `value` (the numerator divided by the denominator) properties, supports `prefillNumerator`/`prefillDenominator` attributes, links two-way to a math child or `bindValueTo` target, and works as the input inside an `<answer>` (with check-work integration).
 
-This also clarifies the `value`/`immediateValue` help-text descriptions across the inputs (`mathInput`, `matrixInput`, `textInput`, `codeEditor`, `fractionInput`): `value` is described simply as the input's value, and `immediateValue` as the value reflecting the user's in-progress edits.
+This also clarifies the `value`/`immediateValue` help-text descriptions for the math inputs (`mathInput`, `matrixInput`, `fractionInput`): `value` is described simply as the input's value, and `immediateValue` as the value reflecting the user's in-progress edits.
 
 Closes #1342.

--- a/.changeset/fraction-input.md
+++ b/.changeset/fraction-input.md
@@ -8,6 +8,6 @@
 
 Add a `<fractionInput>` component.
 
-`<fractionInput>` renders a numerator input box above a denominator input box, separated by a fraction bar; each box accepts a math value like a `<mathInput>`. It exposes `numerator`, `denominator`, and `value` (the numerator divided by the denominator) properties, supports `prefillNumerator`/`prefillDenominator` attributes, and works as the input inside an `<answer>` (with check-work integration).
+`<fractionInput>` renders a numerator input box above a denominator input box, separated by a fraction bar; each box accepts a math value like a `<mathInput>`. It exposes `numerator`, `denominator`, and `value` (the numerator divided by the denominator) properties, supports `prefillNumerator`/`prefillDenominator` attributes, links two-way to a math child or `bindValueTo` target, and works as the input inside an `<answer>` (with check-work integration).
 
 Closes #1342.

--- a/.changeset/fraction-input.md
+++ b/.changeset/fraction-input.md
@@ -10,4 +10,6 @@ Add a `<fractionInput>` component.
 
 `<fractionInput>` renders a numerator input box above a denominator input box, separated by a fraction bar; each box accepts a math value like a `<mathInput>`. It exposes `numerator`, `denominator`, and `value` (the numerator divided by the denominator) properties, supports `prefillNumerator`/`prefillDenominator` attributes, links two-way to a math child or `bindValueTo` target, and works as the input inside an `<answer>` (with check-work integration).
 
+This also clarifies the `value`/`immediateValue` help-text descriptions across the inputs (`mathInput`, `matrixInput`, `textInput`, `codeEditor`, `fractionInput`): `value` is described simply as the input's value, and `immediateValue` as the value reflecting the user's in-progress edits.
+
 Closes #1342.

--- a/packages/docs-nextra/pages/reference/_meta.ts
+++ b/packages/docs-nextra/pages/reference/_meta.ts
@@ -94,6 +94,7 @@ export default {
     figure: { title: "figure" },
     floor: { title: "floor" },
     footnote: { title: "footnote" },
+    fractionInput: { title: "fractionInput" },
     function: { title: "function (Basic Use)" },
     function2: { title: "function (Attributes 1)" },
     function3: { title: "function (Attributes 2)" },

--- a/packages/docs-nextra/pages/reference/componentTypes.mdx
+++ b/packages/docs-nextra/pages/reference/componentTypes.mdx
@@ -98,6 +98,7 @@ Input components collect responses from students or users of your DoenetML activ
     "booleanInput",
     "choice",
     "choiceInput",
+    "fractionInput",
     "mathInput",
     "matrixInput",
     "orbitalDiagramInput",

--- a/packages/docs-nextra/pages/reference/fractionInput.mdx
+++ b/packages/docs-nextra/pages/reference/fractionInput.mdx
@@ -154,7 +154,7 @@ denominator input boxes.
 The `bindValueTo` attribute creates a two-way link between the fraction's
 `value` and another component: editing the boxes updates the bound value, and
 changing the bound value updates the boxes. If the bound value is not a
-fraction, it is placed in the numerator with a blank denominator.
+fraction, it is placed in the numerator over a denominator of 1.
 
 
 

--- a/packages/docs-nextra/pages/reference/fractionInput.mdx
+++ b/packages/docs-nextra/pages/reference/fractionInput.mdx
@@ -62,6 +62,38 @@ marked incorrect).
 
 
 
+---
+
+### Example: Linking the value to another component
+
+
+```doenet-editor-horiz
+<p>
+  <mathInput name="mi" prefill="2/3">
+    <label>Type a fraction</label>
+  </mathInput>
+</p>
+
+<fractionInput name="frac">
+  <label>A fraction linked to the math input</label>
+  $mi
+</fractionInput>
+
+<p>value = $frac</p>
+```
+
+
+
+Referencing another component as a child creates a two-way link between the
+fraction's `value` and that component: editing the boxes updates the linked
+value, and changing the linked value updates the boxes. If the linked value is
+not a fraction, it is placed in the numerator over a denominator of 1.
+
+The `bindValueTo` attribute (`<fractionInput bindValueTo="$mi" />{:dn}`) creates
+the same link, but the child form above is usually clearer.
+
+
+
 ## Attribute Examples
 
 ### Attribute Example: prefillNumerator / prefillDenominator
@@ -130,59 +162,6 @@ Set `format="latex"` to provide prefilled values written in LaTeX.
 
 The `minComponentWidth` attribute adjusts the width of the numerator and
 denominator input boxes.
-
-
-
----
-
-### Attribute Example: bindValueTo
-
-
-```doenet-editor-horiz
-<p>
-  <mathInput name="mi" prefill="2/3">
-    <label>Type a fraction</label>
-  </mathInput>
-</p>
-
-<fractionInput name="frac" bindValueTo="$mi">
-  <label>A fraction bound to the math input</label>
-</fractionInput>
-
-<p>value = $frac</p>
-```
-
-
-
-The `bindValueTo` attribute creates a two-way link between the fraction's
-`value` and another component: editing the boxes updates the bound value, and
-changing the bound value updates the boxes. If the bound value is not a
-fraction, it is placed in the numerator over a denominator of 1.
-
-
-
----
-
-### Child Example: a `<math>{:dn}` fraction
-
-
-```doenet-editor-horiz
-<setup>
-  <math name="f">x/(x+1)</math>
-</setup>
-
-<fractionInput name="frac">
-  <label>Edit the fraction</label>
-  $f
-</fractionInput>
-
-<p>value = $frac</p>
-```
-
-
-
-A `<math>{:dn}` child (here referenced from `<setup>{:dn}`) also links the
-fraction's value, just like `bindValueTo`.
 
 
 

--- a/packages/docs-nextra/pages/reference/fractionInput.mdx
+++ b/packages/docs-nextra/pages/reference/fractionInput.mdx
@@ -33,8 +33,6 @@ separated by a fraction bar. Each box accepts a math value, just like a
 
 A `<fractionInput/>{:dn}` exposes the `numerator` and `denominator` separately,
 as well as the combined `value` (the numerator divided by the denominator).
-Referencing the input directly with `$frac` gives its `value` — the `.value`
-property is optional.
 
 
 

--- a/packages/docs-nextra/pages/reference/fractionInput.mdx
+++ b/packages/docs-nextra/pages/reference/fractionInput.mdx
@@ -76,7 +76,7 @@ marked incorrect).
   <label>Edit the fraction</label>
 </fractionInput>
 
-<p>value = $frac.value</p>
+<p>value = $frac</p>
 ```
 
 
@@ -101,7 +101,7 @@ each box.
   <label>A LaTeX-prefilled fraction</label>
 </fractionInput>
 
-<p>value = $frac.value</p>
+<p>value = $frac</p>
 ```
 
 
@@ -149,7 +149,7 @@ denominator input boxes.
   <label>A fraction bound to the math input</label>
 </fractionInput>
 
-<p>value = $frac.value</p>
+<p>value = $frac</p>
 ```
 
 
@@ -176,7 +176,7 @@ fraction, it is placed in the numerator over a denominator of 1.
   $f
 </fractionInput>
 
-<p>value = $frac.value</p>
+<p>value = $frac</p>
 ```
 
 

--- a/packages/docs-nextra/pages/reference/fractionInput.mdx
+++ b/packages/docs-nextra/pages/reference/fractionInput.mdx
@@ -26,13 +26,15 @@ separated by a fraction bar. Each box accepts a math value, just like a
 
 <p>numerator = $frac.numerator</p>
 <p>denominator = $frac.denominator</p>
-<p>value = $frac.value</p>
+<p>value = $frac</p>
 ```
 
 
 
 A `<fractionInput/>{:dn}` exposes the `numerator` and `denominator` separately,
 as well as the combined `value` (the numerator divided by the denominator).
+Referencing the input directly with `$frac` gives its `value` — the `.value`
+property is optional.
 
 
 
@@ -43,7 +45,7 @@ as well as the combined `value` (the numerator divided by the denominator).
 
 ```doenet-editor-horiz
 <p>Simplify <m>\frac{2}{10}</m>:
-  <answer name="ans">
+  <answer name="ans" symbolicEquality>
     <fractionInput name="frac">
       <shortDescription>Simplify two tenths</shortDescription>
     </fractionInput>
@@ -55,7 +57,10 @@ as well as the combined `value` (the numerator divided by the denominator).
 
 
 Because its `value` is the math expression numerator divided by denominator, a
-`<fractionInput/>{:dn}` can be checked directly by an `<answer>{:dn}`.
+`<fractionInput/>{:dn}` can be checked directly by an `<answer>{:dn}`. Here
+`symbolicEquality` makes the answer compare expressions symbolically, so only
+the reduced fraction <m>\frac{1}{5}</m> is accepted (an unreduced
+<m>\frac{2}{10}</m> is marked incorrect).
 
 
 

--- a/packages/docs-nextra/pages/reference/fractionInput.mdx
+++ b/packages/docs-nextra/pages/reference/fractionInput.mdx
@@ -1,0 +1,178 @@
+import { DoenetViewer, DoenetEditor, DoenetExample } from "../../components"
+
+import { ComponentDisplay, AttrPropDisplay } from "../../components"
+
+
+# `<fractionInput/>{:dn}`
+
+<ComponentDisplay name='fractionInput'/>
+
+`<fractionInput/>{:dn}` is an [Input](../concepts/essentialConcepts#component-types)
+component that renders a numerator input box above a denominator input box,
+separated by a fraction bar. Each box accepts a math value, just like a
+[`<mathInput/>{:dn}`](mathInput).
+
+<AttrPropDisplay name='fractionInput'/>
+
+## Examples
+
+### Example: Default `<fractionInput/>{:dn}`
+
+
+```doenet-editor-horiz
+<fractionInput name="frac">
+  <label>Enter a fraction</label>
+</fractionInput>
+
+<p>numerator = $frac.numerator</p>
+<p>denominator = $frac.denominator</p>
+<p>value = $frac.value</p>
+```
+
+
+
+A `<fractionInput/>{:dn}` exposes the `numerator` and `denominator` separately,
+as well as the combined `value` (the numerator divided by the denominator).
+
+
+
+---
+
+### Example: Using a `<fractionInput/>{:dn}` in an `<answer>{:dn}`
+
+
+```doenet-editor-horiz
+<p>Simplify <m>\frac{2}{10}</m>:
+  <answer name="ans">
+    <fractionInput name="frac">
+      <shortDescription>Simplify two tenths</shortDescription>
+    </fractionInput>
+    <award>1/5</award>
+  </answer>
+</p>
+```
+
+
+
+Because its `value` is the math expression numerator divided by denominator, a
+`<fractionInput/>{:dn}` can be checked directly by an `<answer>{:dn}`.
+
+
+
+## Attribute Examples
+
+### Attribute Example: prefillNumerator / prefillDenominator
+
+
+```doenet-editor-horiz
+<fractionInput
+  name="frac"
+  prefillNumerator="x+1"
+  prefillDenominator="2"
+>
+  <label>Edit the fraction</label>
+</fractionInput>
+
+<p>value = $frac.value</p>
+```
+
+
+
+Use `prefillNumerator` and `prefillDenominator` to set the initial contents of
+each box.
+
+
+
+---
+
+### Attribute Example: format
+
+
+```doenet-editor-horiz
+<fractionInput
+  name="frac"
+  format="latex"
+  prefillNumerator="\frac{a}{b}"
+  prefillDenominator="c"
+>
+  <label>A LaTeX-prefilled fraction</label>
+</fractionInput>
+
+<p>value = $frac.value</p>
+```
+
+
+
+Set `format="latex"` to provide prefilled values written in LaTeX.
+
+
+
+---
+
+### Attribute Example: minComponentWidth
+
+
+```doenet-editor-horiz
+<p>Adjust the slider to change the width of the input boxes:</p>
+<slider name="w" from="10" to="100" step="10">
+  <label>minComponentWidth</label>
+</slider>
+
+<fractionInput name="frac" minComponentWidth="$w">
+  <label>A fraction with adjustable box width</label>
+</fractionInput>
+```
+
+
+
+The `minComponentWidth` attribute adjusts the width of the numerator and
+denominator input boxes.
+
+
+
+## Property Examples
+
+### Property Example: numerator / denominator / value
+
+
+```doenet-editor-horiz
+<fractionInput
+  name="frac"
+  prefillNumerator="3"
+  prefillDenominator="4"
+>
+  <label>Edit the fraction</label>
+</fractionInput>
+
+<p><c>numerator</c> = $frac.numerator</p>
+<p><c>denominator</c> = $frac.denominator</p>
+<p><c>value</c> = $frac.value</p>
+```
+
+
+
+The `numerator` and `denominator` properties give the contents of each box,
+while `value` gives the numerator divided by the denominator.
+
+
+
+---
+
+### Property Example: valueChanged / immediateValueChanged
+
+
+```doenet-editor-horiz
+<fractionInput name="frac">
+  <label>Edit the fraction</label>
+</fractionInput>
+
+<p><c>valueChanged</c> = $frac.valueChanged</p>
+<p><c>immediateValueChanged</c> = $frac.immediateValueChanged</p>
+```
+
+
+
+The `valueChanged` property is `true` once the user has changed either box and
+the page has updated (when the user clicks elsewhere, hits Enter, or interacts
+with another part of the page). The `immediateValueChanged` property becomes
+`true` immediately as the user types.

--- a/packages/docs-nextra/pages/reference/fractionInput.mdx
+++ b/packages/docs-nextra/pages/reference/fractionInput.mdx
@@ -57,8 +57,8 @@ as well as the combined `value` (the numerator divided by the denominator).
 Because its `value` is the math expression numerator divided by denominator, a
 `<fractionInput/>{:dn}` can be checked directly by an `<answer>{:dn}`. Here
 `symbolicEquality` makes the answer compare expressions symbolically, so only
-the reduced fraction <m>\frac{1}{5}</m> is accepted (an unreduced
-<m>\frac{2}{10}</m> is marked incorrect).
+the reduced fraction $\frac{1}{5}$ is accepted (an unreduced $\frac{2}{10}$ is
+marked incorrect).
 
 
 

--- a/packages/docs-nextra/pages/reference/fractionInput.mdx
+++ b/packages/docs-nextra/pages/reference/fractionInput.mdx
@@ -130,6 +130,59 @@ denominator input boxes.
 
 
 
+---
+
+### Attribute Example: bindValueTo
+
+
+```doenet-editor-horiz
+<p>
+  <mathInput name="mi" prefill="2/3">
+    <label>Type a fraction</label>
+  </mathInput>
+</p>
+
+<fractionInput name="frac" bindValueTo="$mi">
+  <label>A fraction bound to the math input</label>
+</fractionInput>
+
+<p>value = $frac.value</p>
+```
+
+
+
+The `bindValueTo` attribute creates a two-way link between the fraction's
+`value` and another component: editing the boxes updates the bound value, and
+changing the bound value updates the boxes. If the bound value is not a
+fraction, it is placed in the numerator with a blank denominator.
+
+
+
+---
+
+### Child Example: a `<math>{:dn}` fraction
+
+
+```doenet-editor-horiz
+<setup>
+  <math name="f">x/(x+1)</math>
+</setup>
+
+<fractionInput name="frac">
+  <label>Edit the fraction</label>
+  $f
+</fractionInput>
+
+<p>value = $frac.value</p>
+```
+
+
+
+A `<math>{:dn}` child (here referenced from `<setup>{:dn}`) also links the
+fraction's value, just like `bindValueTo`.
+
+
+
 ## Property Examples
 
 ### Property Example: numerator / denominator / value

--- a/packages/doenetml-worker-javascript/src/ComponentTypes.js
+++ b/packages/doenetml-worker-javascript/src/ComponentTypes.js
@@ -22,6 +22,7 @@ import * as Divisions from "./components/Divisions";
 import * as Verbatim from "./components/Verbatim";
 import * as Paginator from "./components/Paginator";
 import * as MatrixInput from "./components/MatrixInput";
+import * as FractionInput from "./components/FractionInput";
 import * as Solution from "./components/Solution";
 
 import Document from "./components/Document";
@@ -228,6 +229,7 @@ const componentTypeArray = [
     ...Object.values(Verbatim),
     ...Object.values(Paginator),
     ...Object.values(MatrixInput),
+    ...Object.values(FractionInput),
     ...Object.values(Solution),
     Document,
     Text,

--- a/packages/doenetml-worker-javascript/src/components/CodeEditor.js
+++ b/packages/doenetml-worker-javascript/src/components/CodeEditor.js
@@ -225,7 +225,7 @@ export default class CodeEditor extends BlockComponent {
 
         stateVariableDefinitions.valueChanged = {
             description:
-                "Whether the saved value has been changed from its initial state.",
+                "Whether the value has been changed from its initial state.",
             public: true,
             hasEssential: true,
             defaultValue: false,
@@ -252,7 +252,7 @@ export default class CodeEditor extends BlockComponent {
         };
 
         stateVariableDefinitions.value = {
-            description: "The most recently saved code value.",
+            description: "The code value of the input.",
             public: true,
             shadowingInstructions: {
                 createComponentOfType: "text",
@@ -342,7 +342,7 @@ export default class CodeEditor extends BlockComponent {
 
         stateVariableDefinitions.immediateValueChanged = {
             description:
-                "Whether the live (immediate) value has been changed from its initial state.",
+                "Whether the value, including in-progress edits, has been changed from its initial state.",
             public: true,
             hasEssential: true,
             defaultValue: false,
@@ -372,7 +372,7 @@ export default class CodeEditor extends BlockComponent {
 
         stateVariableDefinitions.immediateValue = {
             description:
-                "The current code in the editor (live, before saving).",
+                "The code value reflecting the user's in-progress edits.",
             public: true,
             shadowingInstructions: {
                 createComponentOfType: "text",

--- a/packages/doenetml-worker-javascript/src/components/CodeEditor.js
+++ b/packages/doenetml-worker-javascript/src/components/CodeEditor.js
@@ -225,7 +225,7 @@ export default class CodeEditor extends BlockComponent {
 
         stateVariableDefinitions.valueChanged = {
             description:
-                "Whether the value has been changed from its initial state.",
+                "Whether the saved value has been changed from its initial state.",
             public: true,
             hasEssential: true,
             defaultValue: false,
@@ -252,7 +252,7 @@ export default class CodeEditor extends BlockComponent {
         };
 
         stateVariableDefinitions.value = {
-            description: "The code value of the input.",
+            description: "The most recently saved code value.",
             public: true,
             shadowingInstructions: {
                 createComponentOfType: "text",
@@ -342,7 +342,7 @@ export default class CodeEditor extends BlockComponent {
 
         stateVariableDefinitions.immediateValueChanged = {
             description:
-                "Whether the value, including in-progress edits, has been changed from its initial state.",
+                "Whether the live (immediate) value has been changed from its initial state.",
             public: true,
             hasEssential: true,
             defaultValue: false,
@@ -372,7 +372,7 @@ export default class CodeEditor extends BlockComponent {
 
         stateVariableDefinitions.immediateValue = {
             description:
-                "The code value reflecting the user's in-progress edits.",
+                "The current code in the editor (live, before saving).",
             public: true,
             shadowingInstructions: {
                 createComponentOfType: "text",

--- a/packages/doenetml-worker-javascript/src/components/FractionInput.js
+++ b/packages/doenetml-worker-javascript/src/components/FractionInput.js
@@ -23,9 +23,8 @@ const blankMath = () => me.fromAst("\uff3f");
 
 // Split a math value into the numerator and denominator that the two input
 // boxes display. A division becomes its two operands; a blank stays blank in
-// both boxes; anything else (not a fraction) goes in the numerator with a
-// blank denominator (mirroring how matrixInput places a non-matrix value in
-// its first cell).
+// both boxes; anything else (a non-fraction, non-blank value) goes in the
+// numerator over a denominator of 1.
 function decomposeFraction(mathValue) {
     let tree = mathValue?.tree;
     if (Array.isArray(tree) && tree[0] === "/") {
@@ -37,16 +36,21 @@ function decomposeFraction(mathValue) {
     if (tree === undefined || tree === "\uff3f") {
         return { numerator: blankMath(), denominator: blankMath() };
     }
-    return { numerator: me.fromAst(tree), denominator: blankMath() };
+    return { numerator: me.fromAst(tree), denominator: me.fromAst(1) };
 }
 
-// Combine the two boxes back into a single math value. When both boxes are
-// blank, the fraction as a whole is blank rather than a fraction of two blanks.
+// Combine the two boxes back into a single math value (the inverse of
+// decomposeFraction). When both boxes are blank, the fraction as a whole is
+// blank rather than a fraction of two blanks. A denominator of 1 over a
+// non-blank numerator collapses to just the numerator.
 function reconstructFraction(numerator, denominator) {
     let numeratorTree = numerator?.tree ?? "\uff3f";
     let denominatorTree = denominator?.tree ?? "\uff3f";
     if (numeratorTree === "\uff3f" && denominatorTree === "\uff3f") {
         return blankMath();
+    }
+    if (denominatorTree === 1 && numeratorTree !== "\uff3f") {
+        return me.fromAst(numeratorTree);
     }
     return me.fromAst(["/", numeratorTree, denominatorTree]);
 }

--- a/packages/doenetml-worker-javascript/src/components/FractionInput.js
+++ b/packages/doenetml-worker-javascript/src/components/FractionInput.js
@@ -1,0 +1,1465 @@
+import Input from "./abstract/Input";
+import me from "math-expressions";
+import { deepCompare, convertValueToMathExpression } from "@doenet/utils";
+import BaseComponent from "./abstract/BaseComponent";
+import {
+    buildNumberDisplayParameters,
+    returnNumberDisplayAttributeComponentShadowing,
+    returnNumberDisplayAttributes,
+    returnNumberDisplayStateVariableDefinitions,
+} from "../utils/numberDisplay";
+import {
+    latexToMathFactory,
+    normalizeLatexString,
+    roundForDisplay,
+    stripLatex,
+} from "../utils/math";
+
+const blankMath = () => me.fromAst("\uff3f");
+
+export class FractionInput extends Input {
+    constructor(args) {
+        super(args);
+
+        this.externalActions = {};
+
+        //Complex because the stateValues isn't defined until later
+        Object.defineProperty(this.externalActions, "submitAnswer", {
+            enumerable: true,
+            get: async function () {
+                let answerAncestor = await this.stateValues.answerAncestor;
+                if (answerAncestor !== null) {
+                    return {
+                        componentIdx: answerAncestor.componentIdx,
+                        actionName: "submitAnswer",
+                    };
+                } else {
+                    return;
+                }
+            }.bind(this),
+        });
+    }
+
+    static componentType = "fractionInput";
+
+    static componentDocs = {
+        summary:
+            "An interactive fraction input with a numerator and a denominator, each accepting a math value.",
+    };
+    static variableForImplicitProp = "value";
+
+    static processWhenJustUpdatedForNewComponent = true;
+
+    static renderChildren = true;
+
+    static createAttributesObject() {
+        let attributes = super.createAttributesObject();
+
+        attributes.prefillNumerator = {
+            description: "Initial value displayed in the numerator input.",
+            createComponentOfType: "math",
+            createStateVariable: "prefillNumerator",
+            defaultValue: blankMath(),
+            public: true,
+            copyComponentAttributesForCreatedComponent: [
+                "format",
+                "functionSymbols",
+                "splitSymbols",
+                "parseScientificNotation",
+            ],
+        };
+        attributes.prefillDenominator = {
+            description: "Initial value displayed in the denominator input.",
+            createComponentOfType: "math",
+            createStateVariable: "prefillDenominator",
+            defaultValue: blankMath(),
+            public: true,
+            copyComponentAttributesForCreatedComponent: [
+                "format",
+                "functionSymbols",
+                "splitSymbols",
+                "parseScientificNotation",
+            ],
+        };
+        attributes.format = {
+            description: "Input format for the numerator and denominator.",
+            createComponentOfType: "text",
+            createStateVariable: "format",
+            defaultValue: "text",
+            public: true,
+            toLowerCase: true,
+            validValues: [
+                {
+                    value: "text",
+                    description: "Plain-text math notation (e.g., `x^2 + 1`).",
+                },
+                {
+                    value: "latex",
+                    description: "LaTeX-formatted math (e.g., `x^{2} + 1`).",
+                },
+            ],
+        };
+        attributes.functionSymbols = {
+            description: "Symbols treated as function names when parsing.",
+            createComponentOfType: "textList",
+            createStateVariable: "functionSymbols",
+            defaultValue: ["f", "g"],
+            public: true,
+        };
+        attributes.splitSymbols = {
+            description:
+                "Whether multi-character symbols are split into a product of variables.",
+            createComponentOfType: "boolean",
+            createStateVariable: "splitSymbols",
+            defaultValue: true,
+            public: true,
+        };
+        attributes.parseScientificNotation = {
+            description:
+                "Whether to parse expressions like 1e3 as scientific notation.",
+            createComponentOfType: "boolean",
+            createStateVariable: "parseScientificNotation",
+            defaultValue: false,
+            public: true,
+        };
+
+        Object.assign(attributes, returnNumberDisplayAttributes());
+
+        attributes.unionFromU = {
+            description: 'Whether "U" between sets is parsed as union.',
+            createComponentOfType: "boolean",
+            createStateVariable: "unionFromU",
+            defaultValue: false,
+            public: true,
+        };
+        attributes.minComponentWidth = {
+            createComponentOfType: "integer",
+            createStateVariable: "minComponentWidth",
+            defaultValue: 0,
+            clamp: [0, Infinity],
+            description:
+                "Minimum rendered width for the numerator and denominator, in pixels.",
+        };
+
+        return attributes;
+    }
+
+    static returnChildGroups() {
+        return [
+            {
+                group: "labels",
+                componentTypes: ["label"],
+            },
+            {
+                group: "descriptions",
+                componentTypes: ["description"],
+            },
+            {
+                group: "shortDescriptions",
+                componentTypes: ["shortDescription"],
+            },
+            {
+                group: "fractionInputComponents",
+                componentTypes: ["_fractionInputComponent"],
+                excludeFromSchema: true,
+            },
+        ];
+    }
+
+    static returnStateVariableDefinitions() {
+        let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        Object.assign(
+            stateVariableDefinitions,
+            returnNumberDisplayStateVariableDefinitions({
+                displayDigitsDefault: 10,
+                displaySmallAsZeroDefault: 0,
+            }),
+        );
+
+        stateVariableDefinitions.valueChanged = {
+            description:
+                "Whether the saved fraction has been changed from its initial state.",
+            public: true,
+            shadowingInstructions: {
+                createComponentOfType: "boolean",
+            },
+            returnDependencies: () => ({
+                fractionChildren: {
+                    dependencyType: "child",
+                    childGroups: ["fractionInputComponents"],
+                    variableNames: ["valueChanged"],
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        valueChanged: dependencyValues.fractionChildren.some(
+                            (child) => child.stateValues.valueChanged,
+                        ),
+                    },
+                };
+            },
+        };
+
+        stateVariableDefinitions.immediateValueChanged = {
+            description:
+                "Whether the live fraction differs from its initial state.",
+            public: true,
+            shadowingInstructions: {
+                createComponentOfType: "boolean",
+            },
+            returnDependencies: () => ({
+                fractionChildren: {
+                    dependencyType: "child",
+                    childGroups: ["fractionInputComponents"],
+                    variableNames: ["immediateValueChanged"],
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        immediateValueChanged:
+                            dependencyValues.fractionChildren.some(
+                                (child) =>
+                                    child.stateValues.immediateValueChanged,
+                            ),
+                    },
+                };
+            },
+        };
+
+        stateVariableDefinitions.numerator = {
+            description: "The most recently saved numerator value.",
+            public: true,
+            shadowingInstructions: {
+                createComponentOfType: "math",
+                addAttributeComponentsShadowingStateVariables:
+                    returnNumberDisplayAttributeComponentShadowing(),
+            },
+            returnDependencies: () => ({
+                fractionChildren: {
+                    dependencyType: "child",
+                    childGroups: ["fractionInputComponents"],
+                    variableNames: ["value"],
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        numerator:
+                            dependencyValues.fractionChildren[0]?.stateValues
+                                .value ?? blankMath(),
+                    },
+                };
+            },
+            inverseDefinition({ desiredStateVariableValues }) {
+                return {
+                    success: true,
+                    instructions: [
+                        {
+                            setDependency: "fractionChildren",
+                            desiredValue: desiredStateVariableValues.numerator,
+                            childIndex: 0,
+                            variableIndex: 0,
+                        },
+                    ],
+                };
+            },
+        };
+
+        stateVariableDefinitions.denominator = {
+            description: "The most recently saved denominator value.",
+            public: true,
+            shadowingInstructions: {
+                createComponentOfType: "math",
+                addAttributeComponentsShadowingStateVariables:
+                    returnNumberDisplayAttributeComponentShadowing(),
+            },
+            returnDependencies: () => ({
+                fractionChildren: {
+                    dependencyType: "child",
+                    childGroups: ["fractionInputComponents"],
+                    variableNames: ["value"],
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        denominator:
+                            dependencyValues.fractionChildren[1]?.stateValues
+                                .value ?? blankMath(),
+                    },
+                };
+            },
+            inverseDefinition({ desiredStateVariableValues }) {
+                return {
+                    success: true,
+                    instructions: [
+                        {
+                            setDependency: "fractionChildren",
+                            desiredValue:
+                                desiredStateVariableValues.denominator,
+                            childIndex: 1,
+                            variableIndex: 0,
+                        },
+                    ],
+                };
+            },
+        };
+
+        stateVariableDefinitions.value = {
+            description:
+                "The most recently saved fraction value (numerator divided by denominator).",
+            public: true,
+            shadowingInstructions: {
+                createComponentOfType: "math",
+                addAttributeComponentsShadowingStateVariables:
+                    returnNumberDisplayAttributeComponentShadowing(),
+            },
+            returnDependencies: () => ({
+                numerator: {
+                    dependencyType: "stateVariable",
+                    variableName: "numerator",
+                },
+                denominator: {
+                    dependencyType: "stateVariable",
+                    variableName: "denominator",
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        value: me.fromAst([
+                            "/",
+                            dependencyValues.numerator.tree,
+                            dependencyValues.denominator.tree,
+                        ]),
+                    },
+                };
+            },
+            inverseDefinition({ desiredStateVariableValues }) {
+                let desiredTree = desiredStateVariableValues.value.tree;
+                if (Array.isArray(desiredTree) && desiredTree[0] === "/") {
+                    return {
+                        success: true,
+                        instructions: [
+                            {
+                                setDependency: "numerator",
+                                desiredValue: me.fromAst(desiredTree[1]),
+                            },
+                            {
+                                setDependency: "denominator",
+                                desiredValue: me.fromAst(desiredTree[2]),
+                            },
+                        ],
+                    };
+                }
+                return { success: false };
+            },
+        };
+
+        stateVariableDefinitions.immediateValue = {
+            description:
+                "The current fraction being entered (live, before saving).",
+            public: true,
+            shadowingInstructions: {
+                createComponentOfType: "math",
+                addAttributeComponentsShadowingStateVariables:
+                    returnNumberDisplayAttributeComponentShadowing(),
+            },
+            returnDependencies: () => ({
+                fractionChildren: {
+                    dependencyType: "child",
+                    childGroups: ["fractionInputComponents"],
+                    variableNames: ["immediateValue"],
+                },
+            }),
+            definition({ dependencyValues }) {
+                let numerator =
+                    dependencyValues.fractionChildren[0]?.stateValues
+                        .immediateValue ?? blankMath();
+                let denominator =
+                    dependencyValues.fractionChildren[1]?.stateValues
+                        .immediateValue ?? blankMath();
+                return {
+                    setValue: {
+                        immediateValue: me.fromAst([
+                            "/",
+                            numerator.tree,
+                            denominator.tree,
+                        ]),
+                    },
+                };
+            },
+            inverseDefinition({ desiredStateVariableValues }) {
+                let desiredTree =
+                    desiredStateVariableValues.immediateValue.tree;
+                if (Array.isArray(desiredTree) && desiredTree[0] === "/") {
+                    return {
+                        success: true,
+                        instructions: [
+                            {
+                                setDependency: "fractionChildren",
+                                desiredValue: me.fromAst(desiredTree[1]),
+                                childIndex: 0,
+                                variableIndex: 0,
+                            },
+                            {
+                                setDependency: "fractionChildren",
+                                desiredValue: me.fromAst(desiredTree[2]),
+                                childIndex: 1,
+                                variableIndex: 0,
+                            },
+                        ],
+                    };
+                }
+                return { success: false };
+            },
+        };
+
+        stateVariableDefinitions.valueForDisplay = {
+            returnDependencies: () => ({
+                value: {
+                    dependencyType: "stateVariable",
+                    variableName: "value",
+                },
+                displayDigits: {
+                    dependencyType: "stateVariable",
+                    variableName: "displayDigits",
+                },
+                displayDecimals: {
+                    dependencyType: "stateVariable",
+                    variableName: "displayDecimals",
+                },
+                displaySmallAsZero: {
+                    dependencyType: "stateVariable",
+                    variableName: "displaySmallAsZero",
+                },
+            }),
+            definition: function ({ dependencyValues }) {
+                let rounded = roundForDisplay({
+                    value: dependencyValues.value,
+                    dependencyValues,
+                });
+
+                return {
+                    setValue: { valueForDisplay: rounded },
+                };
+            },
+        };
+
+        stateVariableDefinitions.text = {
+            description: "The current fraction as a text string.",
+            public: true,
+            shadowingInstructions: {
+                createComponentOfType: "text",
+            },
+            returnDependencies: () => ({
+                valueForDisplay: {
+                    dependencyType: "stateVariable",
+                    variableName: "valueForDisplay",
+                },
+                padZeros: {
+                    dependencyType: "stateVariable",
+                    variableName: "padZeros",
+                },
+                displayDigits: {
+                    dependencyType: "stateVariable",
+                    variableName: "displayDigits",
+                },
+                displayDecimals: {
+                    dependencyType: "stateVariable",
+                    variableName: "displayDecimals",
+                },
+                avoidScientificNotation: {
+                    dependencyType: "stateVariable",
+                    variableName: "avoidScientificNotation",
+                },
+            }),
+            definition: function ({ dependencyValues }) {
+                let params = buildNumberDisplayParameters({
+                    padZeros: dependencyValues.padZeros,
+                    displayDigits: dependencyValues.displayDigits,
+                    displayDecimals: dependencyValues.displayDecimals,
+                    avoidScientificNotation:
+                        dependencyValues.avoidScientificNotation,
+                });
+                return {
+                    setValue: {
+                        text: dependencyValues.valueForDisplay.toString(params),
+                    },
+                };
+            },
+        };
+
+        stateVariableDefinitions.componentType = {
+            returnDependencies: () => ({}),
+            definition: () => ({ setValue: { componentType: "math" } }),
+        };
+
+        stateVariableDefinitions.descriptionChildInd = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                allChildren: {
+                    dependencyType: "child",
+                    includeAllChildren: true,
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        descriptionChildInd:
+                            dependencyValues.allChildren.findLastIndex(
+                                (child) =>
+                                    child.componentType === "description",
+                            ),
+                    },
+                };
+            },
+        };
+
+        stateVariableDefinitions.childIndicesToRender = {
+            returnDependencies: () => ({
+                descriptionChildInd: {
+                    dependencyType: "stateVariable",
+                    variableName: "descriptionChildInd",
+                },
+            }),
+            definition({ dependencyValues }) {
+                const childIndicesToRender = [0, 1];
+
+                if (dependencyValues.descriptionChildInd !== -1) {
+                    childIndicesToRender.push(
+                        dependencyValues.descriptionChildInd,
+                    );
+                }
+
+                return {
+                    setValue: {
+                        childIndicesToRender,
+                    },
+                };
+            },
+            markStale: () => ({ updateRenderedChildren: true }),
+        };
+
+        stateVariableDefinitions.focused = {
+            description:
+                "Whether the fraction input currently has keyboard focus.",
+            public: true,
+            shadowingInstructions: {
+                createComponentOfType: "boolean",
+            },
+            returnDependencies: () => ({
+                fractionChildren: {
+                    dependencyType: "child",
+                    childGroups: ["fractionInputComponents"],
+                    variableNames: ["focused"],
+                },
+            }),
+            definition: ({ dependencyValues }) => ({
+                setValue: {
+                    focused: dependencyValues.fractionChildren.some(
+                        (child) => child.stateValues.focused,
+                    ),
+                },
+            }),
+        };
+
+        return stateVariableDefinitions;
+    }
+
+    static adapters = [
+        {
+            stateVariable: "value",
+            stateVariablesToShadow: Object.keys(
+                returnNumberDisplayStateVariableDefinitions(),
+            ),
+        },
+    ];
+}
+
+export default class FractionComponentInput extends BaseComponent {
+    constructor(args) {
+        super(args);
+
+        Object.assign(this.actions, {
+            updateRawValue: this.updateRawValue.bind(this),
+            updateValue: this.updateValue.bind(this),
+            focusChanged: this.focusChanged.bind(this),
+        });
+    }
+
+    static componentType = "_fractionInputComponent";
+    static rendererType = "mathInput";
+
+    static variableForImplicitProp = "value";
+
+    static createAttributesObject() {
+        let attributes = super.createAttributesObject();
+
+        // "numerator" or "denominator"; set by the fractionInput sugar
+        attributes.part = {
+            createPrimitiveOfType: "string",
+            createStateVariable: "part",
+            defaultValue: null,
+        };
+
+        return attributes;
+    }
+
+    static returnStateVariableDefinitions() {
+        let stateVariableDefinitions = super.returnStateVariableDefinitions();
+
+        stateVariableDefinitions.minWidth = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                fractionInputAncestor: {
+                    dependencyType: "ancestor",
+                    componentType: "fractionInput",
+                    variableNames: ["minComponentWidth"],
+                },
+            }),
+            definition({ dependencyValues }) {
+                if (dependencyValues.fractionInputAncestor) {
+                    return {
+                        setValue: {
+                            minWidth:
+                                dependencyValues.fractionInputAncestor
+                                    .stateValues.minComponentWidth,
+                        },
+                    };
+                } else {
+                    return { setValue: { minWidth: 0 } };
+                }
+            },
+        };
+
+        // don't specify attributes on fractionComponentInput
+        // instead gets these state variables from the parent fractionInput:
+        // format, functionSymbols, splitSymbols, parseScientificNotation
+        // displayDigits, displayDecimals, displaySmallAsZero, unionFromU
+        stateVariableDefinitions.format = {
+            returnDependencies: () => ({
+                parentFormat: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "format",
+                },
+            }),
+            definition({ dependencyValues }) {
+                return { setValue: { format: dependencyValues.parentFormat } };
+            },
+        };
+
+        stateVariableDefinitions.functionSymbols = {
+            returnDependencies: () => ({
+                parentFunctionSymbols: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "functionSymbols",
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        functionSymbols: dependencyValues.parentFunctionSymbols,
+                    },
+                };
+            },
+        };
+
+        stateVariableDefinitions.splitSymbols = {
+            returnDependencies: () => ({
+                parentSplitSymbols: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "splitSymbols",
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        splitSymbols: dependencyValues.parentSplitSymbols,
+                    },
+                };
+            },
+        };
+
+        stateVariableDefinitions.parseScientificNotation = {
+            returnDependencies: () => ({
+                parentParseScientificNotation: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "parseScientificNotation",
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        parseScientificNotation:
+                            dependencyValues.parentParseScientificNotation,
+                    },
+                };
+            },
+        };
+
+        stateVariableDefinitions.displayDigits = {
+            returnDependencies: () => ({
+                parentDisplayDigits: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "displayDigits",
+                },
+            }),
+            definition({ dependencyValues, usedDefault }) {
+                let result = {
+                    setValue: {
+                        displayDigits: dependencyValues.parentDisplayDigits,
+                    },
+                };
+
+                if (usedDefault.parentDisplayDigits) {
+                    result.markAsUsedDefault = { displayDigits: true };
+                }
+
+                return result;
+            },
+        };
+
+        stateVariableDefinitions.displayDecimals = {
+            returnDependencies: () => ({
+                parentDisplayDecimals: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "displayDecimals",
+                },
+            }),
+            definition({ dependencyValues, usedDefault }) {
+                let result = {
+                    setValue: {
+                        displayDecimals: dependencyValues.parentDisplayDecimals,
+                    },
+                };
+
+                if (usedDefault.parentDisplayDecimals) {
+                    result.markAsUsedDefault = { displayDecimals: true };
+                }
+
+                return result;
+            },
+        };
+
+        stateVariableDefinitions.displaySmallAsZero = {
+            returnDependencies: () => ({
+                parentDisplaySmallAsZero: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "displaySmallAsZero",
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        displaySmallAsZero:
+                            dependencyValues.parentDisplaySmallAsZero,
+                    },
+                };
+            },
+        };
+
+        stateVariableDefinitions.padZeros = {
+            returnDependencies: () => ({
+                parentPadZeros: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "padZeros",
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        padZeros: dependencyValues.parentPadZeros,
+                    },
+                };
+            },
+        };
+
+        stateVariableDefinitions.avoidScientificNotation = {
+            returnDependencies: () => ({
+                parentAvoidScientificNotation: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "avoidScientificNotation",
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        avoidScientificNotation:
+                            dependencyValues.parentAvoidScientificNotation,
+                    },
+                };
+            },
+        };
+
+        stateVariableDefinitions.unionFromU = {
+            returnDependencies: () => ({
+                parentUnionFromU: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName: "unionFromU",
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: { unionFromU: dependencyValues.parentUnionFromU },
+                };
+            },
+        };
+
+        // get prefill from parent fractionInput, depending on part
+        stateVariableDefinitions.prefill = {
+            stateVariablesDeterminingDependencies: ["part"],
+            returnDependencies: ({ stateValues }) => ({
+                parentPrefill: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName:
+                        stateValues.part === "denominator"
+                            ? "prefillDenominator"
+                            : "prefillNumerator",
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        prefill: dependencyValues.parentPrefill ?? blankMath(),
+                    },
+                };
+            },
+        };
+
+        stateVariableDefinitions.valueChanged = {
+            public: true,
+            hasEssential: true,
+            defaultValue: false,
+            shadowingInstructions: {
+                createComponentOfType: "boolean",
+            },
+            returnDependencies: () => ({}),
+            definition() {
+                return { useEssentialOrDefaultValue: { valueChanged: true } };
+            },
+            inverseDefinition({ desiredStateVariableValues }) {
+                return {
+                    success: true,
+                    instructions: [
+                        {
+                            setEssentialValue: "valueChanged",
+                            value: Boolean(
+                                desiredStateVariableValues.valueChanged,
+                            ),
+                        },
+                    ],
+                };
+            },
+        };
+
+        stateVariableDefinitions.immediateValueChanged = {
+            public: true,
+            hasEssential: true,
+            defaultValue: false,
+            shadowingInstructions: {
+                createComponentOfType: "boolean",
+            },
+            returnDependencies: () => ({}),
+            definition() {
+                return {
+                    useEssentialOrDefaultValue: { immediateValueChanged: true },
+                };
+            },
+            inverseDefinition({ desiredStateVariableValues }) {
+                return {
+                    success: true,
+                    instructions: [
+                        {
+                            setEssentialValue: "immediateValueChanged",
+                            value: Boolean(
+                                desiredStateVariableValues.immediateValueChanged,
+                            ),
+                        },
+                    ],
+                };
+            },
+        };
+
+        stateVariableDefinitions.value = {
+            hasEssential: true,
+            shadowVariable: true,
+            set: convertValueToMathExpression,
+            returnDependencies: () => ({
+                prefill: {
+                    dependencyType: "stateVariable",
+                    variableName: "prefill",
+                },
+                valueChanged: {
+                    dependencyType: "stateVariable",
+                    variableName: "valueChanged",
+                    onlyToSetInInverseDefinition: true,
+                },
+                immediateValueChanged: {
+                    dependencyType: "stateVariable",
+                    variableName: "immediateValueChanged",
+                    onlyToSetInInverseDefinition: true,
+                },
+            }),
+            definition: function ({ dependencyValues }) {
+                return {
+                    useEssentialOrDefaultValue: {
+                        value: {
+                            defaultValue: dependencyValues.prefill,
+                        },
+                    },
+                };
+            },
+            inverseDefinition: function ({ desiredStateVariableValues }) {
+                return {
+                    success: true,
+                    instructions: [
+                        {
+                            setDependency: "valueChanged",
+                            desiredValue: true,
+                        },
+                        {
+                            setDependency: "immediateValueChanged",
+                            desiredValue: true,
+                        },
+                        {
+                            setEssentialValue: "value",
+                            value: desiredStateVariableValues.value,
+                        },
+                    ],
+                };
+            },
+        };
+
+        stateVariableDefinitions.immediateValue = {
+            hasEssential: true,
+            shadowVariable: true,
+            set: convertValueToMathExpression,
+            returnDependencies: () => ({
+                value: {
+                    dependencyType: "stateVariable",
+                    variableName: "value",
+                },
+                immediateValueChanged: {
+                    dependencyType: "stateVariable",
+                    variableName: "immediateValueChanged",
+                    onlyToSetInInverseDefinition: true,
+                },
+            }),
+            definition: function ({
+                dependencyValues,
+                changes,
+                justUpdatedForNewComponent,
+                usedDefault,
+            }) {
+                if (
+                    changes.value &&
+                    !justUpdatedForNewComponent &&
+                    !usedDefault.value
+                ) {
+                    // only update to value when it changes
+                    // (otherwise, let its essential value change)
+                    return {
+                        setValue: { immediateValue: dependencyValues.value },
+                        setEssentialValue: {
+                            immediateValue: dependencyValues.value,
+                        },
+                    };
+                } else {
+                    return {
+                        useEssentialOrDefaultValue: {
+                            immediateValue: {
+                                defaultValue: dependencyValues.value,
+                            },
+                        },
+                    };
+                }
+            },
+            inverseDefinition: function ({
+                desiredStateVariableValues,
+                initialChange,
+                shadowedVariable,
+            }) {
+                let instructions = [
+                    {
+                        setEssentialValue: "immediateValue",
+                        value: desiredStateVariableValues.immediateValue,
+                    },
+                    {
+                        setDependency: "immediateValueChanged",
+                        desiredValue: true,
+                    },
+                ];
+
+                // if from outside sources, also set value
+                if (!(initialChange || shadowedVariable)) {
+                    instructions.push({
+                        setDependency: "value",
+                        desiredValue: desiredStateVariableValues.immediateValue,
+                    });
+                }
+
+                return {
+                    success: true,
+                    instructions,
+                };
+            },
+        };
+
+        stateVariableDefinitions.valueForDisplay = {
+            returnDependencies: () => ({
+                value: {
+                    dependencyType: "stateVariable",
+                    variableName: "value",
+                },
+                displayDigits: {
+                    dependencyType: "stateVariable",
+                    variableName: "displayDigits",
+                },
+                displayDecimals: {
+                    dependencyType: "stateVariable",
+                    variableName: "displayDecimals",
+                },
+                displaySmallAsZero: {
+                    dependencyType: "stateVariable",
+                    variableName: "displaySmallAsZero",
+                },
+            }),
+            definition: function ({ dependencyValues }) {
+                let rounded = roundForDisplay({
+                    value: dependencyValues.value,
+                    dependencyValues,
+                });
+
+                return {
+                    setValue: { valueForDisplay: rounded },
+                };
+            },
+        };
+
+        stateVariableDefinitions.text = {
+            public: true,
+            description: "The current value as a text string.",
+            shadowingInstructions: {
+                createComponentOfType: "text",
+            },
+            returnDependencies: () => ({
+                valueForDisplay: {
+                    dependencyType: "stateVariable",
+                    variableName: "valueForDisplay",
+                },
+                padZeros: {
+                    dependencyType: "stateVariable",
+                    variableName: "padZeros",
+                },
+                displayDigits: {
+                    dependencyType: "stateVariable",
+                    variableName: "displayDigits",
+                },
+                displayDecimals: {
+                    dependencyType: "stateVariable",
+                    variableName: "displayDecimals",
+                },
+                avoidScientificNotation: {
+                    dependencyType: "stateVariable",
+                    variableName: "avoidScientificNotation",
+                },
+            }),
+            definition: function ({ dependencyValues }) {
+                let params = buildNumberDisplayParameters({
+                    padZeros: dependencyValues.padZeros,
+                    displayDigits: dependencyValues.displayDigits,
+                    displayDecimals: dependencyValues.displayDecimals,
+                    avoidScientificNotation:
+                        dependencyValues.avoidScientificNotation,
+                });
+                return {
+                    setValue: {
+                        text: dependencyValues.valueForDisplay.toString(params),
+                    },
+                };
+            },
+        };
+
+        // raw value from renderer
+        stateVariableDefinitions.rawRendererValue = {
+            description: "The raw value used by the renderer.",
+            forRenderer: true,
+            hasEssential: true,
+            shadowVariable: true,
+            defaultValue: "",
+            provideEssentialValuesInDefinition: true,
+            public: true,
+            shadowingInstructions: {
+                createComponentOfType: "text",
+            },
+            additionalStateVariablesDefined: [
+                {
+                    variableName: "lastValueForDisplay",
+                    hasEssential: true,
+                    shadowVariable: true,
+                    defaultValue: null,
+                    set: convertValueToMathExpression,
+                },
+            ],
+            returnDependencies: () => ({
+                // include immediateValue for inverse definition
+                immediateValue: {
+                    dependencyType: "stateVariable",
+                    variableName: "immediateValue",
+                },
+                valueForDisplay: {
+                    dependencyType: "stateVariable",
+                    variableName: "valueForDisplay",
+                },
+            }),
+            definition({ dependencyValues, essentialValues }) {
+                // use deepCompare of trees rather than equalsViaSyntax
+                // so even tiny numerical differences that within double precision are detected
+                if (
+                    essentialValues.rawRendererValue === undefined ||
+                    !deepCompare(
+                        essentialValues.lastValueForDisplay.tree,
+                        dependencyValues.valueForDisplay.tree,
+                    )
+                ) {
+                    let rawRendererValue = stripLatex(
+                        dependencyValues.valueForDisplay.toLatex(),
+                    );
+                    if (rawRendererValue === "\uff3f") {
+                        rawRendererValue = "";
+                    }
+                    return {
+                        setValue: {
+                            rawRendererValue,
+                            lastValueForDisplay:
+                                dependencyValues.valueForDisplay,
+                        },
+                        setEssentialValue: {
+                            rawRendererValue,
+                            lastValueForDisplay:
+                                dependencyValues.valueForDisplay,
+                        },
+                    };
+                } else {
+                    return {
+                        useEssentialOrDefaultValue: {
+                            rawRendererValue: true,
+                            lastValueForDisplay: true,
+                        },
+                    };
+                }
+            },
+            async inverseDefinition({
+                desiredStateVariableValues,
+                stateValues,
+                essentialValues,
+            }) {
+                const calculateMathExpressionFromLatex = async (text) => {
+                    let expression;
+
+                    text = normalizeLatexString(text, {
+                        unionFromU: await stateValues.unionFromU,
+                    });
+
+                    // replace ^25 with ^{2}5, since mathQuill uses standard latex conventions
+                    // unlike math-expression's latex parser
+                    text = text.replace(/\^(\w)/g, "^{$1}");
+
+                    let fromLatex = latexToMathFactory({
+                        functionSymbols: await stateValues.functionSymbols,
+                        splitSymbols: await stateValues.splitSymbols,
+                        parseScientificNotation:
+                            await stateValues.parseScientificNotation,
+                    });
+
+                    try {
+                        expression = fromLatex(text);
+                    } catch (e) {
+                        expression = me.fromAst("\uFF3F");
+                    }
+                    return expression;
+                };
+
+                let instructions = [];
+
+                if (
+                    typeof desiredStateVariableValues.rawRendererValue ===
+                    "string"
+                ) {
+                    let currentValue = essentialValues.rawRendererValue;
+                    let desiredValue =
+                        desiredStateVariableValues.rawRendererValue;
+
+                    if (currentValue !== desiredValue) {
+                        instructions.push({
+                            setEssentialValue: "rawRendererValue",
+                            value: desiredValue,
+                        });
+                    }
+
+                    let currentMath =
+                        await calculateMathExpressionFromLatex(currentValue);
+                    let desiredMath =
+                        await calculateMathExpressionFromLatex(desiredValue);
+
+                    // use deepCompare of trees rather than equalsViaSyntax
+                    // so even tiny numerical differences that within double precision are detected
+                    if (!deepCompare(desiredMath.tree, currentMath.tree)) {
+                        instructions.push({
+                            setDependency: "immediateValue",
+                            desiredValue: desiredMath,
+                            treatAsInitialChange: true, // so does not change value
+                        });
+                    }
+                } else {
+                    // since desired value was not a string, it must be a math-expression
+                    // always update lastValueForDisplay
+                    // update rawRendererValue
+                    // if desired expression is different from math-expression obtained from current raw value
+                    // do not update immediate value
+
+                    instructions.push({
+                        setEssentialValue: "lastValueForDisplay",
+                        value: desiredStateVariableValues.rawRendererValue,
+                    });
+
+                    let currentMath = await calculateMathExpressionFromLatex(
+                        essentialValues.rawRendererValue,
+                    );
+
+                    // use deepCompare of trees rather than equalsViaSyntax
+                    // so even tiny numerical differences that within double precision are detected
+                    if (
+                        !deepCompare(
+                            desiredStateVariableValues.rawRendererValue.tree,
+                            currentMath.tree,
+                        )
+                    ) {
+                        let desiredValue = stripLatex(
+                            desiredStateVariableValues.rawRendererValue.toLatex(),
+                        );
+                        if (desiredValue === "\uff3f") {
+                            desiredValue = "";
+                        }
+                        instructions.push({
+                            setEssentialValue: "rawRendererValue",
+                            value: desiredValue,
+                        });
+                    }
+                }
+
+                return {
+                    success: true,
+                    instructions,
+                };
+            },
+        };
+
+        stateVariableDefinitions.componentType = {
+            returnDependencies: () => ({}),
+            definition: () => ({ setValue: { componentType: "math" } }),
+        };
+
+        stateVariableDefinitions.focused = {
+            forRenderer: true,
+            hasEssential: true,
+            defaultValue: false,
+            public: true,
+            description:
+                "Whether this part of the fraction input currently has keyboard focus.",
+            shadowingInstructions: {
+                createComponentOfType: "boolean",
+            },
+            ignoreFixed: true,
+            returnDependencies: () => ({}),
+            definition: () => ({
+                useEssentialOrDefaultValue: { focused: true },
+            }),
+            inverseDefinition({ desiredStateVariableValues }) {
+                return {
+                    success: true,
+                    instructions: [
+                        {
+                            setEssentialValue: "focused",
+                            value: Boolean(desiredStateVariableValues.focused),
+                        },
+                    ],
+                };
+            },
+        };
+
+        // Provide an accessible name/description for each part's textarea.
+        stateVariableDefinitions.shortDescription = {
+            forRenderer: true,
+            returnDependencies: () => ({
+                part: {
+                    dependencyType: "stateVariable",
+                    variableName: "part",
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        shortDescription: dependencyValues.part ?? "",
+                    },
+                };
+            },
+        };
+
+        return stateVariableDefinitions;
+    }
+
+    async updateRawValue({
+        rawRendererValue,
+        actionId,
+        sourceInformation = {},
+        skipRendererUpdate = false,
+    }) {
+        if (!(await this.stateValues.disabled)) {
+            return await this.coreFunctions.performUpdate({
+                updateInstructions: [
+                    {
+                        updateType: "updateValue",
+                        componentIdx: this.componentIdx,
+                        stateVariable: "rawRendererValue",
+                        value: rawRendererValue,
+                    },
+                    {
+                        updateType: "setComponentNeedingUpdateValue",
+                        componentIdx: this.componentIdx,
+                    },
+                ],
+                transient: true,
+                actionId,
+                sourceInformation,
+                skipRendererUpdate,
+            });
+        }
+    }
+
+    async updateValue({
+        actionId,
+        sourceInformation = {},
+        skipRendererUpdate = false,
+    }) {
+        if (!(await this.stateValues.disabled)) {
+            let immediateValue = await this.stateValues.immediateValue;
+
+            if (
+                !deepCompare(
+                    (await this.stateValues.value).tree,
+                    immediateValue.tree,
+                )
+            ) {
+                let updateInstructions = [
+                    {
+                        updateType: "updateValue",
+                        componentIdx: this.componentIdx,
+                        stateVariable: "value",
+                        value: immediateValue,
+                    },
+                    // in case value ended up being a different value than requested
+                    // we set immediate value to whatever was the result
+                    // (hence the need to execute update first)
+                    {
+                        updateType: "executeUpdate",
+                    },
+                    {
+                        updateType: "updateValue",
+                        componentIdx: this.componentIdx,
+                        stateVariable: "immediateValue",
+                        valueOfStateVariable: "value",
+                    },
+                    {
+                        updateType: "unsetComponentNeedingUpdateValue",
+                    },
+                ];
+
+                if (immediateValue.tree !== "\uff3f") {
+                    updateInstructions.push({
+                        updateType: "updateValue",
+                        componentIdx: this.componentIdx,
+                        stateVariable: "rawRendererValue",
+                        valueOfStateVariable: "valueForDisplay",
+                    });
+                }
+
+                let event = {
+                    verb: "answered",
+                    object: {
+                        componentIdx: this.componentIdx,
+                        componentType: this.componentType,
+                    },
+                    result: {
+                        response: immediateValue,
+                        responseText: immediateValue.toString(),
+                    },
+                };
+
+                await this.coreFunctions.performUpdate({
+                    updateInstructions,
+                    actionId,
+                    sourceInformation,
+                    skipRendererUpdate: true,
+                    event,
+                });
+
+                return await this.coreFunctions.triggerChainedActions({
+                    componentIdx: this.componentIdx,
+                    actionId,
+                    sourceInformation,
+                    skipRendererUpdate,
+                });
+            } else {
+                // set raw renderer value to save it to the database,
+                // as it might not have been saved
+                // given that updateRawValue is transient
+                await this.coreFunctions.performUpdate({
+                    updateInstructions: [
+                        {
+                            updateType: "updateValue",
+                            componentIdx: this.componentIdx,
+                            stateVariable: "rawRendererValue",
+                            valueOfStateVariable: "rawRendererValue",
+                        },
+                    ],
+                    actionId,
+                    sourceInformation,
+                    skipRendererUpdate,
+                });
+            }
+        }
+    }
+
+    async focusChanged({ focused, actionId, sourceInformation }) {
+        return await this.coreFunctions.performUpdate({
+            updateInstructions: [
+                {
+                    updateType: "updateValue",
+                    componentIdx: this.componentIdx,
+                    stateVariable: "focused",
+                    value: focused,
+                },
+            ],
+            actionId,
+            sourceInformation,
+            overrideReadOnly: true,
+            doNotSave: true,
+        });
+    }
+}

--- a/packages/doenetml-worker-javascript/src/components/FractionInput.js
+++ b/packages/doenetml-worker-javascript/src/components/FractionInput.js
@@ -32,9 +32,7 @@ function isNegatedFractionTree(tree) {
 
 // Split a math value into the numerator and denominator that the two input
 // boxes display. A division becomes its two operands; a negated division puts
-// the sign in the numerator; a blank stays blank in both boxes. (A non-fraction
-// is treated as value-over-1; in practice `value` is kept as a fraction so this
-// is only a safety net.)
+// the sign in the numerator; a blank stays blank in both boxes.
 function decomposeFraction(mathValue) {
     let tree = mathValue?.tree;
     if (isFractionTree(tree)) {
@@ -160,9 +158,6 @@ export class FractionInput extends Input {
         return attributes;
     }
 
-    // Although it will accept any math, the schema shows just math
-    static additionalSchemaChildren = ["math"];
-
     static returnChildGroups() {
         return [
             {
@@ -185,7 +180,6 @@ export class FractionInput extends Input {
             {
                 group: "maths",
                 componentTypes: ["math"],
-                excludeFromSchema: true,
             },
         ];
     }
@@ -204,20 +198,20 @@ export class FractionInput extends Input {
         const inputValueChangedStateVariableDefinitions =
             returnInputValueChangedStateVariableDefinitions({
                 valueChangedDescription:
-                    "Whether the saved fraction has been changed from its initial state.",
+                    "Whether the value has been changed from its initial state.",
                 immediateValueChangedDescription:
-                    "Whether the live fraction differs from its initial state.",
+                    "Whether the value, including in-progress edits, has been changed from its initial state.",
             });
 
         stateVariableDefinitions.valueChanged =
             inputValueChangedStateVariableDefinitions.valueChanged;
 
-        // The fraction's saved value. It is linked to a `<math>` child or the
+        // The fraction's value. It is linked to a `<math>` child or the
         // `bindValueTo` attribute when present (two-way), otherwise it is an
         // essential value seeded from prefillNumerator/prefillDenominator.
         stateVariableDefinitions.value = {
             description:
-                "The most recently saved fraction value (numerator divided by denominator).",
+                "The fraction value of the input (numerator divided by denominator).",
             public: true,
             hasEssential: true,
             shadowVariable: true,
@@ -329,10 +323,10 @@ export class FractionInput extends Input {
         stateVariableDefinitions.immediateValueChanged =
             inputValueChangedStateVariableDefinitions.immediateValueChanged;
 
-        // The live fraction being entered, before it is saved.
+        // The fraction value reflecting the user's in-progress edits.
         stateVariableDefinitions.immediateValue = {
             description:
-                "The current fraction being entered (live, before saving).",
+                "The fraction value reflecting the user's in-progress edits.",
             public: true,
             hasEssential: true,
             shadowVariable: true,
@@ -411,9 +405,9 @@ export class FractionInput extends Input {
         };
 
         // The numerator and denominator boxes display the decomposition of the
-        // saved value; editing one routes back through `value`.
+        // value; editing one routes back through `value`.
         stateVariableDefinitions.numerator = {
-            description: "The most recently saved numerator value.",
+            description: "The numerator of the fraction.",
             public: true,
             shadowingInstructions: {
                 createComponentOfType: "math",
@@ -455,7 +449,7 @@ export class FractionInput extends Input {
         };
 
         stateVariableDefinitions.denominator = {
-            description: "The most recently saved denominator value.",
+            description: "The denominator of the fraction.",
             public: true,
             shadowingInstructions: {
                 createComponentOfType: "math",
@@ -781,7 +775,7 @@ export default class FractionComponentInput extends BaseComponent {
             }),
         );
 
-        // Each box reads its saved value from the parent fractionInput
+        // Each box reads its value from the parent fractionInput
         // (numerator or denominator) and routes edits back to it.
         stateVariableDefinitions.value = {
             stateVariablesDeterminingDependencies: ["part"],

--- a/packages/doenetml-worker-javascript/src/components/FractionInput.js
+++ b/packages/doenetml-worker-javascript/src/components/FractionInput.js
@@ -14,6 +14,7 @@ import {
     mathComponentInputFocusChanged,
     mathComponentInputUpdateRawValue,
     mathComponentInputUpdateValue,
+    returnInputValueChangedStateVariableDefinitions,
     returnMathComponentInputConfigStateVariableDefinitions,
     returnMathComponentInputDisplayStateVariableDefinitions,
     returnMathInputParsingAttributes,
@@ -200,33 +201,16 @@ export class FractionInput extends Input {
             }),
         );
 
-        stateVariableDefinitions.valueChanged = {
-            description:
-                "Whether the saved fraction has been changed from its initial state.",
-            public: true,
-            hasEssential: true,
-            defaultValue: false,
-            shadowingInstructions: {
-                createComponentOfType: "boolean",
-            },
-            returnDependencies: () => ({}),
-            definition() {
-                return { useEssentialOrDefaultValue: { valueChanged: true } };
-            },
-            inverseDefinition({ desiredStateVariableValues }) {
-                return {
-                    success: true,
-                    instructions: [
-                        {
-                            setEssentialValue: "valueChanged",
-                            value: Boolean(
-                                desiredStateVariableValues.valueChanged,
-                            ),
-                        },
-                    ],
-                };
-            },
-        };
+        const inputValueChangedStateVariableDefinitions =
+            returnInputValueChangedStateVariableDefinitions({
+                valueChangedDescription:
+                    "Whether the saved fraction has been changed from its initial state.",
+                immediateValueChangedDescription:
+                    "Whether the live fraction differs from its initial state.",
+            });
+
+        stateVariableDefinitions.valueChanged =
+            inputValueChangedStateVariableDefinitions.valueChanged;
 
         // The fraction's saved value. It is linked to a `<math>` child or the
         // `bindValueTo` attribute when present (two-way), otherwise it is an
@@ -342,35 +326,8 @@ export class FractionInput extends Input {
             },
         };
 
-        stateVariableDefinitions.immediateValueChanged = {
-            description:
-                "Whether the live fraction differs from its initial state.",
-            public: true,
-            hasEssential: true,
-            defaultValue: false,
-            shadowingInstructions: {
-                createComponentOfType: "boolean",
-            },
-            returnDependencies: () => ({}),
-            definition() {
-                return {
-                    useEssentialOrDefaultValue: { immediateValueChanged: true },
-                };
-            },
-            inverseDefinition({ desiredStateVariableValues }) {
-                return {
-                    success: true,
-                    instructions: [
-                        {
-                            setEssentialValue: "immediateValueChanged",
-                            value: Boolean(
-                                desiredStateVariableValues.immediateValueChanged,
-                            ),
-                        },
-                    ],
-                };
-            },
-        };
+        stateVariableDefinitions.immediateValueChanged =
+            inputValueChangedStateVariableDefinitions.immediateValueChanged;
 
         // The live fraction being entered, before it is saved.
         stateVariableDefinitions.immediateValue = {

--- a/packages/doenetml-worker-javascript/src/components/FractionInput.js
+++ b/packages/doenetml-worker-javascript/src/components/FractionInput.js
@@ -12,6 +12,7 @@ import { roundForDisplay } from "../utils/math";
 import {
     defineSubmitAnswerExternalAction,
     mathComponentInputFocusChanged,
+    mathComponentInputUpdateRawValue,
     mathComponentInputUpdateValue,
     returnInputValueChangedStateVariableDefinitions,
     returnMathComponentInputConfigStateVariableDefinitions,
@@ -533,7 +534,7 @@ export default class FractionComponentInput extends BaseComponent {
         super(args);
 
         Object.assign(this.actions, {
-            updateRawValue: this.updateRawValue.bind(this),
+            updateRawValue: mathComponentInputUpdateRawValue.bind(this),
             updateValue: mathComponentInputUpdateValue.bind(this),
             focusChanged: mathComponentInputFocusChanged.bind(this),
         });
@@ -746,33 +747,5 @@ export default class FractionComponentInput extends BaseComponent {
         };
 
         return stateVariableDefinitions;
-    }
-
-    async updateRawValue({
-        rawRendererValue,
-        actionId,
-        sourceInformation = {},
-        skipRendererUpdate = false,
-    }) {
-        if (!(await this.stateValues.disabled)) {
-            return await this.coreFunctions.performUpdate({
-                updateInstructions: [
-                    {
-                        updateType: "updateValue",
-                        componentIdx: this.componentIdx,
-                        stateVariable: "rawRendererValue",
-                        value: rawRendererValue,
-                    },
-                    {
-                        updateType: "setComponentNeedingUpdateValue",
-                        componentIdx: this.componentIdx,
-                    },
-                ],
-                transient: true,
-                actionId,
-                sourceInformation,
-                skipRendererUpdate,
-            });
-        }
     }
 }

--- a/packages/doenetml-worker-javascript/src/components/FractionInput.js
+++ b/packages/doenetml-worker-javascript/src/components/FractionInput.js
@@ -1,6 +1,6 @@
 import Input from "./abstract/Input";
 import me from "math-expressions";
-import { deepCompare, convertValueToMathExpression } from "@doenet/utils";
+import { convertValueToMathExpression } from "@doenet/utils";
 import BaseComponent from "./abstract/BaseComponent";
 import {
     buildNumberDisplayParameters,
@@ -8,12 +8,16 @@ import {
     returnNumberDisplayAttributes,
     returnNumberDisplayStateVariableDefinitions,
 } from "../utils/numberDisplay";
+import { roundForDisplay } from "../utils/math";
 import {
-    latexToMathFactory,
-    normalizeLatexString,
-    roundForDisplay,
-    stripLatex,
-} from "../utils/math";
+    defineSubmitAnswerExternalAction,
+    mathComponentInputFocusChanged,
+    mathComponentInputUpdateValue,
+    returnInputValueChangedStateVariableDefinitions,
+    returnMathComponentInputConfigStateVariableDefinitions,
+    returnMathComponentInputDisplayStateVariableDefinitions,
+    returnMathInputParsingAttributes,
+} from "../utils/mathComponentInput";
 
 const blankMath = () => me.fromAst("\uff3f");
 
@@ -21,23 +25,7 @@ export class FractionInput extends Input {
     constructor(args) {
         super(args);
 
-        this.externalActions = {};
-
-        //Complex because the stateValues isn't defined until later
-        Object.defineProperty(this.externalActions, "submitAnswer", {
-            enumerable: true,
-            get: async function () {
-                let answerAncestor = await this.stateValues.answerAncestor;
-                if (answerAncestor !== null) {
-                    return {
-                        componentIdx: answerAncestor.componentIdx,
-                        actionName: "submitAnswer",
-                    };
-                } else {
-                    return;
-                }
-            }.bind(this),
-        });
+        defineSubmitAnswerExternalAction(this);
     }
 
     static componentType = "fractionInput";
@@ -81,47 +69,7 @@ export class FractionInput extends Input {
                 "parseScientificNotation",
             ],
         };
-        attributes.format = {
-            description: "Input format for the numerator and denominator.",
-            createComponentOfType: "text",
-            createStateVariable: "format",
-            defaultValue: "text",
-            public: true,
-            toLowerCase: true,
-            validValues: [
-                {
-                    value: "text",
-                    description: "Plain-text math notation (e.g., `x^2 + 1`).",
-                },
-                {
-                    value: "latex",
-                    description: "LaTeX-formatted math (e.g., `x^{2} + 1`).",
-                },
-            ],
-        };
-        attributes.functionSymbols = {
-            description: "Symbols treated as function names when parsing.",
-            createComponentOfType: "textList",
-            createStateVariable: "functionSymbols",
-            defaultValue: ["f", "g"],
-            public: true,
-        };
-        attributes.splitSymbols = {
-            description:
-                "Whether multi-character symbols are split into a product of variables.",
-            createComponentOfType: "boolean",
-            createStateVariable: "splitSymbols",
-            defaultValue: true,
-            public: true,
-        };
-        attributes.parseScientificNotation = {
-            description:
-                "Whether to parse expressions like 1e3 as scientific notation.",
-            createComponentOfType: "boolean",
-            createStateVariable: "parseScientificNotation",
-            defaultValue: false,
-            public: true,
-        };
+        Object.assign(attributes, returnMathInputParsingAttributes());
 
         Object.assign(attributes, returnNumberDisplayAttributes());
 
@@ -586,8 +534,8 @@ export default class FractionComponentInput extends BaseComponent {
 
         Object.assign(this.actions, {
             updateRawValue: this.updateRawValue.bind(this),
-            updateValue: this.updateValue.bind(this),
-            focusChanged: this.focusChanged.bind(this),
+            updateValue: mathComponentInputUpdateValue.bind(this),
+            focusChanged: mathComponentInputFocusChanged.bind(this),
         });
     }
 
@@ -612,212 +560,14 @@ export default class FractionComponentInput extends BaseComponent {
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
 
-        stateVariableDefinitions.minWidth = {
-            forRenderer: true,
-            returnDependencies: () => ({
-                fractionInputAncestor: {
-                    dependencyType: "ancestor",
-                    componentType: "fractionInput",
-                    variableNames: ["minComponentWidth"],
-                },
+        // configuration read from the parent fractionInput (parsing,
+        // number-display, width), plus componentType and focused
+        Object.assign(
+            stateVariableDefinitions,
+            returnMathComponentInputConfigStateVariableDefinitions({
+                parentComponentType: "fractionInput",
             }),
-            definition({ dependencyValues }) {
-                if (dependencyValues.fractionInputAncestor) {
-                    return {
-                        setValue: {
-                            minWidth:
-                                dependencyValues.fractionInputAncestor
-                                    .stateValues.minComponentWidth,
-                        },
-                    };
-                } else {
-                    return { setValue: { minWidth: 0 } };
-                }
-            },
-        };
-
-        // don't specify attributes on fractionComponentInput
-        // instead gets these state variables from the parent fractionInput:
-        // format, functionSymbols, splitSymbols, parseScientificNotation
-        // displayDigits, displayDecimals, displaySmallAsZero, unionFromU
-        stateVariableDefinitions.format = {
-            returnDependencies: () => ({
-                parentFormat: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "fractionInput",
-                    variableName: "format",
-                },
-            }),
-            definition({ dependencyValues }) {
-                return { setValue: { format: dependencyValues.parentFormat } };
-            },
-        };
-
-        stateVariableDefinitions.functionSymbols = {
-            returnDependencies: () => ({
-                parentFunctionSymbols: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "fractionInput",
-                    variableName: "functionSymbols",
-                },
-            }),
-            definition({ dependencyValues }) {
-                return {
-                    setValue: {
-                        functionSymbols: dependencyValues.parentFunctionSymbols,
-                    },
-                };
-            },
-        };
-
-        stateVariableDefinitions.splitSymbols = {
-            returnDependencies: () => ({
-                parentSplitSymbols: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "fractionInput",
-                    variableName: "splitSymbols",
-                },
-            }),
-            definition({ dependencyValues }) {
-                return {
-                    setValue: {
-                        splitSymbols: dependencyValues.parentSplitSymbols,
-                    },
-                };
-            },
-        };
-
-        stateVariableDefinitions.parseScientificNotation = {
-            returnDependencies: () => ({
-                parentParseScientificNotation: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "fractionInput",
-                    variableName: "parseScientificNotation",
-                },
-            }),
-            definition({ dependencyValues }) {
-                return {
-                    setValue: {
-                        parseScientificNotation:
-                            dependencyValues.parentParseScientificNotation,
-                    },
-                };
-            },
-        };
-
-        stateVariableDefinitions.displayDigits = {
-            returnDependencies: () => ({
-                parentDisplayDigits: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "fractionInput",
-                    variableName: "displayDigits",
-                },
-            }),
-            definition({ dependencyValues, usedDefault }) {
-                let result = {
-                    setValue: {
-                        displayDigits: dependencyValues.parentDisplayDigits,
-                    },
-                };
-
-                if (usedDefault.parentDisplayDigits) {
-                    result.markAsUsedDefault = { displayDigits: true };
-                }
-
-                return result;
-            },
-        };
-
-        stateVariableDefinitions.displayDecimals = {
-            returnDependencies: () => ({
-                parentDisplayDecimals: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "fractionInput",
-                    variableName: "displayDecimals",
-                },
-            }),
-            definition({ dependencyValues, usedDefault }) {
-                let result = {
-                    setValue: {
-                        displayDecimals: dependencyValues.parentDisplayDecimals,
-                    },
-                };
-
-                if (usedDefault.parentDisplayDecimals) {
-                    result.markAsUsedDefault = { displayDecimals: true };
-                }
-
-                return result;
-            },
-        };
-
-        stateVariableDefinitions.displaySmallAsZero = {
-            returnDependencies: () => ({
-                parentDisplaySmallAsZero: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "fractionInput",
-                    variableName: "displaySmallAsZero",
-                },
-            }),
-            definition({ dependencyValues }) {
-                return {
-                    setValue: {
-                        displaySmallAsZero:
-                            dependencyValues.parentDisplaySmallAsZero,
-                    },
-                };
-            },
-        };
-
-        stateVariableDefinitions.padZeros = {
-            returnDependencies: () => ({
-                parentPadZeros: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "fractionInput",
-                    variableName: "padZeros",
-                },
-            }),
-            definition({ dependencyValues }) {
-                return {
-                    setValue: {
-                        padZeros: dependencyValues.parentPadZeros,
-                    },
-                };
-            },
-        };
-
-        stateVariableDefinitions.avoidScientificNotation = {
-            returnDependencies: () => ({
-                parentAvoidScientificNotation: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "fractionInput",
-                    variableName: "avoidScientificNotation",
-                },
-            }),
-            definition({ dependencyValues }) {
-                return {
-                    setValue: {
-                        avoidScientificNotation:
-                            dependencyValues.parentAvoidScientificNotation,
-                    },
-                };
-            },
-        };
-
-        stateVariableDefinitions.unionFromU = {
-            returnDependencies: () => ({
-                parentUnionFromU: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "fractionInput",
-                    variableName: "unionFromU",
-                },
-            }),
-            definition({ dependencyValues }) {
-                return {
-                    setValue: { unionFromU: dependencyValues.parentUnionFromU },
-                };
-            },
-        };
+        );
 
         // get prefill from parent fractionInput, depending on part
         stateVariableDefinitions.prefill = {
@@ -841,59 +591,10 @@ export default class FractionComponentInput extends BaseComponent {
             },
         };
 
-        stateVariableDefinitions.valueChanged = {
-            public: true,
-            hasEssential: true,
-            defaultValue: false,
-            shadowingInstructions: {
-                createComponentOfType: "boolean",
-            },
-            returnDependencies: () => ({}),
-            definition() {
-                return { useEssentialOrDefaultValue: { valueChanged: true } };
-            },
-            inverseDefinition({ desiredStateVariableValues }) {
-                return {
-                    success: true,
-                    instructions: [
-                        {
-                            setEssentialValue: "valueChanged",
-                            value: Boolean(
-                                desiredStateVariableValues.valueChanged,
-                            ),
-                        },
-                    ],
-                };
-            },
-        };
-
-        stateVariableDefinitions.immediateValueChanged = {
-            public: true,
-            hasEssential: true,
-            defaultValue: false,
-            shadowingInstructions: {
-                createComponentOfType: "boolean",
-            },
-            returnDependencies: () => ({}),
-            definition() {
-                return {
-                    useEssentialOrDefaultValue: { immediateValueChanged: true },
-                };
-            },
-            inverseDefinition({ desiredStateVariableValues }) {
-                return {
-                    success: true,
-                    instructions: [
-                        {
-                            setEssentialValue: "immediateValueChanged",
-                            value: Boolean(
-                                desiredStateVariableValues.immediateValueChanged,
-                            ),
-                        },
-                    ],
-                };
-            },
-        };
+        Object.assign(
+            stateVariableDefinitions,
+            returnInputValueChangedStateVariableDefinitions(),
+        );
 
         stateVariableDefinitions.value = {
             hasEssential: true,
@@ -1020,288 +721,11 @@ export default class FractionComponentInput extends BaseComponent {
             },
         };
 
-        stateVariableDefinitions.valueForDisplay = {
-            returnDependencies: () => ({
-                value: {
-                    dependencyType: "stateVariable",
-                    variableName: "value",
-                },
-                displayDigits: {
-                    dependencyType: "stateVariable",
-                    variableName: "displayDigits",
-                },
-                displayDecimals: {
-                    dependencyType: "stateVariable",
-                    variableName: "displayDecimals",
-                },
-                displaySmallAsZero: {
-                    dependencyType: "stateVariable",
-                    variableName: "displaySmallAsZero",
-                },
-            }),
-            definition: function ({ dependencyValues }) {
-                let rounded = roundForDisplay({
-                    value: dependencyValues.value,
-                    dependencyValues,
-                });
-
-                return {
-                    setValue: { valueForDisplay: rounded },
-                };
-            },
-        };
-
-        stateVariableDefinitions.text = {
-            public: true,
-            description: "The current value as a text string.",
-            shadowingInstructions: {
-                createComponentOfType: "text",
-            },
-            returnDependencies: () => ({
-                valueForDisplay: {
-                    dependencyType: "stateVariable",
-                    variableName: "valueForDisplay",
-                },
-                padZeros: {
-                    dependencyType: "stateVariable",
-                    variableName: "padZeros",
-                },
-                displayDigits: {
-                    dependencyType: "stateVariable",
-                    variableName: "displayDigits",
-                },
-                displayDecimals: {
-                    dependencyType: "stateVariable",
-                    variableName: "displayDecimals",
-                },
-                avoidScientificNotation: {
-                    dependencyType: "stateVariable",
-                    variableName: "avoidScientificNotation",
-                },
-            }),
-            definition: function ({ dependencyValues }) {
-                let params = buildNumberDisplayParameters({
-                    padZeros: dependencyValues.padZeros,
-                    displayDigits: dependencyValues.displayDigits,
-                    displayDecimals: dependencyValues.displayDecimals,
-                    avoidScientificNotation:
-                        dependencyValues.avoidScientificNotation,
-                });
-                return {
-                    setValue: {
-                        text: dependencyValues.valueForDisplay.toString(params),
-                    },
-                };
-            },
-        };
-
-        // raw value from renderer
-        stateVariableDefinitions.rawRendererValue = {
-            description: "The raw value used by the renderer.",
-            forRenderer: true,
-            hasEssential: true,
-            shadowVariable: true,
-            defaultValue: "",
-            provideEssentialValuesInDefinition: true,
-            public: true,
-            shadowingInstructions: {
-                createComponentOfType: "text",
-            },
-            additionalStateVariablesDefined: [
-                {
-                    variableName: "lastValueForDisplay",
-                    hasEssential: true,
-                    shadowVariable: true,
-                    defaultValue: null,
-                    set: convertValueToMathExpression,
-                },
-            ],
-            returnDependencies: () => ({
-                // include immediateValue for inverse definition
-                immediateValue: {
-                    dependencyType: "stateVariable",
-                    variableName: "immediateValue",
-                },
-                valueForDisplay: {
-                    dependencyType: "stateVariable",
-                    variableName: "valueForDisplay",
-                },
-            }),
-            definition({ dependencyValues, essentialValues }) {
-                // use deepCompare of trees rather than equalsViaSyntax
-                // so even tiny numerical differences that within double precision are detected
-                if (
-                    essentialValues.rawRendererValue === undefined ||
-                    !deepCompare(
-                        essentialValues.lastValueForDisplay.tree,
-                        dependencyValues.valueForDisplay.tree,
-                    )
-                ) {
-                    let rawRendererValue = stripLatex(
-                        dependencyValues.valueForDisplay.toLatex(),
-                    );
-                    if (rawRendererValue === "\uff3f") {
-                        rawRendererValue = "";
-                    }
-                    return {
-                        setValue: {
-                            rawRendererValue,
-                            lastValueForDisplay:
-                                dependencyValues.valueForDisplay,
-                        },
-                        setEssentialValue: {
-                            rawRendererValue,
-                            lastValueForDisplay:
-                                dependencyValues.valueForDisplay,
-                        },
-                    };
-                } else {
-                    return {
-                        useEssentialOrDefaultValue: {
-                            rawRendererValue: true,
-                            lastValueForDisplay: true,
-                        },
-                    };
-                }
-            },
-            async inverseDefinition({
-                desiredStateVariableValues,
-                stateValues,
-                essentialValues,
-            }) {
-                const calculateMathExpressionFromLatex = async (text) => {
-                    let expression;
-
-                    text = normalizeLatexString(text, {
-                        unionFromU: await stateValues.unionFromU,
-                    });
-
-                    // replace ^25 with ^{2}5, since mathQuill uses standard latex conventions
-                    // unlike math-expression's latex parser
-                    text = text.replace(/\^(\w)/g, "^{$1}");
-
-                    let fromLatex = latexToMathFactory({
-                        functionSymbols: await stateValues.functionSymbols,
-                        splitSymbols: await stateValues.splitSymbols,
-                        parseScientificNotation:
-                            await stateValues.parseScientificNotation,
-                    });
-
-                    try {
-                        expression = fromLatex(text);
-                    } catch (e) {
-                        expression = me.fromAst("\uFF3F");
-                    }
-                    return expression;
-                };
-
-                let instructions = [];
-
-                if (
-                    typeof desiredStateVariableValues.rawRendererValue ===
-                    "string"
-                ) {
-                    let currentValue = essentialValues.rawRendererValue;
-                    let desiredValue =
-                        desiredStateVariableValues.rawRendererValue;
-
-                    if (currentValue !== desiredValue) {
-                        instructions.push({
-                            setEssentialValue: "rawRendererValue",
-                            value: desiredValue,
-                        });
-                    }
-
-                    let currentMath =
-                        await calculateMathExpressionFromLatex(currentValue);
-                    let desiredMath =
-                        await calculateMathExpressionFromLatex(desiredValue);
-
-                    // use deepCompare of trees rather than equalsViaSyntax
-                    // so even tiny numerical differences that within double precision are detected
-                    if (!deepCompare(desiredMath.tree, currentMath.tree)) {
-                        instructions.push({
-                            setDependency: "immediateValue",
-                            desiredValue: desiredMath,
-                            treatAsInitialChange: true, // so does not change value
-                        });
-                    }
-                } else {
-                    // since desired value was not a string, it must be a math-expression
-                    // always update lastValueForDisplay
-                    // update rawRendererValue
-                    // if desired expression is different from math-expression obtained from current raw value
-                    // do not update immediate value
-
-                    instructions.push({
-                        setEssentialValue: "lastValueForDisplay",
-                        value: desiredStateVariableValues.rawRendererValue,
-                    });
-
-                    let currentMath = await calculateMathExpressionFromLatex(
-                        essentialValues.rawRendererValue,
-                    );
-
-                    // use deepCompare of trees rather than equalsViaSyntax
-                    // so even tiny numerical differences that within double precision are detected
-                    if (
-                        !deepCompare(
-                            desiredStateVariableValues.rawRendererValue.tree,
-                            currentMath.tree,
-                        )
-                    ) {
-                        let desiredValue = stripLatex(
-                            desiredStateVariableValues.rawRendererValue.toLatex(),
-                        );
-                        if (desiredValue === "\uff3f") {
-                            desiredValue = "";
-                        }
-                        instructions.push({
-                            setEssentialValue: "rawRendererValue",
-                            value: desiredValue,
-                        });
-                    }
-                }
-
-                return {
-                    success: true,
-                    instructions,
-                };
-            },
-        };
-
-        stateVariableDefinitions.componentType = {
-            returnDependencies: () => ({}),
-            definition: () => ({ setValue: { componentType: "math" } }),
-        };
-
-        stateVariableDefinitions.focused = {
-            forRenderer: true,
-            hasEssential: true,
-            defaultValue: false,
-            public: true,
-            description:
-                "Whether this part of the fraction input currently has keyboard focus.",
-            shadowingInstructions: {
-                createComponentOfType: "boolean",
-            },
-            ignoreFixed: true,
-            returnDependencies: () => ({}),
-            definition: () => ({
-                useEssentialOrDefaultValue: { focused: true },
-            }),
-            inverseDefinition({ desiredStateVariableValues }) {
-                return {
-                    success: true,
-                    instructions: [
-                        {
-                            setEssentialValue: "focused",
-                            value: Boolean(desiredStateVariableValues.focused),
-                        },
-                    ],
-                };
-            },
-        };
+        // valueForDisplay, text, and rawRendererValue
+        Object.assign(
+            stateVariableDefinitions,
+            returnMathComponentInputDisplayStateVariableDefinitions(),
+        );
 
         // Provide an accessible name/description for each part's textarea.
         stateVariableDefinitions.shortDescription = {
@@ -1350,116 +774,5 @@ export default class FractionComponentInput extends BaseComponent {
                 skipRendererUpdate,
             });
         }
-    }
-
-    async updateValue({
-        actionId,
-        sourceInformation = {},
-        skipRendererUpdate = false,
-    }) {
-        if (!(await this.stateValues.disabled)) {
-            let immediateValue = await this.stateValues.immediateValue;
-
-            if (
-                !deepCompare(
-                    (await this.stateValues.value).tree,
-                    immediateValue.tree,
-                )
-            ) {
-                let updateInstructions = [
-                    {
-                        updateType: "updateValue",
-                        componentIdx: this.componentIdx,
-                        stateVariable: "value",
-                        value: immediateValue,
-                    },
-                    // in case value ended up being a different value than requested
-                    // we set immediate value to whatever was the result
-                    // (hence the need to execute update first)
-                    {
-                        updateType: "executeUpdate",
-                    },
-                    {
-                        updateType: "updateValue",
-                        componentIdx: this.componentIdx,
-                        stateVariable: "immediateValue",
-                        valueOfStateVariable: "value",
-                    },
-                    {
-                        updateType: "unsetComponentNeedingUpdateValue",
-                    },
-                ];
-
-                if (immediateValue.tree !== "\uff3f") {
-                    updateInstructions.push({
-                        updateType: "updateValue",
-                        componentIdx: this.componentIdx,
-                        stateVariable: "rawRendererValue",
-                        valueOfStateVariable: "valueForDisplay",
-                    });
-                }
-
-                let event = {
-                    verb: "answered",
-                    object: {
-                        componentIdx: this.componentIdx,
-                        componentType: this.componentType,
-                    },
-                    result: {
-                        response: immediateValue,
-                        responseText: immediateValue.toString(),
-                    },
-                };
-
-                await this.coreFunctions.performUpdate({
-                    updateInstructions,
-                    actionId,
-                    sourceInformation,
-                    skipRendererUpdate: true,
-                    event,
-                });
-
-                return await this.coreFunctions.triggerChainedActions({
-                    componentIdx: this.componentIdx,
-                    actionId,
-                    sourceInformation,
-                    skipRendererUpdate,
-                });
-            } else {
-                // set raw renderer value to save it to the database,
-                // as it might not have been saved
-                // given that updateRawValue is transient
-                await this.coreFunctions.performUpdate({
-                    updateInstructions: [
-                        {
-                            updateType: "updateValue",
-                            componentIdx: this.componentIdx,
-                            stateVariable: "rawRendererValue",
-                            valueOfStateVariable: "rawRendererValue",
-                        },
-                    ],
-                    actionId,
-                    sourceInformation,
-                    skipRendererUpdate,
-                });
-            }
-        }
-    }
-
-    async focusChanged({ focused, actionId, sourceInformation }) {
-        return await this.coreFunctions.performUpdate({
-            updateInstructions: [
-                {
-                    updateType: "updateValue",
-                    componentIdx: this.componentIdx,
-                    stateVariable: "focused",
-                    value: focused,
-                },
-            ],
-            actionId,
-            sourceInformation,
-            overrideReadOnly: true,
-            doNotSave: true,
-        });
     }
 }

--- a/packages/doenetml-worker-javascript/src/components/FractionInput.js
+++ b/packages/doenetml-worker-javascript/src/components/FractionInput.js
@@ -14,13 +14,42 @@ import {
     mathComponentInputFocusChanged,
     mathComponentInputUpdateRawValue,
     mathComponentInputUpdateValue,
-    returnInputValueChangedStateVariableDefinitions,
     returnMathComponentInputConfigStateVariableDefinitions,
     returnMathComponentInputDisplayStateVariableDefinitions,
     returnMathInputParsingAttributes,
 } from "../utils/mathComponentInput";
 
 const blankMath = () => me.fromAst("\uff3f");
+
+// Split a math value into the numerator and denominator that the two input
+// boxes display. A division becomes its two operands; a blank stays blank in
+// both boxes; anything else (not a fraction) goes in the numerator with a
+// blank denominator (mirroring how matrixInput places a non-matrix value in
+// its first cell).
+function decomposeFraction(mathValue) {
+    let tree = mathValue?.tree;
+    if (Array.isArray(tree) && tree[0] === "/") {
+        return {
+            numerator: me.fromAst(tree[1]),
+            denominator: me.fromAst(tree[2]),
+        };
+    }
+    if (tree === undefined || tree === "\uff3f") {
+        return { numerator: blankMath(), denominator: blankMath() };
+    }
+    return { numerator: me.fromAst(tree), denominator: blankMath() };
+}
+
+// Combine the two boxes back into a single math value. When both boxes are
+// blank, the fraction as a whole is blank rather than a fraction of two blanks.
+function reconstructFraction(numerator, denominator) {
+    let numeratorTree = numerator?.tree ?? "\uff3f";
+    let denominatorTree = denominator?.tree ?? "\uff3f";
+    if (numeratorTree === "\uff3f" && denominatorTree === "\uff3f") {
+        return blankMath();
+    }
+    return me.fromAst(["/", numeratorTree, denominatorTree]);
+}
 
 export class FractionInput extends Input {
     constructor(args) {
@@ -90,8 +119,16 @@ export class FractionInput extends Input {
                 "Minimum rendered width for the numerator and denominator, in pixels.",
         };
 
+        attributes.bindValueTo = {
+            createComponentOfType: "math",
+            description: "Two-way binding target for the fraction's value.",
+        };
+
         return attributes;
     }
+
+    // Although it will accept any math, the schema shows just math
+    static additionalSchemaChildren = ["math"];
 
     static returnChildGroups() {
         return [
@@ -112,6 +149,11 @@ export class FractionInput extends Input {
                 componentTypes: ["_fractionInputComponent"],
                 excludeFromSchema: true,
             },
+            {
+                group: "maths",
+                componentTypes: ["math"],
+                excludeFromSchema: true,
+            },
         ];
     }
 
@@ -130,24 +172,136 @@ export class FractionInput extends Input {
             description:
                 "Whether the saved fraction has been changed from its initial state.",
             public: true,
+            hasEssential: true,
+            defaultValue: false,
             shadowingInstructions: {
                 createComponentOfType: "boolean",
             },
+            returnDependencies: () => ({}),
+            definition() {
+                return { useEssentialOrDefaultValue: { valueChanged: true } };
+            },
+            inverseDefinition({ desiredStateVariableValues }) {
+                return {
+                    success: true,
+                    instructions: [
+                        {
+                            setEssentialValue: "valueChanged",
+                            value: Boolean(
+                                desiredStateVariableValues.valueChanged,
+                            ),
+                        },
+                    ],
+                };
+            },
+        };
+
+        // The fraction's saved value. It is linked to a `<math>` child or the
+        // `bindValueTo` attribute when present (two-way), otherwise it is an
+        // essential value seeded from prefillNumerator/prefillDenominator.
+        stateVariableDefinitions.value = {
+            description:
+                "The most recently saved fraction value (numerator divided by denominator).",
+            public: true,
+            hasEssential: true,
+            shadowVariable: true,
+            shadowingInstructions: {
+                createComponentOfType: "math",
+                addAttributeComponentsShadowingStateVariables:
+                    returnNumberDisplayAttributeComponentShadowing(),
+            },
+            set: convertValueToMathExpression,
             returnDependencies: () => ({
-                fractionChildren: {
+                mathChild: {
                     dependencyType: "child",
-                    childGroups: ["fractionInputComponents"],
-                    variableNames: ["valueChanged"],
+                    childGroups: ["maths"],
+                    variableNames: ["value"],
+                    proceedIfAllChildrenNotMatched: true,
+                },
+                bindValueTo: {
+                    dependencyType: "attributeComponent",
+                    attributeName: "bindValueTo",
+                    variableNames: ["value"],
+                },
+                prefillNumerator: {
+                    dependencyType: "stateVariable",
+                    variableName: "prefillNumerator",
+                },
+                prefillDenominator: {
+                    dependencyType: "stateVariable",
+                    variableName: "prefillDenominator",
+                },
+                valueChanged: {
+                    dependencyType: "stateVariable",
+                    variableName: "valueChanged",
+                    onlyToSetInInverseDefinition: true,
+                },
+                immediateValueChanged: {
+                    dependencyType: "stateVariable",
+                    variableName: "immediateValueChanged",
+                    onlyToSetInInverseDefinition: true,
                 },
             }),
             definition({ dependencyValues }) {
-                return {
-                    setValue: {
-                        valueChanged: dependencyValues.fractionChildren.some(
-                            (child) => child.stateValues.valueChanged,
-                        ),
+                if (dependencyValues.mathChild.length > 0) {
+                    return {
+                        setValue: {
+                            value: dependencyValues.mathChild[0].stateValues
+                                .value,
+                        },
+                    };
+                } else if (dependencyValues.bindValueTo) {
+                    return {
+                        setValue: {
+                            value: dependencyValues.bindValueTo.stateValues
+                                .value,
+                        },
+                    };
+                } else {
+                    return {
+                        useEssentialOrDefaultValue: {
+                            value: {
+                                defaultValue: reconstructFraction(
+                                    dependencyValues.prefillNumerator,
+                                    dependencyValues.prefillDenominator,
+                                ),
+                            },
+                        },
+                    };
+                }
+            },
+            inverseDefinition({
+                desiredStateVariableValues,
+                dependencyValues,
+            }) {
+                let instructions = [
+                    { setDependency: "valueChanged", desiredValue: true },
+                    {
+                        setDependency: "immediateValueChanged",
+                        desiredValue: true,
                     },
-                };
+                ];
+
+                if (dependencyValues.mathChild.length > 0) {
+                    instructions.push({
+                        setDependency: "mathChild",
+                        desiredValue: desiredStateVariableValues.value,
+                        variableIndex: 0,
+                        childIndex: 0,
+                    });
+                } else if (dependencyValues.bindValueTo) {
+                    instructions.push({
+                        setDependency: "bindValueTo",
+                        desiredValue: desiredStateVariableValues.value,
+                        variableIndex: 0,
+                    });
+                } else {
+                    instructions.push({
+                        setEssentialValue: "value",
+                        value: desiredStateVariableValues.value,
+                    });
+                }
+                return { success: true, instructions };
             },
         };
 
@@ -155,29 +309,112 @@ export class FractionInput extends Input {
             description:
                 "Whether the live fraction differs from its initial state.",
             public: true,
+            hasEssential: true,
+            defaultValue: false,
             shadowingInstructions: {
                 createComponentOfType: "boolean",
             },
-            returnDependencies: () => ({
-                fractionChildren: {
-                    dependencyType: "child",
-                    childGroups: ["fractionInputComponents"],
-                    variableNames: ["immediateValueChanged"],
-                },
-            }),
-            definition({ dependencyValues }) {
+            returnDependencies: () => ({}),
+            definition() {
                 return {
-                    setValue: {
-                        immediateValueChanged:
-                            dependencyValues.fractionChildren.some(
-                                (child) =>
-                                    child.stateValues.immediateValueChanged,
+                    useEssentialOrDefaultValue: { immediateValueChanged: true },
+                };
+            },
+            inverseDefinition({ desiredStateVariableValues }) {
+                return {
+                    success: true,
+                    instructions: [
+                        {
+                            setEssentialValue: "immediateValueChanged",
+                            value: Boolean(
+                                desiredStateVariableValues.immediateValueChanged,
                             ),
-                    },
+                        },
+                    ],
                 };
             },
         };
 
+        // The live fraction being entered, before it is saved.
+        stateVariableDefinitions.immediateValue = {
+            description:
+                "The current fraction being entered (live, before saving).",
+            public: true,
+            hasEssential: true,
+            shadowVariable: true,
+            shadowingInstructions: {
+                createComponentOfType: "math",
+                addAttributeComponentsShadowingStateVariables:
+                    returnNumberDisplayAttributeComponentShadowing(),
+            },
+            set: convertValueToMathExpression,
+            returnDependencies: () => ({
+                value: {
+                    dependencyType: "stateVariable",
+                    variableName: "value",
+                },
+                immediateValueChanged: {
+                    dependencyType: "stateVariable",
+                    variableName: "immediateValueChanged",
+                    onlyToSetInInverseDefinition: true,
+                },
+            }),
+            definition({
+                dependencyValues,
+                changes,
+                justUpdatedForNewComponent,
+                usedDefault,
+            }) {
+                if (
+                    changes.value &&
+                    !justUpdatedForNewComponent &&
+                    !usedDefault.value
+                ) {
+                    return {
+                        setValue: { immediateValue: dependencyValues.value },
+                        setEssentialValue: {
+                            immediateValue: dependencyValues.value,
+                        },
+                    };
+                } else {
+                    return {
+                        useEssentialOrDefaultValue: {
+                            immediateValue: {
+                                defaultValue: dependencyValues.value,
+                            },
+                        },
+                    };
+                }
+            },
+            inverseDefinition({
+                desiredStateVariableValues,
+                initialChange,
+                shadowedVariable,
+            }) {
+                let instructions = [
+                    {
+                        setEssentialValue: "immediateValue",
+                        value: desiredStateVariableValues.immediateValue,
+                    },
+                    {
+                        setDependency: "immediateValueChanged",
+                        desiredValue: true,
+                    },
+                ];
+
+                if (!(initialChange || shadowedVariable)) {
+                    instructions.push({
+                        setDependency: "value",
+                        desiredValue: desiredStateVariableValues.immediateValue,
+                    });
+                }
+
+                return { success: true, instructions };
+            },
+        };
+
+        // The numerator and denominator boxes display the decomposition of the
+        // saved value; editing one routes back through `value`.
         stateVariableDefinitions.numerator = {
             description: "The most recently saved numerator value.",
             public: true,
@@ -187,30 +424,33 @@ export class FractionInput extends Input {
                     returnNumberDisplayAttributeComponentShadowing(),
             },
             returnDependencies: () => ({
-                fractionChildren: {
-                    dependencyType: "child",
-                    childGroups: ["fractionInputComponents"],
-                    variableNames: ["value"],
+                value: {
+                    dependencyType: "stateVariable",
+                    variableName: "value",
                 },
             }),
             definition({ dependencyValues }) {
                 return {
                     setValue: {
-                        numerator:
-                            dependencyValues.fractionChildren[0]?.stateValues
-                                .value ?? blankMath(),
+                        numerator: decomposeFraction(dependencyValues.value)
+                            .numerator,
                     },
                 };
             },
-            inverseDefinition({ desiredStateVariableValues }) {
+            inverseDefinition({
+                desiredStateVariableValues,
+                dependencyValues,
+            }) {
+                let { denominator } = decomposeFraction(dependencyValues.value);
                 return {
                     success: true,
                     instructions: [
                         {
-                            setDependency: "fractionChildren",
-                            desiredValue: desiredStateVariableValues.numerator,
-                            childIndex: 0,
-                            variableIndex: 0,
+                            setDependency: "value",
+                            desiredValue: reconstructFraction(
+                                desiredStateVariableValues.numerator,
+                                denominator,
+                            ),
                         },
                     ],
                 };
@@ -226,202 +466,118 @@ export class FractionInput extends Input {
                     returnNumberDisplayAttributeComponentShadowing(),
             },
             returnDependencies: () => ({
-                fractionChildren: {
-                    dependencyType: "child",
-                    childGroups: ["fractionInputComponents"],
-                    variableNames: ["value"],
+                value: {
+                    dependencyType: "stateVariable",
+                    variableName: "value",
                 },
             }),
             definition({ dependencyValues }) {
                 return {
                     setValue: {
-                        denominator:
-                            dependencyValues.fractionChildren[1]?.stateValues
-                                .value ?? blankMath(),
+                        denominator: decomposeFraction(dependencyValues.value)
+                            .denominator,
                     },
                 };
             },
-            inverseDefinition({ desiredStateVariableValues }) {
+            inverseDefinition({
+                desiredStateVariableValues,
+                dependencyValues,
+            }) {
+                let { numerator } = decomposeFraction(dependencyValues.value);
                 return {
                     success: true,
                     instructions: [
                         {
-                            setDependency: "fractionChildren",
-                            desiredValue:
+                            setDependency: "value",
+                            desiredValue: reconstructFraction(
+                                numerator,
                                 desiredStateVariableValues.denominator,
-                            childIndex: 1,
-                            variableIndex: 0,
+                            ),
                         },
                     ],
                 };
             },
         };
 
-        stateVariableDefinitions.value = {
-            description:
-                "The most recently saved fraction value (numerator divided by denominator).",
-            public: true,
-            shadowingInstructions: {
-                createComponentOfType: "math",
-                addAttributeComponentsShadowingStateVariables:
-                    returnNumberDisplayAttributeComponentShadowing(),
-            },
+        // The live numerator/denominator the boxes edit, decomposed from
+        // immediateValue and routed back to it (without committing the value).
+        stateVariableDefinitions.componentImmediateValueNumerator = {
             returnDependencies: () => ({
-                numerator: {
+                immediateValue: {
                     dependencyType: "stateVariable",
-                    variableName: "numerator",
-                },
-                denominator: {
-                    dependencyType: "stateVariable",
-                    variableName: "denominator",
+                    variableName: "immediateValue",
                 },
             }),
             definition({ dependencyValues }) {
-                let numeratorTree = dependencyValues.numerator.tree;
-                let denominatorTree = dependencyValues.denominator.tree;
-
-                // if both parts are blank, the fraction as a whole is blank
-                // rather than a fraction of two blanks
-                if (
-                    numeratorTree === "\uff3f" &&
-                    denominatorTree === "\uff3f"
-                ) {
-                    return { setValue: { value: blankMath() } };
-                }
-
                 return {
                     setValue: {
-                        value: me.fromAst([
-                            "/",
-                            numeratorTree,
-                            denominatorTree,
-                        ]),
+                        componentImmediateValueNumerator: decomposeFraction(
+                            dependencyValues.immediateValue,
+                        ).numerator,
                     },
                 };
             },
-            inverseDefinition({ desiredStateVariableValues }) {
-                let desiredTree = desiredStateVariableValues.value.tree;
-                if (Array.isArray(desiredTree) && desiredTree[0] === "/") {
-                    return {
-                        success: true,
-                        instructions: [
-                            {
-                                setDependency: "numerator",
-                                desiredValue: me.fromAst(desiredTree[1]),
-                            },
-                            {
-                                setDependency: "denominator",
-                                desiredValue: me.fromAst(desiredTree[2]),
-                            },
-                        ],
-                    };
-                }
-                if (desiredTree === "\uff3f") {
-                    // a blank fraction clears both parts
-                    return {
-                        success: true,
-                        instructions: [
-                            {
-                                setDependency: "numerator",
-                                desiredValue: blankMath(),
-                            },
-                            {
-                                setDependency: "denominator",
-                                desiredValue: blankMath(),
-                            },
-                        ],
-                    };
-                }
-                return { success: false };
+            inverseDefinition({
+                desiredStateVariableValues,
+                dependencyValues,
+                initialChange,
+            }) {
+                let { denominator } = decomposeFraction(
+                    dependencyValues.immediateValue,
+                );
+                return {
+                    success: true,
+                    instructions: [
+                        {
+                            setDependency: "immediateValue",
+                            desiredValue: reconstructFraction(
+                                desiredStateVariableValues.componentImmediateValueNumerator,
+                                denominator,
+                            ),
+                            treatAsInitialChange: initialChange,
+                        },
+                    ],
+                };
             },
         };
 
-        stateVariableDefinitions.immediateValue = {
-            description:
-                "The current fraction being entered (live, before saving).",
-            public: true,
-            shadowingInstructions: {
-                createComponentOfType: "math",
-                addAttributeComponentsShadowingStateVariables:
-                    returnNumberDisplayAttributeComponentShadowing(),
-            },
+        stateVariableDefinitions.componentImmediateValueDenominator = {
             returnDependencies: () => ({
-                fractionChildren: {
-                    dependencyType: "child",
-                    childGroups: ["fractionInputComponents"],
-                    variableNames: ["immediateValue"],
+                immediateValue: {
+                    dependencyType: "stateVariable",
+                    variableName: "immediateValue",
                 },
             }),
             definition({ dependencyValues }) {
-                let numerator =
-                    dependencyValues.fractionChildren[0]?.stateValues
-                        .immediateValue ?? blankMath();
-                let denominator =
-                    dependencyValues.fractionChildren[1]?.stateValues
-                        .immediateValue ?? blankMath();
-
-                // if both parts are blank, the fraction as a whole is blank
-                // rather than a fraction of two blanks
-                if (
-                    numerator.tree === "\uff3f" &&
-                    denominator.tree === "\uff3f"
-                ) {
-                    return { setValue: { immediateValue: blankMath() } };
-                }
-
                 return {
                     setValue: {
-                        immediateValue: me.fromAst([
-                            "/",
-                            numerator.tree,
-                            denominator.tree,
-                        ]),
+                        componentImmediateValueDenominator: decomposeFraction(
+                            dependencyValues.immediateValue,
+                        ).denominator,
                     },
                 };
             },
-            inverseDefinition({ desiredStateVariableValues }) {
-                let desiredTree =
-                    desiredStateVariableValues.immediateValue.tree;
-                if (Array.isArray(desiredTree) && desiredTree[0] === "/") {
-                    return {
-                        success: true,
-                        instructions: [
-                            {
-                                setDependency: "fractionChildren",
-                                desiredValue: me.fromAst(desiredTree[1]),
-                                childIndex: 0,
-                                variableIndex: 0,
-                            },
-                            {
-                                setDependency: "fractionChildren",
-                                desiredValue: me.fromAst(desiredTree[2]),
-                                childIndex: 1,
-                                variableIndex: 0,
-                            },
-                        ],
-                    };
-                }
-                if (desiredTree === "\uff3f") {
-                    // a blank fraction clears both parts
-                    return {
-                        success: true,
-                        instructions: [
-                            {
-                                setDependency: "fractionChildren",
-                                desiredValue: blankMath(),
-                                childIndex: 0,
-                                variableIndex: 0,
-                            },
-                            {
-                                setDependency: "fractionChildren",
-                                desiredValue: blankMath(),
-                                childIndex: 1,
-                                variableIndex: 0,
-                            },
-                        ],
-                    };
-                }
-                return { success: false };
+            inverseDefinition({
+                desiredStateVariableValues,
+                dependencyValues,
+                initialChange,
+            }) {
+                let { numerator } = decomposeFraction(
+                    dependencyValues.immediateValue,
+                );
+                return {
+                    success: true,
+                    instructions: [
+                        {
+                            setDependency: "immediateValue",
+                            desiredValue: reconstructFraction(
+                                numerator,
+                                desiredStateVariableValues.componentImmediateValueDenominator,
+                            ),
+                            treatAsInitialChange: initialChange,
+                        },
+                    ],
+                };
             },
         };
 
@@ -628,77 +784,36 @@ export default class FractionComponentInput extends BaseComponent {
             }),
         );
 
-        // get prefill from parent fractionInput, depending on part
-        stateVariableDefinitions.prefill = {
+        // Each box reads its saved value from the parent fractionInput
+        // (numerator or denominator) and routes edits back to it.
+        stateVariableDefinitions.value = {
             stateVariablesDeterminingDependencies: ["part"],
             returnDependencies: ({ stateValues }) => ({
-                parentPrefill: {
+                parentComponentValue: {
                     dependencyType: "parentStateVariable",
                     parentComponentType: "fractionInput",
                     variableName:
                         stateValues.part === "denominator"
-                            ? "prefillDenominator"
-                            : "prefillNumerator",
+                            ? "denominator"
+                            : "numerator",
                 },
             }),
             definition({ dependencyValues }) {
                 return {
                     setValue: {
-                        prefill: dependencyValues.parentPrefill ?? blankMath(),
+                        value:
+                            dependencyValues.parentComponentValue ??
+                            blankMath(),
                     },
                 };
             },
-        };
-
-        Object.assign(
-            stateVariableDefinitions,
-            returnInputValueChangedStateVariableDefinitions(),
-        );
-
-        stateVariableDefinitions.value = {
-            hasEssential: true,
-            shadowVariable: true,
-            set: convertValueToMathExpression,
-            returnDependencies: () => ({
-                prefill: {
-                    dependencyType: "stateVariable",
-                    variableName: "prefill",
-                },
-                valueChanged: {
-                    dependencyType: "stateVariable",
-                    variableName: "valueChanged",
-                    onlyToSetInInverseDefinition: true,
-                },
-                immediateValueChanged: {
-                    dependencyType: "stateVariable",
-                    variableName: "immediateValueChanged",
-                    onlyToSetInInverseDefinition: true,
-                },
-            }),
-            definition: function ({ dependencyValues }) {
-                return {
-                    useEssentialOrDefaultValue: {
-                        value: {
-                            defaultValue: dependencyValues.prefill,
-                        },
-                    },
-                };
-            },
-            inverseDefinition: function ({ desiredStateVariableValues }) {
+            inverseDefinition({ desiredStateVariableValues }) {
                 return {
                     success: true,
                     instructions: [
                         {
-                            setDependency: "valueChanged",
-                            desiredValue: true,
-                        },
-                        {
-                            setDependency: "immediateValueChanged",
-                            desiredValue: true,
-                        },
-                        {
-                            setEssentialValue: "value",
-                            value: desiredStateVariableValues.value,
+                            setDependency: "parentComponentValue",
+                            desiredValue: desiredStateVariableValues.value,
                         },
                     ],
                 };
@@ -706,76 +821,37 @@ export default class FractionComponentInput extends BaseComponent {
         };
 
         stateVariableDefinitions.immediateValue = {
-            hasEssential: true,
-            shadowVariable: true,
-            set: convertValueToMathExpression,
-            returnDependencies: () => ({
-                value: {
-                    dependencyType: "stateVariable",
-                    variableName: "value",
-                },
-                immediateValueChanged: {
-                    dependencyType: "stateVariable",
-                    variableName: "immediateValueChanged",
-                    onlyToSetInInverseDefinition: true,
+            stateVariablesDeterminingDependencies: ["part"],
+            returnDependencies: ({ stateValues }) => ({
+                parentComponentImmediateValue: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType: "fractionInput",
+                    variableName:
+                        stateValues.part === "denominator"
+                            ? "componentImmediateValueDenominator"
+                            : "componentImmediateValueNumerator",
                 },
             }),
-            definition: function ({
-                dependencyValues,
-                changes,
-                justUpdatedForNewComponent,
-                usedDefault,
-            }) {
-                if (
-                    changes.value &&
-                    !justUpdatedForNewComponent &&
-                    !usedDefault.value
-                ) {
-                    // only update to value when it changes
-                    // (otherwise, let its essential value change)
-                    return {
-                        setValue: { immediateValue: dependencyValues.value },
-                        setEssentialValue: {
-                            immediateValue: dependencyValues.value,
-                        },
-                    };
-                } else {
-                    return {
-                        useEssentialOrDefaultValue: {
-                            immediateValue: {
-                                defaultValue: dependencyValues.value,
-                            },
-                        },
-                    };
-                }
+            definition({ dependencyValues }) {
+                return {
+                    setValue: {
+                        immediateValue:
+                            dependencyValues.parentComponentImmediateValue ??
+                            blankMath(),
+                    },
+                };
             },
-            inverseDefinition: function ({
-                desiredStateVariableValues,
-                initialChange,
-                shadowedVariable,
-            }) {
-                let instructions = [
-                    {
-                        setEssentialValue: "immediateValue",
-                        value: desiredStateVariableValues.immediateValue,
-                    },
-                    {
-                        setDependency: "immediateValueChanged",
-                        desiredValue: true,
-                    },
-                ];
-
-                // if from outside sources, also set value
-                if (!(initialChange || shadowedVariable)) {
-                    instructions.push({
-                        setDependency: "value",
-                        desiredValue: desiredStateVariableValues.immediateValue,
-                    });
-                }
-
+            inverseDefinition({ desiredStateVariableValues, initialChange }) {
                 return {
                     success: true,
-                    instructions,
+                    instructions: [
+                        {
+                            setDependency: "parentComponentImmediateValue",
+                            desiredValue:
+                                desiredStateVariableValues.immediateValue,
+                            treatAsInitialChange: initialChange,
+                        },
+                    ],
                 };
             },
         };

--- a/packages/doenetml-worker-javascript/src/components/FractionInput.js
+++ b/packages/doenetml-worker-javascript/src/components/FractionInput.js
@@ -21,16 +21,31 @@ import {
 
 const blankMath = () => me.fromAst("\uff3f");
 
+function isFractionTree(tree) {
+    return Array.isArray(tree) && tree[0] === "/";
+}
+
+function isNegatedFractionTree(tree) {
+    return Array.isArray(tree) && tree[0] === "-" && isFractionTree(tree[1]);
+}
+
 // Split a math value into the numerator and denominator that the two input
-// boxes display. A division becomes its two operands; a blank stays blank in
-// both boxes. (A non-fraction is treated as value-over-1; in practice `value`
-// is kept as a fraction so this is only a safety net.)
+// boxes display. A division becomes its two operands; a negated division puts
+// the sign in the numerator; a blank stays blank in both boxes. (A non-fraction
+// is treated as value-over-1; in practice `value` is kept as a fraction so this
+// is only a safety net.)
 function decomposeFraction(mathValue) {
     let tree = mathValue?.tree;
-    if (Array.isArray(tree) && tree[0] === "/") {
+    if (isFractionTree(tree)) {
         return {
             numerator: me.fromAst(tree[1]),
             denominator: me.fromAst(tree[2]),
+        };
+    }
+    if (isNegatedFractionTree(tree)) {
+        return {
+            numerator: me.fromAst(["-", tree[1][1]]),
+            denominator: me.fromAst(tree[1][2]),
         };
     }
     if (tree === undefined || tree === "\uff3f") {
@@ -56,8 +71,11 @@ function reconstructFraction(numerator, denominator) {
 // definition, transform it to a fraction with a denominator of 1.
 function ensureFraction(mathValue) {
     let tree = mathValue?.tree;
-    if (Array.isArray(tree) && tree[0] === "/") {
+    if (isFractionTree(tree)) {
         return mathValue;
+    }
+    if (isNegatedFractionTree(tree)) {
+        return me.fromAst(["/", ["-", tree[1][1]], tree[1][2]]);
     }
     if (tree === undefined || tree === "\uff3f") {
         return blankMath();

--- a/packages/doenetml-worker-javascript/src/components/FractionInput.js
+++ b/packages/doenetml-worker-javascript/src/components/FractionInput.js
@@ -277,12 +277,24 @@ export class FractionInput extends Input {
                 },
             }),
             definition({ dependencyValues }) {
+                let numeratorTree = dependencyValues.numerator.tree;
+                let denominatorTree = dependencyValues.denominator.tree;
+
+                // if both parts are blank, the fraction as a whole is blank
+                // rather than a fraction of two blanks
+                if (
+                    numeratorTree === "\uff3f" &&
+                    denominatorTree === "\uff3f"
+                ) {
+                    return { setValue: { value: blankMath() } };
+                }
+
                 return {
                     setValue: {
                         value: me.fromAst([
                             "/",
-                            dependencyValues.numerator.tree,
-                            dependencyValues.denominator.tree,
+                            numeratorTree,
+                            denominatorTree,
                         ]),
                     },
                 };
@@ -300,6 +312,22 @@ export class FractionInput extends Input {
                             {
                                 setDependency: "denominator",
                                 desiredValue: me.fromAst(desiredTree[2]),
+                            },
+                        ],
+                    };
+                }
+                if (desiredTree === "\uff3f") {
+                    // a blank fraction clears both parts
+                    return {
+                        success: true,
+                        instructions: [
+                            {
+                                setDependency: "numerator",
+                                desiredValue: blankMath(),
+                            },
+                            {
+                                setDependency: "denominator",
+                                desiredValue: blankMath(),
                             },
                         ],
                     };
@@ -331,6 +359,16 @@ export class FractionInput extends Input {
                 let denominator =
                     dependencyValues.fractionChildren[1]?.stateValues
                         .immediateValue ?? blankMath();
+
+                // if both parts are blank, the fraction as a whole is blank
+                // rather than a fraction of two blanks
+                if (
+                    numerator.tree === "\uff3f" &&
+                    denominator.tree === "\uff3f"
+                ) {
+                    return { setValue: { immediateValue: blankMath() } };
+                }
+
                 return {
                     setValue: {
                         immediateValue: me.fromAst([
@@ -357,6 +395,26 @@ export class FractionInput extends Input {
                             {
                                 setDependency: "fractionChildren",
                                 desiredValue: me.fromAst(desiredTree[2]),
+                                childIndex: 1,
+                                variableIndex: 0,
+                            },
+                        ],
+                    };
+                }
+                if (desiredTree === "\uff3f") {
+                    // a blank fraction clears both parts
+                    return {
+                        success: true,
+                        instructions: [
+                            {
+                                setDependency: "fractionChildren",
+                                desiredValue: blankMath(),
+                                childIndex: 0,
+                                variableIndex: 0,
+                            },
+                            {
+                                setDependency: "fractionChildren",
+                                desiredValue: blankMath(),
                                 childIndex: 1,
                                 variableIndex: 0,
                             },

--- a/packages/doenetml-worker-javascript/src/components/FractionInput.js
+++ b/packages/doenetml-worker-javascript/src/components/FractionInput.js
@@ -23,8 +23,8 @@ const blankMath = () => me.fromAst("\uff3f");
 
 // Split a math value into the numerator and denominator that the two input
 // boxes display. A division becomes its two operands; a blank stays blank in
-// both boxes; anything else (a non-fraction, non-blank value) goes in the
-// numerator over a denominator of 1.
+// both boxes. (A non-fraction is treated as value-over-1; in practice `value`
+// is kept as a fraction so this is only a safety net.)
 function decomposeFraction(mathValue) {
     let tree = mathValue?.tree;
     if (Array.isArray(tree) && tree[0] === "/") {
@@ -41,18 +41,28 @@ function decomposeFraction(mathValue) {
 
 // Combine the two boxes back into a single math value (the inverse of
 // decomposeFraction). When both boxes are blank, the fraction as a whole is
-// blank rather than a fraction of two blanks. A denominator of 1 over a
-// non-blank numerator collapses to just the numerator.
+// blank; otherwise it stays a fraction (a denominator of 1 is kept, e.g. a/1).
 function reconstructFraction(numerator, denominator) {
     let numeratorTree = numerator?.tree ?? "\uff3f";
     let denominatorTree = denominator?.tree ?? "\uff3f";
     if (numeratorTree === "\uff3f" && denominatorTree === "\uff3f") {
         return blankMath();
     }
-    if (denominatorTree === 1 && numeratorTree !== "\uff3f") {
-        return me.fromAst(numeratorTree);
-    }
     return me.fromAst(["/", numeratorTree, denominatorTree]);
+}
+
+// A fractionInput's value is always a fraction (or blank). When a non-fraction
+// value comes in from a child, the bindValueTo attribute, or an inverse
+// definition, transform it to a fraction with a denominator of 1.
+function ensureFraction(mathValue) {
+    let tree = mathValue?.tree;
+    if (Array.isArray(tree) && tree[0] === "/") {
+        return mathValue;
+    }
+    if (tree === undefined || tree === "\uff3f") {
+        return blankMath();
+    }
+    return me.fromAst(["/", tree, 1]);
 }
 
 export class FractionInput extends Input {
@@ -250,15 +260,17 @@ export class FractionInput extends Input {
                 if (dependencyValues.mathChild.length > 0) {
                     return {
                         setValue: {
-                            value: dependencyValues.mathChild[0].stateValues
-                                .value,
+                            value: ensureFraction(
+                                dependencyValues.mathChild[0].stateValues.value,
+                            ),
                         },
                     };
                 } else if (dependencyValues.bindValueTo) {
                     return {
                         setValue: {
-                            value: dependencyValues.bindValueTo.stateValues
-                                .value,
+                            value: ensureFraction(
+                                dependencyValues.bindValueTo.stateValues.value,
+                            ),
                         },
                     };
                 } else {
@@ -278,6 +290,9 @@ export class FractionInput extends Input {
                 desiredStateVariableValues,
                 dependencyValues,
             }) {
+                let desiredValue = ensureFraction(
+                    desiredStateVariableValues.value,
+                );
                 let instructions = [
                     { setDependency: "valueChanged", desiredValue: true },
                     {
@@ -289,20 +304,20 @@ export class FractionInput extends Input {
                 if (dependencyValues.mathChild.length > 0) {
                     instructions.push({
                         setDependency: "mathChild",
-                        desiredValue: desiredStateVariableValues.value,
+                        desiredValue,
                         variableIndex: 0,
                         childIndex: 0,
                     });
                 } else if (dependencyValues.bindValueTo) {
                     instructions.push({
                         setDependency: "bindValueTo",
-                        desiredValue: desiredStateVariableValues.value,
+                        desiredValue,
                         variableIndex: 0,
                     });
                 } else {
                     instructions.push({
                         setEssentialValue: "value",
-                        value: desiredStateVariableValues.value,
+                        value: desiredValue,
                     });
                 }
                 return { success: true, instructions };
@@ -395,10 +410,13 @@ export class FractionInput extends Input {
                 initialChange,
                 shadowedVariable,
             }) {
+                let desiredValue = ensureFraction(
+                    desiredStateVariableValues.immediateValue,
+                );
                 let instructions = [
                     {
                         setEssentialValue: "immediateValue",
-                        value: desiredStateVariableValues.immediateValue,
+                        value: desiredValue,
                     },
                     {
                         setDependency: "immediateValueChanged",
@@ -409,7 +427,7 @@ export class FractionInput extends Input {
                 if (!(initialChange || shadowedVariable)) {
                     instructions.push({
                         setDependency: "value",
-                        desiredValue: desiredStateVariableValues.immediateValue,
+                        desiredValue,
                     });
                 }
 

--- a/packages/doenetml-worker-javascript/src/components/Label.js
+++ b/packages/doenetml-worker-javascript/src/components/Label.js
@@ -872,6 +872,10 @@ export default class Label extends InlineComponent {
                     componentInfoObjects.isInheritedComponentType({
                         inheritedComponentType: inputIdentity.componentType,
                         baseComponentType: "matrixInput",
+                    }) ||
+                    componentInfoObjects.isInheritedComponentType({
+                        inheritedComponentType: inputIdentity.componentType,
+                        baseComponentType: "fractionInput",
                     })
                 ) {
                     forTargetIsGroup = true;

--- a/packages/doenetml-worker-javascript/src/components/Label.js
+++ b/packages/doenetml-worker-javascript/src/components/Label.js
@@ -738,9 +738,9 @@ export default class Label extends InlineComponent {
 
         // This renderer id is only meaningful for single-control targets where
         // the renderer can expose a concrete DOM control id such as `${id}_input`.
-        // Grouped widgets like non-inline choiceInput and matrixInput still need
-        // the input component identity above, but they are labeled through
-        // `aria-labelledby` rather than `htmlFor`.
+        // Grouped widgets like non-inline choiceInput, matrixInput, and
+        // fractionInput still need the input component identity above, but they
+        // are labeled through `aria-labelledby` rather than `htmlFor`.
         stateVariableDefinitions.forTargetRendererId = {
             forRenderer: true,
             stateVariablesDeterminingDependencies: [
@@ -829,9 +829,10 @@ export default class Label extends InlineComponent {
 
         // Group targets are widgets that should consume an external label via
         // `aria-labelledby` on the group container instead of `htmlFor` on a
-        // single DOM control. Today that applies to matrixInput and non-inline
-        // choiceInput. Inline choiceInput remains a single control because the
-        // react-select input exposes a concrete input id.
+        // single DOM control. Today that applies to matrixInput,
+        // fractionInput, and non-inline choiceInput. Inline choiceInput remains
+        // a single control because the react-select input exposes a concrete
+        // input id.
         stateVariableDefinitions.forTargetIsGroup = {
             forRenderer: true,
             stateVariablesDeterminingDependencies: [

--- a/packages/doenetml-worker-javascript/src/components/MathInput.js
+++ b/packages/doenetml-worker-javascript/src/components/MathInput.js
@@ -355,7 +355,7 @@ export default class MathInput extends Input {
 
         stateVariableDefinitions.valueChanged = {
             description:
-                "Whether the saved value has been changed from its initial state.",
+                "Whether the value has been changed from its initial state.",
             public: true,
             hasEssential: true,
             defaultValue: false,
@@ -382,7 +382,7 @@ export default class MathInput extends Input {
         };
 
         stateVariableDefinitions.value = {
-            description: "The most recently saved math value.",
+            description: "The math value of the input.",
             public: true,
             shadowingInstructions: {
                 createComponentOfType: "math",
@@ -528,7 +528,7 @@ export default class MathInput extends Input {
 
         stateVariableDefinitions.immediateValueChanged = {
             description:
-                "Whether the live value differs from its initial state.",
+                "Whether the value, including in-progress edits, has been changed from its initial state.",
             public: true,
             hasEssential: true,
             defaultValue: false,
@@ -558,7 +558,7 @@ export default class MathInput extends Input {
 
         stateVariableDefinitions.immediateValue = {
             description:
-                "The current math value being entered (live, before saving).",
+                "The math value reflecting the user's in-progress edits.",
             public: true,
             shadowingInstructions: {
                 createComponentOfType: "math",

--- a/packages/doenetml-worker-javascript/src/components/MathInput.js
+++ b/packages/doenetml-worker-javascript/src/components/MathInput.js
@@ -19,6 +19,7 @@ import {
     stripLatex,
 } from "../utils/math";
 import { returnMathVectorMatrixStateVariableDefinitions } from "../utils/mathVectorMatrixStateVariables";
+import { defineSubmitAnswerExternalAction } from "../utils/mathComponentInput";
 
 export default class MathInput extends Input {
     constructor(args) {
@@ -29,23 +30,7 @@ export default class MathInput extends Input {
             updateValue: this.updateValue.bind(this),
         });
 
-        this.externalActions = {};
-
-        //Complex because the stateValues isn't defined until later
-        Object.defineProperty(this.externalActions, "submitAnswer", {
-            enumerable: true,
-            get: async function () {
-                let answerAncestor = await this.stateValues.answerAncestor;
-                if (answerAncestor !== null) {
-                    return {
-                        componentIdx: answerAncestor.componentIdx,
-                        actionName: "submitAnswer",
-                    };
-                } else {
-                    return;
-                }
-            }.bind(this),
-        });
+        defineSubmitAnswerExternalAction(this);
     }
     static componentType = "mathInput";
 

--- a/packages/doenetml-worker-javascript/src/components/MatrixInput.js
+++ b/packages/doenetml-worker-javascript/src/components/MatrixInput.js
@@ -19,6 +19,7 @@ import {
     mathComponentInputFocusChanged,
     mathComponentInputUpdateRawValue,
     mathComponentInputUpdateValue,
+    returnInputValueChangedStateVariableDefinitions,
     returnMathComponentInputConfigStateVariableDefinitions,
     returnMathComponentInputDisplayStateVariableDefinitions,
     returnMathInputParsingAttributes,
@@ -197,33 +198,16 @@ export class MatrixInput extends Input {
             }),
         );
 
-        stateVariableDefinitions.valueChanged = {
-            description:
-                "Whether the saved matrix has been changed from its initial state.",
-            public: true,
-            hasEssential: true,
-            defaultValue: false,
-            shadowingInstructions: {
-                createComponentOfType: "boolean",
-            },
-            returnDependencies: () => ({}),
-            definition() {
-                return { useEssentialOrDefaultValue: { valueChanged: true } };
-            },
-            inverseDefinition({ desiredStateVariableValues }) {
-                return {
-                    success: true,
-                    instructions: [
-                        {
-                            setEssentialValue: "valueChanged",
-                            value: Boolean(
-                                desiredStateVariableValues.valueChanged,
-                            ),
-                        },
-                    ],
-                };
-            },
-        };
+        const inputValueChangedStateVariableDefinitions =
+            returnInputValueChangedStateVariableDefinitions({
+                valueChangedDescription:
+                    "Whether the saved matrix has been changed from its initial state.",
+                immediateValueChangedDescription:
+                    "Whether the live matrix differs from its initial state.",
+            });
+
+        stateVariableDefinitions.valueChanged =
+            inputValueChangedStateVariableDefinitions.valueChanged;
 
         stateVariableDefinitions.valueOriginal = {
             hasEssential: true,
@@ -330,35 +314,8 @@ export class MatrixInput extends Input {
             },
         };
 
-        stateVariableDefinitions.immediateValueChanged = {
-            description:
-                "Whether the live matrix differs from its initial state.",
-            public: true,
-            hasEssential: true,
-            defaultValue: false,
-            shadowingInstructions: {
-                createComponentOfType: "boolean",
-            },
-            returnDependencies: () => ({}),
-            definition() {
-                return {
-                    useEssentialOrDefaultValue: { immediateValueChanged: true },
-                };
-            },
-            inverseDefinition({ desiredStateVariableValues }) {
-                return {
-                    success: true,
-                    instructions: [
-                        {
-                            setEssentialValue: "immediateValueChanged",
-                            value: Boolean(
-                                desiredStateVariableValues.immediateValueChanged,
-                            ),
-                        },
-                    ],
-                };
-            },
-        };
+        stateVariableDefinitions.immediateValueChanged =
+            inputValueChangedStateVariableDefinitions.immediateValueChanged;
 
         stateVariableDefinitions.immediateValueOriginal = {
             hasEssential: true,

--- a/packages/doenetml-worker-javascript/src/components/MatrixInput.js
+++ b/packages/doenetml-worker-javascript/src/components/MatrixInput.js
@@ -201,9 +201,9 @@ export class MatrixInput extends Input {
         const inputValueChangedStateVariableDefinitions =
             returnInputValueChangedStateVariableDefinitions({
                 valueChangedDescription:
-                    "Whether the saved matrix has been changed from its initial state.",
+                    "Whether the value has been changed from its initial state.",
                 immediateValueChangedDescription:
-                    "Whether the live matrix differs from its initial state.",
+                    "Whether the value, including in-progress edits, has been changed from its initial state.",
             });
 
         stateVariableDefinitions.valueChanged =
@@ -2099,7 +2099,7 @@ export class MatrixInput extends Input {
         };
 
         stateVariableDefinitions.value = {
-            description: "The most recently saved matrix value.",
+            description: "The matrix value of the input.",
             public: true,
             shadowingInstructions: {
                 createComponentOfType: "math",
@@ -2244,7 +2244,7 @@ export class MatrixInput extends Input {
 
         stateVariableDefinitions.immediateValue = {
             description:
-                "The current matrix being entered (live, before saving).",
+                "The matrix value reflecting the user's in-progress edits.",
             public: true,
             shadowingInstructions: {
                 createComponentOfType: "math",

--- a/packages/doenetml-worker-javascript/src/components/MatrixInput.js
+++ b/packages/doenetml-worker-javascript/src/components/MatrixInput.js
@@ -2,7 +2,6 @@ import Input from "./abstract/Input";
 import me from "math-expressions";
 import {
     deepClone,
-    deepCompare,
     convertValueToMathExpression,
     vectorOperators,
 } from "@doenet/utils";
@@ -14,12 +13,15 @@ import {
     returnNumberDisplayAttributes,
     returnNumberDisplayStateVariableDefinitions,
 } from "../utils/numberDisplay";
+import { roundForDisplay } from "../utils/math";
 import {
-    latexToMathFactory,
-    normalizeLatexString,
-    roundForDisplay,
-    stripLatex,
-} from "../utils/math";
+    defineSubmitAnswerExternalAction,
+    mathComponentInputFocusChanged,
+    mathComponentInputUpdateValue,
+    returnMathComponentInputConfigStateVariableDefinitions,
+    returnMathComponentInputDisplayStateVariableDefinitions,
+    returnMathInputParsingAttributes,
+} from "../utils/mathComponentInput";
 
 const vectorAndListOperators = ["list", ...vectorOperators];
 
@@ -32,23 +34,7 @@ export class MatrixInput extends Input {
             updateNumColumns: this.updateNumColumns.bind(this),
         });
 
-        this.externalActions = {};
-
-        //Complex because the stateValues isn't defined until later
-        Object.defineProperty(this.externalActions, "submitAnswer", {
-            enumerable: true,
-            get: async function () {
-                let answerAncestor = await this.stateValues.answerAncestor;
-                if (answerAncestor !== null) {
-                    return {
-                        componentIdx: answerAncestor.componentIdx,
-                        actionName: "submitAnswer",
-                    };
-                } else {
-                    return;
-                }
-            }.bind(this),
-        });
+        defineSubmitAnswerExternalAction(this);
     }
 
     static componentType = "matrixInput";
@@ -110,47 +96,7 @@ export class MatrixInput extends Input {
                 "parseScientificNotation",
             ],
         };
-        attributes.format = {
-            description: "Input format for each cell.",
-            createComponentOfType: "text",
-            createStateVariable: "format",
-            defaultValue: "text",
-            public: true,
-            toLowerCase: true,
-            validValues: [
-                {
-                    value: "text",
-                    description: "Plain-text math notation (e.g., `x^2 + 1`).",
-                },
-                {
-                    value: "latex",
-                    description: "LaTeX-formatted math (e.g., `x^{2} + 1`).",
-                },
-            ],
-        };
-        attributes.functionSymbols = {
-            description: "Symbols treated as function names when parsing.",
-            createComponentOfType: "textList",
-            createStateVariable: "functionSymbols",
-            defaultValue: ["f", "g"],
-            public: true,
-        };
-        attributes.splitSymbols = {
-            description:
-                "Whether multi-character symbols are split into a product of variables.",
-            createComponentOfType: "boolean",
-            createStateVariable: "splitSymbols",
-            defaultValue: true,
-            public: true,
-        };
-        attributes.parseScientificNotation = {
-            description:
-                "Whether to parse expressions like 1e3 as scientific notation.",
-            createComponentOfType: "boolean",
-            createStateVariable: "parseScientificNotation",
-            defaultValue: false,
-            public: true,
-        };
+        Object.assign(attributes, returnMathInputParsingAttributes());
 
         Object.assign(attributes, returnNumberDisplayAttributes());
 
@@ -3445,8 +3391,8 @@ export default class MatrixComponentInput extends BaseComponent {
 
         Object.assign(this.actions, {
             updateRawValue: this.updateRawValue.bind(this),
-            updateValue: this.updateValue.bind(this),
-            focusChanged: this.focusChanged.bind(this),
+            updateValue: mathComponentInputUpdateValue.bind(this),
+            focusChanged: mathComponentInputFocusChanged.bind(this),
         });
     }
 
@@ -3458,29 +3404,14 @@ export default class MatrixComponentInput extends BaseComponent {
     static returnStateVariableDefinitions() {
         let stateVariableDefinitions = super.returnStateVariableDefinitions();
 
-        stateVariableDefinitions.minWidth = {
-            forRenderer: true,
-            returnDependencies: () => ({
-                matrixInputAncestor: {
-                    dependencyType: "ancestor",
-                    componentType: "matrixInput",
-                    variableNames: ["minComponentWidth"],
-                },
+        // configuration read from the parent matrixInput (parsing,
+        // number-display, width), plus componentType and focused
+        Object.assign(
+            stateVariableDefinitions,
+            returnMathComponentInputConfigStateVariableDefinitions({
+                parentComponentType: "matrixInput",
             }),
-            definition({ dependencyValues }) {
-                if (dependencyValues.matrixInputAncestor) {
-                    return {
-                        setValue: {
-                            minWidth:
-                                dependencyValues.matrixInputAncestor.stateValues
-                                    .minComponentWidth,
-                        },
-                    };
-                } else {
-                    return { setValue: { minWidth: 0 } };
-                }
-            },
-        };
+        );
 
         // matrixComponentInput should be created as a replacement from matrixInputRow
         // and given rowInd and colInd in the essential state
@@ -3502,191 +3433,6 @@ export default class MatrixComponentInput extends BaseComponent {
             }),
         };
 
-        // don't specify attributes on matrixComponentInput
-        // instead gets these state variables from the parent matrixInput:
-        // format, functionSymbols, splitSymbols, parseScientificNotation
-        // displayDigits, displayDecimals, displaySmallAsZero, unionFromU
-        stateVariableDefinitions.format = {
-            returnDependencies: () => ({
-                parentFormat: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "matrixInput",
-                    variableName: "format",
-                },
-            }),
-            definition({ dependencyValues }) {
-                return { setValue: { format: dependencyValues.parentFormat } };
-            },
-        };
-
-        stateVariableDefinitions.functionSymbols = {
-            returnDependencies: () => ({
-                parentFunctionSymbols: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "matrixInput",
-                    variableName: "functionSymbols",
-                },
-            }),
-            definition({ dependencyValues }) {
-                return {
-                    setValue: {
-                        functionSymbols: dependencyValues.parentFunctionSymbols,
-                    },
-                };
-            },
-        };
-
-        stateVariableDefinitions.splitSymbols = {
-            returnDependencies: () => ({
-                parentSplitSymbols: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "matrixInput",
-                    variableName: "splitSymbols",
-                },
-            }),
-            definition({ dependencyValues }) {
-                return {
-                    setValue: {
-                        splitSymbols: dependencyValues.parentSplitSymbols,
-                    },
-                };
-            },
-        };
-
-        stateVariableDefinitions.parseScientificNotation = {
-            returnDependencies: () => ({
-                parentParseScientificNotation: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "matrixInput",
-                    variableName: "parseScientificNotation",
-                },
-            }),
-            definition({ dependencyValues }) {
-                return {
-                    setValue: {
-                        parseScientificNotation:
-                            dependencyValues.parentParseScientificNotation,
-                    },
-                };
-            },
-        };
-
-        stateVariableDefinitions.displayDigits = {
-            returnDependencies: () => ({
-                parentDisplayDigits: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "matrixInput",
-                    variableName: "displayDigits",
-                },
-            }),
-            definition({ dependencyValues, usedDefault }) {
-                let result = {
-                    setValue: {
-                        displayDigits: dependencyValues.parentDisplayDigits,
-                    },
-                };
-
-                if (usedDefault.parentDisplayDigits) {
-                    result.markAsUsedDefault = { displayDigits: true };
-                }
-
-                return result;
-            },
-        };
-
-        stateVariableDefinitions.displayDecimals = {
-            returnDependencies: () => ({
-                parentDisplayDecimals: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "matrixInput",
-                    variableName: "displayDecimals",
-                },
-            }),
-            definition({ dependencyValues, usedDefault }) {
-                let result = {
-                    setValue: {
-                        displayDecimals: dependencyValues.parentDisplayDecimals,
-                    },
-                };
-
-                if (usedDefault.parentDisplayDecimals) {
-                    result.markAsUsedDefault = { displayDecimals: true };
-                }
-
-                return result;
-            },
-        };
-
-        stateVariableDefinitions.displaySmallAsZero = {
-            returnDependencies: () => ({
-                parentDisplaySmallAsZero: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "matrixInput",
-                    variableName: "displaySmallAsZero",
-                },
-            }),
-            definition({ dependencyValues }) {
-                return {
-                    setValue: {
-                        displaySmallAsZero:
-                            dependencyValues.parentDisplaySmallAsZero,
-                    },
-                };
-            },
-        };
-
-        stateVariableDefinitions.padZeros = {
-            returnDependencies: () => ({
-                parentPadZeros: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "matrixInput",
-                    variableName: "padZeros",
-                },
-            }),
-            definition({ dependencyValues }) {
-                return {
-                    setValue: {
-                        padZeros: dependencyValues.parentPadZeros,
-                    },
-                };
-            },
-        };
-
-        stateVariableDefinitions.avoidScientificNotation = {
-            returnDependencies: () => ({
-                parentAvoidScientificNotation: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "matrixInput",
-                    variableName: "avoidScientificNotation",
-                },
-            }),
-            definition({ dependencyValues }) {
-                return {
-                    setValue: {
-                        avoidScientificNotation:
-                            dependencyValues.parentAvoidScientificNotation,
-                    },
-                };
-            },
-        };
-
-        stateVariableDefinitions.unionFromU = {
-            returnDependencies: () => ({
-                parentUnionFromU: {
-                    dependencyType: "parentStateVariable",
-                    parentComponentType: "matrixInput",
-                    variableName: "unionFromU",
-                },
-            }),
-            definition({ dependencyValues }) {
-                return {
-                    setValue: { unionFromU: dependencyValues.parentUnionFromU },
-                };
-            },
-        };
-
-        // get value from parent matrixInput
-        // using specified rowInd and colInd
         stateVariableDefinitions.value = {
             stateVariablesDeterminingDependencies: ["rowInd", "colInd"],
             returnDependencies: ({ stateValues }) => {
@@ -3786,296 +3532,11 @@ export default class MatrixComponentInput extends BaseComponent {
             },
         };
 
-        stateVariableDefinitions.valueForDisplay = {
-            returnDependencies: () => ({
-                value: {
-                    dependencyType: "stateVariable",
-                    variableName: "value",
-                },
-                displayDigits: {
-                    dependencyType: "stateVariable",
-                    variableName: "displayDigits",
-                },
-                displayDecimals: {
-                    dependencyType: "stateVariable",
-                    variableName: "displayDecimals",
-                },
-                displaySmallAsZero: {
-                    dependencyType: "stateVariable",
-                    variableName: "displaySmallAsZero",
-                },
-            }),
-            definition: function ({ dependencyValues }) {
-                // round any decimal numbers to the significant digits
-                // determined by displaydigits or displaydecimals
-                let rounded = roundForDisplay({
-                    value: dependencyValues.value,
-                    dependencyValues,
-                });
-
-                return {
-                    setValue: { valueForDisplay: rounded },
-                };
-            },
-        };
-
-        stateVariableDefinitions.text = {
-            public: true,
-            description: "The current matrix as a text string.",
-            shadowingInstructions: {
-                createComponentOfType: "text",
-            },
-            returnDependencies: () => ({
-                valueForDisplay: {
-                    dependencyType: "stateVariable",
-                    variableName: "valueForDisplay",
-                },
-                padZeros: {
-                    dependencyType: "stateVariable",
-                    variableName: "padZeros",
-                },
-                displayDigits: {
-                    dependencyType: "stateVariable",
-                    variableName: "displayDigits",
-                },
-                displayDecimals: {
-                    dependencyType: "stateVariable",
-                    variableName: "displayDecimals",
-                },
-                avoidScientificNotation: {
-                    dependencyType: "stateVariable",
-                    variableName: "avoidScientificNotation",
-                },
-            }),
-            definition: function ({ dependencyValues }) {
-                let params = buildNumberDisplayParameters({
-                    padZeros: dependencyValues.padZeros,
-                    displayDigits: dependencyValues.displayDigits,
-                    displayDecimals: dependencyValues.displayDecimals,
-                    avoidScientificNotation:
-                        dependencyValues.avoidScientificNotation,
-                });
-                return {
-                    setValue: {
-                        text: dependencyValues.valueForDisplay.toString(params),
-                    },
-                };
-            },
-        };
-
-        // raw value from renderer
-        stateVariableDefinitions.rawRendererValue = {
-            description: "The raw value used by the renderer.",
-            forRenderer: true,
-            hasEssential: true,
-            shadowVariable: true,
-            defaultValue: "",
-            provideEssentialValuesInDefinition: true,
-            public: true,
-            shadowingInstructions: {
-                createComponentOfType: "text",
-            },
-            additionalStateVariablesDefined: [
-                {
-                    variableName: "lastValueForDisplay",
-                    hasEssential: true,
-                    shadowVariable: true,
-                    defaultValue: null,
-                    set: convertValueToMathExpression,
-                },
-            ],
-            returnDependencies: () => ({
-                // include immediateValue for inverse definition
-                immediateValue: {
-                    dependencyType: "stateVariable",
-                    variableName: "immediateValue",
-                },
-                valueForDisplay: {
-                    dependencyType: "stateVariable",
-                    variableName: "valueForDisplay",
-                },
-            }),
-            definition({ dependencyValues, essentialValues }) {
-                // console.log(`definition of raw value for ${componentIdx}`)
-                // console.log(dependencyValues, essentialValues)
-
-                // use deepCompare of trees rather than equalsViaSyntax
-                // so even tiny numerical differences that within double precision are detected
-                if (
-                    essentialValues.rawRendererValue === undefined ||
-                    !deepCompare(
-                        essentialValues.lastValueForDisplay.tree,
-                        dependencyValues.valueForDisplay.tree,
-                    )
-                ) {
-                    let rawRendererValue = stripLatex(
-                        dependencyValues.valueForDisplay.toLatex(),
-                    );
-                    if (rawRendererValue === "\uff3f") {
-                        rawRendererValue = "";
-                    }
-                    return {
-                        setValue: {
-                            rawRendererValue,
-                            lastValueForDisplay:
-                                dependencyValues.valueForDisplay,
-                        },
-                        setEssentialValue: {
-                            rawRendererValue,
-                            lastValueForDisplay:
-                                dependencyValues.valueForDisplay,
-                        },
-                    };
-                } else {
-                    return {
-                        useEssentialOrDefaultValue: {
-                            rawRendererValue: true,
-                            lastValueForDisplay: true,
-                        },
-                    };
-                }
-            },
-            async inverseDefinition({
-                desiredStateVariableValues,
-                stateValues,
-                essentialValues,
-            }) {
-                // console.log(`inverse definition of rawRenderer value for ${componentIdx}`, desiredStateVariableValues, essentialValues)
-
-                const calculateMathExpressionFromLatex = async (text) => {
-                    let expression;
-
-                    text = normalizeLatexString(text, {
-                        unionFromU: await stateValues.unionFromU,
-                    });
-
-                    // replace ^25 with ^{2}5, since mathQuill uses standard latex conventions
-                    // unlike math-expression's latex parser
-                    text = text.replace(/\^(\w)/g, "^{$1}");
-
-                    let fromLatex = latexToMathFactory({
-                        functionSymbols: await stateValues.functionSymbols,
-                        splitSymbols: await stateValues.splitSymbols,
-                        parseScientificNotation:
-                            await stateValues.parseScientificNotation,
-                    });
-
-                    try {
-                        expression = fromLatex(text);
-                    } catch (e) {
-                        // TODO: error on bad text
-                        expression = me.fromAst("\uFF3F");
-                    }
-                    return expression;
-                };
-
-                let instructions = [];
-
-                if (
-                    typeof desiredStateVariableValues.rawRendererValue ===
-                    "string"
-                ) {
-                    let currentValue = essentialValues.rawRendererValue;
-                    let desiredValue =
-                        desiredStateVariableValues.rawRendererValue;
-
-                    if (currentValue !== desiredValue) {
-                        instructions.push({
-                            setEssentialValue: "rawRendererValue",
-                            value: desiredValue,
-                        });
-                    }
-
-                    let currentMath =
-                        await calculateMathExpressionFromLatex(currentValue);
-                    let desiredMath =
-                        await calculateMathExpressionFromLatex(desiredValue);
-
-                    // use deepCompare of trees rather than equalsViaSyntax
-                    // so even tiny numerical differences that within double precision are detected
-                    if (!deepCompare(desiredMath.tree, currentMath.tree)) {
-                        instructions.push({
-                            setDependency: "immediateValue",
-                            desiredValue: desiredMath,
-                            treatAsInitialChange: true, // so does not change value
-                        });
-                    }
-                } else {
-                    // since desired value was not a string, it must be a math-expression
-                    // always update lastValueForDisplay
-                    // update rawRendererValue
-                    // if desired expression is different from math-expression obtained from current raw value
-                    // do not update immediate value
-
-                    instructions.push({
-                        setEssentialValue: "lastValueForDisplay",
-                        value: desiredStateVariableValues.rawRendererValue,
-                    });
-
-                    let currentMath = await calculateMathExpressionFromLatex(
-                        essentialValues.rawRendererValue,
-                    );
-
-                    // use deepCompare of trees rather than equalsViaSyntax
-                    // so even tiny numerical differences that within double precision are detected
-                    if (
-                        !deepCompare(
-                            desiredStateVariableValues.rawRendererValue.tree,
-                            currentMath.tree,
-                        )
-                    ) {
-                        let desiredValue = stripLatex(
-                            desiredStateVariableValues.rawRendererValue.toLatex(),
-                        );
-                        if (desiredValue === "\uff3f") {
-                            desiredValue = "";
-                        }
-                        instructions.push({
-                            setEssentialValue: "rawRendererValue",
-                            value: desiredValue,
-                        });
-                    }
-                }
-
-                return {
-                    success: true,
-                    instructions,
-                };
-            },
-        };
-
-        stateVariableDefinitions.componentType = {
-            returnDependencies: () => ({}),
-            definition: () => ({ setValue: { componentType: "math" } }),
-        };
-
-        stateVariableDefinitions.focused = {
-            forRenderer: true,
-            hasEssential: true,
-            defaultValue: false,
-            public: true,
-            description:
-                "Whether the matrix input currently has keyboard focus.",
-            shadowingInstructions: {
-                createComponentOfType: "boolean",
-            },
-            ignoreFixed: true,
-            returnDependencies: () => ({}),
-            definition: () => ({
-                useEssentialOrDefaultValue: { focused: true },
-            }),
-            inverseDefinition({ desiredStateVariableValues }) {
-                return {
-                    success: true,
-                    instructions: [
-                        {
-                            setEssentialValue: "focused",
-                            value: Boolean(desiredStateVariableValues.focused),
-                        },
-                    ],
-                };
-            },
-        };
+        // valueForDisplay, text, and rawRendererValue
+        Object.assign(
+            stateVariableDefinitions,
+            returnMathComponentInputDisplayStateVariableDefinitions(),
+        );
 
         // Provide an accessible name/description for each cell's textarea.
         // The mathInput renderer now exposes this text via a visually-hidden
@@ -4135,123 +3596,5 @@ export default class MatrixComponentInput extends BaseComponent {
                 skipRendererUpdate,
             });
         }
-    }
-
-    async updateValue({
-        actionId,
-        sourceInformation = {},
-        skipRendererUpdate = false,
-    }) {
-        if (!(await this.stateValues.disabled)) {
-            let immediateValue = await this.stateValues.immediateValue;
-
-            if (
-                !deepCompare(
-                    (await this.stateValues.value).tree,
-                    immediateValue.tree,
-                )
-            ) {
-                let updateInstructions = [
-                    {
-                        updateType: "updateValue",
-                        componentIdx: this.componentIdx,
-                        stateVariable: "value",
-                        value: immediateValue,
-                    },
-                    // in case value ended up being a different value than requested
-                    // we set immediate value to whatever was the result
-                    // (hence the need to execute update first)
-                    {
-                        updateType: "executeUpdate",
-                    },
-                    {
-                        updateType: "updateValue",
-                        componentIdx: this.componentIdx,
-                        stateVariable: "immediateValue",
-                        valueOfStateVariable: "value",
-                    },
-                    {
-                        updateType: "unsetComponentNeedingUpdateValue",
-                    },
-                ];
-
-                if (immediateValue.tree !== "\uff3f") {
-                    updateInstructions.push({
-                        updateType: "updateValue",
-                        componentIdx: this.componentIdx,
-                        stateVariable: "rawRendererValue",
-                        valueOfStateVariable: "valueForDisplay",
-                    });
-                }
-
-                let event = {
-                    verb: "answered",
-                    object: {
-                        componentIdx: this.componentIdx,
-                        componentType: this.componentType,
-                    },
-                    result: {
-                        response: immediateValue,
-                        responseText: immediateValue.toString(),
-                    },
-                };
-
-                let answerAncestor = await this.stateValues.answerAncestor;
-                if (answerAncestor) {
-                    event.context = {
-                        answerAncestor: answerAncestor.componentIdx,
-                    };
-                }
-
-                await this.coreFunctions.performUpdate({
-                    updateInstructions,
-                    actionId,
-                    sourceInformation,
-                    skipRendererUpdate: true,
-                    event,
-                });
-
-                return await this.coreFunctions.triggerChainedActions({
-                    componentIdx: this.componentIdx,
-                    actionId,
-                    sourceInformation,
-                    skipRendererUpdate,
-                });
-            } else {
-                // set raw renderer value to save it to the database,
-                // as it might not have been saved
-                // given that updateRawValue is transient
-                await this.coreFunctions.performUpdate({
-                    updateInstructions: [
-                        {
-                            updateType: "updateValue",
-                            componentIdx: this.componentIdx,
-                            stateVariable: "rawRendererValue",
-                            valueOfStateVariable: "rawRendererValue",
-                        },
-                    ],
-                    actionId,
-                    sourceInformation,
-                    skipRendererUpdate,
-                });
-            }
-        }
-    }
-
-    async focusChanged({ focused, actionId, sourceInformation }) {
-        return await this.coreFunctions.performUpdate({
-            updateInstructions: [
-                {
-                    updateType: "updateValue",
-                    componentIdx: this.componentIdx,
-                    stateVariable: "focused",
-                    value: focused,
-                },
-            ],
-            actionId,
-            sourceInformation,
-            overrideReadOnly: true,
-            doNotSave: true,
-        });
     }
 }

--- a/packages/doenetml-worker-javascript/src/components/MatrixInput.js
+++ b/packages/doenetml-worker-javascript/src/components/MatrixInput.js
@@ -17,6 +17,7 @@ import { roundForDisplay } from "../utils/math";
 import {
     defineSubmitAnswerExternalAction,
     mathComponentInputFocusChanged,
+    mathComponentInputUpdateRawValue,
     mathComponentInputUpdateValue,
     returnMathComponentInputConfigStateVariableDefinitions,
     returnMathComponentInputDisplayStateVariableDefinitions,
@@ -3390,7 +3391,7 @@ export default class MatrixComponentInput extends BaseComponent {
         super(args);
 
         Object.assign(this.actions, {
-            updateRawValue: this.updateRawValue.bind(this),
+            updateRawValue: mathComponentInputUpdateRawValue.bind(this),
             updateValue: mathComponentInputUpdateValue.bind(this),
             focusChanged: mathComponentInputFocusChanged.bind(this),
         });
@@ -3569,32 +3570,5 @@ export default class MatrixComponentInput extends BaseComponent {
         };
 
         return stateVariableDefinitions;
-    }
-
-    async updateRawValue({
-        rawRendererValue,
-        actionId,
-        sourceInformation = {},
-        skipRendererUpdate = false,
-    }) {
-        if (!(await this.stateValues.disabled)) {
-            return await this.coreFunctions.performUpdate({
-                updateInstructions: [
-                    {
-                        updateType: "updateValue",
-                        componentIdx: this.componentIdx,
-                        stateVariable: "rawRendererValue",
-                        value: rawRendererValue,
-                    },
-                    {
-                        updateType: "setComponentNeedingUpdateValue",
-                        componentIdx: this.componentIdx,
-                    },
-                ],
-                actionId,
-                sourceInformation,
-                skipRendererUpdate,
-            });
-        }
     }
 }

--- a/packages/doenetml-worker-javascript/src/components/TextInput.js
+++ b/packages/doenetml-worker-javascript/src/components/TextInput.js
@@ -206,7 +206,7 @@ export default class Textinput extends Input {
 
         stateVariableDefinitions.valueChanged = {
             description:
-                "Whether the saved text has been changed from its initial state.",
+                "Whether the value has been changed from its initial state.",
             public: true,
             hasEssential: true,
             defaultValue: false,
@@ -233,7 +233,7 @@ export default class Textinput extends Input {
         };
 
         stateVariableDefinitions.value = {
-            description: "The most recently saved text value.",
+            description: "The text value of the input.",
             public: true,
             shadowingInstructions: {
                 createComponentOfType: "text",
@@ -333,7 +333,7 @@ export default class Textinput extends Input {
 
         stateVariableDefinitions.immediateValueChanged = {
             description:
-                "Whether the live text differs from its initial state.",
+                "Whether the value, including in-progress edits, has been changed from its initial state.",
             public: true,
             hasEssential: true,
             defaultValue: false,
@@ -363,7 +363,7 @@ export default class Textinput extends Input {
 
         stateVariableDefinitions.immediateValue = {
             description:
-                "The current text being entered (live, before saving).",
+                "The text value reflecting the user's in-progress edits.",
             public: true,
             shadowingInstructions: {
                 createComponentOfType: "text",

--- a/packages/doenetml-worker-javascript/src/components/TextInput.js
+++ b/packages/doenetml-worker-javascript/src/components/TextInput.js
@@ -206,7 +206,7 @@ export default class Textinput extends Input {
 
         stateVariableDefinitions.valueChanged = {
             description:
-                "Whether the value has been changed from its initial state.",
+                "Whether the saved text has been changed from its initial state.",
             public: true,
             hasEssential: true,
             defaultValue: false,
@@ -233,7 +233,7 @@ export default class Textinput extends Input {
         };
 
         stateVariableDefinitions.value = {
-            description: "The text value of the input.",
+            description: "The most recently saved text value.",
             public: true,
             shadowingInstructions: {
                 createComponentOfType: "text",
@@ -333,7 +333,7 @@ export default class Textinput extends Input {
 
         stateVariableDefinitions.immediateValueChanged = {
             description:
-                "Whether the value, including in-progress edits, has been changed from its initial state.",
+                "Whether the live text differs from its initial state.",
             public: true,
             hasEssential: true,
             defaultValue: false,
@@ -363,7 +363,7 @@ export default class Textinput extends Input {
 
         stateVariableDefinitions.immediateValue = {
             description:
-                "The text value reflecting the user's in-progress edits.",
+                "The current text being entered (live, before saving).",
             public: true,
             shadowingInstructions: {
                 createComponentOfType: "text",

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/fractioninput.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/fractioninput.test.ts
@@ -35,10 +35,14 @@ describe("FractionInput tag tests @group3", async () => {
                 stateVariables[await resolvePathToNodeIdx("fi")].stateValues
                     .denominator.tree,
             ).eqls(denominator);
+            const expectedValue =
+                numerator === "＿" && denominator === "＿"
+                    ? "＿"
+                    : ["/", numerator, denominator];
             expect(
                 stateVariables[await resolvePathToNodeIdx("fi")].stateValues
                     .value.tree,
-            ).eqls(["/", numerator, denominator]);
+            ).eqls(expectedValue);
             expect(
                 stateVariables[await resolvePathToNodeIdx("num")].stateValues
                     .value.tree,
@@ -50,7 +54,7 @@ describe("FractionInput tag tests @group3", async () => {
             expect(
                 stateVariables[await resolvePathToNodeIdx("val")].stateValues
                     .value.tree,
-            ).eqls(["/", numerator, denominator]);
+            ).eqls(expectedValue);
         }
 
         await check_items("＿", "＿");
@@ -124,7 +128,7 @@ describe("FractionInput tag tests @group3", async () => {
         expect(
             stateVariables[await resolvePathToNodeIdx("fi")].stateValues.value
                 .tree,
-        ).eqls(["/", "＿", "＿"]);
+        ).eqls("＿");
 
         await updateFractionInputValueToImmediateValue({
             part: "numerator",

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/fractioninput.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/fractioninput.test.ts
@@ -194,4 +194,111 @@ describe("FractionInput tag tests @group3", async () => {
                 .creditAchieved,
         ).eq(0);
     });
+
+    it("bindValueTo a fraction, two-way", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <math name="src">2/3</math>
+    <fractionInput name="fi" bindValueTo="$src" />
+    `,
+        });
+
+        async function check(numerator: any, denominator: any) {
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            expect(
+                stateVariables[await resolvePathToNodeIdx("fi")].stateValues
+                    .numerator.tree,
+            ).eqls(numerator);
+            expect(
+                stateVariables[await resolvePathToNodeIdx("fi")].stateValues
+                    .denominator.tree,
+            ).eqls(denominator);
+            expect(
+                stateVariables[await resolvePathToNodeIdx("fi")].stateValues
+                    .value.tree,
+            ).eqls(["/", numerator, denominator]);
+            expect(
+                stateVariables[await resolvePathToNodeIdx("src")].stateValues
+                    .value.tree,
+            ).eqls(["/", numerator, denominator]);
+        }
+
+        // bound value seeds the two boxes
+        await check(2, 3);
+
+        // editing the denominator flows back to the bound math
+        await updateFractionInputValue({
+            latex: "5",
+            part: "denominator",
+            componentIdx: await resolvePathToNodeIdx("fi"),
+            core,
+        });
+        await check(2, 5);
+    });
+
+    it("bindValueTo a non-fraction puts it in the numerator", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <math name="src">5</math>
+    <fractionInput name="fi" bindValueTo="$src" />
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues
+                .numerator.tree,
+        ).eqls(5);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues
+                .denominator.tree,
+        ).eqls("＿");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues.value
+                .tree,
+        ).eqls(5);
+
+        // filling in the denominator turns it into a fraction, flowing back
+        await updateFractionInputValue({
+            latex: "2",
+            part: "denominator",
+            componentIdx: await resolvePathToNodeIdx("fi"),
+            core,
+        });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues.value
+                .tree,
+        ).eqls(["/", 5, 2]);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("src")].stateValues.value
+                .tree,
+        ).eqls(["/", 5, 2]);
+    });
+
+    it("math child links the value", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <fractionInput name="fi"><math>a/b</math></fractionInput>
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues
+                .numerator.tree,
+        ).eqls("a");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues
+                .denominator.tree,
+        ).eqls("b");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues.value
+                .tree,
+        ).eqls(["/", "a", "b"]);
+    });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/fractioninput.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/fractioninput.test.ts
@@ -239,7 +239,7 @@ describe("FractionInput tag tests @group3", async () => {
         await check(2, 5);
     });
 
-    it("bindValueTo a non-fraction puts it in the numerator", async () => {
+    it("bindValueTo a non-fraction puts it over a denominator of 1", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
     <math name="src">5</math>
@@ -255,7 +255,7 @@ describe("FractionInput tag tests @group3", async () => {
         expect(
             stateVariables[await resolvePathToNodeIdx("fi")].stateValues
                 .denominator.tree,
-        ).eqls("＿");
+        ).eqls(1);
         expect(
             stateVariables[await resolvePathToNodeIdx("fi")].stateValues.value
                 .tree,
@@ -278,6 +278,38 @@ describe("FractionInput tag tests @group3", async () => {
             stateVariables[await resolvePathToNodeIdx("src")].stateValues.value
                 .tree,
         ).eqls(["/", 5, 2]);
+    });
+
+    it("editing the numerator over a denominator of 1 stays a non-fraction", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <math name="src">5</math>
+    <fractionInput name="fi" bindValueTo="$src" />
+    `,
+        });
+
+        // denominator seeds to 1; changing only the numerator keeps the bound
+        // value a non-fraction (numerator over 1 collapses to the numerator)
+        await updateFractionInputValue({
+            latex: "6",
+            part: "numerator",
+            componentIdx: await resolvePathToNodeIdx("fi"),
+            core,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues.value
+                .tree,
+        ).eqls(6);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("src")].stateValues.value
+                .tree,
+        ).eqls(6);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues
+                .denominator.tree,
+        ).eqls(1);
     });
 
     it("math child links the value", async () => {

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/fractioninput.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/fractioninput.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestCore } from "../utils/test-core";
+import {
+    submitAnswer,
+    updateFractionInputImmediateValue,
+    updateFractionInputValue,
+    updateFractionInputValueToImmediateValue,
+} from "../utils/actions";
+
+const Mock = vi.fn();
+vi.stubGlobal("postMessage", Mock);
+vi.mock("hyperformula");
+
+describe("FractionInput tag tests @group3", async () => {
+    it("numerator, denominator, and value", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <fractionInput name="fi" />
+    <p>Numerator: <math extend="$fi.numerator" name="num" /></p>
+    <p>Denominator: <math extend="$fi.denominator" name="den" /></p>
+    <p>Value: <math extend="$fi.value" name="val" /></p>
+    `,
+        });
+
+        async function check_items(numerator: any, denominator: any) {
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            expect(
+                stateVariables[await resolvePathToNodeIdx("fi")].stateValues
+                    .numerator.tree,
+            ).eqls(numerator);
+            expect(
+                stateVariables[await resolvePathToNodeIdx("fi")].stateValues
+                    .denominator.tree,
+            ).eqls(denominator);
+            expect(
+                stateVariables[await resolvePathToNodeIdx("fi")].stateValues
+                    .value.tree,
+            ).eqls(["/", numerator, denominator]);
+            expect(
+                stateVariables[await resolvePathToNodeIdx("num")].stateValues
+                    .value.tree,
+            ).eqls(numerator);
+            expect(
+                stateVariables[await resolvePathToNodeIdx("den")].stateValues
+                    .value.tree,
+            ).eqls(denominator);
+            expect(
+                stateVariables[await resolvePathToNodeIdx("val")].stateValues
+                    .value.tree,
+            ).eqls(["/", numerator, denominator]);
+        }
+
+        await check_items("＿", "＿");
+
+        await updateFractionInputValue({
+            latex: "2",
+            part: "numerator",
+            componentIdx: await resolvePathToNodeIdx("fi"),
+            core,
+        });
+        await check_items(2, "＿");
+
+        await updateFractionInputValue({
+            latex: "3",
+            part: "denominator",
+            componentIdx: await resolvePathToNodeIdx("fi"),
+            core,
+        });
+        await check_items(2, 3);
+
+        await updateFractionInputValue({
+            latex: "x+1",
+            part: "numerator",
+            componentIdx: await resolvePathToNodeIdx("fi"),
+            core,
+        });
+        await check_items(["+", "x", 1], 3);
+    });
+
+    it("prefill numerator and denominator", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <fractionInput name="fi" prefillNumerator="5" prefillDenominator="x" />
+    `,
+        });
+
+        const stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues
+                .numerator.tree,
+        ).eqls(5);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues
+                .denominator.tree,
+        ).eqls("x");
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues.value
+                .tree,
+        ).eqls(["/", 5, "x"]);
+    });
+
+    it("immediate value updates separately from value", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <fractionInput name="fi" />
+    `,
+        });
+
+        await updateFractionInputImmediateValue({
+            latex: "7",
+            part: "numerator",
+            componentIdx: await resolvePathToNodeIdx("fi"),
+            core,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues
+                .immediateValue.tree,
+        ).eqls(["/", 7, "＿"]);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues.value
+                .tree,
+        ).eqls(["/", "＿", "＿"]);
+
+        await updateFractionInputValueToImmediateValue({
+            part: "numerator",
+            componentIdx: await resolvePathToNodeIdx("fi"),
+            core,
+        });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues.value
+                .tree,
+        ).eqls(["/", 7, "＿"]);
+    });
+
+    it("fraction input in answer", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <answer name="ans">
+        <fractionInput name="fi" />
+        <award><math>2/3</math></award>
+    </answer>
+    `,
+        });
+
+        await updateFractionInputValue({
+            latex: "2",
+            part: "numerator",
+            componentIdx: await resolvePathToNodeIdx("fi"),
+            core,
+        });
+        await updateFractionInputValue({
+            latex: "3",
+            part: "denominator",
+            componentIdx: await resolvePathToNodeIdx("fi"),
+            core,
+        });
+
+        await submitAnswer({
+            componentIdx: await resolvePathToNodeIdx("ans"),
+            core,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("ans")].stateValues
+                .creditAchieved,
+        ).eq(1);
+
+        await updateFractionInputValue({
+            latex: "1",
+            part: "numerator",
+            componentIdx: await resolvePathToNodeIdx("fi"),
+            core,
+        });
+        await submitAnswer({
+            componentIdx: await resolvePathToNodeIdx("ans"),
+            core,
+        });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("ans")].stateValues
+                .creditAchieved,
+        ).eq(0);
+    });
+});

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/fractioninput.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/fractioninput.test.ts
@@ -239,6 +239,46 @@ describe("FractionInput tag tests @group3", async () => {
         await check(2, 5);
     });
 
+    it("bindValueTo a negative fraction keeps the sign in the numerator", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <math name="src">-2/3</math>
+    <fractionInput name="fi" bindValueTo="$src" />
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues
+                .numerator.tree,
+        ).eqls(["-", 2]);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues
+                .denominator.tree,
+        ).eqls(3);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues.value
+                .tree,
+        ).eqls(["/", ["-", 2], 3]);
+
+        await updateFractionInputValue({
+            latex: "5",
+            part: "denominator",
+            componentIdx: await resolvePathToNodeIdx("fi"),
+            core,
+        });
+
+        stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues.value
+                .tree,
+        ).eqls(["/", ["-", 2], 5]);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("src")].stateValues.value
+                .tree,
+        ).eqls(["/", ["-", 2], 5]);
+    });
+
     it("bindValueTo a non-fraction puts it over a denominator of 1", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
@@ -332,5 +372,27 @@ describe("FractionInput tag tests @group3", async () => {
             stateVariables[await resolvePathToNodeIdx("fi")].stateValues.value
                 .tree,
         ).eqls(["/", "a", "b"]);
+    });
+
+    it("math child with a negative fraction keeps the sign in the numerator", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <fractionInput name="fi"><math>-4/5</math></fractionInput>
+    `,
+        });
+
+        let stateVariables = await core.returnAllStateVariables(false, true);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues
+                .numerator.tree,
+        ).eqls(["-", 4]);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues
+                .denominator.tree,
+        ).eqls(5);
+        expect(
+            stateVariables[await resolvePathToNodeIdx("fi")].stateValues.value
+                .tree,
+        ).eqls(["/", ["-", 4], 5]);
     });
 });

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/fractioninput.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/fractioninput.test.ts
@@ -374,6 +374,44 @@ describe("FractionInput tag tests @group3", async () => {
         ).eqls(["/", "a", "b"]);
     });
 
+    it("reference child links the value two-way", async () => {
+        let { core, resolvePathToNodeIdx } = await createTestCore({
+            doenetML: `
+    <mathInput name="src" prefill="2/3" />
+    <fractionInput name="fi">$src</fractionInput>
+    `,
+        });
+
+        async function check(numerator: any, denominator: any) {
+            const stateVariables = await core.returnAllStateVariables(
+                false,
+                true,
+            );
+            expect(
+                stateVariables[await resolvePathToNodeIdx("fi")].stateValues
+                    .numerator.tree,
+            ).eqls(numerator);
+            expect(
+                stateVariables[await resolvePathToNodeIdx("fi")].stateValues
+                    .denominator.tree,
+            ).eqls(denominator);
+            expect(
+                stateVariables[await resolvePathToNodeIdx("src")].stateValues
+                    .value.tree,
+            ).eqls(["/", numerator, denominator]);
+        }
+
+        await check(2, 3);
+
+        await updateFractionInputValue({
+            latex: "5",
+            part: "denominator",
+            componentIdx: await resolvePathToNodeIdx("fi"),
+            core,
+        });
+        await check(2, 5);
+    });
+
     it("math child with a negative fraction keeps the sign in the numerator", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `

--- a/packages/doenetml-worker-javascript/src/test/tagSpecific/fractioninput.test.ts
+++ b/packages/doenetml-worker-javascript/src/test/tagSpecific/fractioninput.test.ts
@@ -259,7 +259,7 @@ describe("FractionInput tag tests @group3", async () => {
         expect(
             stateVariables[await resolvePathToNodeIdx("fi")].stateValues.value
                 .tree,
-        ).eqls(5);
+        ).eqls(["/", 5, 1]);
 
         // filling in the denominator turns it into a fraction, flowing back
         await updateFractionInputValue({
@@ -280,7 +280,7 @@ describe("FractionInput tag tests @group3", async () => {
         ).eqls(["/", 5, 2]);
     });
 
-    it("editing the numerator over a denominator of 1 stays a non-fraction", async () => {
+    it("editing the numerator keeps the denominator of 1", async () => {
         let { core, resolvePathToNodeIdx } = await createTestCore({
             doenetML: `
     <math name="src">5</math>
@@ -288,8 +288,8 @@ describe("FractionInput tag tests @group3", async () => {
     `,
         });
 
-        // denominator seeds to 1; changing only the numerator keeps the bound
-        // value a non-fraction (numerator over 1 collapses to the numerator)
+        // denominator seeds to 1; the value stays a fraction (not collapsed),
+        // so changing the numerator keeps a denominator of 1
         await updateFractionInputValue({
             latex: "6",
             part: "numerator",
@@ -301,11 +301,11 @@ describe("FractionInput tag tests @group3", async () => {
         expect(
             stateVariables[await resolvePathToNodeIdx("fi")].stateValues.value
                 .tree,
-        ).eqls(6);
+        ).eqls(["/", 6, 1]);
         expect(
             stateVariables[await resolvePathToNodeIdx("src")].stateValues.value
                 .tree,
-        ).eqls(6);
+        ).eqls(["/", 6, 1]);
         expect(
             stateVariables[await resolvePathToNodeIdx("fi")].stateValues
                 .denominator.tree,

--- a/packages/doenetml-worker-javascript/src/test/utils/actions.ts
+++ b/packages/doenetml-worker-javascript/src/test/utils/actions.ts
@@ -284,6 +284,94 @@ export async function updateMatrixInputValueToImmediateValue({
     }
 }
 
+async function fractionInputPartIdx({
+    componentIdx,
+    part,
+    core,
+    stateVariables,
+}: {
+    componentIdx: number;
+    part: "numerator" | "denominator";
+    core: PublicDoenetMLCore;
+    stateVariables?: any;
+}) {
+    if (stateVariables === undefined) {
+        stateVariables = await core.returnAllStateVariables(false, true);
+    }
+    let fractionInput = stateVariables[componentIdx];
+    let childInd = part === "denominator" ? 1 : 0;
+    return fractionInput.activeChildren[childInd]?.componentIdx;
+}
+
+export async function updateFractionInputValue({
+    latex,
+    componentIdx,
+    part,
+    core,
+}: {
+    latex: string;
+    componentIdx: number;
+    part: "numerator" | "denominator";
+    core: PublicDoenetMLCore;
+}) {
+    let partIdx = await fractionInputPartIdx({ componentIdx, part, core });
+
+    if (partIdx !== undefined) {
+        await core.requestAction({
+            componentIdx: partIdx,
+            actionName: "updateRawValue",
+            args: { rawRendererValue: latex },
+        });
+        await core.requestAction({
+            componentIdx: partIdx,
+            actionName: "updateValue",
+            args: {},
+        });
+    }
+}
+
+export async function updateFractionInputImmediateValue({
+    latex,
+    componentIdx,
+    part,
+    core,
+}: {
+    latex: string;
+    componentIdx: number;
+    part: "numerator" | "denominator";
+    core: PublicDoenetMLCore;
+}) {
+    let partIdx = await fractionInputPartIdx({ componentIdx, part, core });
+
+    if (partIdx !== undefined) {
+        await core.requestAction({
+            componentIdx: partIdx,
+            actionName: "updateRawValue",
+            args: { rawRendererValue: latex },
+        });
+    }
+}
+
+export async function updateFractionInputValueToImmediateValue({
+    componentIdx,
+    part,
+    core,
+}: {
+    componentIdx: number;
+    part: "numerator" | "denominator";
+    core: PublicDoenetMLCore;
+}) {
+    let partIdx = await fractionInputPartIdx({ componentIdx, part, core });
+
+    if (partIdx !== undefined) {
+        await core.requestAction({
+            componentIdx: partIdx,
+            actionName: "updateValue",
+            args: {},
+        });
+    }
+}
+
 export async function updateMatrixInputNumRows({
     numRows,
     componentIdx,

--- a/packages/doenetml-worker-javascript/src/utils/mathComponentInput.js
+++ b/packages/doenetml-worker-javascript/src/utils/mathComponentInput.js
@@ -536,6 +536,40 @@ export function returnMathComponentInputDisplayStateVariableDefinitions() {
 }
 
 /**
+ * Shared `updateRawValue` action for a math-input cell: stores the latest raw
+ * (LaTeX) value from the renderer and flags the component as needing a value
+ * update. The update is transient so each keystroke does not add a row to the
+ * database. Bind to the component instance in its constructor.
+ */
+export async function mathComponentInputUpdateRawValue({
+    rawRendererValue,
+    actionId,
+    sourceInformation = {},
+    skipRendererUpdate = false,
+}) {
+    if (!(await this.stateValues.disabled)) {
+        return await this.coreFunctions.performUpdate({
+            updateInstructions: [
+                {
+                    updateType: "updateValue",
+                    componentIdx: this.componentIdx,
+                    stateVariable: "rawRendererValue",
+                    value: rawRendererValue,
+                },
+                {
+                    updateType: "setComponentNeedingUpdateValue",
+                    componentIdx: this.componentIdx,
+                },
+            ],
+            transient: true,
+            actionId,
+            sourceInformation,
+            skipRendererUpdate,
+        });
+    }
+}
+
+/**
  * Shared `updateValue` action for a math-input cell: when the live
  * `immediateValue` differs from the saved `value`, commit it (and refresh the
  * renderer's raw value), emitting an "answered" event and triggering any

--- a/packages/doenetml-worker-javascript/src/utils/mathComponentInput.js
+++ b/packages/doenetml-worker-javascript/src/utils/mathComponentInput.js
@@ -99,10 +99,14 @@ export function returnMathInputParsingAttributes() {
  * The `valueChanged` / `immediateValueChanged` essential booleans, public so
  * authors can detect whether a user has edited the input.
  */
-export function returnInputValueChangedStateVariableDefinitions() {
+export function returnInputValueChangedStateVariableDefinitions({
+    valueChangedDescription,
+    immediateValueChangedDescription,
+} = {}) {
     const stateVariableDefinitions = {};
 
     stateVariableDefinitions.valueChanged = {
+        description: valueChangedDescription,
         public: true,
         hasEssential: true,
         defaultValue: false,
@@ -127,6 +131,7 @@ export function returnInputValueChangedStateVariableDefinitions() {
     };
 
     stateVariableDefinitions.immediateValueChanged = {
+        description: immediateValueChangedDescription,
         public: true,
         hasEssential: true,
         defaultValue: false,

--- a/packages/doenetml-worker-javascript/src/utils/mathComponentInput.js
+++ b/packages/doenetml-worker-javascript/src/utils/mathComponentInput.js
@@ -1,0 +1,668 @@
+import me from "math-expressions";
+import { deepCompare, convertValueToMathExpression } from "@doenet/utils";
+import { buildNumberDisplayParameters } from "./numberDisplay";
+import {
+    latexToMathFactory,
+    normalizeLatexString,
+    roundForDisplay,
+    stripLatex,
+} from "./math";
+
+/**
+ * Shared building blocks for the internal math-input "cell" components that
+ * back a `<matrixInput>` (each `_matrixComponentInput`) and a `<fractionInput>`
+ * (its numerator/denominator `_fractionInputComponent`). Both render with the
+ * `mathInput` renderer, read their parsing/number-display configuration from
+ * their parent input, and convert between a raw LaTeX string and a math value.
+ *
+ * The parts that genuinely differ between the two — where `value` /
+ * `immediateValue` come from, and the accessible `shortDescription` — stay in
+ * the individual component classes.
+ */
+
+/**
+ * Define a `submitAnswer` external action on an input component that delegates
+ * to its `answerAncestor`. Call from the component constructor.
+ */
+export function defineSubmitAnswerExternalAction(component) {
+    component.externalActions = {};
+
+    // Complex because the stateValues isn't defined until later
+    Object.defineProperty(component.externalActions, "submitAnswer", {
+        enumerable: true,
+        get: async function () {
+            let answerAncestor = await this.stateValues.answerAncestor;
+            if (answerAncestor !== null) {
+                return {
+                    componentIdx: answerAncestor.componentIdx,
+                    actionName: "submitAnswer",
+                };
+            } else {
+                return;
+            }
+        }.bind(component),
+    });
+}
+
+/**
+ * The parsing attributes (`format`, `functionSymbols`, `splitSymbols`,
+ * `parseScientificNotation`) shared by inputs that parse math the same way a
+ * `<mathInput>` does.
+ */
+export function returnMathInputParsingAttributes() {
+    return {
+        format: {
+            description: "Input format for the math entered.",
+            createComponentOfType: "text",
+            createStateVariable: "format",
+            defaultValue: "text",
+            public: true,
+            toLowerCase: true,
+            validValues: [
+                {
+                    value: "text",
+                    description: "Plain-text math notation (e.g., `x^2 + 1`).",
+                },
+                {
+                    value: "latex",
+                    description: "LaTeX-formatted math (e.g., `x^{2} + 1`).",
+                },
+            ],
+        },
+        functionSymbols: {
+            description: "Symbols treated as function names when parsing.",
+            createComponentOfType: "textList",
+            createStateVariable: "functionSymbols",
+            defaultValue: ["f", "g"],
+            public: true,
+        },
+        splitSymbols: {
+            description:
+                "Whether multi-character symbols are split into a product of variables.",
+            createComponentOfType: "boolean",
+            createStateVariable: "splitSymbols",
+            defaultValue: true,
+            public: true,
+        },
+        parseScientificNotation: {
+            description:
+                "Whether to parse expressions like 1e3 as scientific notation.",
+            createComponentOfType: "boolean",
+            createStateVariable: "parseScientificNotation",
+            defaultValue: false,
+            public: true,
+        },
+    };
+}
+
+/**
+ * The `valueChanged` / `immediateValueChanged` essential booleans, public so
+ * authors can detect whether a user has edited the input.
+ */
+export function returnInputValueChangedStateVariableDefinitions() {
+    const stateVariableDefinitions = {};
+
+    stateVariableDefinitions.valueChanged = {
+        public: true,
+        hasEssential: true,
+        defaultValue: false,
+        shadowingInstructions: {
+            createComponentOfType: "boolean",
+        },
+        returnDependencies: () => ({}),
+        definition() {
+            return { useEssentialOrDefaultValue: { valueChanged: true } };
+        },
+        inverseDefinition({ desiredStateVariableValues }) {
+            return {
+                success: true,
+                instructions: [
+                    {
+                        setEssentialValue: "valueChanged",
+                        value: Boolean(desiredStateVariableValues.valueChanged),
+                    },
+                ],
+            };
+        },
+    };
+
+    stateVariableDefinitions.immediateValueChanged = {
+        public: true,
+        hasEssential: true,
+        defaultValue: false,
+        shadowingInstructions: {
+            createComponentOfType: "boolean",
+        },
+        returnDependencies: () => ({}),
+        definition() {
+            return {
+                useEssentialOrDefaultValue: { immediateValueChanged: true },
+            };
+        },
+        inverseDefinition({ desiredStateVariableValues }) {
+            return {
+                success: true,
+                instructions: [
+                    {
+                        setEssentialValue: "immediateValueChanged",
+                        value: Boolean(
+                            desiredStateVariableValues.immediateValueChanged,
+                        ),
+                    },
+                ],
+            };
+        },
+    };
+
+    return stateVariableDefinitions;
+}
+
+/**
+ * Configuration state variables a math-input cell reads from its parent input
+ * (`parentComponentType`): the parsing options, the number-display options, the
+ * cell width, plus the constant `componentType` (`"math"`) and the `focused`
+ * flag.
+ */
+export function returnMathComponentInputConfigStateVariableDefinitions({
+    parentComponentType,
+}) {
+    const stateVariableDefinitions = {};
+
+    stateVariableDefinitions.minWidth = {
+        forRenderer: true,
+        returnDependencies: () => ({
+            inputAncestor: {
+                dependencyType: "ancestor",
+                componentType: parentComponentType,
+                variableNames: ["minComponentWidth"],
+            },
+        }),
+        definition({ dependencyValues }) {
+            return {
+                setValue: {
+                    minWidth: dependencyValues.inputAncestor
+                        ? dependencyValues.inputAncestor.stateValues
+                              .minComponentWidth
+                        : 0,
+                },
+            };
+        },
+    };
+
+    // these are passed straight through from the parent input
+    for (const varName of [
+        "format",
+        "functionSymbols",
+        "splitSymbols",
+        "parseScientificNotation",
+        "displaySmallAsZero",
+        "padZeros",
+        "avoidScientificNotation",
+        "unionFromU",
+    ]) {
+        stateVariableDefinitions[varName] = {
+            returnDependencies: () => ({
+                parentValue: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType,
+                    variableName: varName,
+                },
+            }),
+            definition({ dependencyValues }) {
+                return {
+                    setValue: { [varName]: dependencyValues.parentValue },
+                };
+            },
+        };
+    }
+
+    // displayDigits and displayDecimals additionally propagate usedDefault so
+    // the cell's number display respects whether the parent used a default
+    for (const varName of ["displayDigits", "displayDecimals"]) {
+        stateVariableDefinitions[varName] = {
+            returnDependencies: () => ({
+                parentValue: {
+                    dependencyType: "parentStateVariable",
+                    parentComponentType,
+                    variableName: varName,
+                },
+            }),
+            definition({ dependencyValues, usedDefault }) {
+                let result = {
+                    setValue: { [varName]: dependencyValues.parentValue },
+                };
+
+                if (usedDefault.parentValue) {
+                    result.markAsUsedDefault = { [varName]: true };
+                }
+
+                return result;
+            },
+        };
+    }
+
+    stateVariableDefinitions.componentType = {
+        returnDependencies: () => ({}),
+        definition: () => ({ setValue: { componentType: "math" } }),
+    };
+
+    stateVariableDefinitions.focused = {
+        forRenderer: true,
+        hasEssential: true,
+        defaultValue: false,
+        public: true,
+        description: "Whether this input currently has keyboard focus.",
+        shadowingInstructions: {
+            createComponentOfType: "boolean",
+        },
+        ignoreFixed: true,
+        returnDependencies: () => ({}),
+        definition: () => ({
+            useEssentialOrDefaultValue: { focused: true },
+        }),
+        inverseDefinition({ desiredStateVariableValues }) {
+            return {
+                success: true,
+                instructions: [
+                    {
+                        setEssentialValue: "focused",
+                        value: Boolean(desiredStateVariableValues.focused),
+                    },
+                ],
+            };
+        },
+    };
+
+    return stateVariableDefinitions;
+}
+
+/**
+ * The display state variables that turn a cell's `value` / `immediateValue`
+ * into rounded display values, a `text` string, and the `rawRendererValue`
+ * (LaTeX) the renderer edits. Requires the cell to define `value`,
+ * `immediateValue`, and the number-display config (see
+ * {@link returnMathComponentInputConfigStateVariableDefinitions}).
+ */
+export function returnMathComponentInputDisplayStateVariableDefinitions() {
+    const stateVariableDefinitions = {};
+
+    stateVariableDefinitions.valueForDisplay = {
+        returnDependencies: () => ({
+            value: {
+                dependencyType: "stateVariable",
+                variableName: "value",
+            },
+            displayDigits: {
+                dependencyType: "stateVariable",
+                variableName: "displayDigits",
+            },
+            displayDecimals: {
+                dependencyType: "stateVariable",
+                variableName: "displayDecimals",
+            },
+            displaySmallAsZero: {
+                dependencyType: "stateVariable",
+                variableName: "displaySmallAsZero",
+            },
+        }),
+        definition: function ({ dependencyValues }) {
+            let rounded = roundForDisplay({
+                value: dependencyValues.value,
+                dependencyValues,
+            });
+
+            return {
+                setValue: { valueForDisplay: rounded },
+            };
+        },
+    };
+
+    stateVariableDefinitions.text = {
+        public: true,
+        description: "The current value as a text string.",
+        shadowingInstructions: {
+            createComponentOfType: "text",
+        },
+        returnDependencies: () => ({
+            valueForDisplay: {
+                dependencyType: "stateVariable",
+                variableName: "valueForDisplay",
+            },
+            padZeros: {
+                dependencyType: "stateVariable",
+                variableName: "padZeros",
+            },
+            displayDigits: {
+                dependencyType: "stateVariable",
+                variableName: "displayDigits",
+            },
+            displayDecimals: {
+                dependencyType: "stateVariable",
+                variableName: "displayDecimals",
+            },
+            avoidScientificNotation: {
+                dependencyType: "stateVariable",
+                variableName: "avoidScientificNotation",
+            },
+        }),
+        definition: function ({ dependencyValues }) {
+            let params = buildNumberDisplayParameters({
+                padZeros: dependencyValues.padZeros,
+                displayDigits: dependencyValues.displayDigits,
+                displayDecimals: dependencyValues.displayDecimals,
+                avoidScientificNotation:
+                    dependencyValues.avoidScientificNotation,
+            });
+            return {
+                setValue: {
+                    text: dependencyValues.valueForDisplay.toString(params),
+                },
+            };
+        },
+    };
+
+    // raw value from renderer
+    stateVariableDefinitions.rawRendererValue = {
+        description: "The raw value used by the renderer.",
+        forRenderer: true,
+        hasEssential: true,
+        shadowVariable: true,
+        defaultValue: "",
+        provideEssentialValuesInDefinition: true,
+        public: true,
+        shadowingInstructions: {
+            createComponentOfType: "text",
+        },
+        additionalStateVariablesDefined: [
+            {
+                variableName: "lastValueForDisplay",
+                hasEssential: true,
+                shadowVariable: true,
+                defaultValue: null,
+                set: convertValueToMathExpression,
+            },
+        ],
+        returnDependencies: () => ({
+            // include immediateValue for inverse definition
+            immediateValue: {
+                dependencyType: "stateVariable",
+                variableName: "immediateValue",
+            },
+            valueForDisplay: {
+                dependencyType: "stateVariable",
+                variableName: "valueForDisplay",
+            },
+        }),
+        definition({ dependencyValues, essentialValues }) {
+            // use deepCompare of trees rather than equalsViaSyntax
+            // so even tiny numerical differences that within double precision are detected
+            if (
+                essentialValues.rawRendererValue === undefined ||
+                !deepCompare(
+                    essentialValues.lastValueForDisplay.tree,
+                    dependencyValues.valueForDisplay.tree,
+                )
+            ) {
+                let rawRendererValue = stripLatex(
+                    dependencyValues.valueForDisplay.toLatex(),
+                );
+                if (rawRendererValue === "\uff3f") {
+                    rawRendererValue = "";
+                }
+                return {
+                    setValue: {
+                        rawRendererValue,
+                        lastValueForDisplay: dependencyValues.valueForDisplay,
+                    },
+                    setEssentialValue: {
+                        rawRendererValue,
+                        lastValueForDisplay: dependencyValues.valueForDisplay,
+                    },
+                };
+            } else {
+                return {
+                    useEssentialOrDefaultValue: {
+                        rawRendererValue: true,
+                        lastValueForDisplay: true,
+                    },
+                };
+            }
+        },
+        async inverseDefinition({
+            desiredStateVariableValues,
+            stateValues,
+            essentialValues,
+        }) {
+            const calculateMathExpressionFromLatex = async (text) => {
+                let expression;
+
+                text = normalizeLatexString(text, {
+                    unionFromU: await stateValues.unionFromU,
+                });
+
+                // replace ^25 with ^{2}5, since mathQuill uses standard latex conventions
+                // unlike math-expression's latex parser
+                text = text.replace(/\^(\w)/g, "^{$1}");
+
+                let fromLatex = latexToMathFactory({
+                    functionSymbols: await stateValues.functionSymbols,
+                    splitSymbols: await stateValues.splitSymbols,
+                    parseScientificNotation:
+                        await stateValues.parseScientificNotation,
+                });
+
+                try {
+                    expression = fromLatex(text);
+                } catch (e) {
+                    expression = me.fromAst("\uFF3F");
+                }
+                return expression;
+            };
+
+            let instructions = [];
+
+            if (
+                typeof desiredStateVariableValues.rawRendererValue === "string"
+            ) {
+                let currentValue = essentialValues.rawRendererValue;
+                let desiredValue = desiredStateVariableValues.rawRendererValue;
+
+                if (currentValue !== desiredValue) {
+                    instructions.push({
+                        setEssentialValue: "rawRendererValue",
+                        value: desiredValue,
+                    });
+                }
+
+                let currentMath =
+                    await calculateMathExpressionFromLatex(currentValue);
+                let desiredMath =
+                    await calculateMathExpressionFromLatex(desiredValue);
+
+                // use deepCompare of trees rather than equalsViaSyntax
+                // so even tiny numerical differences that within double precision are detected
+                if (!deepCompare(desiredMath.tree, currentMath.tree)) {
+                    instructions.push({
+                        setDependency: "immediateValue",
+                        desiredValue: desiredMath,
+                        treatAsInitialChange: true, // so does not change value
+                    });
+                }
+            } else {
+                // since desired value was not a string, it must be a math-expression
+                // always update lastValueForDisplay
+                // update rawRendererValue
+                // if desired expression is different from math-expression obtained from current raw value
+                // do not update immediate value
+
+                instructions.push({
+                    setEssentialValue: "lastValueForDisplay",
+                    value: desiredStateVariableValues.rawRendererValue,
+                });
+
+                let currentMath = await calculateMathExpressionFromLatex(
+                    essentialValues.rawRendererValue,
+                );
+
+                // use deepCompare of trees rather than equalsViaSyntax
+                // so even tiny numerical differences that within double precision are detected
+                if (
+                    !deepCompare(
+                        desiredStateVariableValues.rawRendererValue.tree,
+                        currentMath.tree,
+                    )
+                ) {
+                    let desiredValue = stripLatex(
+                        desiredStateVariableValues.rawRendererValue.toLatex(),
+                    );
+                    if (desiredValue === "\uff3f") {
+                        desiredValue = "";
+                    }
+                    instructions.push({
+                        setEssentialValue: "rawRendererValue",
+                        value: desiredValue,
+                    });
+                }
+            }
+
+            return {
+                success: true,
+                instructions,
+            };
+        },
+    };
+
+    return stateVariableDefinitions;
+}
+
+/**
+ * Shared `updateValue` action for a math-input cell: when the live
+ * `immediateValue` differs from the saved `value`, commit it (and refresh the
+ * renderer's raw value), emitting an "answered" event and triggering any
+ * chained actions. Bind to the component instance in its constructor.
+ */
+export async function mathComponentInputUpdateValue({
+    actionId,
+    sourceInformation = {},
+    skipRendererUpdate = false,
+}) {
+    if (!(await this.stateValues.disabled)) {
+        let immediateValue = await this.stateValues.immediateValue;
+
+        if (
+            !deepCompare(
+                (await this.stateValues.value).tree,
+                immediateValue.tree,
+            )
+        ) {
+            let updateInstructions = [
+                {
+                    updateType: "updateValue",
+                    componentIdx: this.componentIdx,
+                    stateVariable: "value",
+                    value: immediateValue,
+                },
+                // in case value ended up being a different value than requested
+                // we set immediate value to whatever was the result
+                // (hence the need to execute update first)
+                {
+                    updateType: "executeUpdate",
+                },
+                {
+                    updateType: "updateValue",
+                    componentIdx: this.componentIdx,
+                    stateVariable: "immediateValue",
+                    valueOfStateVariable: "value",
+                },
+                {
+                    updateType: "unsetComponentNeedingUpdateValue",
+                },
+            ];
+
+            if (immediateValue.tree !== "\uff3f") {
+                updateInstructions.push({
+                    updateType: "updateValue",
+                    componentIdx: this.componentIdx,
+                    stateVariable: "rawRendererValue",
+                    valueOfStateVariable: "valueForDisplay",
+                });
+            }
+
+            let event = {
+                verb: "answered",
+                object: {
+                    componentIdx: this.componentIdx,
+                    componentType: this.componentType,
+                },
+                result: {
+                    response: immediateValue,
+                    responseText: immediateValue.toString(),
+                },
+            };
+
+            let answerAncestor = await this.stateValues.answerAncestor;
+            if (answerAncestor) {
+                event.context = {
+                    answerAncestor: answerAncestor.componentIdx,
+                };
+            }
+
+            await this.coreFunctions.performUpdate({
+                updateInstructions,
+                actionId,
+                sourceInformation,
+                skipRendererUpdate: true,
+                event,
+            });
+
+            return await this.coreFunctions.triggerChainedActions({
+                componentIdx: this.componentIdx,
+                actionId,
+                sourceInformation,
+                skipRendererUpdate,
+            });
+        } else {
+            // set raw renderer value to save it to the database,
+            // as it might not have been saved
+            // given that updateRawValue is transient
+            await this.coreFunctions.performUpdate({
+                updateInstructions: [
+                    {
+                        updateType: "updateValue",
+                        componentIdx: this.componentIdx,
+                        stateVariable: "rawRendererValue",
+                        valueOfStateVariable: "rawRendererValue",
+                    },
+                ],
+                actionId,
+                sourceInformation,
+                skipRendererUpdate,
+            });
+        }
+    }
+}
+
+/**
+ * Shared `focusChanged` action for a math-input cell. Bind to the component
+ * instance in its constructor.
+ */
+export async function mathComponentInputFocusChanged({
+    focused,
+    actionId,
+    sourceInformation,
+}) {
+    return await this.coreFunctions.performUpdate({
+        updateInstructions: [
+            {
+                updateType: "updateValue",
+                componentIdx: this.componentIdx,
+                stateVariable: "focused",
+                value: focused,
+            },
+        ],
+        actionId,
+        sourceInformation,
+        overrideReadOnly: true,
+        doNotSave: true,
+    });
+}

--- a/packages/doenetml/src/Viewer/renderers/fractionInput.css
+++ b/packages/doenetml/src/Viewer/renderers/fractionInput.css
@@ -1,0 +1,34 @@
+.doenet-viewer .fraction-input {
+    position: relative;
+    margin: 6px;
+    display: inline-block;
+    vertical-align: middle;
+    width: auto;
+
+    & table {
+        border-collapse: collapse;
+    }
+
+    /* Override the default mathInput wrapper margin (0 4px 4px 4px), which
+       would otherwise push the numerator farther from the bar than the
+       denominator and make each box narrower than its cell (so the bar
+       overhangs). A symmetric margin keeps the gaps equal and the bar flush
+       with the boxes. */
+    & div.mathInputWrapper {
+        margin: 0;
+    }
+
+    & .fractionNumerator,
+    & .fractionDenominator {
+        text-align: center;
+        /* A little vertical space so the focus-state double border on the
+           input boxes doesn't touch the bar. */
+        padding: 4px 0;
+    }
+
+    & .fractionVinculum {
+        height: 0;
+        padding: 0;
+        border-bottom: 2px solid currentColor;
+    }
+}

--- a/packages/doenetml/src/Viewer/renderers/fractionInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/fractionInput.tsx
@@ -1,0 +1,183 @@
+import React, { useRef } from "react";
+import useDoenetRenderer, {
+    UseDoenetRendererProps,
+} from "../useDoenetRenderer";
+import { MathJax } from "better-react-mathjax";
+
+import "./fractionInput.css";
+import "./mathInput.css";
+import {
+    calculateValidationState,
+    createCheckWorkComponent,
+} from "./utils/checkWork";
+import { DescriptionPopover } from "./utils/Description";
+import { useSubmitActionWithDelay } from "./utils/useSubmitActionWithDelay";
+
+interface FractionInputSVs {
+    [key: string]: any;
+    hidden: boolean;
+    disabled: boolean;
+    label: string;
+    labelHasLatex: boolean;
+    labelPosition?: string;
+    forceFullCheckWorkButton: boolean;
+    justSubmitted: boolean;
+    shortDescription?: string;
+    descriptionChildInd?: number;
+    externalLabelRendererIds?: string[];
+}
+
+export default React.memo(function FractionInput(
+    props: UseDoenetRendererProps,
+) {
+    let { id, SVs, actions, children, callAction } =
+        useDoenetRenderer<FractionInputSVs>(props);
+
+    // need to use a ref for validation state as handlePressEnter
+    // does not update to current values
+    let validationState = useRef<
+        "unvalidated" | "correct" | "incorrect" | "partialcorrect"
+    >("unvalidated");
+
+    if (SVs.hidden) {
+        return null;
+    }
+
+    validationState.current = calculateValidationState(SVs);
+
+    const { isPending, submitActionWithPending } = useSubmitActionWithDelay({
+        actionKey: "submitAnswer",
+        actions,
+        callAction,
+        validationState: validationState.current,
+        justSubmitted: SVs.justSubmitted,
+    });
+
+    const checkWorkComponent = createCheckWorkComponent(
+        SVs,
+        id,
+        validationState.current,
+        submitActionWithPending,
+        SVs.forceFullCheckWorkButton,
+        isPending,
+    );
+
+    let label: React.ReactNode = SVs.label;
+    const hasLabel =
+        typeof SVs.label === "string" ? SVs.label.trim() !== "" : !!SVs.label;
+    const labelId = `${id}-label`;
+    if (SVs.labelHasLatex) {
+        label = (
+            <MathJax hideUntilTypeset={"first"} inline dynamic>
+                {label}
+            </MathJax>
+        );
+    }
+
+    const shortDescription = SVs.shortDescription || undefined;
+    const externalLabelRendererIds = SVs.externalLabelRendererIds ?? [];
+    const groupLabelledByIds = [
+        hasLabel ? labelId : null,
+        ...externalLabelRendererIds,
+    ]
+        .filter(Boolean)
+        .join(" ");
+
+    const descriptionChild =
+        SVs.descriptionChildInd !== undefined &&
+        SVs.descriptionChildInd !== -1 &&
+        children[SVs.descriptionChildInd];
+
+    let descriptionId: string | undefined = undefined;
+    let description: React.ReactNode | null = null;
+
+    if (descriptionChild) {
+        descriptionId = `${id}-description-content`;
+        description = (
+            <DescriptionPopover>
+                <div id={descriptionId}>{descriptionChild}</div>
+            </DescriptionPopover>
+        );
+    }
+
+    const labelComponent = hasLabel ? (
+        <span
+            id={labelId}
+            style={{
+                marginRight: SVs.labelPosition === "right" ? undefined : "5px",
+                marginLeft: SVs.labelPosition === "right" ? "5px" : undefined,
+            }}
+        >
+            {label}
+        </span>
+    ) : null;
+
+    const fractionInputRow = (
+        <span
+            style={{
+                display: "inline-flex",
+                alignItems: "flex-start",
+                // The input row flows as inline content so a wrapping line keeps
+                // it aligned with the surrounding text baseline.
+                verticalAlign: "middle",
+            }}
+        >
+            <div className="fraction-input" id={id}>
+                <table
+                    aria-labelledby={groupLabelledByIds || undefined}
+                    aria-label={
+                        !groupLabelledByIds ? shortDescription : undefined
+                    }
+                    aria-description={
+                        groupLabelledByIds ? shortDescription : undefined
+                    }
+                    aria-details={descriptionId}
+                >
+                    <tbody>
+                        <tr>
+                            <td className="fractionNumerator">{children[0]}</td>
+                        </tr>
+                        <tr>
+                            <td className="fractionVinculum"></td>
+                        </tr>
+                        <tr>
+                            <td className="fractionDenominator">
+                                {children[1]}
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <div style={{ marginRight: "4px" }}></div>
+            {checkWorkComponent}
+            {description}
+        </span>
+    );
+
+    return (
+        <React.Fragment>
+            <div
+                // `display: inline` so the label and fraction flow with the
+                // surrounding paragraph text. See mathInput.tsx for the full
+                // rationale.
+                style={{
+                    display: "inline",
+                    margin: "0 4px",
+                }}
+                id={`${id}-container`}
+            >
+                {SVs.labelPosition === "right" ? (
+                    <>
+                        {fractionInputRow}
+                        {labelComponent}
+                    </>
+                ) : (
+                    <>
+                        {labelComponent}
+                        {fractionInputRow}
+                    </>
+                )}
+            </div>
+        </React.Fragment>
+    );
+});

--- a/packages/doenetml/src/Viewer/renderers/fractionInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/fractionInput.tsx
@@ -116,9 +116,9 @@ export default React.memo(function FractionInput(
         <span
             style={{
                 display: "inline-flex",
-                alignItems: "flex-start",
-                // The input row flows as inline content so a wrapping line keeps
-                // it aligned with the surrounding text baseline.
+                // Vertically center the check-work button next to the fraction
+                // rather than pinning it to the top.
+                alignItems: "center",
                 verticalAlign: "middle",
             }}
         >

--- a/packages/parser/src/dast-normalize/component-sugar/descriptionAttribute.ts
+++ b/packages/parser/src/dast-normalize/component-sugar/descriptionAttribute.ts
@@ -15,6 +15,7 @@ export function descriptionAttributeSugar(node: DastElement) {
             "choiceInput",
             "booleanInput",
             "matrixInput",
+            "fractionInput",
         ].includes(node.name)
     ) {
         // This should be unreachable

--- a/packages/parser/src/dast-normalize/component-sugar/fractionInput.ts
+++ b/packages/parser/src/dast-normalize/component-sugar/fractionInput.ts
@@ -1,0 +1,30 @@
+import { DastElement } from "../../types";
+
+/**
+ * Add the numerator and denominator input boxes as children of a
+ * `<fractionInput>`. Each is a `_fractionInputComponent` tagged with its
+ * `part` so the parent can route prefills and values to the correct box.
+ */
+export function fractionInputSugar(node: DastElement) {
+    const makeInput = (part: string): DastElement => ({
+        type: "element",
+        name: "_fractionInputComponent",
+        attributes: {
+            part: {
+                type: "attribute",
+                name: "part",
+                children: [{ type: "text", value: part }],
+            },
+        },
+        children: [],
+        position: node.position,
+        source_doc: node.source_doc,
+    });
+
+    node.children.splice(
+        0,
+        0,
+        makeInput("numerator"),
+        makeInput("denominator"),
+    );
+}

--- a/packages/parser/src/dast-normalize/normalize-dast.ts
+++ b/packages/parser/src/dast-normalize/normalize-dast.ts
@@ -17,6 +17,7 @@ import { postponeRenderSugar } from "./component-sugar/postponeRender";
 import { pluginEnforceValidNames } from "./enforce-valid-names";
 import { pretzelSugar } from "./component-sugar/pretzel";
 import { descriptionAttributeSugar } from "./component-sugar/descriptionAttribute";
+import { fractionInputSugar } from "./component-sugar/fractionInput";
 import { graphSugar } from "./component-sugar/graph";
 import { answerSugar } from "./component-sugar/answer";
 import { pluginApplyDeprecations } from "./deprecations";
@@ -233,6 +234,10 @@ const pluginComponentSugar: Plugin<[], DastRoot, DastRoot> = () => {
                 case "choiceInput":
                 case "matrixInput":
                     descriptionAttributeSugar(node);
+                    break;
+                case "fractionInput":
+                    descriptionAttributeSugar(node);
+                    fractionInputSugar(node);
                     break;
             }
         });

--- a/packages/test-cypress/cypress/e2e/accessibility/basicTests.cy.js
+++ b/packages/test-cypress/cypress/e2e/accessibility/basicTests.cy.js
@@ -630,6 +630,7 @@ describe("Basic accessibility tests", { tags: ["@group5"] }, function () {
     </p>
     <p><booleanInput><label>yes</label></booleanInput></p>
     <p><matrixInput><label>A:</label></matrixInput></p>
+    <p><fractionInput><label>A fraction:</label></fractionInput></p>
 
   `,
                 },
@@ -685,6 +686,9 @@ describe("Basic accessibility tests", { tags: ["@group5"] }, function () {
         <p><label for="$mat">A:</label></p>
         <p><matrixInput name="mat"/></p>
 
+        <p><label for="$frac">A fraction:</label></p>
+        <p><fractionInput name="frac"/></p>
+
     `,
                 },
                 "*",
@@ -736,6 +740,7 @@ describe("Basic accessibility tests", { tags: ["@group5"] }, function () {
     </p>
     <p><booleanInput><shortDescription>yes</shortDescription></booleanInput></p>
     <p><matrixInput><shortDescription>A</shortDescription></matrixInput></p>
+    <p><fractionInput><shortDescription>A fraction</shortDescription></fractionInput></p>
 
   `,
                 },

--- a/packages/test-cypress/cypress/e2e/tagSpecific/fractioninput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/fractioninput.cy.js
@@ -74,4 +74,33 @@ describe("FractionInput Tag Tests", { tags: ["@group4"] }, function () {
         cy.get("#frac_button").should("contain.text", "Check Work").click();
         cy.get("#frac_button").should("contain.text", "Correct");
     });
+
+    it("bindValueTo a math input, two-way", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+        <mathInput name="mi" prefill="2/3"><label>src</label></mathInput>
+        <fractionInput name="frac" bindValueTo="$mi">
+            <label>bound fraction</label>
+        </fractionInput>
+
+        <p name="pNum">numerator: $frac.numerator</p>
+        <p name="pDen">denominator: $frac.denominator</p>
+        `,
+                },
+                "*",
+            );
+        });
+
+        // bound value seeds the two boxes
+        cy.get("#pNum").should("have.text", "numerator: 2");
+        cy.get("#pDen").should("have.text", "denominator: 3");
+
+        // editing the denominator box flows back to the bound math input
+        cy.get("#frac textarea").eq(1).type("{end}{backspace}5{enter}", {
+            force: true,
+        });
+        cy.get("#pDen").should("have.text", "denominator: 5");
+    });
 });

--- a/packages/test-cypress/cypress/e2e/tagSpecific/fractioninput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/fractioninput.cy.js
@@ -1,0 +1,77 @@
+describe("FractionInput Tag Tests", { tags: ["@group4"] }, function () {
+    beforeEach(() => {
+        cy.clearIndexedDB();
+        cy.visit("/");
+    });
+
+    it("type into numerator and denominator", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+        <fractionInput name="frac">
+            <label>Enter a fraction</label>
+        </fractionInput>
+
+        <p name="pNum">numerator: $frac.numerator</p>
+        <p name="pDen">denominator: $frac.denominator</p>
+        <p name="pVal">value: $frac.value</p>
+        `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#frac textarea").eq(0).type("2{enter}", { force: true });
+        cy.get("#frac textarea").eq(1).type("3{enter}", { force: true });
+
+        cy.get("#pNum").should("have.text", "numerator: 2");
+        cy.get("#pDen").should("have.text", "denominator: 3");
+        cy.get("#pVal").should("contain.text", "2");
+    });
+
+    it("prefill numerator and denominator", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+        <fractionInput name="frac" prefillNumerator="5" prefillDenominator="7">
+            <label>Edit the fraction</label>
+        </fractionInput>
+
+        <p name="pNum">numerator: $frac.numerator</p>
+        <p name="pDen">denominator: $frac.denominator</p>
+        `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#pNum").should("have.text", "numerator: 5");
+        cy.get("#pDen").should("have.text", "denominator: 7");
+    });
+
+    it("fraction input in answer", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+        <answer name="ans">
+            <fractionInput name="frac">
+                <shortDescription>Simplify two tenths</shortDescription>
+            </fractionInput>
+            <award>1/5</award>
+        </answer>
+        `,
+                },
+                "*",
+            );
+        });
+
+        cy.get("#frac textarea").eq(0).type("1", { force: true });
+        cy.get("#frac textarea").eq(1).type("5", { force: true });
+
+        cy.get("#frac_button").should("contain.text", "Check Work").click();
+        cy.get("#frac_button").should("contain.text", "Correct");
+    });
+});


### PR DESCRIPTION
Adds a new interactive `<fractionInput>` component: a numerator input box above a denominator input box, separated by a fraction bar, with each box accepting a math value like a `<mathInput>`.

Closes #1342.

## Behavior

- Exposes `numerator`, `denominator`, and `value` (numerator divided by denominator) properties, plus the standard `text`/`immediateValue`/`valueChanged`/etc.
- Works as the input inside an `<answer>` (check-work integration).
- `prefillNumerator` / `prefillDenominator` attributes seed the two boxes.
- A math/reference child (for example `$mi`) or the `bindValueTo` attribute creates a two-way link with the value (following the `matrixInput` precedent). A bound **non-fraction** value is placed in the numerator over a denominator of `1`; a bound **negative fraction** keeps the sign in the numerator. The `value` always stays a fraction (e.g. `a/1`, never collapsed). A fully-blank fraction reports a single blank value.

## Implementation

- Worker component `FractionInput.js` (the `fractionInput` input plus an internal `_fractionInputComponent` box, rendered with the `mathInput` renderer). The two boxes are injected by a parser DAST-normalize sugar (`component-sugar/fractionInput.ts`); each is tagged with its `part`.
- Renderer `fractionInput.tsx` (+ css) stacks the two boxes with a vinculum.
- The internal value plumbing shared with `matrixInput`/`mathInput` was extracted into `utils/mathComponentInput.js` (config/display state variables, the `updateRawValue`/`updateValue`/`focusChanged` actions, the `submitAnswer` external action, the shared parsing attributes, and the shared `valueChanged`/`immediateValueChanged` state-variable definitions), removing ~1,400 lines of duplication. As part of this, `matrixInput`'s cell `updateRawValue` was standardized on the (currently inert) `transient: true` flag to match the other inputs.
- Reworded the `value`/`numerator`/`denominator`/`valueChanged` and `immediateValue`/`immediateValueChanged` state-variable descriptions for the **math inputs** (`mathInput`, `matrixInput`, `fractionInput`): `value` is described simply as the input's value, and `immediateValue` as the value reflecting the user's in-progress edits (dropping the "saved" framing). The same rewording for the non-math inputs, and broader adoption of the shared helpers, are in a follow-up PR.

## Docs & tests

- Reference page `pages/reference/fractionInput.mdx`, plus `componentTypes.mdx` and `_meta.ts` entries; schema regenerated.
- Vitest (`fractioninput.test.ts`, including linked negative fractions and reference-child linking), Cypress (`fractioninput.cy.js`), and accessibility cases cover the new component. Existing matrixInput tests cover the shared cell-logic refactor.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)