### PR TITLE
fix: defer renderer updates during section-wide check work submission

### DIFF
--- a/.changeset/section-wide-check-work-feedback-flash.md
+++ b/.changeset/section-wide-check-work-feedback-flash.md
@@ -1,0 +1,11 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Answer: stop a partial-credit `<feedback>` from briefly flashing on screen when a section-wide check-work button submits multiple answers at once.
+
+`submitAllAnswers` submits each enclosed answer with `skipRendererUpdate: true` so the renderer only updates once, on the final `numSubmissions` bump. However, `performUpdate` forced a renderer fan-out whenever the update carried a `recordItemSubmission` instruction (every answer submission does), ignoring `skipRendererUpdate`. That pushed the renderer mid-loop while the section's aggregated `creditAchieved` was at an intermediate partial value, so feedback gated on a partial-credit condition flashed and then disappeared. The renderer fan-out now honors `skipRendererUpdate`; normal single submissions still render via their trailing `triggerChainedActions` flush.

--- a/packages/doenetml-worker-javascript/src/components/Video.js
+++ b/packages/doenetml-worker-javascript/src/components/Video.js
@@ -606,6 +606,12 @@ export default class Video extends BlockComponent {
             }
         }
 
+        // segmentsWatched (and the secondsWatched/fractionWatched derived
+        // from it) are not rendered, so there is no optimistic edit to
+        // reconcile: don't force this component into the renderer-update set
+        // (canSkipUpdatingRenderer) and defer the fan-out
+        // (skipRendererUpdate). recordVideoWatched fires throughout
+        // playback, so this avoids needless renderer churn.
         await this.coreFunctions.performUpdate({
             updateInstructions: [
                 {

--- a/packages/doenetml-worker-javascript/src/components/Video.js
+++ b/packages/doenetml-worker-javascript/src/components/Video.js
@@ -606,12 +606,15 @@ export default class Video extends BlockComponent {
             }
         }
 
-        // segmentsWatched (and the secondsWatched/fractionWatched derived
-        // from it) are not rendered, so there is no optimistic edit to
-        // reconcile: don't force this component into the renderer-update set
-        // (canSkipUpdatingRenderer) and defer the fan-out
-        // (skipRendererUpdate). recordVideoWatched fires throughout
-        // playback, so this avoids needless renderer churn.
+        // canSkipUpdatingRenderer is the video-specific part: segmentsWatched
+        // (and the secondsWatched/fractionWatched derived from it) are not
+        // rendered, so there is no optimistic edit to reconcile. Without it,
+        // this component would be forced into the renderer-update set and
+        // needlessly re-rendered on every watched segment as the video plays.
+        // skipRendererUpdate is just the usual action idiom: defer the single
+        // renderer fan-out to the trailing triggerChainedActions, which
+        // performs it (or leaves it deferred if this action was itself
+        // chained).
         await this.coreFunctions.performUpdate({
             updateInstructions: [
                 {

--- a/packages/doenetml-worker-javascript/src/core/UpdateExecutor.ts
+++ b/packages/doenetml-worker-javascript/src/core/UpdateExecutor.ts
@@ -65,21 +65,32 @@ type PerformUpdateArgs = {
      */
     doNotSave?: boolean;
     /**
-     * Skip renderer work that only mirrors the incoming instructions: the
-     * read-only mirror path and the writable-path bookkeeping that forces
-     * instruction components into the renderer-update set. Pair with
-     * `skipRendererUpdate` when the caller also wants to defer the final
-     * renderer fan-out.
+     * Opt out of *forcing* this update's own target components into the
+     * renderer-update set. Normally those components are queued
+     * unconditionally so the renderer is re-sent their authoritative
+     * `forRenderer` values — even when nothing actually changed — which is
+     * how an optimistic renderer edit (text typed into an input, a dragged
+     * point) gets confirmed or reverted once core processes or rejects the
+     * requested change. Set this only when the targeted state variables are
+     * not rendered, so there is no optimistic edit to reconcile and
+     * re-sending would be wasted work (e.g. the video component recording
+     * watch progress into its non-rendered `segmentsWatched`). It does not
+     * suppress renderer updates for *other* state variables that genuinely
+     * changed as a result of this update: those are still queued by
+     * staleness propagation.
      */
     canSkipUpdatingRenderer?: boolean;
     /**
-     * Skip only the late `updateAllChangedRenderers` call at the end of
-     * `performUpdate`, while still letting the early read-only path and
-     * the components-to-update bookkeeping run. Callers that defer renderer
-     * updates this way are responsible for issuing a later renderer update
-     * (e.g. answer submission flushes via its trailing
-     * `triggerChainedActions`, and `submitAllAnswers` flushes once on its
-     * final `numSubmissions` update).
+     * Postpone this update's final `updateAllChangedRenderers` fan-out so a
+     * batch of updates can finish before the UI changes, avoiding
+     * intermediate states flashing on screen. Components still accumulate in
+     * the pending renderer set; the caller is responsible for a later update
+     * or action *without* this flag that flushes them. For example, each
+     * answer submission defers its fan-out and `submitAllAnswers` flushes
+     * once on its final `numSubmissions` update; a lone answer submission
+     * flushes via its trailing `triggerChainedActions`. Unrelated to
+     * `canSkipUpdatingRenderer`: this only times *when* the fan-out happens,
+     * not *which* components it covers.
      */
     skipRendererUpdate?: boolean;
     sourceInformation?: SourceInformation;
@@ -235,10 +246,11 @@ export class UpdateExecutor {
      *
      * After the loop, `executeUpdateStateVariables` runs once more on
      * any leftover `newStateVariableValues`. Unless
-     * `canSkipUpdatingRenderer` is set, the update instructions' components
-     * are marked for renderer reconciliation before
-     * `processStateVariableTriggers` runs. The final
-     * `updateAllChangedRenderers` fan-out then runs only when
+     * `canSkipUpdatingRenderer` is set, each instruction's target component
+     * is queued into `componentsToUpdateRenderers` so an optimistic
+     * renderer edit can be confirmed or reverted (see that flag). Then
+     * `processStateVariableTriggers` runs, and the final
+     * `updateAllChangedRenderers` fan-out runs only when
      * `skipRendererUpdate` is false. Essential values saved during
      * definitions are merged into the cumulative changes log so they
      * persist on the next save.
@@ -369,9 +381,12 @@ export class UpdateExecutor {
 
         newStateVariableValuesProcessed.push(newStateVariableValues);
 
-        // Unless explicitly skipped, mark the instruction components for the
-        // next renderer reconciliation. This lets renderers revert optimistic
-        // edits even when inverse definitions reject the requested changes.
+        // Queue each instruction's target component so the renderer is
+        // re-sent its authoritative forRenderer values. This send happens
+        // even when the requested change was rejected or left the value
+        // unchanged, letting a renderer that optimistically showed the edit
+        // revert to core's value. canSkipUpdatingRenderer opts out when the
+        // targets are not rendered, so there is nothing to reconcile.
         if (!canSkipUpdatingRenderer) {
             updateInstructions.forEach((comp) => {
                 if (comp.componentIdx != undefined) {

--- a/packages/doenetml-worker-javascript/src/core/UpdateExecutor.ts
+++ b/packages/doenetml-worker-javascript/src/core/UpdateExecutor.ts
@@ -65,9 +65,11 @@ type PerformUpdateArgs = {
      */
     doNotSave?: boolean;
     /**
-     * Skip *both* renderer-update paths (the read-only mirror and the
-     * post-update fan-out). Used when the caller will re-issue updates
-     * imminently and renderer churn would be wasted.
+     * Skip renderer work that only mirrors the incoming instructions: the
+     * read-only mirror path and the writable-path bookkeeping that forces
+     * instruction components into the renderer-update set. Pair with
+     * `skipRendererUpdate` when the caller also wants to defer the final
+     * renderer fan-out.
      */
     canSkipUpdatingRenderer?: boolean;
     /**
@@ -232,10 +234,12 @@ export class UpdateExecutor {
      *     downstream answer-submission detection.
      *
      * After the loop, `executeUpdateStateVariables` runs once more on
-     * any leftover `newStateVariableValues`, then
-     * `processStateVariableTriggers` and `updateAllChangedRenderers` run
-     * conditionally based on the `skipRendererUpdate` /
-     * `canSkipUpdatingRenderer` flags. Essential values saved during
+     * any leftover `newStateVariableValues`. Unless
+     * `canSkipUpdatingRenderer` is set, the update instructions' components
+     * are marked for renderer reconciliation before
+     * `processStateVariableTriggers` runs. The final
+     * `updateAllChangedRenderers` fan-out then runs only when
+     * `skipRendererUpdate` is false. Essential values saved during
      * definitions are merged into the cumulative changes log so they
      * persist on the next save.
      *

--- a/packages/doenetml-worker-javascript/src/core/UpdateExecutor.ts
+++ b/packages/doenetml-worker-javascript/src/core/UpdateExecutor.ts
@@ -73,8 +73,11 @@ type PerformUpdateArgs = {
     /**
      * Skip only the late `updateAllChangedRenderers` call at the end of
      * `performUpdate`, while still letting the early read-only path and
-     * the components-to-update bookkeeping run. Submission-recording
-     * updates override this and always fan out.
+     * the components-to-update bookkeeping run. Callers that defer renderer
+     * updates this way are responsible for issuing a later renderer update
+     * (e.g. answer submission flushes via its trailing
+     * `triggerChainedActions`, and `submitAllAnswers` flushes once on its
+     * final `numSubmissions` update).
      */
     skipRendererUpdate?: boolean;
     sourceInformation?: SourceInformation;
@@ -377,7 +380,7 @@ export class UpdateExecutor {
 
         await this.core.processStateVariableTriggers();
 
-        if (!skipRendererUpdate || recordComponentSubmissions.length > 0) {
+        if (!skipRendererUpdate) {
             await this.core.updateAllChangedRenderers(
                 sourceInformation,
                 actionId,

--- a/packages/doenetml-worker-javascript/src/core/UpdateExecutor.ts
+++ b/packages/doenetml-worker-javascript/src/core/UpdateExecutor.ts
@@ -369,9 +369,9 @@ export class UpdateExecutor {
 
         newStateVariableValuesProcessed.push(newStateVariableValues);
 
-        // always update the renderers from the update instructions themselves,
-        // as even if changes were prevented, the renderers need to be given that information
-        // so they can revert if the showed the changes before hearing back from core
+        // Unless explicitly skipped, mark the instruction components for the
+        // next renderer reconciliation. This lets renderers revert optimistic
+        // edits even when inverse definitions reject the requested changes.
         if (!canSkipUpdatingRenderer) {
             updateInstructions.forEach((comp) => {
                 if (comp.componentIdx != undefined) {


### PR DESCRIPTION
## Problem

When a section uses **section-wide check work** (`sectionWideCheckWork`) and contains multiple answers, clicking the single section-wide "Check Work" button can briefly flash a partial-credit `<feedback>` box on screen, which then disappears — even when every answer is correct.

`submitAllAnswers` (`packages/doenetml-worker-javascript/src/utils/scoredSection.js`) submits each enclosed answer with `skipRendererUpdate: true`, so the renderer should update only once, on the final `numSubmissions` bump.

However, `performUpdate` (`packages/doenetml-worker-javascript/src/core/UpdateExecutor.ts`) guarded its renderer fan-out with:

```js
if (!skipRendererUpdate || recordComponentSubmissions.length > 0) {
    await this.core.updateAllChangedRenderers(...);
}
```

Every answer submission carries a `recordItemSubmission` instruction, so `recordComponentSubmissions.length > 0` is always true during submission — forcing a renderer fan-out and overriding the caller's `skipRendererUpdate: true`. This pushes the renderer mid-loop, while the section's aggregated `creditAchieved` is at an intermediate partial value (1/4, 2/4, 3/4), so feedback gated on a partial-credit condition flashes and then hides once all answers are submitted.

## Fix

The renderer fan-out now honors `skipRendererUpdate`:

```js
if (!skipRendererUpdate) {
    await this.core.updateAllChangedRenderers(...);
}
```

This is safe because both `recordItemSubmission` producers (`Answer.submitAnswer`, `Pretzel`) always follow their `performUpdate` with `triggerChainedActions`, which flushes renderers at the end when `skipRendererUpdate` is `false`:

- **Normal single submit** (`skipRendererUpdate: false`): still renders via the trailing `triggerChainedActions` flush — now once instead of twice.
- **Section-wide submit** (`skipRendererUpdate: true`, only from `submitAllAnswers`): no mid-loop renders; the final `numSubmissions` `updateValue` flushes the whole accumulated set once, showing the final state with no partial-credit flash.

The only caller passing `skipRendererUpdate: true` to `submitAnswer` is `submitAllAnswers`; all other callers default to `false`.

The diff also corrects the adjacent renderer-update flag docs in `performUpdate`. `skipRendererUpdate` is documented as purely postponing the final fan-out (the caller flushes later), while `canSkipUpdatingRenderer` is documented as opting out of forcing the instruction's own target components into the renderer-update set — only safe when those targets are not rendered (e.g. the video component's non-rendered `segmentsWatched`), with a clarifying comment added at that call site.

## Testing

- `sectionWideCheckWork.test.ts` — 13/13 pass
- `answer.test.ts` — 178 pass, 2 skipped
- No TypeScript diagnostics

The flash is a transient renderer push, so it isn't directly asserted by the state-based unit suites, but those confirm submission/credit behavior is unchanged.

Closes #1353.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)

