### PR TITLE
fix: render math in dark mode in the VS Code preview

### DIFF
--- a/.changeset/vscode-preview-dark-mode-math.md
+++ b/.changeset/vscode-preview-dark-mode-math.md
@@ -1,0 +1,8 @@
+---
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+VS Code extension: render math in dark mode.
+
+The preview window passed a boolean `darkMode` to `DoenetViewer`, but the viewer expects the string `"dark"` or `"light"`. Because the renderers compare `darkMode === "dark"`, the boolean always fell through to light-mode colors, so math inside `<m>`/`<math>` was drawn in the light-mode text color (black) and was invisible against VS Code's dark themes. The preview now passes `darkMode={darkMode ? "dark" : "light"}`.

--- a/packages/vscode-extension/src/preview-window/App.tsx
+++ b/packages/vscode-extension/src/preview-window/App.tsx
@@ -77,7 +77,10 @@ function App() {
                 </VSCodeButton>
             </div>
             <div className="doenet-preview">
-                <DoenetViewer doenetML={source} darkMode={darkMode} />
+                <DoenetViewer
+                    doenetML={source}
+                    darkMode={darkMode ? "dark" : "light"}
+                />
             </div>
         </div>
     );


### PR DESCRIPTION
## Problem

In the VS Code extension's DoenetML preview, math inside `<m>`/`<math>` is invisible when VS Code uses a **dark** color theme. It renders fine in light themes.

## Cause

The preview window holds `darkMode` as a **boolean** and passes it straight through:

```tsx
<DoenetViewer doenetML={source} darkMode={darkMode} />
```

But `DoenetViewer` (and `DocViewer`) type `darkMode` as `"dark" | "light"`, and the renderers branch on `darkMode === "dark"` (e.g. `packages/doenetml/src/Viewer/renderers/math.tsx`). A boolean `true` is never `=== "dark"`, so the viewer always falls back to **light-mode** colors. Regular text picks up VS Code's CSS text color and stays visible, but the math text/stroke color comes from the renderer's resolved style — light-mode black — which is invisible on a dark background.

## Fix

Pass the string the viewer expects:

```tsx
<DoenetViewer
    doenetML={source}
    darkMode={darkMode ? "dark" : "light"}
/>
```

One line in `packages/vscode-extension/src/preview-window/App.tsx`.

## Testing

Verified locally by applying the equivalent change to the installed extension's built preview bundle: with a dark VS Code theme, math inside `<m>`/`<math>` that was previously invisible now renders in the correct light color, and light-theme behavior is unchanged.

`prettier --check` passes on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)