### PR TITLE
fix: correct context help when cursor is on a tag boundary

### DIFF
--- a/.changeset/context-help-tag-boundary.md
+++ b/.changeset/context-help-tag-boundary.md
@@ -8,6 +8,6 @@
 
 Editor: Fix context-sensitive help when the cursor sits on a tag boundary.
 
-When the cursor is immediately before a tag (e.g. `|<text/>`), the help panel now reports the surrounding context — the parent element, or the document top level — instead of claiming the cursor is inside the element and suggesting its children. When the cursor is inside a self-closing tag's `/>` (e.g. `<text/|>`), the panel now shows element-level help rather than the element's children.
+When the cursor is immediately before a tag (e.g. `|<text/>`, including after whitespace or indentation), the help panel now reports the surrounding context — the parent element, or the document top level — instead of claiming the cursor is inside the element and suggesting its children. When the cursor is inside a self-closing tag's `/>` (e.g. `<text/|>`), the panel now shows element-level help rather than the element's children.
 
 Closes #1327.

--- a/.changeset/context-help-tag-boundary.md
+++ b/.changeset/context-help-tag-boundary.md
@@ -8,6 +8,6 @@
 
 Editor: Fix context-sensitive help when the cursor sits on a tag boundary.
 
-When the cursor is immediately before a tag (e.g. `|<text/>`, including after whitespace or indentation), the help panel now reports the surrounding context — the parent element, or the document top level — instead of claiming the cursor is inside the element and suggesting its children. When the cursor is inside a self-closing tag's `/>` (e.g. `<text/|>`), the panel now shows element-level help rather than the element's children.
+When the cursor is immediately before a tag (e.g. `|<text/>`, including after whitespace or indentation), the help panel now reports the surrounding context — the parent element, or the document top level — instead of claiming the cursor is inside the element and suggesting its children. The same now holds when the cursor sits between a closed child and its parent's close tag (e.g. `<p><math>x</math>|</p>` or `<p><math/>|</p>`), where the panel reports the parent (`p`) rather than the just-closed child (`math`). When the cursor is inside a self-closing tag's `/>` (e.g. `<text/|>`), the panel now shows element-level help rather than the element's children.
 
 Closes #1327.

--- a/.changeset/context-help-tag-boundary.md
+++ b/.changeset/context-help-tag-boundary.md
@@ -1,0 +1,13 @@
+---
+"@doenet/doenetml": patch
+"@doenet/standalone": patch
+"@doenet/doenetml-iframe": patch
+"@doenet/vscode-extension": patch
+"doenet-vscode-extension": patch
+---
+
+Editor: Fix context-sensitive help when the cursor sits on a tag boundary.
+
+When the cursor is immediately before a tag (e.g. `|<text/>`), the help panel now reports the surrounding context — the parent element, or the document top level — instead of claiming the cursor is inside the element and suggesting its children. When the cursor is inside a self-closing tag's `/>` (e.g. `<text/|>`), the panel now shows element-level help rather than the element's children.
+
+Closes #1327.

