### PR TITLE
fix(viewer): apply style text color to inline choiceInput options

### DIFF
--- a/.changeset/inline-choiceinput-text-color.md
+++ b/.changeset/inline-choiceinput-text-color.md
@@ -1,0 +1,13 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Apply each option's style text color in an inline `<choiceInput>`, matching the behavior of a block `<choiceInput>`.
+
+Inline choice inputs render their options through a select dropdown, which previously suppressed the text color from the options' style definitions. The displayed value and the unselected (and focused) menu options now render with their style text colors; the currently selected, dark-highlighted menu option keeps white text for contrast.
+
+Closes #1352.

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -28,9 +28,11 @@ type Option = { value: number; label: any; isDisabled: boolean };
  * 1. isHidden: indicates that the content is being rendered invisibly to size the select input.
  *    It is used by the math renderer to turn off hideUntilTypeset, which would cause it to
  *    overwrite the invisible rendering and add tab stops to the invisible content.
- * 2. inOption: indicates that the content is being rendered inside a select option.
- *    It is used to turn off color specifications so that the font color of selected options
- *    can be set to white for contrast.
+ * 2. inOption: indicates that the content is being rendered inside the currently
+ *    selected (highlighted) select option. Because that option uses a dark
+ *    background, it is used to turn off color specifications so that the font
+ *    color can be set to white for contrast. Unselected options and the
+ *    displayed value render with their own style colors.
  */
 export const ChoiceInputInlineContext = createContext<{
     isHidden: boolean;
@@ -231,7 +233,22 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
             // interfering with option selection.
             Option: (props: any) => (
                 <components.Option {...props}>
-                    <div style={{ pointerEvents: "none" }}>{props.label}</div>
+                    {/*
+                     * Render the option content with its style colors, except
+                     * for the currently selected option, which is highlighted
+                     * with a dark background. There, the text color is left to
+                     * react-select (white) for contrast.
+                     */}
+                    <ChoiceInputInlineContext.Provider
+                        value={{
+                            isHidden: false,
+                            inOption: !!props.isSelected,
+                        }}
+                    >
+                        <div style={{ pointerEvents: "none" }}>
+                            {props.label}
+                        </div>
+                    </ChoiceInputInlineContext.Provider>
                 </components.Option>
             ),
             // Add aria-details to the internal input used by react-select.
@@ -398,7 +415,7 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                     }}
                 >
                     <ChoiceInputInlineContext.Provider
-                        value={{ isHidden: false, inOption: true }}
+                        value={{ isHidden: false, inOption: false }}
                     >
                         <Select
                             id={id}

--- a/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
+++ b/packages/doenetml/src/Viewer/renderers/choiceInput.tsx
@@ -28,11 +28,12 @@ type Option = { value: number; label: any; isDisabled: boolean };
  * 1. isHidden: indicates that the content is being rendered invisibly to size the select input.
  *    It is used by the math renderer to turn off hideUntilTypeset, which would cause it to
  *    overwrite the invisible rendering and add tab stops to the invisible content.
- * 2. inOption: indicates that the content is being rendered inside the currently
- *    selected (highlighted) select option. Because that option uses a dark
+ * 2. inOption: indicates that the content is being rendered inside a selected
+ *    (highlighted) select option. Because a selected option uses a dark
  *    background, it is used to turn off color specifications so that the font
- *    color can be set to white for contrast. Unselected options and the
- *    displayed value render with their own style colors.
+ *    color can be set to white for contrast. (With selectMultiple, more than
+ *    one option can be selected at once.) Unselected options and the displayed
+ *    value render with their own style colors.
  */
 export const ChoiceInputInlineContext = createContext<{
     isHidden: boolean;
@@ -235,9 +236,9 @@ export default React.memo(function ChoiceInput(props: UseDoenetRendererProps) {
                 <components.Option {...props}>
                     {/*
                      * Render the option content with its style colors, except
-                     * for the currently selected option, which is highlighted
-                     * with a dark background. There, the text color is left to
-                     * react-select (white) for contrast.
+                     * for selected options, which are highlighted with a dark
+                     * background. There, the text color is left to react-select
+                     * (white) for contrast.
                      */}
                     <ChoiceInputInlineContext.Provider
                         value={{

--- a/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
+++ b/packages/test-cypress/cypress/e2e/tagSpecific/choiceinput.cy.js
@@ -1445,4 +1445,55 @@ describe("ChoiceInput Tag Tests", { tags: ["@group3"] }, function () {
         cy.get("#ci_choice2_input").blur();
         cy.get("#fv").should("have.text", "focused: false");
     });
+
+    it("inline choiceInput options use their style text color", () => {
+        cy.window().then(async (win) => {
+            win.postMessage(
+                {
+                    doenetML: `
+    <setup>
+        <styleDefinition styleNumber="2" textColor="green" />
+        <styleDefinition styleNumber="3" textColor="red" />
+    </setup>
+
+    <choiceInput name="ci" inline placeholder="Choose fruit">
+      <choice><text styleNumber="2">apple</text></choice>
+      <choice><text styleNumber="3">banana</text></choice>
+      <choice><text>cherry</text></choice>
+    </choiceInput>
+    `,
+                },
+                "*",
+            );
+        });
+
+        const green = "rgb(0, 128, 0)";
+        const red = "rgb(255, 0, 0)";
+        const black = "rgb(0, 0, 0)";
+        const white = "rgb(255, 255, 255)";
+
+        cy.log("Open the menu: unselected options show their style color");
+        cy.get("#ci").click();
+        getOpenInlineChoiceMenu().within(() => {
+            cy.contains("apple").should("have.css", "color", green);
+            cy.contains("banana").should("have.css", "color", red);
+            cy.contains("cherry").should("have.css", "color", black);
+        });
+
+        cy.log("Select the green option; the displayed value keeps its color");
+        getOpenInlineChoiceMenu().within(() => {
+            cy.contains("apple").click({ force: true });
+        });
+        cy.get("#ci").contains("apple").should("have.css", "color", green);
+
+        cy.log(
+            "Reopen the menu: the selected option uses white text for contrast",
+        );
+        cy.get("#ci").click();
+        getOpenInlineChoiceMenu().within(() => {
+            cy.contains("apple").should("have.css", "color", white);
+            cy.contains("banana").should("have.css", "color", red);
+            cy.contains("cherry").should("have.css", "color", black);
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Addresses #1352: text color from a choice's style definition is now applied to the options of an **inline** `<choiceInput>`, matching the behavior that already worked for a block `<choiceInput>`.

Inline choice inputs render their options through a `react-select` dropdown. The `ChoiceInputInlineContext` previously set `inOption: true` around the whole select, which made the descendant renderers (text, math, number, etc.) skip the color from their style definitions.

## Changes

- The select's context now uses `inOption: false`, so the **displayed value** and the **unselected/focused menu options** render with their style text colors.
- The custom `Option` component sets `inOption` to the option's `isSelected` flag, so only the **currently selected, dark-highlighted option** keeps white text for contrast.
- Updated the `ChoiceInputInlineContext` doc comment to describe the new behavior.

## Testing

- Added a Cypress spec (`choiceinput.cy.js`) that checks the style text colors of the menu options and the displayed value, including white-for-contrast on the selected option.
- The full `choiceinput.cy.js` suite passes (17/17) against a fresh build.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)