### PR TITLE
fix: render fractionInput vinculum reliably on high-DPI displays

### DIFF
--- a/.changeset/fraction-input-vinculum-retina.md
+++ b/.changeset/fraction-input-vinculum-retina.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Fix the `<fractionInput>` fraction bar (vinculum) not rendering on high-DPI displays.
+
+The bar was drawn as a `border-bottom` on an empty, zero-height table cell inside a `border-collapse: collapse` table. On high-DPI (e.g. Retina) screens the browser snaps that collapsed hairline to the device-pixel grid and rounds it away to nothing, so the vinculum disappeared in Chrome, Safari, and Brave on those displays. It is now painted as a solid 2px-high block (`background-color: currentColor`), which rasterizes reliably at any `devicePixelRatio`.

--- a/packages/doenetml/src/Viewer/renderers/fractionInput.css
+++ b/packages/doenetml/src/Viewer/renderers/fractionInput.css
@@ -27,8 +27,14 @@
     }
 
     & .fractionVinculum {
-        height: 0;
+        /* Paint the bar as a solid 2px-high block rather than a border on an
+           empty, zero-height cell. A collapsed border on an empty zero-height
+           cell gets snapped to the device-pixel grid and rounds away to
+           nothing on high-DPI (e.g. Retina) displays, so the vinculum would
+           vanish on those screens. A filled background box of explicit height
+           rasterizes reliably at any devicePixelRatio. */
+        height: 2px;
         padding: 0;
-        border-bottom: 2px solid currentColor;
+        background-color: currentColor;
     }
 }


### PR DESCRIPTION
## Problem

A user reported the `<fractionInput>` fraction bar (vinculum) was missing in Chrome, Safari, and Brave on their Mac, while it rendered fine on Linux.

## Cause

The bar was drawn as a `border-bottom: 2px solid currentColor` on an **empty, zero-height `<td>`** inside a `border-collapse: collapse` table. On high-DPI (e.g. Retina) displays (`devicePixelRatio: 2`), the browser snaps that collapsed hairline to the device-pixel grid and rounds it away to nothing — so the vinculum disappears. The common factor across the three failing browsers is the *display*, not the engine (Blink + WebKit), which is why it reproduced everywhere on the Mac but not on a 1× Linux screen.

## Fix

Paint the bar as a solid 2px-high block (`background-color: currentColor`) rather than a border on a zero-height empty cell. A filled background box of explicit height rasterizes reliably at any `devicePixelRatio`.

```css
& .fractionVinculum {
    height: 2px;
    padding: 0;
    background-color: currentColor;
}
```

## Verification

Rendered a `<fractionInput>` in a headless Chrome context with `deviceScaleFactor: 2` (the reproduction condition) and confirmed the bar now appears between the numerator and denominator boxes.

Follow-up from #1345.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)