### PR TITLE
ci: harden devcontainer npm ci against missing rollup optional dep

### DIFF
--- a/.devcontainer/npm-install-with-rollup-check.sh
+++ b/.devcontainer/npm-install-with-rollup-check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -eu
 
 if [ "$#" -eq 0 ]; then
     echo "usage: $0 <npm install command>"

--- a/.devcontainer/npm-install-with-rollup-check.sh
+++ b/.devcontainer/npm-install-with-rollup-check.sh
@@ -7,6 +7,13 @@ if [ "$#" -eq 0 ]; then
     exit 2
 fi
 
+# Operate on the repository root (the parent of this script's directory) so the
+# node_modules we wipe and reinstall — and the require('rollup') check below —
+# always target the intended workspace-root install, regardless of the caller's
+# working directory.
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir/.."
+
 for attempt in 1 2 3; do
     rm -rf node_modules
     # npm can exit 0 while silently skipping platform-specific optional

--- a/.devcontainer/npm-install-with-rollup-check.sh
+++ b/.devcontainer/npm-install-with-rollup-check.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+    echo "usage: $0 <npm install command>"
+    exit 2
+fi
+
+for attempt in 1 2 3; do
+    rm -rf node_modules
+    # npm can exit 0 while silently skipping platform-specific optional
+    # dependencies (npm/cli#4828). Loading rollup exercises its native binding
+    # resolver, so this fails immediately when npm omitted the needed package.
+    if "$@" && node -e "require('rollup')"; then
+        exit 0
+    fi
+    if [ "$attempt" -eq 3 ]; then
+        echo "$* failed or rollup native dependency missing after $attempt attempts"
+        exit 1
+    fi
+    echo "$* failed or rollup native dependency missing on attempt $attempt, retrying..."
+    sleep 15
+done

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -eu
 
 # Use VIM as the command line git editor. Not everyone's preference, but oh well...
 git config core.editor vim

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # Use VIM as the command line git editor. Not everyone's preference, but oh well...
 git config core.editor vim
 
 # Initial build required for development
-npm install
+bash .devcontainer/npm-install-with-rollup-check.sh npm install
 npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,16 +301,8 @@ jobs:
               uses: devcontainers/ci@v0.3
               with:
                   runCmd: |
-                      for attempt in 1 2 3; do
-                          rm -rf node_modules
-                          # `npm ci` can exit 0 while silently skipping platform-specific optional
-                          # dependencies (npm bug npm/cli#4828), which later breaks rollup at build
-                          # time with "Cannot find module '@rollup/rollup-linux-x64-gnu'". Verify the
-                          # native binding actually loads before accepting the install.
-                          if npm ci && node -e "require('@rollup/rollup-linux-x64-gnu')"; then break; fi
-                          if [ "$attempt" -eq 3 ]; then echo "npm ci failed after $attempt attempts" && exit 1; fi
-                          echo "npm ci attempt $attempt failed, retrying..." && sleep 15
-                      done
+                      set -euo pipefail
+                      bash .devcontainer/npm-install-with-rollup-check.sh npm ci
                       # This package runs tests in a headless browser. If it can run, the other tests should too.
                       npm run build -w packages/doenetml-to-pretext
                       npm run test -w packages/doenetml-to-pretext
@@ -332,16 +324,8 @@ jobs:
               uses: devcontainers/ci@v0.3
               with:
                   runCmd: |
-                      for attempt in 1 2 3; do
-                          rm -rf node_modules
-                          # `npm ci` can exit 0 while silently skipping platform-specific optional
-                          # dependencies (npm bug npm/cli#4828), which later breaks rollup at build
-                          # time with "Cannot find module '@rollup/rollup-linux-x64-gnu'". Verify the
-                          # native binding actually loads before accepting the install.
-                          if npm ci && node -e "require('@rollup/rollup-linux-x64-gnu')"; then break; fi
-                          if [ "$attempt" -eq 3 ]; then echo "npm ci failed after $attempt attempts" && exit 1; fi
-                          echo "npm ci attempt $attempt failed, retrying..." && sleep 15
-                      done
+                      set -euo pipefail
+                      bash .devcontainer/npm-install-with-rollup-check.sh npm ci
                       npm run build -w packages/doenetml-to-pretext
                       npm run test -w packages/doenetml-to-pretext
                       npm run build -w packages/doenetml-to-pretext-python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,12 @@ jobs:
               with:
                   runCmd: |
                       for attempt in 1 2 3; do