--- a/packages/lsp-tools/src/context-help/computeContextHelp.test.ts
+++ b/packages/lsp-tools/src/context-help/computeContextHelp.test.ts
@@ -135,26 +135,32 @@ describe("computeContextHelp — element help", () => {
 });
 
 describe("computeContextHelp — cursor on a tag boundary (#1327)", () => {
-    it("reports the top level (not the element's children) when the cursor is just before a top-level tag", async () => {
-        const source = `<text/>`;
-        // Offset 0: cursor sits immediately before the opening `<`, so it is
-        // outside `<text>` and at the document top level.
-        const help = await helpAt(source, 0);
-        expect(help.kind).toBe("suggestions");
-        if (help.kind === "suggestions") {
-            expect(help.context).toEqual({ topLevel: true });
-        }
-    });
-
-    it("reports the parent element (not the element's children) when the cursor is just before a nested tag", async () => {
-        const source = `<p><text/></p>`;
-        // Offset 3: cursor sits immediately before `<text>`, inside `<p>`'s body.
-        const help = await helpAt(source, 3);
-        expect(help.kind).toBe("suggestions");
-        if (help.kind === "suggestions") {
-            expect(help.context).toEqual({ elementName: "p" });
-        }
-    });
+    it.each([
+        ["before top-level tag", `<text/>`, 0, { topLevel: true }],
+        ["before spaced top-level tag", ` <text/>`, 1, { topLevel: true }],
+        ["before nested tag", `<p><text/></p>`, 3, { elementName: "p" }],
+        [
+            "before spaced nested tag",
+            `<p> <text/></p>`,
+            4,
+            { elementName: "p" },
+        ],
+        [
+            "before indented nested tag",
+            `<p>\n  <text/></p>`,
+            6,
+            { elementName: "p" },
+        ],
+    ])(
+        "reports surrounding suggestions %s",
+        async (_name, source, offset, context) => {
+            const help = await helpAt(source, offset);
+            expect(help.kind).toBe("suggestions");
+            if (help.kind === "suggestions") {
+                expect(help.context).toEqual(context);
+            }
+        },
+    );
 
     it("reports element help (not children) when the cursor is inside a self-closing tag's `/>`", async () => {
         const source = `<text/>`;

--- a/packages/lsp-tools/src/context-help/computeContextHelp.test.ts
+++ b/packages/lsp-tools/src/context-help/computeContextHelp.test.ts
@@ -151,6 +151,18 @@ describe("computeContextHelp — cursor on a tag boundary (#1327)", () => {
             6,
             { elementName: "p" },
         ],
+        [
+            "between a closed child and the parent's close tag",
+            `<p><math>x</math></p>`,
+            `<p><math>x</math></p>`.indexOf("</p>"),
+            { elementName: "p" },
+        ],
+        [
+            "between a self-closed child and the parent's close tag",
+            `<p><math/></p>`,
+            `<p><math/></p>`.indexOf("</p>"),
+            { elementName: "p" },
+        ],
     ])(
         "reports surrounding suggestions %s",
         async (_name, source, offset, context) => {

--- a/packages/lsp-tools/src/context-help/computeContextHelp.test.ts
+++ b/packages/lsp-tools/src/context-help/computeContextHelp.test.ts
@@ -134,6 +134,43 @@ describe("computeContextHelp — element help", () => {
     });
 });
 
+describe("computeContextHelp — cursor on a tag boundary (#1327)", () => {
+    it("reports the top level (not the element's children) when the cursor is just before a top-level tag", async () => {
+        const source = `<text/>`;
+        // Offset 0: cursor sits immediately before the opening `<`, so it is
+        // outside `<text>` and at the document top level.
+        const help = await helpAt(source, 0);
+        expect(help.kind).toBe("suggestions");
+        if (help.kind === "suggestions") {
+            expect(help.context).toEqual({ topLevel: true });
+        }
+    });
+
+    it("reports the parent element (not the element's children) when the cursor is just before a nested tag", async () => {
+        const source = `<p><text/></p>`;
+        // Offset 3: cursor sits immediately before `<text>`, inside `<p>`'s body.
+        const help = await helpAt(source, 3);
+        expect(help.kind).toBe("suggestions");
+        if (help.kind === "suggestions") {
+            expect(help.context).toEqual({ elementName: "p" });
+        }
+    });
+
+    it("reports element help (not children) when the cursor is inside a self-closing tag's `/>`", async () => {
+        const source = `<text/>`;
+        // Offset 6: cursor sits between `/` and `>`, still inside the open tag.
+        const help = await helpAt(source, 6);
+        expect(help).toMatchObject({ kind: "element", elementName: "text" });
+    });
+
+    it("reports element help inside a nested self-closing tag's `/>`", async () => {
+        const source = `<p><text/></p>`;
+        // Offset 9: between `/` and `>` of the nested `<text/>`.
+        const help = await helpAt(source, 9);
+        expect(help).toMatchObject({ kind: "element", elementName: "text" });
+    });
+});
+
 describe("computeContextHelp — attribute help", () => {
     it("returns attribute help with description and defaultValue", async () => {
         const source = `<point draggable="true"/>`;

--- a/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
+++ b/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
@@ -80,9 +80,10 @@ export function elementAtOffsetWithContext(
         const rightNodeType = rightNode.type.name as LezerSyntaxNodeName;
         if (atNodeBoundary && rightNodeType === "StartCloseTag") {
             // Cursor is at the boundary between some element's `>` and the
-            // immediately following close tag's `</`. Either way the cursor is
-            // in a body, so skip the switch below (its `EndTag → openTag` case
-            // would otherwise overwrite this). Which body it is depends on
+            // immediately following close tag's `</`. Whether that `>` opens
+            // or closes an element, the cursor sits in *a* body, so set `body`
+            // and skip the switch below (its `EndTag → openTag` case would
+            // otherwise overwrite this). Which element's body it is depends on
             // whether the `>` to the left *opens* or *closes* an element.
             cursorPosition = "body";
             const leftElement = this.nodeAtOffset(leftNode.from, {

--- a/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
+++ b/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
@@ -38,15 +38,22 @@ export function elementAtOffsetWithContext(
         cursorPosition = "body";
     }
 
+    // The cursor sits exactly on an element's opening `<` (`node.start === offset`),
+    // so it is positioned *before* that element — i.e. in the body of whatever
+    // contains it, not inside the element. Reclassify as the container's body.
+    // When the container is another element we report that element; when the
+    // element is top-level (parent is the document root, e.g. `|<text/>` at
+    // offset 0) we report `null` so callers treat it as top-level body rather
+    // than suggesting the element's own children (#1327). The `prevChar` guard
+    // skips whitespace / newline / `<` (handled elsewhere) but allows an empty
+    // `prevChar`, which only occurs at offset 0.
     if (
         node?.type === "element" &&
         node.position?.start?.offset === offset &&
-        parent?.type === "element" &&
-        prevChar &&
-        !prevChar.match(/(\s|\n|<)/)
+        (!prevChar || !prevChar.match(/(\s|\n|<)/))
     ) {
         cursorPosition = "body";
-        node = parent as DastElement;
+        node = parent?.type === "element" ? (parent as DastElement) : null;
     }
 
     if (!node) {
@@ -118,6 +125,14 @@ export function elementAtOffsetWithContext(
                 }
                 case "OpenTag":
                 case "SelfClosingTag":
+                    cursorPosition = "openTag";
+                    break;
+                case "SelfCloseEndTag":
+                    // Cursor is inside a self-closing tag's `/>` token (e.g.
+                    // `<text/|>`, between the `/` and `>`). That's still within
+                    // the open tag, so report `openTag` — element-level help —
+                    // rather than leaving it `unknown`, which falls through to
+                    // suggesting the element's (nonexistent) children (#1327).
                     cursorPosition = "openTag";
                     break;
                 case "EndTag":

--- a/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
+++ b/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
@@ -79,17 +79,41 @@ export function elementAtOffsetWithContext(
             : leftNode;
         const rightNodeType = rightNode.type.name as LezerSyntaxNodeName;
         if (atNodeBoundary && rightNodeType === "StartCloseTag") {
-            // Cursor is at the boundary between an OpenTag's `>` and the
-            // immediately following close tag's `</` (i.e.
-            // `<mathInput>|</mathInput>` — the very position the
-            // autocompleter drops the cursor after inserting a tag pair).
-            // That's the body of the element on the left. Skip the switch
-            // below — its `EndTag → openTag` case would overwrite this
-            // classification, since `leftNode` here is the OpenTag's `>` token.
+            // Cursor is at the boundary between some element's `>` and the
+            // immediately following close tag's `</`. Either way the cursor is
+            // in a body, so skip the switch below (its `EndTag → openTag` case
+            // would otherwise overwrite this). Which body it is depends on
+            // whether the `>` to the left *opens* or *closes* an element.
             cursorPosition = "body";
-            node = this.nodeAtOffset(leftNode.from, {
+            const leftElement = this.nodeAtOffset(leftNode.from, {
                 type: "element",
             }) as DastElement | null;
+            // XXX Fix this after the CodeMirror update
+            // @ts-ignore
+            const leftParentType = leftNode.parent?.type?.name as
+                | LezerSyntaxNodeName
+                | undefined;
+            if (
+                leftElement &&
+                (leftParentType === "CloseTag" ||
+                    leftParentType === "SelfClosingTag")
+            ) {
+                // The `>`/`/>` to the left *closes* the element on the left, so
+                // that element is finished and the cursor is in the *parent's*
+                // body (i.e. `<p><math>x</math>|</p>` is the body of `<p>`, not
+                // `<math>`, and `<p><math/>|</p>` likewise — #1327).
+                const parentElement = this.getParent(leftElement);
+                node =
+                    parentElement?.type === "element"
+                        ? (parentElement as DastElement)
+                        : null;
+            } else {
+                // The cursor is in the body of the element on the left: either
+                // right after its *open* tag (`<mathInput>|</mathInput>` — the
+                // position the autocompleter drops the cursor after inserting a
+                // tag pair) or within its body content (`<a> |</a>`).
+                node = leftElement;
+            }
         } else {
             const lezerNodeType = lezerNode.type.name as LezerSyntaxNodeName;
             const lezerNodeParentType = lezerNode.parent?.type?.name as

--- a/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
+++ b/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
@@ -88,8 +88,6 @@ export function elementAtOffsetWithContext(
             const leftElement = this.nodeAtOffset(leftNode.from, {
                 type: "element",
             }) as DastElement | null;
-            // XXX Fix this after the CodeMirror update
-            // @ts-ignore
             const leftParentType = leftNode.parent?.type?.name as
                 | LezerSyntaxNodeName
                 | undefined;

--- a/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
+++ b/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
@@ -20,6 +20,7 @@ export function elementAtOffsetWithContext(
     }
 
     let cursorPosition: CursorPosition = "unknown";
+    let cursorIsTopLevelBody = false;
     const prevChar = this.source.charAt(offset - 1);
     const exactNodeAtOffset = this.nodeAtOffset(offset);
     const parent = exactNodeAtOffset ? this.getParent(exactNodeAtOffset) : null;
@@ -43,10 +44,19 @@ export function elementAtOffsetWithContext(
     // than inside the element itself (#1327).
     if (node?.type === "element" && node.position?.start?.offset === offset) {
         cursorPosition = "body";
-        node = parent?.type === "element" ? (parent as DastElement) : null;
+        const isNamedElement = node.name !== "";
+        if (parent?.type === "element") {
+            node = parent as DastElement;
+        } else {
+            node = null;
+            // Represent top-level body context as `{ node: null, cursorPosition: "body" }`,
+            // but keep a lone `<` as `unknown` so partial-tag handling below
+            // preserves its existing behavior.
+            cursorIsTopLevelBody = parent?.type === "root" && isNamedElement;
+        }
     }
 
-    if (!node) {
+    if (!node && !cursorIsTopLevelBody) {
         cursorPosition = "unknown";
     }
     if (node && cursorPosition === "unknown") {
@@ -115,14 +125,8 @@ export function elementAtOffsetWithContext(
                 }
                 case "OpenTag":
                 case "SelfClosingTag":
-                    cursorPosition = "openTag";
-                    break;
                 case "SelfCloseEndTag":
-                    // Cursor is inside a self-closing tag's `/>` token (e.g.
-                    // `<text/|>`, between the `/` and `>`). That's still within
-                    // the open tag, so report `openTag` — element-level help —
-                    // rather than leaving it `unknown`, which falls through to
-                    // suggesting the element's (nonexistent) children (#1327).
+                    // `/>` is still open-tag context for self-closing elements.
                     cursorPosition = "openTag";
                     break;
                 case "EndTag":

--- a/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
+++ b/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
@@ -97,10 +97,11 @@ export function elementAtOffsetWithContext(
                 (leftParentType === "CloseTag" ||
                     leftParentType === "SelfClosingTag")
             ) {
-                // The `>`/`/>` to the left *closes* the element on the left, so
-                // that element is finished and the cursor is in the *parent's*
-                // body (i.e. `<p><math>x</math>|</p>` is the body of `<p>`, not
-                // `<math>`, and `<p><math/>|</p>` likewise — #1327).
+                // The token to the left is a close-tag's `>` or a self-closing
+                // `/>`, so it *closes* the element on the left; that element is
+                // finished and the cursor is in the *parent's* body (i.e.
+                // `<p><math>x</math>|</p>` is the body of `<p>`, not `<math>`,
+                // and `<p><math/>|</p>` likewise — #1327).
                 const parentElement = this.getParent(leftElement);
                 node =
                     parentElement?.type === "element"

--- a/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
+++ b/packages/lsp-tools/src/doenet-source-object/methods/element-at-offset.ts
@@ -39,19 +39,9 @@ export function elementAtOffsetWithContext(
     }
 
     // The cursor sits exactly on an element's opening `<` (`node.start === offset`),
-    // so it is positioned *before* that element — i.e. in the body of whatever
-    // contains it, not inside the element. Reclassify as the container's body.
-    // When the container is another element we report that element; when the
-    // element is top-level (parent is the document root, e.g. `|<text/>` at
-    // offset 0) we report `null` so callers treat it as top-level body rather
-    // than suggesting the element's own children (#1327). The `prevChar` guard
-    // skips whitespace / newline / `<` (handled elsewhere) but allows an empty
-    // `prevChar`, which only occurs at offset 0.
-    if (
-        node?.type === "element" &&
-        node.position?.start?.offset === offset &&
-        (!prevChar || !prevChar.match(/(\s|\n|<)/))
-    ) {
+    // so it is positioned before that element in the containing body rather
+    // than inside the element itself (#1327).
+    if (node?.type === "element" && node.position?.start?.offset === offset) {
         cursorPosition = "body";
         node = parent?.type === "element" ? (parent as DastElement) : null;
     }

--- a/packages/lsp-tools/test/doenet-source-object.test.ts
+++ b/packages/lsp-tools/test/doenet-source-object.test.ts
@@ -306,6 +306,40 @@ describe("DoenetSourceObject", () => {
         }
     });
 
+    it("Reports the container (not the element) when the cursor is on a tag boundary (#1327)", () => {
+        let source: string;
+        let sourceObj: DoenetSourceObject;
+
+        // Cursor immediately before a top-level `<text/>` is at the document
+        // top level, not inside `<text>`.
+        source = `<text/>`;
+        sourceObj = new DoenetSourceObject(source);
+        {
+            let { node } = sourceObj.elementAtOffsetWithContext(0);
+            expect(node).toEqual(null);
+        }
+
+        // Cursor immediately before a nested `<text/>` is in the parent's body.
+        source = `<p><text/></p>`;
+        sourceObj = new DoenetSourceObject(source);
+        {
+            let { cursorPosition, node } =
+                sourceObj.elementAtOffsetWithContext(3);
+            expect(cursorPosition).toEqual("body");
+            expect(node).toMatchObject({ type: "element", name: "p" });
+        }
+
+        // Cursor inside a self-closing tag's `/>` is in the open tag.
+        source = `<text/>`;
+        sourceObj = new DoenetSourceObject(source);
+        {
+            let { cursorPosition, node } =
+                sourceObj.elementAtOffsetWithContext(6);
+            expect(cursorPosition).toEqual("openTag");
+            expect(node).toMatchObject({ type: "element", name: "text" });
+        }
+    });
+
     it("Can get element ranges", () => {
         let source: string;
         let sourceObj: DoenetSourceObject;

--- a/packages/lsp-tools/test/doenet-source-object.test.ts
+++ b/packages/lsp-tools/test/doenet-source-object.test.ts
@@ -311,9 +311,10 @@ describe("DoenetSourceObject", () => {
             { source: `<text/>`, offset: 0 },
             { source: ` <text/>`, offset: 1 },
         ]) {
-            const { node } = new DoenetSourceObject(
+            const { cursorPosition, node } = new DoenetSourceObject(
                 source,
             ).elementAtOffsetWithContext(offset);
+            expect(cursorPosition).toEqual("body");
             expect(node).toEqual(null);
         }
 

--- a/packages/lsp-tools/test/doenet-source-object.test.ts
+++ b/packages/lsp-tools/test/doenet-source-object.test.ts
@@ -337,6 +337,47 @@ describe("DoenetSourceObject", () => {
         expect(node).toMatchObject({ type: "element", name: "text" });
     });
 
+    it("Reports the parent container when the cursor sits between adjacent closing tags (#1327)", () => {
+        // The cursor is right after an element that is already closed and
+        // right before the parent's close tag. It belongs to the parent's
+        // body, not the just-closed element's body.
+        for (const source of [
+            `<p><math>x</math></p>`,
+            `<p><math></math></p>`,
+            `<p><math/></p>`,
+        ]) {
+            const offset = source.indexOf("</p>");
+            const { cursorPosition, node } = new DoenetSourceObject(
+                source,
+            ).elementAtOffsetWithContext(offset);
+            expect(cursorPosition).toEqual("body");
+            expect(node).toMatchObject({ type: "element", name: "p" });
+        }
+
+        // Nesting deeper than one level still reports the immediate container.
+        {
+            const source = `<section><p>hi</p></section>`;
+            const offset = source.indexOf("</section>");
+            const { cursorPosition, node } = new DoenetSourceObject(
+                source,
+            ).elementAtOffsetWithContext(offset);
+            expect(cursorPosition).toEqual("body");
+            expect(node).toMatchObject({ type: "element", name: "section" });
+        }
+
+        // The autocompleter's `<tag>|</tag>` position must still report the
+        // element's own body (cursor sits after the element's *open* tag).
+        {
+            const source = `<mathInput></mathInput>`;
+            const offset = source.indexOf("</mathInput>");
+            const { cursorPosition, node } = new DoenetSourceObject(
+                source,
+            ).elementAtOffsetWithContext(offset);
+            expect(cursorPosition).toEqual("body");
+            expect(node).toMatchObject({ type: "element", name: "mathInput" });
+        }
+    });
+
     it("Can get element ranges", () => {
         let source: string;
         let sourceObj: DoenetSourceObject;

--- a/packages/lsp-tools/test/doenet-source-object.test.ts
+++ b/packages/lsp-tools/test/doenet-source-object.test.ts
@@ -307,37 +307,33 @@ describe("DoenetSourceObject", () => {
     });
 
     it("Reports the container (not the element) when the cursor is on a tag boundary (#1327)", () => {
-        let source: string;
-        let sourceObj: DoenetSourceObject;
-
-        // Cursor immediately before a top-level `<text/>` is at the document
-        // top level, not inside `<text>`.
-        source = `<text/>`;
-        sourceObj = new DoenetSourceObject(source);
-        {
-            let { node } = sourceObj.elementAtOffsetWithContext(0);
+        for (const { source, offset } of [
+            { source: `<text/>`, offset: 0 },
+            { source: ` <text/>`, offset: 1 },
+        ]) {
+            const { node } = new DoenetSourceObject(
+                source,
+            ).elementAtOffsetWithContext(offset);
             expect(node).toEqual(null);
         }
 
-        // Cursor immediately before a nested `<text/>` is in the parent's body.
-        source = `<p><text/></p>`;
-        sourceObj = new DoenetSourceObject(source);
-        {
-            let { cursorPosition, node } =
-                sourceObj.elementAtOffsetWithContext(3);
+        for (const { source, offset } of [
+            { source: `<p><text/></p>`, offset: 3 },
+            { source: `<p> <text/></p>`, offset: 4 },
+            { source: `<p>\n  <text/></p>`, offset: 6 },
+        ]) {
+            const { cursorPosition, node } = new DoenetSourceObject(
+                source,
+            ).elementAtOffsetWithContext(offset);
             expect(cursorPosition).toEqual("body");
             expect(node).toMatchObject({ type: "element", name: "p" });
         }
 
-        // Cursor inside a self-closing tag's `/>` is in the open tag.
-        source = `<text/>`;
-        sourceObj = new DoenetSourceObject(source);
-        {
-            let { cursorPosition, node } =
-                sourceObj.elementAtOffsetWithContext(6);
-            expect(cursorPosition).toEqual("openTag");
-            expect(node).toMatchObject({ type: "element", name: "text" });
-        }
+        const { cursorPosition, node } = new DoenetSourceObject(
+            `<text/>`,
+        ).elementAtOffsetWithContext(6);
+        expect(cursorPosition).toEqual("openTag");
+        expect(node).toMatchObject({ type: "element", name: "text" });
     });
 
     it("Can get element ranges", () => {

--- a/packages/lsp-tools/test/macro-resolution.test.ts
+++ b/packages/lsp-tools/test/macro-resolution.test.ts
@@ -128,8 +128,14 @@ describe("DoenetSourceObject", () => {
         expect(
             sourceObj.getAddressableNamesAtOffset(source.indexOf("<a")),
         ).toEqual([["x"], ["z"], ["x", "z"]]);
+        // A cursor *inside* `<a>`'s opening tag (past the `<`, e.g. in the
+        // tag's whitespace/attributes) is within `<a>`, so it resolves from
+        // `<a>`'s scope, closest first.
+        expect(
+            sourceObj.getAddressableNamesAtOffset(source.indexOf("<a") + 2),
+        ).toEqual([["z"], ["x"], ["x", "z"]]);
         // A cursor inside `<a>`'s body (here on child `<b>`'s boundary, which
-        // resolves to its container `<a>`) sees `<a>`'s scope, closest first.
+        // resolves to its container `<a>`) likewise sees `<a>`'s scope.
         expect(
             sourceObj.getAddressableNamesAtOffset(source.indexOf("<b")),
         ).toEqual([["z"], ["x"], ["x", "z"]]);
@@ -160,6 +166,20 @@ describe("DoenetSourceObject", () => {
             ["x"],
             ["z"],
             ["w"],
+            ["x", "y"],
+            ["x", "z"],
+            ["x", "w"],
+            ["x", "y", "z"],
+        ]);
+        // Cursor *inside* `<a>`'s opening tag (past the `<`): `<a>`'s scope.
+        expect(
+            sourceObj.getAddressableNamesAtOffset(source.indexOf("<a") + 2),
+        ).toEqual([
+            ["y"],
+            ["z"],
+            ["w"],
+            ["y", "z"],
+            ["x"],
             ["x", "y"],
             ["x", "z"],
             ["x", "w"],

--- a/packages/lsp-tools/test/macro-resolution.test.ts
+++ b/packages/lsp-tools/test/macro-resolution.test.ts
@@ -122,8 +122,16 @@ describe("DoenetSourceObject", () => {
             ["z"],
             ["x", "z"],
         ]);
+        // The cursor on `<a>`'s opening `<` sits *before* `<a>` in the
+        // top-level body (#1327), so it resolves names from the top-level
+        // scope — the same as offset 0 — rather than from inside `<a>`.
         expect(
             sourceObj.getAddressableNamesAtOffset(source.indexOf("<a")),
+        ).toEqual([["x"], ["z"], ["x", "z"]]);
+        // A cursor inside `<a>`'s body (here on child `<b>`'s boundary, which
+        // resolves to its container `<a>`) sees `<a>`'s scope, closest first.
+        expect(
+            sourceObj.getAddressableNamesAtOffset(source.indexOf("<b")),
         ).toEqual([["z"], ["x"], ["x", "z"]]);
 
         source = ` <a name="x">
@@ -145,8 +153,21 @@ describe("DoenetSourceObject", () => {
             ["x", "w"],
             ["x", "y", "z"],
         ]);
+        // Cursor on `<a>`'s opening `<`: top-level scope (#1327).
         expect(
             sourceObj.getAddressableNamesAtOffset(source.indexOf("<a")),
+        ).toEqual([
+            ["x"],
+            ["z"],
+            ["w"],
+            ["x", "y"],
+            ["x", "z"],
+            ["x", "w"],
+            ["x", "y", "z"],
+        ]);
+        // Cursor inside `<a>`'s body (on child `<b>`'s boundary): `<a>`'s scope.
+        expect(
+            sourceObj.getAddressableNamesAtOffset(source.indexOf("<b")),
         ).toEqual([
             ["y"],
             ["z"],


### PR DESCRIPTION
## Problem

When the cursor sits on a tag boundary, the context-sensitive help panel misreports which element the cursor is in and suggests typing the wrong element's children:

- `|<text/>` (cursor immediately before a tag, including after whitespace/indentation) — should report the surrounding context (parent element, or document top level), not the element's children.
- `<p><math>x</math>|</p>` / `<p><math/>|</p>` (cursor between a closed child and its parent's close tag) — should report the parent (`p`), not the just-closed child (`math`).
- `<text/|>` (cursor inside a self-closing tag's `/>`) — should show element-level help, not children.

## Cause

`elementAtOffsetWithContext` (`packages/lsp-tools/.../element-at-offset.ts`) returned the wrong element with a `cursorPosition` that fell through to `suggestionsHelp(node)`, which uses the node as the *container* and suggests *its* children.

- The existing start-of-tag reclassification only fired when the parent was an element and `prevChar` was a normal character, so it missed top-level tags and tags preceded by whitespace/indentation.
- The `StartCloseTag` boundary branch (the `<tag>|</tag>` autocomplete position) assumed the `>` to the cursor's left always belongs to an *open* tag, so it reported that element's body. When that `>` actually *closes* a child (`</math>|</p>` or a self-closing `<math/>|</p>`), the child is already finished and the cursor belongs to the *parent's* body — but the branch still reported the closed child.
- The cursor-inside-`/>` position resolves to a `SelfCloseEndTag` lezer node, which had no `case` in the classification switch and stayed `unknown`.

## Fix

- Reclassify any cursor positioned exactly on an element's opening `<` as the containing body: report the parent element, or `null` (top-level body) when the parent is the document root.
- In the `StartCloseTag` boundary branch, decide the body owner by what the left `>` does: if it *closes* an element (its lezer parent is a `CloseTag` or `SelfClosingTag`), report that element's parent; otherwise report the element on the left (open tag or in-body whitespace).
- Add a `SelfCloseEndTag` case that classifies the cursor as `openTag` (element-level help).

## Side effect: name-resolution scope at a tag boundary

`getAddressableNamesAtOffset` (used for macro-name autocomplete) shares `elementAtOffsetWithContext`. The boundary reclassification generalizes a behavior `main` already applied to *nested* tags to *top-level* tags too: a cursor sitting exactly on an element's opening `<` now resolves names from the surrounding (parent/top-level) scope instead of from inside that element. The cursor still resolves from an element's own scope once it is inside that element's body. `macro-resolution.test.ts` is updated to assert this, keeping coverage of the inside-the-body scope via a position one level in.

## Tests

- `computeContextHelp.test.ts`: `#1327` block asserting top-level / parent suggestions before a tag (whitespace and indentation cases), parent suggestions between adjacent closing tags, and element help inside `/>`.
- `doenet-source-object.test.ts`: classification assertions for the boundary positions, including a dedicated block for the cursor between adjacent closing tags (and a non-regression check for the `<tag>|</tag>` autocomplete position).
- `macro-resolution.test.ts`: updated boundary assertions for `getAddressableNamesAtOffset` to match the surrounding-scope behavior, plus inside-the-body assertions that preserve the original scope coverage.
- Full `@doenet/lsp-tools` suite passes (577 tests).

Closes #1327.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)

