### PR TITLE
ci: make npm publish resilient to transient provenance failures

### DIFF
--- a/.github/scripts/npm-publish-with-retry.mjs
+++ b/.github/scripts/npm-publish-with-retry.mjs
@@ -24,6 +24,8 @@
  *   - After a failed attempt it re-checks the registry: if the version now
  *     exists (the publish succeeded server-side despite a client-side error),
  *     it is treated as success.
+ *   - On every successful path, ensures any requested/configured dist-tag points
+ *     to the published version.
  *
  * Configuration (environment variables):
  *   NPM_PUBLISH_MAX_ATTEMPTS    - total attempts before giving up (default 4)
@@ -271,7 +273,7 @@ function ensureExplicitDistTag() {
     return false;
 }
 
-function treatAlreadyPublishedAsSuccess(message) {
+function finishPublishedVersion(message) {
     if (!ensureExplicitDistTag()) {
         process.exit(1);
     }
@@ -293,9 +295,7 @@ function runPublish() {
 
 async function main() {
     if (alreadyPublished()) {
-        treatAlreadyPublishedAsSuccess(
-            `✔ ${spec} is already published; skipping.`,
-        );
+        finishPublishedVersion(`✔ ${spec} is already published; skipping.`);
         return;
     }
 
@@ -306,12 +306,12 @@ async function main() {
         const { status, output } = runPublish();
 
         if (status === 0) {
-            console.log(`✔ Published ${spec}.`);
+            finishPublishedVersion(`✔ Published ${spec}.`);
             return;
         }
 
         if (matchesAny(output, ALREADY_PUBLISHED_PATTERNS)) {
-            treatAlreadyPublishedAsSuccess(
+            finishPublishedVersion(
                 `✔ ${spec} is already published (publish reported a conflict); treating as success.`,
             );
             return;
@@ -321,7 +321,7 @@ async function main() {
         // reported an error (e.g. the token read failed after upload). Confirm
         // against the registry before deciding to retry.
         if (alreadyPublished()) {
-            treatAlreadyPublishedAsSuccess(
+            finishPublishedVersion(
                 `✔ ${spec} is now present on the registry despite the error; treating as success.`,
             );
             return;

--- a/.github/scripts/npm-publish-with-retry.mjs
+++ b/.github/scripts/npm-publish-with-retry.mjs
@@ -1,0 +1,214 @@
+/**
+ * Publish an npm package with retries and idempotency.
+ *
+ * npm's provenance/Trusted-Publishing path occasionally fails with transient
+ * errors (most notably `IDENTITY_TOKEN_READ_ERROR` while retrieving the OIDC
+ * identity token, plus assorted network/5xx blips). A single flaky publish
+ * would otherwise fail the whole release job even though the build and all the
+ * other packages succeeded. This wrapper retries those transient failures and
+ * treats an already-published version as success, so the release pipeline is
+ * resilient to flakiness and safe to re-run.
+ *
+ * Usage:
+ *   node .github/scripts/npm-publish-with-retry.mjs <publish-dir> [npm publish args...]
+ *
+ * Example (from a package directory):
+ *   node ../../.github/scripts/npm-publish-with-retry.mjs dist --tag dev
+ *
+ * Behavior:
+ *   - Reads name@version from <publish-dir>/package.json.
+ *   - If that exact version is already on the registry, skips (success).
+ *   - Otherwise runs `npm publish` (forwarding the extra args) in <publish-dir>,
+ *     retrying on transient errors with exponential backoff.
+ *   - After a failed attempt it re-checks the registry: if the version now
+ *     exists (the publish succeeded server-side despite a client-side error),
+ *     it is treated as success.
+ *
+ * Configuration (environment variables):
+ *   NPM_PUBLISH_MAX_ATTEMPTS    - total attempts before giving up (default 4)
+ *   NPM_PUBLISH_RETRY_DELAY_MS  - base backoff delay in ms (default 10000)
+ *   NPM_PUBLISH_MAX_DELAY_MS    - backoff delay cap in ms (default 60000)
+ */
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const [, , publishDir, ...publishArgs] = process.argv;
+
+if (!publishDir) {
+    console.error(
+        "Usage: node npm-publish-with-retry.mjs <publish-dir> [npm publish args...]",
+    );
+    process.exit(1);
+}
+
+const maxAttempts = Number(process.env.NPM_PUBLISH_MAX_ATTEMPTS ?? 4);
+const baseDelayMs = Number(process.env.NPM_PUBLISH_RETRY_DELAY_MS ?? 10_000);
+const maxDelayMs = Number(process.env.NPM_PUBLISH_MAX_DELAY_MS ?? 60_000);
+
+const cwd = resolve(process.cwd(), publishDir);
+
+let pkg;
+try {
+    pkg = JSON.parse(readFileSync(resolve(cwd, "package.json"), "utf8"));
+} catch (error) {
+    console.error(
+        `Could not read package.json in ${cwd}: ${error.message ?? error}`,
+    );
+    process.exit(1);
+}
+
+const { name, version } = pkg;
+if (!name || !version) {
+    console.error(`package.json in ${cwd} is missing a name or version.`);
+    process.exit(1);
+}
+const spec = `${name}@${version}`;
+
+/**
+ * Patterns that indicate the version is already published. Re-publishing the
+ * same version is impossible, so we treat this as success (idempotent re-runs).
+ */
+const ALREADY_PUBLISHED_PATTERNS = [
+    /EPUBLISHCONFLICT/i,
+    /cannot publish over/i,
+    /previously published version/i,
+    /\b403\b[^\n]*over/i,
+];
+
+/**
+ * Patterns for transient failures that are worth retrying. The OIDC identity
+ * token read error is the motivating case; the rest are common network/registry
+ * blips during publish + provenance signing.
+ */
+const TRANSIENT_PATTERNS = [
+    /IDENTITY_TOKEN_READ_ERROR/i,
+    /error retrieving identity token/i,
+    /provenance/i,
+    /sigstore/i,
+    /fulcio/i,
+    /rekor/i,
+    /transparency log/i,
+    /ECONNRESET/i,
+    /ETIMEDOUT/i,
+    /ENOTFOUND/i,
+    /EAI_AGAIN/i,
+    /ECONNREFUSED/i,
+    /EPIPE/i,
+    /socket hang up/i,
+    /network/i,
+    /request to .* failed/i,
+    /fetch failed/i,
+    /\b429\b/,
+    /\b5\d\d\b/,
+    /Internal Server Error/i,
+    /Service Unavailable/i,
+    /Bad Gateway/i,
+    /Gateway Time-?out/i,
+    /registry returned/i,
+];
+
+function matchesAny(text, patterns) {
+    return patterns.some((pattern) => pattern.test(text));
+}
+
+function sleep(ms) {
+    return new Promise((res) => setTimeout(res, ms));
+}
+
+/**
+ * Returns true if the exact name@version is already available on the registry.
+ */
+function alreadyPublished() {
+    const result = spawnSync(
+        "npm",
+        ["view", spec, "version", "--no-workspaces"],
+        { encoding: "utf8" },
+    );
+    if (result.status === 0) {
+        return result.stdout.trim() === version;
+    }
+    // A non-zero exit here typically means the package or version does not
+    // exist yet (E404), which is exactly the "not published" case.
+    return false;
+}
+
+function runPublish() {
+    console.log(`\n$ npm publish ${publishArgs.join(" ")}  (in ${cwd})`);
+    const result = spawnSync("npm", ["publish", ...publishArgs], {
+        cwd,
+        encoding: "utf8",
+    });
+    if (result.stdout) {
+        process.stdout.write(result.stdout);
+    }
+    if (result.stderr) {
+        process.stderr.write(result.stderr);
+    }
+    return {
+        status: result.status,
+        output: `${result.stdout ?? ""}\n${result.stderr ?? ""}`,
+    };
+}
+
+async function main() {
+    if (alreadyPublished()) {
+        console.log(`✔ ${spec} is already published; skipping.`);
+        return;
+    }
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        console.log(
+            `\n=== Publishing ${spec} (attempt ${attempt}/${maxAttempts}) ===`,
+        );
+        const { status, output } = runPublish();
+
+        if (status === 0) {
+            console.log(`✔ Published ${spec}.`);
+            return;
+        }
+
+        if (matchesAny(output, ALREADY_PUBLISHED_PATTERNS)) {
+            console.log(
+                `✔ ${spec} is already published (publish reported a conflict); treating as success.`,
+            );
+            return;
+        }
+
+        // The publish may have succeeded server-side even though the client
+        // reported an error (e.g. the token read failed after upload). Confirm
+        // against the registry before deciding to retry.
+        if (alreadyPublished()) {
+            console.log(
+                `✔ ${spec} is now present on the registry despite the error; treating as success.`,
+            );
+            return;
+        }
+
+        const transient = matchesAny(output, TRANSIENT_PATTERNS);
+        if (!transient) {
+            console.error(
+                `✖ Publishing ${spec} failed with a non-transient error; not retrying.`,
+            );
+            process.exit(status ?? 1);
+        }
+
+        if (attempt === maxAttempts) {
+            console.error(
+                `✖ Publishing ${spec} still failing after ${maxAttempts} attempts; giving up.`,
+            );
+            process.exit(status ?? 1);
+        }
+
+        const delay = Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
+        console.warn(
+            `⚠ Transient failure publishing ${spec}; retrying in ${Math.round(
+                delay / 1000,
+            )}s...`,
+        );
+        await sleep(delay);
+    }
+}
+
+await main();

--- a/.github/scripts/npm-publish-with-retry.mjs
+++ b/.github/scripts/npm-publish-with-retry.mjs
@@ -17,7 +17,8 @@
  *
  * Behavior:
  *   - Reads name@version from <publish-dir>/package.json.
- *   - If that exact version is already on the registry, skips (success).
+ *   - If that exact version is already on the registry, ensures any explicitly
+ *     requested dist-tag points to it, then skips (success).
  *   - Otherwise runs `npm publish` (forwarding the extra args) in <publish-dir>,
  *     retrying on transient errors with exponential backoff.
  *   - After a failed attempt it re-checks the registry: if the version now
@@ -43,9 +44,9 @@ if (!publishDir) {
     process.exit(1);
 }
 
-const maxAttempts = Number(process.env.NPM_PUBLISH_MAX_ATTEMPTS ?? 4);
-const baseDelayMs = Number(process.env.NPM_PUBLISH_RETRY_DELAY_MS ?? 10_000);
-const maxDelayMs = Number(process.env.NPM_PUBLISH_MAX_DELAY_MS ?? 60_000);
+const maxAttempts = readIntegerEnv("NPM_PUBLISH_MAX_ATTEMPTS", 4, 1);
+const baseDelayMs = readIntegerEnv("NPM_PUBLISH_RETRY_DELAY_MS", 10_000, 0);
+const maxDelayMs = readIntegerEnv("NPM_PUBLISH_MAX_DELAY_MS", 60_000, 0);
 
 const cwd = resolve(process.cwd(), publishDir);
 
@@ -65,6 +66,7 @@ if (!name || !version) {
     process.exit(1);
 }
 const spec = `${name}@${version}`;
+const explicitPublishTag = getExplicitPublishTag();
 
 /**
  * Patterns that indicate the version is already published. Re-publishing the
@@ -113,6 +115,77 @@ function matchesAny(text, patterns) {
     return patterns.some((pattern) => pattern.test(text));
 }
 
+function getExplicitPublishTag() {
+    let tag = process.env.npm_config_tag;
+
+    for (let i = 0; i < publishArgs.length; i++) {
+        const arg = publishArgs[i];
+        if (arg === "--tag") {
+            const nextArg = publishArgs[i + 1];
+            if (!nextArg || nextArg.startsWith("-")) {
+                console.error("Missing value for npm publish argument --tag.");
+                process.exit(1);
+            }
+            tag = nextArg;
+            i++;
+        } else if (arg.startsWith("--tag=")) {
+            tag = arg.slice("--tag=".length);
+            if (!tag) {
+                console.error("Missing value for npm publish argument --tag.");
+                process.exit(1);
+            }
+        }
+    }
+
+    return tag;
+}
+
+/**
+ * Read integer configuration from the environment and fail loudly on typos.
+ */
+function readIntegerEnv(name, defaultValue, minValue) {
+    const rawValue = process.env[name];
+    if (rawValue == null || rawValue.trim() === "") {
+        return defaultValue;
+    }
+
+    const parsed = Number(rawValue);
+    if (!Number.isInteger(parsed) || parsed < minValue) {
+        console.error(
+            `${name} must be an integer greater than or equal to ${minValue}; received ${JSON.stringify(
+                rawValue,
+            )}.`,
+        );
+        process.exit(1);
+    }
+    return parsed;
+}
+
+function combinedOutput(result) {
+    return [
+        result.stdout,
+        result.stderr,
+        result.error?.message,
+        result.signal ? `Process terminated by signal ${result.signal}` : "",
+    ]
+        .filter(Boolean)
+        .join("\n");
+}
+
+function writeCommandOutput(result, commandName) {
+    if (result.stdout) {
+        process.stdout.write(result.stdout);
+    }
+    if (result.stderr) {
+        process.stderr.write(result.stderr);
+    }
+    if (result.error) {
+        console.error(
+            `${commandName} failed to start: ${result.error.message}`,
+        );
+    }
+}
+
 function sleep(ms) {
     return new Promise((res) => setTimeout(res, ms));
 }
@@ -126,6 +199,12 @@ function alreadyPublished() {
         ["view", spec, "version", "--no-workspaces"],
         { encoding: "utf8" },
     );
+    if (result.error) {
+        console.warn(
+            `Could not check whether ${spec} is already published: ${result.error.message}`,
+        );
+        return false;
+    }
     if (result.status === 0) {
         return result.stdout.trim() === version;
     }
@@ -134,27 +213,89 @@ function alreadyPublished() {
     return false;
 }
 
+function publishedVersionForTag(tag) {
+    const result = spawnSync(
+        "npm",
+        ["view", name, "dist-tags", "--json", "--no-workspaces"],
+        { encoding: "utf8" },
+    );
+    if (result.error) {
+        console.warn(
+            `Could not check npm dist-tags for ${name}: ${result.error.message}`,
+        );
+        return undefined;
+    }
+    if (result.status !== 0) {
+        return undefined;
+    }
+
+    try {
+        return JSON.parse(result.stdout)[tag];
+    } catch (error) {
+        console.warn(
+            `Could not parse npm dist-tags for ${name}: ${error.message ?? error}`,
+        );
+        return undefined;
+    }
+}
+
+function ensureExplicitDistTag() {
+    if (!explicitPublishTag) {
+        return true;
+    }
+
+    const taggedVersion = publishedVersionForTag(explicitPublishTag);
+    if (taggedVersion === version) {
+        return true;
+    }
+
+    const previousTagMessage = taggedVersion
+        ? ` (currently ${taggedVersion})`
+        : "";
+    console.log(
+        `Ensuring npm dist-tag ${name}@${explicitPublishTag} points to ${version}${previousTagMessage}.`,
+    );
+    const result = spawnSync(
+        "npm",
+        ["dist-tag", "add", spec, explicitPublishTag, "--no-workspaces"],
+        { encoding: "utf8" },
+    );
+    writeCommandOutput(result, "npm dist-tag add");
+    if (result.status === 0) {
+        return true;
+    }
+
+    console.error(
+        `Could not ensure npm dist-tag ${name}@${explicitPublishTag} points to ${version}.`,
+    );
+    return false;
+}
+
+function treatAlreadyPublishedAsSuccess(message) {
+    if (!ensureExplicitDistTag()) {
+        process.exit(1);
+    }
+    console.log(message);
+}
+
 function runPublish() {
     console.log(`\n$ npm publish ${publishArgs.join(" ")}  (in ${cwd})`);
     const result = spawnSync("npm", ["publish", ...publishArgs], {
         cwd,
         encoding: "utf8",
     });
-    if (result.stdout) {
-        process.stdout.write(result.stdout);
-    }
-    if (result.stderr) {
-        process.stderr.write(result.stderr);
-    }
+    writeCommandOutput(result, "npm publish");
     return {
         status: result.status,
-        output: `${result.stdout ?? ""}\n${result.stderr ?? ""}`,
+        output: combinedOutput(result),
     };
 }
 
 async function main() {
     if (alreadyPublished()) {
-        console.log(`✔ ${spec} is already published; skipping.`);
+        treatAlreadyPublishedAsSuccess(
+            `✔ ${spec} is already published; skipping.`,
+        );
         return;
     }
 
@@ -170,7 +311,7 @@ async function main() {
         }
 
         if (matchesAny(output, ALREADY_PUBLISHED_PATTERNS)) {
-            console.log(
+            treatAlreadyPublishedAsSuccess(
                 `✔ ${spec} is already published (publish reported a conflict); treating as success.`,
             );
             return;
@@ -180,7 +321,7 @@ async function main() {
         // reported an error (e.g. the token read failed after upload). Confirm
         // against the registry before deciding to retry.
         if (alreadyPublished()) {
-            console.log(
+            treatAlreadyPublishedAsSuccess(
                 `✔ ${spec} is now present on the registry despite the error; treating as success.`,
             );
             return;

--- a/.github/workflows/publish-prefigure.yml
+++ b/.github/workflows/publish-prefigure.yml
@@ -77,8 +77,7 @@ jobs:
               env:
                   NPM_TAG: ${{ inputs.npm_tag }}
               run: |
-                  cd packages/prefigure/dist
-                  npm publish --tag "${NPM_TAG}"
+                  node .github/scripts/npm-publish-with-retry.mjs packages/prefigure/dist --tag "${NPM_TAG}"
 
             - name: Purge jsDelivr cache
               if: ${{ !inputs.dry_run }}

--- a/packages/doenetml-iframe/package.json
+++ b/packages/doenetml-iframe/package.json
@@ -27,7 +27,7 @@
         "build:component": "wireit",
         "build:iframe-viewer": "wireit",
         "build:iframe-editor": "wireit",
-        "publish": "npm run build && cd dist/component && npm publish",
+        "publish": "npm run build && node ../../.github/scripts/npm-publish-with-retry.mjs dist/component",
         "test": "echo \"No tests \"",
         "test-cypress": "cypress open --component",
         "test-cypress-all": "cypress run --component -b 'chrome' --config video=false --headless"

--- a/packages/doenetml/package.json
+++ b/packages/doenetml/package.json
@@ -31,7 +31,7 @@
         "test": "vitest",
         "test-cypress": "cypress open --component",
         "test-cypress-all": "cypress run --component -b 'chrome' --config video=false --headless",
-        "publish": "npm run build && cd dist && npm publish"
+        "publish": "npm run build && node ../../.github/scripts/npm-publish-with-retry.mjs dist"
     },
     "wireit": {
         "build:dev": {

--- a/packages/prefigure/package.json
+++ b/packages/prefigure/package.json
@@ -31,7 +31,7 @@
         "preview": "vite preview",
         "setup": "vite-node scripts/fetch-pyodide-packages.ts && vite-node scripts/fetch-liblouis.ts",
         "verify-wheel-sync": "vite-node --script scripts/verify-wheel-sync.ts",
-        "publish": "npm run build && npm run verify-wheel-sync && cd dist && npm publish"
+        "publish": "npm run build && npm run verify-wheel-sync && node ../../.github/scripts/npm-publish-with-retry.mjs dist"
     },
     "wireit": {
         "build": {

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -26,7 +26,7 @@
         "build": "wireit",
         "test": "echo \"No tests \"",
         "preview": "vite preview",
-        "publish": "npm run build && cd dist && npm publish"
+        "publish": "npm run build && node ../../.github/scripts/npm-publish-with-retry.mjs dist"
     },
     "wireit": {
         "build": {

--- a/packages/v06-to-v07/package.json
+++ b/packages/v06-to-v07/package.json
@@ -25,7 +25,7 @@
         "dev": "vite",
         "watch": "vite build --watch",
         "build": "wireit",
-        "publish": "npm run build && cd dist && npm publish",
+        "publish": "npm run build && node ../../.github/scripts/npm-publish-with-retry.mjs dist",
         "test": "vitest"
     },
     "wireit": {


### PR DESCRIPTION
## Problem

The dev release job in [run 28029064771](https://github.com/Doenet/DoenetML/actions/runs/28029064771/job/82964489589) failed during **Publish dev release**, even though every package built and several published fine:

```
npm error code IDENTITY_TOKEN_READ_ERROR
npm error error retrieving identity token
workspace @doenet/doenetml-iframe@0.7.20-dev...
```

`@doenet/doenetml` and `@doenet/standalone` published successfully **with** provenance immediately before, and `@doenet/v06-to-v07` published successfully **after** — only `@doenet/doenetml-iframe` hit the error. This is a transient failure on npm's OIDC Trusted-Publishing / sigstore provenance path (retrieving the short-lived identity token), not a configuration problem. A single flaky publish currently fails the whole release.

## Change

Add a reusable wrapper `​.github/scripts/npm-publish-with-retry.mjs` that:

- **Skips** a version already present on the registry, so re-running a release job is idempotent (no `EPUBLISHCONFLICT`).
- **Ensures** any requested/configured dist-tag points to the published version before declaring success (via `npm dist-tag add` when needed), so a rerun or publish with a different/missing tag still updates npm instead of silently going green.
- **Retries** `npm publish` on transient errors (`IDENTITY_TOKEN_READ_ERROR`, provenance/sigstore/network/5xx/429, etc.) with exponential backoff.
- **Re-checks** the registry after a failed attempt, in case the publish actually succeeded server-side despite a client-side error.
- **Fails fast** on non-transient errors (auth/validation) so real misconfigurations aren't masked.

Retry behavior is configurable via `NPM_PUBLISH_MAX_ATTEMPTS`, `NPM_PUBLISH_RETRY_DELAY_MS`, and `NPM_PUBLISH_MAX_DELAY_MS`. These are validated as integers and the wrapper fails fast on a malformed value, so a typo can't make the publish loop run zero times and exit successfully without publishing.

Wired into every `npm publish` call site:

- `packages/doenetml`, `packages/standalone`, `packages/doenetml-iframe`, `packages/v06-to-v07`, `packages/prefigure` publish scripts.
- The direct publish step in `.github/workflows/publish-prefigure.yml`.

The `--tag <tag>` argument that the release workflows pass through is forwarded to the underlying `npm publish` unchanged.

## Testing

Validated the script locally against the real registry and with a stubbed `npm`:

- Already-published version → skips (exit 0); with `--tag dev` pointing elsewhere, runs `npm dist-tag add` first, then skips.
- Successful publish with `--tag dev` → forwards the tag to `npm publish`, then verifies/repairs the dist-tag before exiting successfully.
- Transient error (`IDENTITY_TOKEN_READ_ERROR`, `ECONNRESET`) → retries with backoff, then either succeeds on a later attempt or gives up non-zero after max attempts.
- Non-transient error (`ENEEDAUTH`, `E404`) → fails fast without retrying.
- Malformed `NPM_PUBLISH_MAX_ATTEMPTS` → fails fast instead of silently skipping the publish.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)