-                          npm ci && break
+                          rm -rf node_modules
+                          # `npm ci` can exit 0 while silently skipping platform-specific optional
+                          # dependencies (npm bug npm/cli#4828), which later breaks rollup at build
+                          # time with "Cannot find module '@rollup/rollup-linux-x64-gnu'". Verify the
+                          # native binding actually loads before accepting the install.
+                          if npm ci && node -e "require('@rollup/rollup-linux-x64-gnu')"; then break; fi
                           if [ "$attempt" -eq 3 ]; then echo "npm ci failed after $attempt attempts" && exit 1; fi
                           echo "npm ci attempt $attempt failed, retrying..." && sleep 15
                       done
@@ -328,7 +333,12 @@ jobs:
               with:
                   runCmd: |
                       for attempt in 1 2 3; do
-                          npm ci && break
+                          rm -rf node_modules
+                          # `npm ci` can exit 0 while silently skipping platform-specific optional
+                          # dependencies (npm bug npm/cli#4828), which later breaks rollup at build
+                          # time with "Cannot find module '@rollup/rollup-linux-x64-gnu'". Verify the
+                          # native binding actually loads before accepting the install.
+                          if npm ci && node -e "require('@rollup/rollup-linux-x64-gnu')"; then break; fi
                           if [ "$attempt" -eq 3 ]; then echo "npm ci failed after $attempt attempts" && exit 1; fi
                           echo "npm ci attempt $attempt failed, retrying..." && sleep 15
                       done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,7 @@ jobs:
               uses: devcontainers/ci@v0.3
               with:
                   runCmd: |
-                      set -euo pipefail
+                      set -eu
                       bash .devcontainer/npm-install-with-rollup-check.sh npm ci
                       # This package runs tests in a headless browser. If it can run, the other tests should too.
                       npm run build -w packages/doenetml-to-pretext
@@ -324,7 +324,7 @@ jobs:
               uses: devcontainers/ci@v0.3
               with:
                   runCmd: |
-                      set -euo pipefail
+                      set -eu
                       bash .devcontainer/npm-install-with-rollup-check.sh npm ci
                       npm run build -w packages/doenetml-to-pretext
                       npm run test -w packages/doenetml-to-pretext


### PR DESCRIPTION
## Summary

A recent CI run of the **DoenetML to PreTeXt Tests** devcontainer job failed with:

```
Error: Cannot find module @rollup/rollup-linux-x64-gnu
```

This is npm's optional-dependency bug ([npm/cli#4828](https://github.com/npm/cli/issues/4828)): an install can intermittently exit **0 while silently omitting** Rollup's platform-specific native binary. The previous retry loop (`npm ci && break`) accepted that broken install, so the missing module only surfaced later at Rollup build time, outside the retry's reach.

## What changed

A shared `.devcontainer/npm-install-with-rollup-check.sh` helper now retries installs up to 3×. Each attempt:

1. Removes `node_modules` first, clearing any partial/stale install state.
2. Runs the requested install command (`npm install` for devcontainer creation, `npm ci` in CI `runCmd`).
3. Accepts the install only if `node -e "require('rollup')"` succeeds, which exercises Rollup's native binding resolver without hard-coding a specific libc/architecture package name.

The helper is used in both places that can install before the devcontainer tests run:

- `.devcontainer/postCreateCommand.sh`, because `devcontainers/ci` starts the container before executing `runCmd`.
- The two devcontainer `runCmd` blocks in `.github/workflows/ci.yml`.

If npm drops the optional Rollup package, the guard fails immediately, `node_modules` is wiped, and the install is retried instead of failing later during the build.

## Scope

This hardens only the devcontainer path, where the flake occurred and where retries already existed. The plain `- run: npm ci` steps in other jobs are theoretically vulnerable to the same npm bug but have not exhibited it; they are intentionally left unchanged for now.

🤖 Generated with [GitHub Copilot](https://github.com/features/copilot)